### PR TITLE
fix: accounts failure exit codes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ extras_require = {
         "pytest>=6.0,<7.0",  # Core testing package
         "pytest-xdist",  # multi-process runner
         "pytest-cov",  # Coverage analyzer plugin
+        "pytest-mock",  # For creating mocks
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
         "hypothesis-jsonschema==0.19.0",  # JSON Schema fuzzer extension
     ],

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -99,7 +99,7 @@ NOTIFY_COLORS = {
 
 def notify(type_, msg):
     """Prepends a message with a colored tag and outputs it to the console."""
-    click.echo(f"{click.style(type_, fg=NOTIFY_COLORS[type_])}: {msg}")
+    click.echo(f"{click.style(type_, fg=NOTIFY_COLORS[type_])}: {msg}", err=type_ == "ERROR")
 
 
 class Abort(click.ClickException):
@@ -107,7 +107,7 @@ class Abort(click.ClickException):
 
     def show(self, file=None):
         """Override default ``show`` to print CLI errors in red text."""
-        click.secho(f"Error: {self.format_message()}", err=True, fg="bright_red")
+        notify("ERROR", self.format_message())
 
 
 def deep_merge(dict1, dict2):

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -6,7 +6,7 @@ from eth_account import Account as EthAccount  # type: ignore
 from eth_utils import to_bytes
 
 from ape import accounts
-from ape.utils import notify
+from ape.utils import Abort, notify
 
 # NOTE: Must used the instantiated version of `AccountsContainer` in `accounts`
 container = accounts.containers["accounts"]
@@ -57,8 +57,7 @@ def _list():
 @click.argument("alias")
 def generate(alias):
     if alias in accounts.aliases:
-        notify("ERROR", f"Account with alias '{alias}' already exists")
-        return
+        raise Abort(f"Account with alias '{alias}' is already in use")
 
     path = container.data_folder.joinpath(f"{alias}.json")
     extra_entropy = click.prompt(
@@ -81,16 +80,14 @@ def generate(alias):
 @click.argument("alias")
 def _import(alias):
     if alias in accounts.aliases:
-        notify("ERROR", f"Account with alias '{alias}' already exists")
-        return
+        raise Abort(f"Account with alias '{alias}' is already in use")
 
     path = container.data_folder.joinpath(f"{alias}.json")
     key = click.prompt("Enter Private Key", hide_input=True)
     try:
         account = EthAccount.from_key(to_bytes(hexstr=key))
     except Exception as error:
-        notify("ERROR", f"Key can't be imported {error}")
-        return
+        raise Abort(f"Key can't be imported: {error}")
     passphrase = click.prompt(
         "Create Passphrase",
         hide_input=True,

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -45,3 +45,8 @@ def ape_cli():
     from ape._cli import cli
 
     yield cli
+
+
+def assert_failure(result, expected_output):
+    assert result.exit_code == 1
+    assert f"ERROR: {expected_output}" in result.output

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -4,9 +4,13 @@ from pathlib import Path
 import pytest  # type: ignore
 from eth_account import Account  # type: ignore
 
+from .conftest import assert_failure
+
 ALIAS = "test"
 PASSWORD = "a"
 PRIVATE_KEY = "0000000000000000000000000000000000000000000000000000000000000001"
+IMPORT_VALID_INPUT = "\n".join([f"0x{PRIVATE_KEY}", PASSWORD, PASSWORD])
+GENERATE_VALID_INPUT = "\n".join(["random entropy", PASSWORD, PASSWORD])
 
 
 @pytest.fixture
@@ -61,23 +65,50 @@ def test_account():
 
 def test_import(ape_cli, runner, test_account, test_keyfile_path):
     assert not test_keyfile_path.exists()
-    # Add account from private key
-    valid_input = ["0x" + PRIVATE_KEY, PASSWORD, PASSWORD]
-    result = runner.invoke(ape_cli, ["accounts", "import", ALIAS], input="\n".join(valid_input))
+    # Add account from private keys
+    result = runner.invoke(ape_cli, ["accounts", "import", ALIAS], input=IMPORT_VALID_INPUT)
     assert result.exit_code == 0
     assert test_account.address in result.output
     assert ALIAS in result.output
     assert test_keyfile_path.exists()
 
 
+def test_import_alias_already_in_use(ape_cli, runner, test_account, test_keyfile_path):
+    def invoke_import():
+        return runner.invoke(ape_cli, ["accounts", "import", ALIAS], input=IMPORT_VALID_INPUT)
+
+    result = invoke_import()
+    assert result.exit_code == 0
+    result = invoke_import()
+    assert_failure(result, f"Account with alias '{ALIAS}' is already in use")
+
+
+def test_import_account_instantiation_failure(
+    mocker, ape_cli, runner, test_account, test_keyfile_path
+):
+    eth_account_from_key_patch = mocker.patch("ape_accounts._cli.EthAccount.from_key")
+    eth_account_from_key_patch.side_effect = Exception("Can't instantiate this account!")
+    result = runner.invoke(ape_cli, ["accounts", "import", ALIAS], input=IMPORT_VALID_INPUT)
+    assert_failure(result, "Key can't be imported: Can't instantiate this account!")
+
+
 def test_generate(ape_cli, runner, test_keyfile_path):
     assert not test_keyfile_path.exists()
     # Generate new private key
-    valid_input = ["random entropy", PASSWORD, PASSWORD]
-    result = runner.invoke(ape_cli, ["accounts", "generate", ALIAS], input="\n".join(valid_input))
+    result = runner.invoke(ape_cli, ["accounts", "generate", ALIAS], input=GENERATE_VALID_INPUT)
     assert result.exit_code == 0
     assert ALIAS in result.output
     assert test_keyfile_path.exists()
+
+
+def test_generate_alias_already_in_use(ape_cli, runner, test_account, test_keyfile_path):
+    def invoke_generate():
+        return runner.invoke(ape_cli, ["accounts", "generate", ALIAS], input=GENERATE_VALID_INPUT)
+
+    result = invoke_generate()
+    assert result.exit_code == 0
+    result = invoke_generate()
+    assert_failure(result, f"Account with alias '{ALIAS}' is already in use")
 
 
 def test_list(ape_cli, runner, test_keyfile):


### PR DESCRIPTION
### What I did

Fixes issue where `ape accounts import <alias>` and `ape accounts generate <alias>` would return 0 exit codes when they failed to import or generate accounts.

Additionally, changed `notify()` to detect when it's `ERROR` and print to `stderr` instead. Thus, `Abort()` can just use `notify()` now in its implementation.

I added tests - I am trying to get a sense of how to write tests for this project.

Also, I added `pytest-mock`, I hope that is okay? It is magical!

This is all part of the efforts of custom exceptions + musing about exception handling. It by no means resolves that issue (I have another branch for that), but it is helpful to have while thinking about exceptions as a whole.

Related issue: #132

### How I did it

I tried to write a unit test and it failed so I realized it was not doing what I thought was expected behavior.l

### How to verify it

Do:

```
ape accounts import <alias-that-already-exists>
echo $?
>>> 1
```

Notice that it's `1` now (was `0` before!)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
