### PR TITLE
fix: limit ape_accounts plugin to KeyfileAccounts

### DIFF
--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -20,6 +20,10 @@ class AddressAPI:
 
         return self._provider
 
+    @provider.setter
+    def provider(self, value: ProviderAPI):
+        self._provider = value
+
     @property
     def _receipt_class(self) -> Type[ReceiptAPI]:
         return self.provider.network.ecosystem.receipt_class

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterator, Type
+from typing import Dict, Iterator, List, Type
 
 from dataclassy import dataclass
 from pluggy import PluginManager  # type: ignore
@@ -41,8 +41,14 @@ class AccountManager:
         for container in self.containers.values():
             yield from container.aliases
 
-    def get_typed_aliases(self, type_: Type[AccountAPI]) -> Iterator[str]:
-        return [a.alias for a in self if isinstance(a, type_)]
+    def get_accounts_by_type(self, type_: Type[AccountAPI]) -> List[AccountAPI]:
+        accounts_with_type = []
+        for account in self:
+            if isinstance(account, type_):
+                self._inject_provider(account)
+                accounts_with_type.append(account)
+
+        return accounts_with_type
 
     def __len__(self) -> int:
         return sum(len(container) for container in self.containers.values())
@@ -50,8 +56,7 @@ class AccountManager:
     def __iter__(self) -> Iterator[AccountAPI]:
         for container in self.containers.values():
             for account in container:
-                # NOTE: Inject provider
-                account._provider = self.network_manager.active_provider
+                self._inject_provider(account)
                 yield account
 
     def __repr__(self) -> str:
@@ -63,8 +68,7 @@ class AccountManager:
 
         for account in self:
             if account.alias and account.alias == alias:
-                # NOTE: Inject provider
-                account._provider = self.network_manager.active_provider
+                self._inject_provider(account)
                 return account
 
         raise IndexError(f"No account with alias `{alias}`.")
@@ -77,8 +81,7 @@ class AccountManager:
     def __getitem_int(self, account_id: int) -> AccountAPI:
         for idx, account in enumerate(self.__iter__()):
             if account_id == idx:
-                # NOTE: Inject provider
-                account._provider = self.network_manager.active_provider
+                self._inject_provider(account)
                 return account
 
         raise IndexError(f"No account at index `{account_id}`.")
@@ -90,11 +93,14 @@ class AccountManager:
         for container in self.containers.values():
             if account_id in container:
                 account = container[account_id]
-                # NOTE: Inject provider
-                account._provider = self.network_manager.active_provider
+                self._inject_provider(account)
                 return account
 
         raise IndexError(f"No account with address `{account_id}`.")
 
     def __contains__(self, address: AddressType) -> bool:
         return any(address in container for container in self.containers.values())
+
+    def _inject_provider(self, account: AccountAPI):
+        if self.network_manager.active_provider is not None:
+            account.provider = self.network_manager.active_provider

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterator
+from typing import Dict, Iterator, Type
 
 from dataclassy import dataclass
 from pluggy import PluginManager  # type: ignore
@@ -40,6 +40,9 @@ class AccountManager:
     def aliases(self) -> Iterator[str]:
         for container in self.containers.values():
             yield from container.aliases
+
+    def get_typed_aliases(self, type_: Type[AccountAPI]) -> Iterator[str]:
+        return [a.alias for a in self if isinstance(a, type_)]
 
     def __len__(self) -> int:
         return sum(len(container) for container in self.containers.values())

--- a/src/ape/options.py
+++ b/src/ape/options.py
@@ -1,5 +1,6 @@
-import click
 from typing import List, Type
+
+import click
 
 from ape import accounts, networks
 from ape.api.accounts import AccountAPI
@@ -50,11 +51,15 @@ class Alias(click.Choice):
     @property
     def choices(self) -> List[str]:  # type: ignore
         # NOTE: This is a hack to lazy-load the aliases so CLI invocation works properly
-        return accounts.get_typed_aliases(self._account_type)
+        return [
+            a.alias
+            for a in accounts.get_accounts_by_type(self._account_type)
+            if a.alias is not None
+        ]
 
 
-def _require_non_existing_alias(arg, type_: Type[AccountAPI] = KeyfileAccount):
-    if arg in accounts.get_typed_aliases(type_):
+def _require_non_existing_alias(arg):
+    if arg in accounts.aliases:
         raise AliasAlreadyInUseError(arg)
     return arg
 

