### PR TITLE
fix: remove unused network type after geth --dev was added

### DIFF
--- a/src/ape_test/__init__.py
+++ b/src/ape_test/__init__.py
@@ -1,12 +1,6 @@
 from ape import plugins
-from ape.api import create_network_type
 
 from .providers import LocalNetwork
-
-
-@plugins.register(plugins.NetworkPlugin)
-def networks():
-    yield "ethereum", "development", create_network_type(chain_id=69, network_id=69)
 
 
 @plugins.register(plugins.ProviderPlugin)


### PR DESCRIPTION
### What I did
Remove the extra network object that we added in `ape_test`, since `ape_ethereum` is defining it now.

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
