### PR TITLE
fix: use ape-specific types for messages and msg/txn signatures

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -1,10 +1,13 @@
 from pathlib import Path
 from typing import Callable, Iterator, List, Optional, Type, Union
 
-from eth_account.datastructures import SignedMessage, SignedTransaction
-from eth_account.messages import SignableMessage  # type: ignore
-
-from ape.types import AddressType, ContractType
+from ape.types import (
+    AddressType,
+    ContractType,
+    MessageSignature,
+    SignableMessage,
+    TransactionSignature,
+)
 from ape.utils import cached_property
 
 from .address import AddressAPI
@@ -36,11 +39,11 @@ class AccountAPI(AddressAPI):
         return None
 
     @abstractmethod
-    def sign_message(self, msg: SignableMessage) -> Optional[SignedMessage]:
+    def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
         ...
 
     @abstractmethod
-    def sign_transaction(self, txn: TransactionAPI) -> Optional[SignedTransaction]:
+    def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:
         ...
 
     def call(self, txn: TransactionAPI, send_everything: bool = False) -> ReceiptAPI:

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from typing import Iterator, List, Optional
 
 from dataclassy import as_dict
-from eth_account.datastructures import SignedTransaction
 
+from ape.types import TransactionSignature
 from ape.utils import notify
 
 from . import networks
@@ -23,7 +23,7 @@ class TransactionAPI:
     gas_price: Optional[int] = None  # NOTE: `Optional` only to denote using default behavior
     data: bytes = b""
 
-    signature: Optional[SignedTransaction] = None
+    signature: Optional[TransactionSignature] = None
 
     def __post_init__(self):
         if not self.is_valid:

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -2,6 +2,7 @@ from eth_typing import ChecksumAddress as AddressType
 
 from .contract import ABI, Bytecode, Checksum, Compiler, ContractType, Source
 from .manifest import PackageManifest, PackageMeta
+from .signatures import MessageSignature, SignableMessage, TransactionSignature
 
 __all__ = [
     "ABI",
@@ -10,7 +11,10 @@ __all__ = [
     "Checksum",
     "Compiler",
     "ContractType",
+    "MessageSignature",
     "PackageManifest",
     "PackageMeta",
+    "SignableMessage",
     "Source",
+    "TransactionSignature",
 ]

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -1,7 +1,8 @@
-from typing import Iterator
+from typing import Iterator, Union
 
 from dataclassy import dataclass
 from eth_account.messages import SignableMessage  # type: ignore
+from eth_utils import to_bytes
 
 
 @dataclass(frozen=True, slots=True, kwargs=True)
@@ -10,8 +11,9 @@ class _Signature:
     r: bytes
     s: bytes
 
-    def __iter__(self) -> Iterator[bytes]:
-        yield bytes(self.v)
+    def __iter__(self) -> Iterator[Union[int, bytes]]:
+        # NOTE: Allows tuple destructuring
+        yield self.v
         yield self.r
         yield self.s
 
@@ -19,10 +21,10 @@ class _Signature:
         return f"<{self.__class__.__name__} v={self.v} r={self.r.hex()} s={self.s.hex()}>"
 
     def encode_vrs(self) -> bytes:
-        return bytes(self.v) + self.r + self.s
+        return to_bytes(self.v) + self.r + self.s
 
     def encode_rsv(self) -> bytes:
-        return self.r + self.s + bytes(self.v)
+        return self.r + self.s + to_bytes(self.v)
 
 
 class MessageSignature(_Signature):

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -1,0 +1,36 @@
+from typing import Iterator
+
+from dataclassy import dataclass
+from eth_account.messages import SignableMessage  # type: ignore
+
+
+@dataclass(frozen=True, slots=True, kwargs=True)
+class _Signature:
+    v: int
+    r: bytes
+    s: bytes
+
+    def __iter__(self) -> Iterator[bytes]:
+        yield bytes(self.v)
+        yield self.r
+        yield self.s
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} v={self.v} r={self.r.hex()} s={self.s.hex()}>"
+
+    def encode_vrs(self) -> bytes:
+        return bytes(self.v) + self.r + self.s
+
+    def encode_rsv(self) -> bytes:
+        return self.r + self.s + bytes(self.v)
+
+
+class MessageSignature(_Signature):
+    pass
+
+
+class TransactionSignature(_Signature):
+    pass
+
+
+_ = SignableMessage

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -4,12 +4,10 @@ from typing import Iterator, Optional
 
 import click
 from eth_account import Account as EthAccount  # type: ignore
-from eth_account.datastructures import SignedMessage, SignedTransaction  # type: ignore
-from eth_account.messages import SignableMessage  # type: ignore
 
 from ape.api import AccountAPI, AccountContainerAPI, TransactionAPI
 from ape.convert import to_address
-from ape.types import AddressType
+from ape.types import AddressType, MessageSignature, SignableMessage, TransactionSignature
 
 
 class AccountContainer(AccountContainerAPI):
@@ -115,14 +113,16 @@ class KeyfileAccount(AccountAPI):
 
         self._keyfile.unlink()
 
-    def sign_message(self, msg: SignableMessage) -> Optional[SignedMessage]:
+    def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
         if self.locked and not click.confirm(f"{msg}\n\nSign: "):
             return None
 
-        return EthAccount.sign_message(msg, self.__key)
+        signed_msg = EthAccount.sign_message(msg, self.__key)
+        return MessageSignature(v=signed_msg.v, r=signed_msg.r, s=signed_msg.s)  # type: ignore
 
-    def sign_transaction(self, txn: TransactionAPI) -> Optional[SignedTransaction]:
+    def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:
         if self.locked and not click.confirm(f"{txn}\n\nSign: "):
             return None
 
-        return EthAccount.sign_transaction(txn.as_dict(), self.__key)
+        signed_txn = EthAccount.sign_transaction(txn.as_dict(), self.__key)
+        return TransactionSignature(v=signed_txn.v, r=signed_txn.r, s=signed_txn.s)  # type: ignore

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from eth_abi import decode_abi as abi_decode
 from eth_abi import encode_abi as abi_encode
 from eth_abi.exceptions import InsufficientDataBytes
-from eth_account import Account as EthAccount
+from eth_account import Account as EthAccount  # type: ignore
 from eth_account._utils.legacy_transactions import (  # type: ignore
     encode_transaction,
     serializable_unsigned_transaction_from_dict,


### PR DESCRIPTION
### What I did

Related issue: #

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