--- a/src/ape/options.py
+++ b/src/ape/options.py
@@ -1,6 +1,8 @@
 import click
+from typing import List
 
-from ape import networks
+from ape import accounts, networks
+from ape.exceptions import AliasAlreadyInUseError
 
 
 class NetworkChoice(click.Choice):
@@ -31,3 +33,30 @@ def verbose_option(help=""):
         default=False,
         help=help,
     )
+
+
+class Alias(click.Choice):
+    """Wraps ``click.Choice`` to load account aliases for the active project at runtime."""
+
+    name = "alias"
+
+    def __init__(self):
+        # NOTE: we purposely skip the constructor of `Choice`
+        self.case_sensitive = False
+
+    @property
+    def choices(self) -> List[str]:  # type: ignore
+        # NOTE: This is a hack to lazy-load the aliases so CLI invocation works properly
+        return list(accounts.aliases)
+
+
+def _require_non_existing_alias(arg):
+    if arg in accounts.aliases:
+        raise AliasAlreadyInUseError(arg)
+    return arg
+
+
+existing_alias_argument = click.argument("alias", type=Alias())
+non_existing_alias_argument = click.argument(
+    "alias", callback=lambda ctx, param, arg: _require_non_existing_alias(arg)
+)

--- a/src/ape/options.py
+++ b/src/ape/options.py
@@ -1,8 +1,10 @@
 import click
-from typing import List
+from typing import List, Type
 
 from ape import accounts, networks
+from ape.api.accounts import AccountAPI
 from ape.exceptions import AliasAlreadyInUseError
+from ape_accounts import KeyfileAccount
 
 
 class NetworkChoice(click.Choice):
@@ -40,18 +42,19 @@ class Alias(click.Choice):
 
     name = "alias"
 
-    def __init__(self):
+    def __init__(self, account_type: Type[AccountAPI] = KeyfileAccount):
         # NOTE: we purposely skip the constructor of `Choice`
         self.case_sensitive = False
+        self._account_type = account_type
 
     @property
     def choices(self) -> List[str]:  # type: ignore
         # NOTE: This is a hack to lazy-load the aliases so CLI invocation works properly
-        return list(accounts.aliases)
+        return accounts.get_typed_aliases(self._account_type)
 
 
-def _require_non_existing_alias(arg):
-    if arg in accounts.aliases:
+def _require_non_existing_alias(arg, type_: Type[AccountAPI] = KeyfileAccount):
+    if arg in accounts.get_typed_aliases(type_):
         raise AliasAlreadyInUseError(arg)
     return arg
 

--- a/src/ape/options.py
+++ b/src/ape/options.py
@@ -50,7 +50,6 @@ class Alias(click.Choice):
 
     @property
     def choices(self) -> List[str]:  # type: ignore
