### PR TITLE
fix: remove production asserts

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -147,7 +147,9 @@ class ProviderContextManager:
     def __exit__(self, *args, **kwargs):
         # Put our providers back the way it was
         provider = self._connected_providers.pop()
-        assert self.provider == provider
+        if self.provider != provider:
+            raise ValueError("Previous provider value unknown")
+
         provider.disconnect()
 
         if self._connected_providers:

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -102,6 +102,7 @@ class ProjectManager:
             # Recalculate checksum if it doesn't exist yet
             cached = cached_sources[path]
             cached.compute_checksum(algorithm="md5")
+
             assert cached.checksum  # to tell mypy this can't be None
 
             # File contents changed in source code folder?

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -45,14 +45,15 @@ def get_relative_path(target: Path, anchor: Path) -> Path:
     which may or may not share a common ancestor.
     NOTE: Both paths must be absolute
     """
-    assert anchor.is_absolute()
-    assert target.is_absolute()
+    if not target.is_absolute():
+        raise ValueError("'target' must be an absolute path")
+    if not anchor.is_absolute():
+        raise ValueError("'anchor' must be an absolute path")
 
     anchor_copy = Path(str(anchor))
     levels_deep = 0
     while not is_relative_to(anchor_copy, target):
         levels_deep += 1
-        assert anchor_copy != anchor_copy.parent
         anchor_copy = anchor_copy.parent
 
     return Path("/".join(".." for _ in range(levels_deep))).joinpath(

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -5,12 +5,12 @@ import pytest
 from ape.utils import get_relative_path
 
 _TEST_DIRECTORY_PATH = Path("/This/is/a/test/")
-_TEST_FILE_PATH = _TEST_DIRECTORY_PATH / "scripts" / "deploy.py"
+_TEST_FILE_PATH = _TEST_DIRECTORY_PATH / "scripts" / "script.py"
 
 
 def test_get_relative_path_from_project():
     actual = get_relative_path(_TEST_FILE_PATH, _TEST_DIRECTORY_PATH)
-    expected = Path("scripts/deploy.py")
+    expected = Path("scripts/script.py")
     assert actual == expected
 
 
@@ -21,7 +21,7 @@ def test_get_relative_path_given_relative_path():
 
     assert str(err.value) == "'target' must be an absolute path"
 
-    relative_project_path = Path("../ApeProjects/koko-token")
+    relative_project_path = Path("../This/is/a/test")
 
     with pytest.raises(ValueError) as err:
         get_relative_path(_TEST_FILE_PATH, relative_project_path)

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -4,12 +4,12 @@ import pytest
 
 from ape.utils import get_relative_path
 
-_TEST_PROJECT_PATH = Path("/Users/koko/ApeProjects/koko-token/")
-_TEST_SCRIPT_PATH = _TEST_PROJECT_PATH / "scripts" / "deploy.py"
+_TEST_DIRECTORY_PATH = Path("/This/is/a/test/")
+_TEST_FILE_PATH = _TEST_DIRECTORY_PATH / "scripts" / "deploy.py"
 
 
 def test_get_relative_path_from_project():
-    actual = get_relative_path(_TEST_SCRIPT_PATH, _TEST_PROJECT_PATH)
+    actual = get_relative_path(_TEST_FILE_PATH, _TEST_DIRECTORY_PATH)
     expected = Path("scripts/deploy.py")
     assert actual == expected
 
@@ -17,20 +17,20 @@ def test_get_relative_path_from_project():
 def test_get_relative_path_given_relative_path():
     relative_script_path = Path("../deploy.py")
     with pytest.raises(ValueError) as err:
-        get_relative_path(relative_script_path, _TEST_PROJECT_PATH)
+        get_relative_path(relative_script_path, _TEST_DIRECTORY_PATH)
 
     assert str(err.value) == "'target' must be an absolute path"
 
     relative_project_path = Path("../ApeProjects/koko-token")
 
     with pytest.raises(ValueError) as err:
-        get_relative_path(_TEST_SCRIPT_PATH, relative_project_path)
+        get_relative_path(_TEST_FILE_PATH, relative_project_path)
 
     assert str(err.value) == "'anchor' must be an absolute path"
 
 
 def test_get_relative_path_same_path():
-    actual = get_relative_path(_TEST_SCRIPT_PATH, _TEST_SCRIPT_PATH)
+    actual = get_relative_path(_TEST_FILE_PATH, _TEST_FILE_PATH)
     assert actual == Path()
 
 

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytest
+
+from ape.utils import get_relative_path
+
+_TEST_PROJECT_PATH = Path("/Users/koko/ApeProjects/koko-token/")
+_TEST_SCRIPT_PATH = _TEST_PROJECT_PATH / "scripts" / "deploy.py"
+
+
+def test_get_relative_path_from_project():
+    actual = get_relative_path(_TEST_SCRIPT_PATH, _TEST_PROJECT_PATH)
+    expected = Path("scripts/deploy.py")
+    assert actual == expected
+
+
+def test_get_relative_path_given_relative_path():
+    relative_script_path = Path("../deploy.py")
+    with pytest.raises(ValueError) as err:
+        get_relative_path(relative_script_path, _TEST_PROJECT_PATH)
+
+    assert str(err.value) == "'target' must be an absolute path"
+
+    relative_project_path = Path("../ApeProjects/koko-token")
+
+    with pytest.raises(ValueError) as err:
+        get_relative_path(_TEST_SCRIPT_PATH, relative_project_path)
+
+    assert str(err.value) == "'anchor' must be an absolute path"
+
+
+def test_get_relative_path_same_path():
+    actual = get_relative_path(_TEST_SCRIPT_PATH, _TEST_SCRIPT_PATH)
+    assert actual == Path()
+
+
+def test_get_relative_path_roots():
+    root = Path("/")
+    actual = get_relative_path(root, root)
+    assert actual == Path()


### PR DESCRIPTION
### What I did

Remove a few `assert` statements from production code.
Reason:
When compiling optimized python coded (`.pyo` files), `assert` statements get removed. They should be avoided in non-debugging or testing scenarios.

fixes: #147 

More info:
https://bandit.readthedocs.io/en/latest/plugins/b101_assert_used.html#b101-test-for-use-of-assert

Related issue: #132

### How I did it

Noticed the issue from a `bandit` scan.
Realized these should probably be errors instead of `assert` statements.
Changed them to raise `ValueError()` instead.

### How to verify it

I wrote unit tests for this one.

_however_ I am still not exactly sure where to put these types of functional unit tests. Should it be in more of an abstract collection such as `test_paths`?

I _really_ prefer tests to match more of the projects structure. This way, if I want to see some examples (As a contributor) to how a method or class works, I know exactly where to find it. It helps audit the tests, outside of just coverage. That is why I put it in `test_utils`. However, that does not seem to be the way it is done on this project. Help!

Writing the tests for `get_relative_path()` makes me completely understand how the method behaves (so I know I am not breaking it, in this case).

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
