### PR TITLE
fix: handle exceptions when loading plugin packages

### DIFF
--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -9,6 +9,7 @@ import click
 import yaml
 
 from ape.plugins import clean_plugin_name
+from ape.utils import notify
 
 
 def display_config(ctx, param, value):
@@ -47,7 +48,10 @@ class ApeCLI(click.MultiCommand):
 
     def get_command(self, ctx, name):
         if name in self.commands:
-            return self.commands[name]()
+            try:
+                return self.commands[name]()
+            except Exception:
+                notify("WARNING", f"Error loading cli endpoint for plugin 'ape_{name}'")
 
         # NOTE: don't return anything so Click displays proper error
 

--- a/src/ape/plugins/__init__.py
+++ b/src/ape/plugins/__init__.py
@@ -3,6 +3,8 @@ import importlib
 import pkgutil
 from typing import Callable, Iterator, Tuple, Type, cast
 
+from ape.utils import notify
+
 from .account import AccountPlugin
 from .compiler import CompilerPlugin
 from .config import Config
@@ -74,7 +76,11 @@ class PluginManager:
         # NOTE: This actually loads the plugins, and should only be done once
         for _, name, ispkg in pkgutil.iter_modules():
             if name.startswith("ape_") and ispkg:
-                plugin_manager.register(importlib.import_module(name))
+                try:
+                    plugin_manager.register(importlib.import_module(name))
+                except Exception:
+                    notify("WARNING", f"Error loading plugin package '{name}'")
+                    # notify("DEBUG", str(e))
 
     def __getattr__(self, attr_name: str) -> Iterator[Tuple[str, tuple]]:
         if not hasattr(plugin_manager.hook, attr_name):


### PR DESCRIPTION
### What I did
- [x] Handle exceptions when doing plugin registration and loading CLI endpoints
- [x] Handle partially implemented API objects

fixes: #119

### How I did it

### How to verify it
- Add an exception to a core plugin `__init__.py`, to show that it doesn't load and raises a warning instead
- Remove a necessary API abstractmethod, to show it doesn't register and raises a warning instead

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- ~~[ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