-        # NOTE: This is a hack to lazy-load the aliases so CLI invocation works properly
         return [
             a.alias
             for a in accounts.get_accounts_by_type(self._account_type)

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -7,9 +7,9 @@ from eth_utils import to_bytes
 from ape import accounts
 from ape.options import existing_alias_argument, non_existing_alias_argument
 from ape.utils import Abort, notify
+from ape_accounts import KeyfileAccount
 
 # NOTE: Must used the instantiated version of `AccountsContainer` in `accounts`
-
 container = accounts.containers["accounts"]
 
 
@@ -81,7 +81,7 @@ def _import(alias):
 
 
 @cli.command(short_help="Change the password of an existing account")
-@existing_alias_argument
+@existing_alias_argument(account_type=KeyfileAccount)
 def change_password(alias):
     account = accounts.load(alias)
     account.change_password()
@@ -89,7 +89,7 @@ def change_password(alias):
 
 
 @cli.command(short_help="Delete an existing account")
-@existing_alias_argument
+@existing_alias_argument(account_type=KeyfileAccount)
 def delete(alias):
     account = accounts.load(alias)
     account.delete()

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -9,6 +9,7 @@ from ape.options import existing_alias_argument, non_existing_alias_argument
 from ape.utils import Abort, notify
 
 # NOTE: Must used the instantiated version of `AccountsContainer` in `accounts`
+
 container = accounts.containers["accounts"]
 
 

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -23,19 +23,20 @@ def cli():
 
 # Different name because `list` is a keyword
 @cli.command(name="list", short_help="List available local accounts")
-def _list():
-    key_file_accounts = accounts.containers.get("accounts", [])
-    if len(key_file_accounts) == 0:
+@click.option("--all", help="Output accounts from all plugins", is_flag=True)
+def _list(all):
+    accounts_to_output = accounts if all else accounts.containers.get("accounts", [])
+    if len(accounts_to_output) == 0:
         notify("WARNING", "No accounts found.")
         return
 
-    elif len(key_file_accounts) > 1:
+    elif len(accounts_to_output) > 1:
         click.echo(f"Found {len(accounts)} accounts:")
 
     else:
         click.echo("Found 1 account:")
 
-    for account in key_file_accounts:
+    for account in accounts_to_output:
         alias_display = f" (alias: '{account.alias}')" if account.alias else ""
         click.echo(f"  {account.address}{alias_display}")
 

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -39,17 +39,18 @@ def cli():
 # Different name because `list` is a keyword
 @cli.command(name="list", short_help="List available accounts")
 def _list():
-    if len(accounts) == 0:
+    key_file_accounts = accounts.containers.get("accounts", [])
+    if len(key_file_accounts) == 0:
         notify("WARNING", "No accounts found.")
         return
 
-    elif len(accounts) > 1:
+    elif len(key_file_accounts) > 1:
         click.echo(f"Found {len(accounts)} accounts:")
 
     else:
         click.echo("Found 1 account:")
 
-    for account in accounts:
+    for account in key_file_accounts:
         alias_display = f" (alias: '{account.alias}')" if account.alias else ""
         click.echo(f"  {account.address}{alias_display}")
 

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -37,7 +37,7 @@ def cli():
 
 
 # Different name because `list` is a keyword
-@cli.command(name="list", short_help="List available accounts")
+@cli.command(name="list", short_help="List available local accounts")
 def _list():
     key_file_accounts = accounts.containers.get("accounts", [])
     if len(key_file_accounts) == 0:

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -150,12 +150,12 @@ def test_change_password(ape_cli, runner, test_keyfile):
     result = runner.invoke(
         ape_cli, ["accounts", "change-password", ALIAS], input="\n".join(valid_input) + "\n"
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
 
 
 def test_delete(ape_cli, runner, test_keyfile):
     assert test_keyfile.exists()
     # Delete Account
     result = runner.invoke(ape_cli, ["accounts", "delete", ALIAS], input=PASSWORD + "\n")
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert not test_keyfile.exists()

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -69,7 +69,7 @@ def test_import(ape_cli, runner, test_account, test_keyfile_path):
     assert not test_keyfile_path.exists()
     # Add account from private keys
     result = runner.invoke(ape_cli, ["accounts", "import", ALIAS], input=IMPORT_VALID_INPUT)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert test_account.address in result.output
     assert ALIAS in result.output
     assert test_keyfile_path.exists()
@@ -80,7 +80,7 @@ def test_import_alias_already_in_use(ape_cli, runner, test_account, test_keyfile
         return runner.invoke(ape_cli, ["accounts", "import", ALIAS], input=IMPORT_VALID_INPUT)
 
     result = invoke_import()
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     result = invoke_import()
     assert_failure(result, f"Account with alias '{ALIAS}' already in use")
 
@@ -98,7 +98,7 @@ def test_generate(ape_cli, runner, test_keyfile_path):
     assert not test_keyfile_path.exists()
     # Generate new private key
     result = runner.invoke(ape_cli, ["accounts", "generate", ALIAS], input=GENERATE_VALID_INPUT)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert ALIAS in result.output
     assert test_keyfile_path.exists()
 
@@ -108,7 +108,7 @@ def test_generate_alias_already_in_use(ape_cli, runner, test_account, test_keyfi
         return runner.invoke(ape_cli, ["accounts", "generate", ALIAS], input=GENERATE_VALID_INPUT)
 
     result = invoke_generate()
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     result = invoke_generate()
     assert_failure(result, f"Account with alias '{ALIAS}' already in use")
 


### PR DESCRIPTION
### What I did

fixes: #156 

### How I did it

Loop through the `accounts` container rather than all the accounts containers accounts.

### How to verify it

1.) Install another account API plugin
2.) Add an account
3.) Run `ape accounts list` and notice that account does not show up in the list

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
