### PR TITLE
fix: updates eth-account requirement - fixes breaking change 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "backports.cached_property ; python_version<'3.8'",
         "click>=8.0.0",
         "dataclassy>=0.10.3,<1.0",
-        "eth-account>=0.5.2,<0.6.0",
+        "eth-account>=0.5.5,<0.6.0",
         "pluggy>=0.13.1,<1.0",
         "PyGithub>=1.54,<2.0",
         "pyyaml>=0.2.5",


### PR DESCRIPTION
### What I did

updated the `eth-account` requirement to match pull 103

fixes: #106

### How I did it

`"eth-account>=0.5.5,<0.6.0",`

### How to verify it

if you install 0.5.4 it doesn't work with the new pull from ape

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
