### PR TITLE
feat: use click handler for web3 loggers

### DIFF
--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -154,7 +154,7 @@ class CliLogger:
         self._logger.debug(stack_trace)
 
 
-def _get_logger(name) -> logging.Logger:
+def _get_logger(name: str) -> logging.Logger:
     """Get a logger with the given ``name`` and configure it for usage with Click."""
     cli_logger = logging.getLogger(name)
     handler = ClickHandler(echo_kwargs=CLICK_ECHO_KWARGS)


### PR DESCRIPTION
### What I did

Set the web3 loggers from our logging module.
This is useful when doing `--verbosity DEBUG` and you are debugging a potential issue in web3.py, it will display request params and such, which is helpful for validating JSON-RPC requests.

### How I did it

Locate the loggers used in JSON-RPC requests.
Grab the logger-singletons in our `CliLogger` class.
Set their levels on the callback method `set_level`

### How to verify it

Try to deploy a simple smart contract with the verbosity level set to DEBUG, such as 

```bash
ape run deploy --network ethereum:development:http --verbosity DEBUG
```

where the deploy script looks something like 

```python
def main():
    test_account = accounts.load("hardhat_0")
    contract_type = project.AgeStorage
    contract = test_account.deploy(contract_type)
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
