### PR TITLE
chore: refactor and test networks list command

### DIFF
--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -1,15 +1,15 @@
 from typing import Dict
 
-try:
-    from importlib import metadata  # type: ignore
-except ImportError:
-    import importlib_metadata as metadata  # type: ignore
-
 import click
 import yaml
 
 from ape.plugins import clean_plugin_name
 from ape.utils import notify
+
+try:
+    from importlib import metadata  # type: ignore
+except ImportError:
+    import importlib_metadata as metadata  # type: ignore
 
 
 def display_config(ctx, param, value):

--- a/src/ape_networks/_cli.py
+++ b/src/ape_networks/_cli.py
@@ -2,6 +2,8 @@ import click
 
 from ape import networks
 
+_PREFIX_SPACING = "    "
+
 
 @click.group(short_help="Manage networks")
 def cli():
@@ -13,33 +15,38 @@ def cli():
 @cli.command(name="list", short_help="List registered networks")
 def _list():
     click.echo("ecosystems:")
-    default_ecosystem = networks.default_ecosystem.name
     for ecosystem_name in networks:
-        if ecosystem_name == default_ecosystem:
-            click.echo(f"- name: {ecosystem_name}  # Default")
-        else:
-            click.echo(f"- name: {ecosystem_name}")
+        _echo_ecosystem(ecosystem_name)
 
-        ecosystem = networks[ecosystem_name]
 
-        default_network = ecosystem.default_network
-        for network_name in getattr(networks, ecosystem_name):
+def _echo_ecosystem(name):
+    _echo_output(name, networks.default_ecosystem.name)
+    ecosystem = networks[name]
 
-            if network_name == default_network:
-                click.echo(f"  - name: {network_name}  # Default")
-            else:
-                click.echo(f"  - name: {network_name}")
+    for network_name in getattr(networks, name):
+        _echo_network(ecosystem, network_name)
 
-            network = ecosystem[network_name]
 
-            if network.explorer:
-                click.echo(f"    explorer: {network.explorer.name}")
+def _echo_network(ecosystem, name):
+    _echo_output(name, ecosystem.default_network)
+    network = ecosystem[name]
 
-            click.echo("    providers:")
+    if network.explorer:
+        click.echo(f"{_PREFIX_SPACING}explorer: {network.explorer.name}")
 
-            default_provider = network.default_provider
-            for provider_name in network.providers:
-                if provider_name == default_provider:
-                    click.echo(f"    - {provider_name}  # Default")
-                else:
-                    click.echo(f"    - {provider_name}")
+    click.echo(f"{_PREFIX_SPACING}providers:")
+
+    for provider_name in network.providers:
+        _echo_output(provider_name, network.default_provider)
+
+
+def _echo_output(name, default_name):
+    output = _create_output_line(name)
+    if name == default_name:
+        output = f"{output}  # Default"
+
+    click.echo(output)
+
+
+def _create_output_line(output):
+    return f"{_PREFIX_SPACING}- {output}"

--- a/tests/integration/cli/test_networks.py
+++ b/tests/integration/cli/test_networks.py
@@ -1,0 +1,29 @@
+_DEFAULT_NETWORKS_LIST = """
+ecosystems:
+    - ethereum  # Default
+    - mainnet
+    providers:
+    - http  # Default
+    - ropsten
+    providers:
+    - http  # Default
+    - kovan
+    providers:
+    - http  # Default
+    - rinkeby
+    providers:
+    - http  # Default
+    - goerli
+    providers:
+    - http  # Default
+    - development  # Default
+    providers:
+    - http  # Default
+    - test
+"""
+
+
+def test_list(ape_cli, runner):
+    result = runner.invoke(ape_cli, ["networks", "list"])
+    expected = _DEFAULT_NETWORKS_LIST.strip()
+    assert expected in result.output


### PR DESCRIPTION
### What I did

Whilst trying to figure out how to add a network (similarly to `brownie networks add`), I noticed that the `network list` command could be refactored. I also noticed there was not a test for it, so I added that as well.

### How I did it

Pulled out shared logic, broke up the large command-method's implementation to use sub-methods, added a simple test.

### How to verify it

Run `ape networks list`, the output should be the same as it was before.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
