### PR TITLE
fix: deprecation warning for `__init__` in dataclassy.dataclass

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -50,7 +50,7 @@ class EcosystemAPI:
         else:
             raise  # No networks found!
 
-    def __init__(self):
+    def __post_init__(self):
         if len(self.networks) == 0:
             raise  # Must define at least one network in ecosystem
 

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -22,7 +22,7 @@ class ConfigManager:
     plugin_manager: PluginManager
     _plugin_configs: Dict[str, ConfigItem] = dict()
 
-    def __init__(self):
+    def __post_init__(self):
         config_file = self.PROJECT_FOLDER / CONFIG_FILE_NAME
 
         if config_file.exists():

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -20,7 +20,7 @@ class ProjectManager:
 
     dependencies: Dict[str, PackageManifest] = dict()
 
-    def __init__(self):
+    def __post_init__(self):
         if isinstance(self.path, str):
             self.path = Path(self.path)
 

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -33,7 +33,7 @@ class AccountContainer(AccountContainerAPI):
 class KeyfileAccount(AccountAPI):
     _keyfile: Path
 
-    def __init__(self):
+    def __post_init__(self):
         self.locked = True
         self.__cached_key = None
 

--- a/src/ape_infura/providers.py
+++ b/src/ape_infura/providers.py
@@ -9,7 +9,7 @@ from ape.api import ProviderAPI
 class Infura(Web3, ProviderAPI):
     _web3: Web3 = None  # type: ignore
 
-    def __init__(self):
+    def __post_init__(self):
         key = os.environ.get("WEB3_INFURA_PROJECT_ID") or os.environ.get("WEB3_INFURA_API_KEY")
         self._web3 = Web3(HTTPProvider(f"https://{self.network.name}.infura.io/v3/{key}"))
         self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -12,7 +12,7 @@ class LocalNetwork(Web3, ProviderAPI):
     def disconnect(self):
         pass
 
-    def __init__(self):
+    def __post_init__(self):
         self._web3 = Web3(EthereumTesterProvider())
 
     def transfer_cost(self, address: str) -> int:


### PR DESCRIPTION
Noticed this deprecation warning with `dataclassy`
```
DeprecationWarning: Defining post-initialisation logic in __init__ is deprecated and will be removed in a forthcoming version. 
Please rename your method to __post_init__.
```