### PR TITLE
fix: handle missing compiler extensions

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -73,6 +73,9 @@ class ProjectManager:
 
     @property
     def sources(self) -> List[Path]:
+        """All the source files in the project.
+        Excludes files with extensions that don't have a registered compiler.
+        """
         files: List[Path] = []
         for extension in self.compilers.registered_compilers:
             files.extend(self._contracts_folder.rglob("*" + extension))

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -1,11 +1,44 @@
 from itertools import chain
 from pathlib import Path
+from typing import Dict, List, Optional
 
 import click
 
+from ape.types import ContractType
 from ape.utils import notify
 
 flatten = chain.from_iterable
+
+
+class _ContractsSource:
+    """
+    A helper class that is able to figure out which source files to
+    compile.
+    """
+
+    def __init__(self, use_cache: bool):
+        # NOTE: Lazy load so that testing works properly
+        from ape import project
+
+        self._project = project
+        self._use_cache = use_cache
+
+    @property
+    def root(self) -> Path:
+        return self._project.path / "contracts"
+
+    def select_paths(self, file_paths: Optional[List[Path]]):
+        # If not given sources, assume user wants to compile all source files.
+        # Excludes files without registered compilers.
+        if not file_paths:
+            return self._project.sources
+
+        expanded_file_paths = flatten([d.rglob("*.*") if d.is_dir() else [d] for d in file_paths])
+        return [c.resolve() for c in expanded_file_paths if c.resolve() in self._project.sources]
+
+    def compile(self) -> Dict[str, ContractType]:
+        # TODO: only compile selected contracts
+        return self._project.load_contracts(self._use_cache)
 
 
 @click.command(short_help="Compile select contract source files")
@@ -39,65 +72,68 @@ def cli(filepaths, use_cache, display_size):
     Note that ape automatically recompiles any changed contracts each time
     a project is loaded. You do not have to manually trigger a recompile.
     """
-    # NOTE: Lazy load so that testing works properly
-    from ape import project
-
-    # Expand source tree based on selection
-    if not filepaths:
-        if not (project.path / "contracts").exists():
-            notify("WARNING", "No 'contracts/' directory detected")
-            return
-
-        # If no paths are specified, use all local project sources
-        contract_filepaths = project.sources
-
-    else:
-        # Expand any folder paths
-        expanded_filepaths = flatten([d.rglob("*.*") if d.is_dir() else [d] for d in filepaths])
-        # Filter by what's in our project's source tree
-        # NOTE: Make the paths absolute like `project.sources`
-        contract_filepaths = [
-            c.resolve() for c in expanded_filepaths if c.resolve() in project.sources
-        ]
-
-    if not contract_filepaths:
-        if filepaths:
-            selected_paths = "', '".join(str(p.resolve()) for p in filepaths)
-
-        else:
-            selected_paths = str(project.path / "contracts")
-
-        extensions = ", ".join(set(f.suffix for f in selected_paths))
-        notify("WARNING", f"No compilers detected for the following extensions: {extensions}")
+    source = _ContractsSource(use_cache)
+    missing_source = not source.root.exists() or not source.root.iterdir()
+    if not filepaths and missing_source:
+        notify("WARNING", "No 'contracts/' directory detected")
         return
 
-    # TODO: only compile selected contracts
-    contract_types = project.load_contracts(use_cache)
+    selected_file_paths = source.select_paths(filepaths)
+    source_file_paths = list(source.root.iterdir())
+    unable_to_select_all = len(source_file_paths) > len(selected_file_paths)
 
-    # Display bytecode size for *all* contract types (not just ones we compiled)
+    if not selected_file_paths or unable_to_select_all:
+        _warn_for_missing_extensions(selected_file_paths, source_file_paths)
+
+    contract_types = source.compile()
+
     if display_size:
-        codesize = []
-        for contract in contract_types.values():
-            if not contract.deploymentBytecode:
-                continue  # Skip if not bytecode to display
+        _display_byte_code_sizes(contract_types)
 
-            bytecode = contract.deploymentBytecode.bytecode
 
-            if bytecode:
-                codesize.append((contract.contractName, len(bytecode) // 2))
+def _warn_for_missing_extensions(registered_sources: List[Path], all_sources: List[Path]):
+    """
+    Figures out what extensions are missing from registered compilers and warns
+    the user about them.
+    """
+    extensions_unable_to_compile = set()
+    for path in all_sources:
+        if path not in registered_sources:
+            extensions_unable_to_compile.add(path.suffix)
 
-        if not codesize:
-            notify("INFO", "No contracts with bytecode to display")
-            return
+    if extensions_unable_to_compile:
+        extensions_str = ", ".join(extensions_unable_to_compile)
+        message = f"No compilers detected for the following extensions: {extensions_str}"
+    else:
+        message = "Nothing to compile"
 
-        click.echo()
-        click.echo("============ Deployment Bytecode Sizes ============")
-        indent = max(len(i[0]) for i in codesize)
-        for name, size in sorted(codesize, key=lambda k: k[1], reverse=True):
-            pct = size / 24577
-            # pct_color = color(next((i[1] for i in CODESIZE_COLORS if pct >= i[0]), ""))
-            # TODO Get colors fixed for bytecode size output
-            # click.echo(f"  {name:<{indent}}  -  {size:>6,}B  ({pct_color}{pct:.2%}{color})")
-            click.echo(f"  {name:<{indent}}  -  {size:>6,}B  ({pct:.2%})")
+    notify("WARNING", message)
 
-        click.echo()
+
+def _display_byte_code_sizes(contract_types: Dict[str, ContractType]):
+    # Display bytecode size for *all* contract types (not just ones we compiled)
+    code_size = []
+    for contract in contract_types.values():
+        if not contract.deploymentBytecode:
+            continue  # Skip if not bytecode to display
+
+        bytecode = contract.deploymentBytecode.bytecode
+
+        if bytecode:
+            code_size.append((contract.contractName, len(bytecode) // 2))
+
+    if not code_size:
+        notify("INFO", "No contracts with bytecode to display")
+        return
+
+    click.echo()
+    click.echo("============ Deployment Bytecode Sizes ============")
+    indent = max(len(i[0]) for i in code_size)
+    for name, size in sorted(code_size, key=lambda k: k[1], reverse=True):
+        pct = size / 24577
+        # pct_color = color(next((i[1] for i in CODESIZE_COLORS if pct >= i[0]), ""))
+        # TODO Get colors fixed for bytecode size output
+        # click.echo(f"  {name:<{indent}}  -  {size:>6,}B  ({pct_color}{pct:.2%}{color})")
+        click.echo(f"  {name:<{indent}}  -  {size:>6,}B  ({pct:.2%})")
+
+    click.echo()


### PR DESCRIPTION
### What I did

fixes: #166

### How I did it

* Make sure to work with paths on path methods
* Correctly calculate the extensions that are missing from registered compilers
* Handle the case where the contracts/ directory is empty (As far as error message goes).

### How to verify it

Start off without any compiler plugins

1. Create a `contracts/` directory with a Solidity file and a Vyper file
2. Run `ape compile`

You should get the error message: `WARNING: No compilers detected for the following extensions: .vy, .sol`

3. Add a Vyper plugin via `ape plugins add vyper`

It should compile the solidity file and warn about the vyper file:

`WARNING: No compilers detected for the following extensions: .sol`

4. Add the Solidity plugin

It should compile both files and not warn.

5. Move both files out of the directory and run `ape compile`

It should warn with 

`WARNING: No compilers detected for the following extensions: .sol`

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
