### PR TITLE
fix: pin jedi to 0.17.2 to prevent issue with IPython 7.16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         "pyyaml>=0.2.5",
         "importlib-metadata ; python_version<'3.8'",
         "IPython==7.16",  # Pinned for py3.6
+        "jedi==0.17.2",  # Pinned for IPython 7.16 incompatibility
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],
@@ -75,7 +76,12 @@ setup(
     },
     python_requires=">=3.6,<3.9",
     extras_require=extras_require,
-    py_modules=["ape", "ape_accounts", "ape_compile"],
+    py_modules=[
+        "ape",
+        "ape_accounts",
+        "ape_compile",
+        "ape_console",
+    ],
     license="Apache-2.0",
     zip_safe=False,
     keywords="ethereum",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ import ape
         ["accounts"],
         ["accounts", "list"],
         ["compile"],
+        ["console"],
     ),
 )
 def test_invocation(ape_cli, runner, args):


### PR DESCRIPTION
Noticed a small issue when trying to do tab completion in the console. This pin fixes it temporarily until a new release of IPython happens