### PR TITLE
fix: allow all kwargs for txn pass-through in AccountAPI

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -61,15 +61,13 @@ class AccountAPI(AddressAPI):
         self,
         account: Union[str, "AddressAPI"],
         value: int = None,
-        data: bytes = None,
+        **kwargs,
     ) -> ReceiptAPI:
         txn = self._transaction_class(  # type: ignore
             sender=self.address,
             receiver=account.address if isinstance(account, AddressAPI) else account,
+            **kwargs,
         )
-
-        if data:
-            txn.data = data
 
         if value:
             txn.value = value


### PR DESCRIPTION
Allow specifying additional kwargs like `gas_price = 10` etc.
