### PR TITLE
fix: add config help message

### DIFF
--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -60,6 +60,7 @@ class ApeCLI(click.MultiCommand):
     is_eager=True,
     expose_value=False,
     callback=display_config,
+    help="Show configuration options (using `ape-config.yaml`)",
 )
 def cli():
     pass


### PR DESCRIPTION
Just a quick PR to add a help message for the `--config` flag