### PR TITLE
fix: make contract calls work

### DIFF
--- a/src/ape/api/contracts.py
+++ b/src/ape/api/contracts.py
@@ -62,6 +62,7 @@ class ContractCall:
 
     def __call__(self, *args, **kwargs) -> Any:
         txn = self.encode(*args, **kwargs)
+        txn.chain_id = self.provider.network.chain_id
 
         if "sender" in kwargs and not isinstance(kwargs["sender"], str):
             txn.sender = kwargs["sender"].address

--- a/src/ape_http/providers.py
+++ b/src/ape_http/providers.py
@@ -100,8 +100,7 @@ class EthereumProvider(ProviderAPI):
         Executes a new message call immediately without creating a
         transaction on the block chain.
         """
-        data = txn.encode()
-        return self._web3.eth.call(data)
+        return self._web3.eth.call(txn.as_dict())
 
     def get_transaction(self, txn_hash: str) -> ReceiptAPI:
         """


### PR DESCRIPTION
### What I did

fixes: #183 

### How I did it

* Realized we were passing bytes to `web3.eth.call` instead of a dict.
* Removed the `encode()` call and just used `as_dict()` on the txn before passing it to `web3.eth.call()`
* Got some error about the chain ID, so set that in the `Contract.__call__()` method

### How to verify it

Create a simple contract like this:

```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.6.0;

contract MyNumber {
    int public number = 42;
}
```

Call it in a script like this:

```python
from ape import accounts
from ape import project


def main():
    test_account = accounts.load("hardhat_0")
    contract_type = project.MyNumber
    contract = test_account.deploy(contract_type)
    my_num = contract.number(sender=test_account)
    print(my_num)

```

It should print out `42`.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
