### PR TITLE
fix: use getattr for EthereumProvider network configs instead of dictionary key lookup

### DIFF
--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -35,7 +35,7 @@ class ConfigItem:
         if attrname in self.__slots__:
             return getattr(self, attrname)
 
-        raise KeyError(f"''{attrname}'")
+        raise KeyError(f"{attrname!r}")
 
 
 class ConfigDict(ConfigItem):

--- a/src/ape_http/providers.py
+++ b/src/ape_http/providers.py
@@ -30,7 +30,7 @@ class EthereumProvider(ProviderAPI):
 
     @property
     def uri(self) -> str:
-        return self.config[self.network.ecosystem.name][self.network.name]["uri"]
+        return getattr(self.config, self.network.ecosystem.name)[self.network.name]["uri"]
 
     def connect(self):
         self._web3 = Web3(HTTPProvider(self.uri))


### PR DESCRIPTION
I am inheriting from NetworkConfig for Hardhat, but the behavior of key
lookup vs. attribute lookup is different for the base class vs.
inherited class.

Base NetworkConfig class:

    (Pdb) self.config
    NetworkConfig(ethereum={'development': {'uri': 'http://localhost:8555'}})
    (Pdb) self.config['ethereum']
    {'development': {'uri': 'http://localhost:8555'}}
    (Pdb) getattr(self.config, 'ethereum')
    {'development': {'uri': 'http://localhost:8555'}}

Vs. my inherited class where the key lookup fails:

    (Pdb) self.config
    HardhatNetworkConfig(ethereum={'development': {'uri': 'http://localhost:8555'}}, fork_url=None, fork_block_number=None, port=8555)
    (Pdb) self.config['ethereum']
    *** KeyError: "''ethereum'"
    (Pdb) self.config.ethereum
    {'development': {'uri': 'http://localhost:8555'}}

Since attribute lookup works on both classes, let's just use that.

Also fixed a typo in the KeyError raised by the ConfigItem class.

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
