### PR TITLE
fix: chain ID for geth --dev was incorrect, so add local network

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -7,7 +7,7 @@ from pluggy import PluginManager  # type: ignore
 from ape.types import ABI, AddressType
 from ape.utils import cached_property
 
-from .base import abstractdataclass, abstractmethod
+from .base import abstractdataclass, abstractmethod, dataclass
 from .config import ConfigItem
 
 if TYPE_CHECKING:
@@ -156,7 +156,7 @@ class ProviderContextManager:
             self.network_manager.active_provider = self._connected_providers[-1]
 
 
-@abstractdataclass
+@dataclass
 class NetworkAPI:
     """
     A Network is a wrapper around a Provider for a specific Ecosystem
@@ -176,14 +176,15 @@ class NetworkAPI:
         return self.config_manager.get_config(self.ecosystem.name)
 
     @property
-    @abstractmethod
     def chain_id(self) -> int:
-        ...
+        # NOTE: Unless overriden, returns same as `provider.chain_id`
+        with self.use_provider(self.default_provider) as p:
+            return p.chain_id
 
     @property
-    @abstractmethod
     def network_id(self) -> int:
-        ...
+        # NOTE: Unless overriden, returns same as chain_id
+        return self.chain_id
 
     @cached_property
     def explorer(self) -> Optional["ExplorerAPI"]:

--- a/src/ape_ethereum/__init__.py
+++ b/src/ape_ethereum/__init__.py
@@ -1,5 +1,5 @@
 from ape import plugins
-from ape.api import create_network_type
+from ape.api import NetworkAPI, create_network_type
 
 from .converters import WeiConversions
 from .ecosystem import NETWORKS, Ethereum
@@ -20,5 +20,5 @@ def networks():
     for network_name, network_params in NETWORKS.items():
         yield "ethereum", network_name, create_network_type(*network_params)
 
-    # TODO: Move to ape-test 1st party plugin
-    yield "ethereum", "development", create_network_type(chain_id=69, network_id=69)
+    # NOTE: This works for `geth --dev` as it gets chain_id from itself
+    yield "ethereum", "development", NetworkAPI


### PR DESCRIPTION
### What I did
I noticed when using `geth --dev` with the console, there was an issue where the chain ID disagrees with what's expected.