### PR TITLE
chore: deprecate Python 3.6 support; upgrade IPython

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
-                python-version: [3.6, 3.7, 3.8, 3.9]
+                python-version: [3.7, 3.8, 3.9]
 
         steps:
         - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ape is a framework for Web3 Python applications and smart contracts, with advanc
 
 ## Dependencies
 
-* [python3](https://www.python.org/downloads) version 3.6 or greater, python3-dev
+* [python3](https://www.python.org/downloads) version 3.7 or greater, python3-dev
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ write_to = "src/ape/version.py"
 # character.
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38']
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]

--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,7 @@ setup(
         "pyyaml>=0.2.5",
         "importlib-metadata",
         "singledispatchmethod ; python_version<'3.8'",
-        "IPython==7.16",  # Pinned for py3.6
-        "jedi==0.17.2",  # Pinned for IPython 7.16 incompatibility
+        "IPython>=7.25",
         "web3[tester]>=5.18.0,<6.0.0",
     ],
     entry_points={
@@ -83,7 +82,7 @@ setup(
             "ape_networks=ape_networks._cli:cli",
         ],
     },
-    python_requires=">=3.6,<3.10",
+    python_requires=">=3.7,<3.10",
     extras_require=extras_require,
     py_modules=[
         "ape",
@@ -123,7 +122,6 @@ setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
### What I did
Removed support for Python 3.6 for the Ape tool. IPython was having difficulties with this version, and due to a change in how core dataclasses work, one of our dependencies was also having an issue with that version, preventing the merge of #89.

Related: https://github.com/biqqles/dataclassy/issues/52
