### PR TITLE
refactor: create cli module

### DIFF
--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -5,9 +5,9 @@ from typing import Any, Dict
 import click
 import yaml
 
+from ape.cli.utils import Abort, notify
 from ape.exceptions import ApeException
 from ape.plugins import clean_plugin_name
-from ape.utils import Abort, notify
 
 try:
     from importlib import metadata  # type: ignore

--- a/src/ape/api/contracts.py
+++ b/src/ape/api/contracts.py
@@ -2,8 +2,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from eth_utils import to_bytes
 
+from ape.cli.utils import notify
 from ape.types import ABI, AddressType, ContractType
-from ape.utils import notify
 
 from ..exceptions import ContractCallError, ContractDeployError
 from .address import Address, AddressAPI

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -4,8 +4,8 @@ from typing import Iterator, List, Optional
 
 from dataclassy import as_dict
 
+from ape.cli.utils import notify
 from ape.types import TransactionSignature
-from ape.utils import notify
 
 from ..exceptions import ProviderError
 from . import networks

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -31,3 +31,6 @@ def verbose_option(help=""):
         default=False,
         help=help,
     )
+
+
+__all__ = ["network_option", "verbose_option"]

--- a/src/ape/cli/utils.py
+++ b/src/ape/cli/utils.py
@@ -1,0 +1,25 @@
+import click
+
+
+class Abort(click.ClickException):
+    """Wrapper around a CLI exception"""
+
+    def show(self, file=None):
+        """Override default ``show`` to print CLI errors in red text."""
+        notify("ERROR", self.format_message())
+
+
+NOTIFY_COLORS = {
+    "WARNING": "bright_red",
+    "ERROR": "bright_red",
+    "SUCCESS": "bright_green",
+    "INFO": "blue",
+}
+
+
+def notify(type_, msg):
+    """Prepends a message with a colored tag and outputs it to the console."""
+    click.echo(f"{click.style(type_, fg=NOTIFY_COLORS[type_])}: {msg}", err=type_ == "ERROR")
+
+
+__all__ = ["Abort", "notify"]

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -4,9 +4,10 @@ from typing import Dict, List, Set
 from dataclassy import dataclass
 
 from ape.api.compiler import CompilerAPI
+from ape.cli.utils import notify
 from ape.plugins import PluginManager
 from ape.types import ContractType
-from ape.utils import cached_property, notify
+from ape.utils import cached_property
 
 from ..exceptions import CompilerError
 from .config import ConfigManager

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -5,10 +5,11 @@ from eth_utils import is_checksum_address, is_hex, is_hex_address, to_checksum_a
 from hexbytes import HexBytes
 
 from ape.api import AddressAPI, ConverterAPI
+from ape.cli.utils import notify
 from ape.exceptions import ConversionError
 from ape.plugins import PluginManager
 from ape.types import AddressType
-from ape.utils import cached_property, notify
+from ape.utils import cached_property
 
 from .config import ConfigManager
 from .networks import NetworkManager

--- a/src/ape/plugins/__init__.py
+++ b/src/ape/plugins/__init__.py
@@ -3,7 +3,7 @@ import importlib
 import pkgutil
 from typing import Any, Callable, Iterator, Tuple, Type, cast
 
-from ape.utils import notify
+from ape.cli.utils import notify
 
 from .account import AccountPlugin
 from .compiler import CompilerPlugin

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -7,9 +7,10 @@ from hashlib import md5
 from pathlib import Path
 from typing import Any, Dict
 
-import click
 import yaml
 from importlib_metadata import PackageNotFoundError, packages_distributions, version
+
+from ape.cli.utils import notify
 
 try:
     from functools import cached_property
@@ -89,29 +90,6 @@ def get_package_version(obj: Any) -> str:
         return ""
 
 
-NOTIFY_COLORS = {
-    "WARNING": "bright_red",
-    "ERROR": "bright_red",
-    "SUCCESS": "bright_green",
-    "INFO": "blue",
-}
-
-
-def notify(type_, msg, file=None):
-    """Prepends a message with a colored tag and outputs it to the console."""
-    click.echo(
-        f"{click.style(type_, fg=NOTIFY_COLORS[type_])}: {msg}", file=file, err=type_ == "ERROR"
-    )
-
-
-class Abort(click.ClickException):
-    """Wrapper around a CLI exception"""
-
-    def show(self, file=None):
-        """Override default ``show`` to print CLI errors in red text."""
-        notify("ERROR", self.format_message(), file=file)
-
-
 def deep_merge(dict1, dict2):
     """Return a new dictionary by merging two dictionaries recursively."""
 
@@ -166,6 +144,5 @@ __all__ = [
     "deep_merge",
     "expand_environment_variables",
     "load_config",
-    "notify",
     "singledispatchmethod",
 ]

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -6,8 +6,9 @@ from eth_account import Account as EthAccount  # type: ignore
 from eth_utils import to_bytes
 
 from ape import accounts
+from ape.cli.utils import Abort
 from ape.exceptions import AliasAlreadyInUseError
-from ape.utils import Abort, notify
+from ape.utils import notify
 
 # NOTE: Must used the instantiated version of `AccountsContainer` in `accounts`
 container = accounts.containers["accounts"]

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import click
 
-from ape.utils import notify
+from ape.cli.utils import notify
 
 flatten = chain.from_iterable
 

--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -5,7 +5,7 @@ import IPython  # type: ignore
 
 from ape import networks
 from ape import project as default_project
-from ape.options import network_option, verbose_option
+from ape.cli.options import network_option, verbose_option
 from ape.version import version as ape_version  # type: ignore
 
 

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -8,8 +8,9 @@ import click
 from github import Github
 
 from ape import config
+from ape.cli.utils import Abort, notify
 from ape.plugins import clean_plugin_name, plugin_manager
-from ape.utils import Abort, get_package_version, notify
+from ape.utils import get_package_version
 
 # Plugins included with ape core
 FIRST_CLASS_PLUGINS: Set[str] = {

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -5,8 +5,9 @@ from pathlib import Path
 import click
 
 from ape import config, networks
-from ape.options import network_option, verbose_option
-from ape.utils import Abort, get_relative_path
+from ape.cli.options import network_option, verbose_option
+from ape.cli.utils import Abort
+from ape.utils import get_relative_path
 from ape_console._cli import console
 
 # TODO: Migrate this to a CLI toolkit under ``ape``


### PR DESCRIPTION
### What I did

Create a share CLI module

Related to: #145

### How I did it

Discussed here: #140  on how to refactor the CLI to re-use shared options and utils, both for us and for 3rd party plugins.

### How to verify it

Make sure you can import the shared CLI definitions

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
