### PR TITLE
refactor: allow more network choices via defaults

### DIFF
--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -13,7 +13,7 @@ class NetworkChoice(click.Choice):
         super().__init__(list(networks.network_choices), case_sensitive)
 
     def get_metavar(self, param):
-        return "ecosystem-name[:network-name[:provider-name]]"
+        return "[ecosystem-name][:[network-name][:[provider-name]]]"
 
 
 @click.command(short_help="Load the console", context_settings=dict(ignore_unknown_options=True))


### PR DESCRIPTION
### What I did
Allow more network choices e.g. `:goerli`, `::test`, `bsc::test`

### How to verify it
Try it