### PR TITLE
fix: update package version extractor function to work properly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         "pluggy>=0.13.1,<1.0",
         "PyGithub>=1.54,<2.0",
         "pyyaml>=0.2.5",
-        "importlib-metadata ; python_version<'3.8'",
+        "importlib-metadata",
         "singledispatchmethod ; python_version<'3.8'",
         "IPython==7.16",  # Pinned for py3.6
         "jedi==0.17.2",  # Pinned for IPython 7.16 incompatibility

--- a/src/ape/__init__.py
+++ b/src/ape/__init__.py
@@ -7,19 +7,9 @@ from .managers.config import ConfigManager as _ConfigManager
 from .managers.networks import NetworkManager as _NetworkManager
 from .managers.project import ProjectManager as _ProjectManager
 from .plugins import PluginManager as _PluginManager
+from .utils import get_package_version
 
-try:
-    from importlib.metadata import PackageNotFoundError as _PackageNotFoundError  # type: ignore
-    from importlib.metadata import version as _version  # type: ignore
-except ModuleNotFoundError:
-    from importlib_metadata import PackageNotFoundError as _PackageNotFoundError  # type: ignore
-    from importlib_metadata import version as _version  # type: ignore
-
-try:
-    __version__ = _version(__name__)
-except _PackageNotFoundError:
-    # package is not installed
-    __version__ = "<unknown>"
+__version__ = get_package_version(__name__)
 
 
 # NOTE: DO NOT OVERWRITE


### PR DESCRIPTION
Before, package versions weren't being properly detected by our version extraction function, and it also wasn't very portable. This PR solves both those issues, and fixes a few latent bugs with plugin management