### PR TITLE
fix: improve error handling for unimplemented plugins

### DIFF
--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -56,9 +56,10 @@ class ApeCLI(click.MultiCommand):
             bad_arg, list(usage_error.ctx.command.commands.keys()), cutoff=_DIFFLIB_CUT_OFF
         )
         if suggested_commands:
-            usage_error.message = (
-                f"No such command '{bad_arg}'. Did you mean {' or '.join(suggested_commands)}?"
-            )
+            if bad_arg not in suggested_commands:
+                usage_error.message = (
+                    f"No such command '{bad_arg}'. Did you mean {' or '.join(suggested_commands)}?"
+                )
 
         raise usage_error
 

--- a/src/ape/plugins/__init__.py
+++ b/src/ape/plugins/__init__.py
@@ -124,9 +124,15 @@ class PluginManager:
                 yield clean_plugin_name(plugin_name), results
 
             else:
-                notify(
-                    "WARNING", f"'{results.__name__}' from '{plugin_name}' is not fully implemented"
-                )
+                _warn_not_fully_implemented_error(results, plugin_name)
+
+
+def _warn_not_fully_implemented_error(results, plugin_name):
+    if isinstance(results, (tuple, list)):
+        class_names = ", ".join((r.__name__ for r in results))
+    else:
+        class_names = results.__name__
+    notify("WARNING", f"'{class_names}' from '{plugin_name}' is not fully implemented")
 
 
 __all__ = [


### PR DESCRIPTION
### What I did

During implementing the ledger plugin, I had two points of confusion when it  came to the errors from ape.
1.) the suggested command sometimes was identical to the one I typed
2.) I would get an error `such and such has no attribute __name__` during the handling of the actual error.

This PR addresses both of those.

I didn't create an issue because it is a very small bug that is non-critical.

### How I did it

* If the bad arg is the same as the suggested arg, don't say `"did you mean <same-thing-you-just-typed>"`
* Check first if the plugin type is a tuple or list and if it is, use comprehension to form the type names in the warning message.

### How to verify it

Install a bad plugin (not fully implemented). Make sure the error messages make sense and you don't run into the issues I described above. You can additionally verify them from the main branch to see that it was a problem before.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
