### PR TITLE
fix: abstract.py creates error RuntimeError: No active exception to reraise

### DIFF
--- a/src/ape/types/abstract.py
+++ b/src/ape/types/abstract.py
@@ -50,7 +50,7 @@ def to_dict(v: Any) -> Optional[Union[list, dict, str, int, bool]]:
         return v
 
     else:
-        raise  # Unhandled type
+        raise Exception("Unhandled type")
 
 
 @dc.dataclass(slots=True, kwargs=True, repr=True)


### PR DESCRIPTION
### What I did
raise exception instead of raise #

Related issue: #
fix https://github.com/ApeWorX/ape/issues/71

### How I did it
`raise Exception("Unhandled type")`

### How to verify it


### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
