### PR TITLE
refactor: change how signing API works

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Callable, Iterator, List, Optional, Type, Union
 
-from eth_account.datastructures import SignedMessage  # type: ignore
+from eth_account.datastructures import SignedMessage, SignedTransaction
 from eth_account.messages import SignableMessage  # type: ignore
 
 from ape.types import AddressType, ContractType
@@ -39,9 +39,9 @@ class AccountAPI(AddressAPI):
     def sign_message(self, msg: SignableMessage) -> Optional[SignedMessage]:
         ...
 
-    def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionAPI]:
-        # NOTE: Some accounts may not offer signing things
-        return txn
+    @abstractmethod
+    def sign_transaction(self, txn: TransactionAPI) -> Optional[SignedTransaction]:
+        ...
 
     def call(self, txn: TransactionAPI) -> ReceiptAPI:
         txn.chain_id = self.provider.network.chain_id
@@ -53,12 +53,12 @@ class AccountAPI(AddressAPI):
         if txn.gas_limit * txn.gas_price + txn.value > self.balance:
             raise Exception("Transfer value meets or exceeds account balance")
 
-        signed_txn = self.sign_transaction(txn)
+        txn.signature = self.sign_transaction(txn)
 
-        if not signed_txn:
+        if not txn.signature:
             raise Exception("User didn't sign!")
 
-        return self.provider.send_transaction(signed_txn)
+        return self.provider.send_transaction(txn)
 
     @cached_property
     def _convert(self) -> Callable:

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Iterator, List, Optional
 
 from dataclassy import as_dict
+from eth_account.datastructures import SignedTransaction
 
 from ape.utils import notify
 
@@ -22,7 +23,7 @@ class TransactionAPI:
     gas_price: int = 0
     data: bytes = b""
 
-    signature: bytes = b""
+    signature: Optional[SignedTransaction] = None
 
     def __post_init__(self):
         if not self.is_valid:

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -4,7 +4,7 @@ from typing import Iterator, Optional
 
 import click
 from eth_account import Account as EthAccount  # type: ignore
-from eth_account.datastructures import SignedMessage  # type: ignore
+from eth_account.datastructures import SignedMessage, SignedTransaction  # type: ignore
 from eth_account.messages import SignableMessage  # type: ignore
 
 from ape.api import AccountAPI, AccountContainerAPI, TransactionAPI
@@ -121,16 +121,8 @@ class KeyfileAccount(AccountAPI):
 
         return EthAccount.sign_message(msg, self.__key)
 
-    def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionAPI]:
+    def sign_transaction(self, txn: TransactionAPI) -> Optional[SignedTransaction]:
         if self.locked and not click.confirm(f"{txn}\n\nSign: "):
             return None
 
-        signed_txn = EthAccount.sign_transaction(txn.as_dict(), self.__key)
-
-        txn.signature = (
-            signed_txn.v.to_bytes(1, "big")
-            + signed_txn.r.to_bytes(32, "big")
-            + signed_txn.s.to_bytes(32, "big")
-        )
-
-        return txn
+        return EthAccount.sign_transaction(txn.as_dict(), self.__key)


### PR DESCRIPTION
### What I did
The signing API needed to be refactored to account for using signatures properly. The way we encoded and decoded them before was really bad, so we want to not do that anymore.

### How I did it
modified `AccountAPI.sign_transaction` from returning the input `TransactionAPI` with the signature to returning `SignedTransaction`. It was optional before, but the semantic here changes a bit because now it returns the signature directly.

@sabotagebeats this will affect your work in `ape-trezor`. Please watch for when this merges and update accordingly.