### PR TITLE
feat: json compiler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
         "ape_networks",
         "ape_plugins",
         "ape_test",
+        "ape_pm",
     ],
     license="Apache-2.0",
     zip_safe=False,
@@ -108,6 +109,7 @@ setup(
         "ape_etherscan": ["py.typed"],
         "ape_infura": ["py.typed"],
         "ape_test": ["py.typed"],
+        "ape_pm": ["py.typed"],
     },
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -42,7 +42,7 @@ class CompilerManager:
         for extension in extensions:
             paths_to_compile = [path for path in contract_filepaths if path.suffix == extension]
             for path in paths_to_compile:
-                notify("INFO", f"Compiling '{path.relative_to(Path.cwd())}'")
+                notify("INFO", f"Compiling '{path.relative_to(self.config.PROJECT_FOLDER)}'")
             for contract_type in self.registered_compilers[extension].compile(paths_to_compile):
 
                 if contract_type.contractName in contract_types:

--- a/src/ape_pm/__init__.py
+++ b/src/ape_pm/__init__.py
@@ -1,0 +1,8 @@
+from ape import plugins
+
+from .compiler import PackageCompiler
+
+
+@plugins.register(plugins.CompilerPlugin)
+def register_compiler():
+    return (".json",), PackageCompiler

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+from typing import List
+
+from ape.api.compiler import CompilerAPI
+from ape.types import ContractType, PackageManifest
+
+
+class PackageCompiler(CompilerAPI):
+    @property
+    def name(self) -> str:
+        return "ethpm"
+
+    def compile(self, filepaths: List[Path]) -> List[ContractType]:
+        contract_types: List[ContractType] = []
+        for path in filepaths:
+            manifest = PackageManifest.from_dict(json.loads(path.read_text()))
+
+            if manifest.contractTypes:
+                contract_types.extend(manifest.contractTypes.values())
+
+        return contract_types

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -14,9 +14,19 @@ class PackageCompiler(CompilerAPI):
     def compile(self, filepaths: List[Path]) -> List[ContractType]:
         contract_types: List[ContractType] = []
         for path in filepaths:
-            manifest = PackageManifest.from_dict(json.loads(path.read_text()))
+            data = json.load(path.open())
+            if "manifest" in data:
+                manifest = PackageManifest.from_dict(data)
 
-            if manifest.contractTypes:
-                contract_types.extend(manifest.contractTypes.values())
+                if manifest.contractTypes:  # type: ignore
+                    contract_types.extend(manifest.contractTypes.values())  # type: ignore
+
+            else:
+                contract_types.append(
+                    ContractType(  # type: ignore
+                        contractName=path.stem,
+                        abi=json.load(path.open()),
+                    )
+                )
 
         return contract_types

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from tempfile import mkdtemp
 
 import pytest  # type: ignore
+import requests
 from click.testing import CliRunner
 
 from ape import config
@@ -22,3 +23,26 @@ def data_folder():
 def ape_cli(data_folder):
     config.DATA_FOLDER = data_folder
     yield cli
+
+
+@pytest.fixture(
+    scope="session",
+    params=[
+        # From https://github.com/ethpm/ethpm-spec/tree/master/examples
+        "escrow",
+        "owned",
+        "piper-coin",
+        "safe-math-lib",
+        "standard-token",
+        "transferable",
+        "wallet-with-send",
+        "wallet",
+    ],
+)
+def manifest(request):
+    # NOTE: `v3-pretty.json` exists for each, and can be used for debugging
+    manifest_uri = (
+        "https://raw.githubusercontent.com/ethpm/ethpm-spec/master/examples/"
+        f"{request.param}/v3.json"
+    )
+    yield requests.get(manifest_uri).json()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest  # type: ignore
 import requests
 from click.testing import CliRunner
 
-from ape import config
+from ape import Project, config
 from ape._cli import cli
 
 
@@ -22,9 +22,21 @@ def data_folder():
 
 
 @pytest.fixture(scope="session")
+def project_folder():
+    project_folder = Path(mkdtemp())
+    config.PROJECT_FOLDER = project_folder
+    yield project_folder
+
+
+@pytest.fixture(scope="session")
 def ape_cli():
     # TODO: Ensure cli is invoked with project_folder
     yield cli
+
+
+@pytest.fixture(scope="session")
+def project(project_folder):
+    yield Project(project_folder)
 
 
 @pytest.fixture(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,12 +16,14 @@ def runner():
 
 @pytest.fixture(scope="session")
 def data_folder():
-    yield Path(mkdtemp())
+    data_folder = Path(mkdtemp())
+    config.DATA_FOLDER = data_folder
+    yield data_folder
 
 
 @pytest.fixture(scope="session")
-def ape_cli(data_folder):
-    config.DATA_FOLDER = data_folder
+def ape_cli():
+    # TODO: Ensure cli is invoked with project_folder
     yield cli
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest  # type: ignore
@@ -54,3 +55,21 @@ def test_keygen(ape_cli, runner, alias, password, private_key):
 
     if keyfile.exists():
         keyfile.unlink()
+
+
+def test_compile(project_folder, project, manifest):
+    # Nothing to start (no manifests in folder)
+    contracts_folder = project_folder / "contracts"
+    contracts_folder.mkdir(exist_ok=True)
+    assert len(project.contracts) == 0
+
+    # Add a manifest to the folder, now it will compile it
+    manifest_file = contracts_folder / (manifest["name"] + ".json")
+    manifest_file.write_text(json.dumps(manifest))
+    assert len(project.contracts) == (
+        len(manifest["contractTypes"]) if "contractTypes" in manifest else 0
+    )
+
+    # Remove it from the folder, nothing to compile now
+    manifest_file.unlink()
+    assert len(project.contracts) == 0

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -19,25 +19,5 @@ def test_manifest_parsing(manifest_dict):
     assert manifest.to_dict() == manifest_dict
 
 
-@pytest.mark.parametrize(
-    "example",
-    [
-        # From https://github.com/ethpm/ethpm-spec/tree/master/examples
-        "escrow",
-        "owned",
-        "piper-coin",
-        "safe-math-lib",
-        "standard-token",
-        "transferable",
-        "wallet-with-send",
-        "wallet",
-    ],
-)
-def test_example_manifests(example):
-    # NOTE: `v3-pretty.json` exists for each, and can be used for debugging
-    manifest_uri = (
-        f"https://raw.githubusercontent.com/ethpm/ethpm-spec/master/examples/{example}/v3.json"
-    )
-    manifest_dict = requests.get(manifest_uri).json()
-    manifest = PackageManifest.from_dict(manifest_dict)
-    assert manifest.to_dict() == manifest_dict
+def test_example_manifests(manifest):
+    assert PackageManifest.from_dict(manifest).to_dict() == manifest


### PR DESCRIPTION
This PR adds support for "compiling" `ContractType`s from JSON files (either ethPM Manifests, or JSON ABI files)

fixes: #29

depends on: #32

---

TODO:

- [x] Create tests