### PR TITLE
chore: upgrade python syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ cd ape-accounts
 python3 -m venv venv
 source venv/bin/activate
 
-# install brownie into the virtual environment
+# install ape into the virtual environment
 python setup.py install
 
 # install the developer dependencies (-e is interactive mode)

--- a/build_docs.py
+++ b/build_docs.py
@@ -2,8 +2,6 @@
 Used with the `docs` Github action to make versioned docs directories in the
 gh-pages branch.
 """
-
-
 import argparse
 import os
 import re

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,9 +3,7 @@
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-
 # -- Path setup --------------------------------------------------------------
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 from setuptools import find_packages, setup  # type: ignore
 
 extras_require = {

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -71,8 +71,7 @@ class EcosystemAPI:
         """
         Provides the set of all valid Network names in the ecosystem
         """
-        for name in self.networks:
-            yield name
+        yield from self.networks
 
     def __getitem__(self, network_name: str) -> "NetworkAPI":
         if network_name in self.networks:

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -39,8 +39,7 @@ class AccountManager:
     @property
     def aliases(self) -> Iterator[str]:
         for container in self.containers.values():
-            for alias in container.aliases:
-                yield alias
+            yield from container.aliases
 
     def __len__(self) -> int:
         return sum(len(container) for container in self.containers.values())

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -35,8 +35,7 @@ class NetworkManager:
         }
 
     def __iter__(self) -> Iterator[str]:
-        for ecosystem_name in self.ecosystems:
-            yield ecosystem_name
+        yield from self.ecosystems
 
     def __getitem__(self, ecosystem_name: str) -> EcosystemAPI:
         if ecosystem_name not in self.ecosystems:

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional
 import requests
 from dataclassy import dataclass
 
-from ape.types import Checksum, Compiler, ContractType, PackageManifest, Source  # PackageMeta
+from ape.types import Checksum, Compiler, ContractType, PackageManifest, Source
 from ape.utils import compute_checksum
 
 from .compilers import CompilerManager

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -144,7 +144,7 @@ def load_config(path: Path, expand_envars=True, must_exist=False) -> Dict:
         return config or {}
 
     elif must_exist:
-        raise IOError(f"{path} does not exist!")
+        raise OSError(f"{path} does not exist!")
 
     else:
         return {}

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -4,11 +4,11 @@ from eth_abi import decode_abi as abi_decode
 from eth_abi import encode_abi as abi_encode
 from eth_abi.exceptions import InsufficientDataBytes
 from eth_account import Account as EthAccount  # type: ignore
-from eth_account._utils.legacy_transactions import (  # type: ignore
+from eth_account._utils.legacy_transactions import (
     encode_transaction,
     serializable_unsigned_transaction_from_dict,
 )
-from eth_utils import keccak, to_bytes, to_int  # type: ignore
+from eth_utils import keccak, to_bytes, to_int
 from hexbytes import HexBytes
 
 from ape.api import ContractLog, EcosystemAPI, ReceiptAPI, TransactionAPI, TransactionStatusEnum

--- a/src/ape_http/providers.py
+++ b/src/ape_http/providers.py
@@ -1,6 +1,6 @@
 from typing import Iterator
 
-from web3 import HTTPProvider, Web3  # type: ignore
+from web3 import HTTPProvider, Web3
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.middleware import geth_poa_middleware
 

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -1,6 +1,6 @@
 from typing import Iterator
 
-from web3 import EthereumTesterProvider, Web3  # type: ignore
+from web3 import EthereumTesterProvider, Web3
 
 from ape.api import ProviderAPI, ReceiptAPI, TransactionAPI
 

--- a/tests/functional/manifests/test_manifest.py
+++ b/tests/functional/manifests/test_manifest.py
@@ -1,6 +1,6 @@
 import pytest  # type: ignore
 import requests
-from hypothesis import HealthCheck, given, settings  # type: ignore
+from hypothesis import HealthCheck, given, settings
 from hypothesis_jsonschema import from_schema  # type: ignore
 
 from ape.types.manifest import PackageManifest


### PR DESCRIPTION
### What I did

I ran `pyupgrade` to upgrade the code base to use syntax for python 3.7 or greater.

During the last meeting, I showed some of the changes. I have concluded that:

1.) The team does not always want to use the latest syntax during cases they find it confusing
2.) The team is not immediately attracted to the idea of another pre-commit hook modifying code.

And also, some contrary things about `pyupgrade`:

1.) `pyupgrade` works best a pre-commit hook. This is because it takes a list of python files as arguments.
2.) `pyupgrade` does not have an opt-out feature natively, but there is a fork that does.

Thus, it does not seem like a good time to automate the usage of `pyupgrade` because of these conflicts.

Related issue: # n/a

### How I did it

I made the precommit hook, ran it, and then removed the precommit. I could have instead ran `pyupgrade` on all the python files.  (also used the `--py37-plus` flag).

### How to verify it

Ensure the changes align with practices we believe are good, as far as using upgraded syntax goes.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
