### PR TITLE
Feat/handle interupts

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,5 @@ exclude =
 	docs
 	build
 per-file-ignores =
-    src/ape/__init__.py: E402  # Need signal handler before imports
+    # Need signal handler before imports
+    src/ape/__init__.py: E402

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,5 @@ exclude =
 	venv*
 	docs
 	build
+per-file-ignores =
+    src/ape/__init__.py: E402  # Need signal handler before imports

--- a/src/ape/__init__.py
+++ b/src/ape/__init__.py
@@ -1,3 +1,7 @@
+import signal
+
+signal.signal(signal.SIGINT, lambda s, f: _sys.exit(130))
+
 import sys as _sys
 from functools import partial as _partial
 from pathlib import Path as _Path


### PR DESCRIPTION
### What I did

Related issue: #158 

### How I did it

Add this code to the top of `ape.__init__.py` (earliest point in execution).
```python
import signal

signal.signal(signal.SIGINT, lambda s, f: _sys.exit(130))
```

Note that it is best to put it here because it is a lengthy process to import the managers from ape, so you can easily interrupr the process at that point and it is not graceful.

Additionally, this violates `flake8` E402, which is definitely a good rule but I feel at this time that this is an edge case so I did a `flake8` per-file ignore for this rule in the `flake8` config.

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
