### PR TITLE
fix: error warning not accurate for uninstalled compiler

### DIFF
--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -1,5 +1,4 @@
 from itertools import chain
-from os import listdir
 from pathlib import Path
 
 import click

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -1,5 +1,6 @@
 from itertools import chain
 from pathlib import Path
+from os import listdir
 
 import click
 
@@ -67,7 +68,13 @@ def cli(filepaths, use_cache, display_size):
         else:
             selected_paths = str(project.path / "contracts")
 
-        notify("WARNING", f"No project files detected in '{selected_paths}'")
+        if any(".sol" or ".vy" in s for s in listdir(selected_paths)):
+            if any(".sol" in s for s in listdir(selected_paths)):
+                notify("WARNING", "The required compiler plugin Ape-Solidity is not installed")
+            if any(".vy" in s for s in listdir(selected_paths)):
+                notify("WARNING", "The required compiler plugin Ape-Vyper is not installed")
+        else:
+            notify("WARNING", f"No contract files detected in '{selected_paths}'")
         return
 
     # TODO: only compile selected contracts

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -68,13 +68,8 @@ def cli(filepaths, use_cache, display_size):
         else:
             selected_paths = str(project.path / "contracts")
 
-        if any(".sol" or ".vy" in s for s in listdir(selected_paths)):
-            if any(".sol" in s for s in listdir(selected_paths)):
-                notify("WARNING", "The required compiler plugin Ape-Solidity is not installed")
-            if any(".vy" in s for s in listdir(selected_paths)):
-                notify("WARNING", "The required compiler plugin Ape-Vyper is not installed")
-        else:
-            notify("WARNING", f"No contract files detected in '{selected_paths}'")
+        extensions = ", ".join(set(f.suffix for f in selected_paths))
+        notify("WARNING", f"No compilers detected for the following extensions: {extensions}")
         return
 
     # TODO: only compile selected contracts

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -1,6 +1,6 @@
 from itertools import chain
-from pathlib import Path
 from os import listdir
+from pathlib import Path
 
 import click
 


### PR DESCRIPTION
### What I did

changed error messages to be more reflective of actual error regarding uninstalled compiler. 

Related issue: # fix: https://github.com/ApeWorX/ape/issues/85

### How I did it

modified the compiler _cli file to look for .vy and .sol files in os.listdir contract folder to base error messages on

### How to verify it

try to compile vyper files with no vyper plugin, it should tell you no vyper plugin is installed. same with solidity plugin. 
if there are no .vy or .sol in contracts folder it should say so, and if there is no contracts folder it should say so. 

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
