### PR TITLE
fix: error message for provider failure was not descriptive

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -246,10 +246,13 @@ class NetworkAPI:
             provider_name = provider_name.split(":")[0]
 
         if provider_name in self.providers:
-            return ProviderContextManager(
-                self.ecosystem.network_manager,
-                self.providers[provider_name](provider_settings=provider_settings),
-            )
+            try:
+                return ProviderContextManager(
+                    self.ecosystem.network_manager,
+                    self.providers[provider_name](provider_settings=provider_settings),
+                )
+            except TypeError as e:
+                raise Exception(f"Plugin {provider_name} failed to load!")
 
         else:
             raise Exception("Not a registered provider name")


### PR DESCRIPTION
### What I did
fixed nondescriptive error message `TypeError: Can't instantiate abstract class Infura with abstract methods chain_id`
Related issue: # 
https://github.com/ApeWorX/ape/issues/119
https://github.com/ApeWorX/ape-infura/issues/1

### How I did it
wrapped the offending line in `try... except`

### How to verify it
I run `ape console --network ethereum:ropsten:infura` but the infura plugin is broken


### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
