### PR TITLE
fix: remove unused type ignore comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
 
+[tool.mypy]
+warn_unused_ignores = true
+
 [tool.setuptools_scm]
 write_to = "src/ape/version.py"
 

--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -11,7 +11,7 @@ from ape.logging import logger
 from ape.plugins import clean_plugin_name
 
 try:
-    from importlib import metadata  # type: ignore
+    from importlib import metadata
 except ImportError:
     import importlib_metadata as metadata  # type: ignore
 
@@ -66,7 +66,7 @@ class ApeCLI(click.MultiCommand):
     @property
     def commands(self) -> Dict:
         if not self._commands:
-            entry_points = metadata.entry_points()  # type: ignore
+            entry_points = metadata.entry_points()
 
             if "ape_cli_subcommands" not in entry_points:
                 raise Abort("Missing registered cli subcommands")

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -2,7 +2,7 @@ from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Type
 
-from pluggy import PluginManager  # type: ignore
+from pluggy import PluginManager
 
 from ape.types import ABI, AddressType
 from ape.utils import cached_property

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -23,7 +23,7 @@ class Alias(click.Choice):
         self._account_type = account_type
 
     @property
-    def choices(self) -> List[str]:  # type: ignore
+    def choices(self) -> List[str]:
         options = (
             list(accounts)
             if not self._account_type
@@ -59,7 +59,7 @@ class PromptChoice(click.ParamType):
             choice = self.choices[self.choice_index]
             return choice
         except Exception:
-            self.fail("Invalid choice", param=param)
+            return self.fail("Invalid choice", param=param)
 
 
 class NetworkChoice(click.Choice):

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -96,7 +96,7 @@ class CliLogger:
         _logger = _get_logger("ape")
         self.error = _logger.error
         self.warning = _logger.warning
-        self.success = _logger.success  # type: ignore
+        self.success = _logger.success
         self.info = _logger.info
         self.debug = _logger.debug
         self._logger = _logger

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -1,7 +1,7 @@
 from typing import Dict, Iterator, List, Type
 
 from dataclassy import dataclass
-from pluggy import PluginManager  # type: ignore
+from pluggy import PluginManager
 
 from ape.api.accounts import AccountAPI, AccountContainerAPI
 from ape.types import AddressType

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -2,7 +2,7 @@ from typing import Dict, Iterator, Optional
 
 import yaml
 from dataclassy import dataclass
-from pluggy import PluginManager  # type: ignore
+from pluggy import PluginManager
 
 from ape.api import EcosystemAPI, ProviderAPI, ProviderContextManager
 from ape.exceptions import NetworkError

--- a/src/ape/plugins/pluggy_patch.py
+++ b/src/ape/plugins/pluggy_patch.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, TypeVar, cast
 
-import pluggy  # type: ignore
+import pluggy
 
 F = TypeVar("F", bound=Callable[..., Any])
 hookimpl = cast(Callable[[F], F], pluggy.HookimplMarker("ape"))

--- a/src/ape/types/abstract.py
+++ b/src/ape/types/abstract.py
@@ -41,7 +41,7 @@ def to_dict(v: Any) -> Optional[Union[list, dict, str, int, bool]]:
         return v.to_dict()
 
     elif isinstance(v, list):
-        return [to_dict(i) for i in v]  # type: ignore
+        return [to_dict(i) for i in v]
 
     elif isinstance(v, dict):
         return {k: to_dict(i) for k, i in v.items()}

--- a/src/ape/types/manifest.py
+++ b/src/ape/types/manifest.py
@@ -63,7 +63,7 @@ class PackageManifest(FileMixin, SerializableType):
         # NOTE: Special 1-level dict with key in type as arg
         if "contractTypes" in params and params["contractTypes"]:
             for name in params["contractTypes"]:
-                params["contractTypes"][name] = ContractType.from_dict(  # type: ignore
+                params["contractTypes"][name] = ContractType.from_dict(
                     {
                         # NOTE: We inject this parameter ourselves, remove it when serializing
                         "contractName": name,

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -1,7 +1,7 @@
 from typing import Iterator, Union
 
 from dataclassy import dataclass
-from eth_account.messages import SignableMessage  # type: ignore
+from eth_account.messages import SignableMessage
 from eth_utils import to_bytes
 
 

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -13,12 +13,12 @@ from importlib_metadata import PackageNotFoundError, packages_distributions, ver
 from ape.logging import logger
 
 try:
-    from functools import cached_property  # type: ignore
+    from functools import cached_property
 except ImportError:
     from backports.cached_property import cached_property  # type: ignore
 
 try:
-    from functools import singledispatchmethod  # type: ignore
+    from functools import singledispatchmethod
 except ImportError:
     from singledispatchmethod import singledispatchmethod  # type: ignore
 

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -1,7 +1,7 @@
 import json
 
 import click
-from eth_account import Account as EthAccount  # type: ignore
+from eth_account import Account as EthAccount
 from eth_utils import to_bytes
 
 from ape import accounts

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Iterator, Optional
 
 import click
-from eth_account import Account as EthAccount  # type: ignore
+from eth_account import Account as EthAccount
 
 from ape.api import AccountAPI, AccountContainerAPI, TransactionAPI
 from ape.convert import to_address

--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -2,11 +2,11 @@ import faulthandler
 import logging
 
 import click
-import IPython  # type: ignore
+import IPython
 
 from ape import project as default_project
 from ape.cli import NetworkBoundCommand, ape_cli_context, network_option
-from ape.version import version as ape_version  # type: ignore
+from ape.version import version as ape_version
 
 
 @click.command(

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from eth_abi import decode_abi as abi_decode
 from eth_abi import encode_abi as abi_encode
 from eth_abi.exceptions import InsufficientDataBytes
-from eth_account import Account as EthAccount  # type: ignore
+from eth_account import Account as EthAccount
 from eth_account._utils.legacy_transactions import (
     encode_transaction,
     serializable_unsigned_transaction_from_dict,

--- a/src/ape_http/providers.py
+++ b/src/ape_http/providers.py
@@ -27,7 +27,7 @@ class NetworkConfig(ConfigItem):
 
 
 class EthereumProvider(ProviderAPI):
-    _web3: Web3 = None  # type: ignore
+    _web3: Web3 = None
 
     @property
     def uri(self) -> str:
@@ -60,7 +60,7 @@ class EthereumProvider(ProviderAPI):
         to allow the transaction to complete.
         The transaction will not be added to the blockchain.
         """
-        return self._web3.eth.estimate_gas(txn.as_dict())  # type: ignore
+        return self._web3.eth.estimate_gas(txn.as_dict())
 
     @property
     def chain_id(self) -> int:
@@ -81,19 +81,19 @@ class EthereumProvider(ProviderAPI):
         """
         Returns the number of transactions sent from an address.
         """
-        return self._web3.eth.getTransactionCount(address)  # type: ignore
+        return self._web3.eth.getTransactionCount(address)
 
     def get_balance(self, address: str) -> int:
         """
         Returns the balance of the account of a given address.
         """
-        return self._web3.eth.getBalance(address)  # type: ignore
+        return self._web3.eth.getBalance(address)
 
     def get_code(self, address: str) -> bytes:
         """
         Returns code at a given address.
         """
-        return self._web3.eth.getCode(address)  # type: ignore
+        return self._web3.eth.getCode(address)
 
     def send_call(self, txn: TransactionAPI) -> bytes:
         """
@@ -107,8 +107,8 @@ class EthereumProvider(ProviderAPI):
         Returns the information about a transaction requested by transaction hash.
         """
         # TODO: Work on API that let's you work with ReceiptAPI and re-send transactions
-        receipt = self._web3.eth.wait_for_transaction_receipt(txn_hash)  # type: ignore
-        txn = self._web3.eth.get_transaction(txn_hash)  # type: ignore
+        receipt = self._web3.eth.wait_for_transaction_receipt(txn_hash)
+        txn = self._web3.eth.get_transaction(txn_hash)
         return self.network.ecosystem.receipt_class.decode({**txn, **receipt})
 
     def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
@@ -123,4 +123,4 @@ class EthereumProvider(ProviderAPI):
         """
         Returns an array of all logs matching a given set of filter parameters.
         """
-        return iter(self._web3.eth.get_logs(filter_params))  # type: ignore
+        return iter(self._web3.eth.get_logs(filter_params))

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -6,7 +6,7 @@ from ape.api import ProviderAPI, ReceiptAPI, TransactionAPI
 
 
 class LocalNetwork(ProviderAPI):
-    _web3: Web3 = None  # type: ignore
+    _web3: Web3 = None
 
     def connect(self):
         pass
@@ -21,7 +21,7 @@ class LocalNetwork(ProviderAPI):
         self._web3 = Web3(EthereumTesterProvider())
 
     def estimate_gas_cost(self, txn: TransactionAPI) -> int:
-        return self._web3.eth.estimate_gas(txn.as_dict())  # type: ignore
+        return self._web3.eth.estimate_gas(txn.as_dict())
 
     @property
     def chain_id(self) -> int:
@@ -33,13 +33,13 @@ class LocalNetwork(ProviderAPI):
         return 0
 
     def get_nonce(self, address: str) -> int:
-        return self._web3.eth.get_transaction_count(address)  # type: ignore
+        return self._web3.eth.get_transaction_count(address)
 
     def get_balance(self, address: str) -> int:
-        return self._web3.eth.get_balance(address)  # type: ignore
+        return self._web3.eth.get_balance(address)
 
     def get_code(self, address: str) -> bytes:
-        return self._web3.eth.get_code(address)  # type: ignore
+        return self._web3.eth.get_code(address)
 
     def send_call(self, txn: TransactionAPI) -> bytes:
         data = txn.as_dict()
@@ -49,8 +49,8 @@ class LocalNetwork(ProviderAPI):
 
     def get_transaction(self, txn_hash: str) -> ReceiptAPI:
         # TODO: Work on API that let's you work with ReceiptAPI and re-send transactions
-        receipt = self._web3.eth.wait_for_transaction_receipt(txn_hash)  # type: ignore
-        txn = self._web3.eth.get_transaction(txn_hash)  # type: ignore
+        receipt = self._web3.eth.wait_for_transaction_receipt(txn_hash)
+        txn = self._web3.eth.get_transaction(txn_hash)
         return self.network.ecosystem.receipt_class.decode({**txn, **receipt})
 
     def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
@@ -58,4 +58,4 @@ class LocalNetwork(ProviderAPI):
         return self.get_transaction(txn_hash.hex())
 
     def get_events(self, **filter_params) -> Iterator[dict]:
-        return iter(self._web3.eth.get_logs(filter_params))  # type: ignore
+        return iter(self._web3.eth.get_logs(filter_params))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from tempfile import mkdtemp
 
-import pytest  # type: ignore
+import pytest
 
 import ape
 

--- a/tests/functional/conversion/test_ether.py
+++ b/tests/functional/conversion/test_ether.py
@@ -1,4 +1,4 @@
-import pytest  # type: ignore
+import pytest
 from ape_ethereum.converters import ETHER_UNITS
 from eth_typing import ChecksumAddress
 from hypothesis import given

--- a/tests/functional/manifests/conftest.py
+++ b/tests/functional/manifests/conftest.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-import pytest  # type: ignore
+import pytest
 
 
 @pytest.fixture(

--- a/tests/functional/manifests/test_manifest.py
+++ b/tests/functional/manifests/test_manifest.py
@@ -1,7 +1,7 @@
-import pytest  # type: ignore
+import pytest
 import requests
 from hypothesis import HealthCheck, given, settings
-from hypothesis_jsonschema import from_schema  # type: ignore
+from hypothesis_jsonschema import from_schema
 
 from ape.types.manifest import PackageManifest
 

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -2,7 +2,7 @@ import os
 from distutils.dir_util import copy_tree
 from pathlib import Path
 
-import pytest  # type: ignore
+import pytest
 from click.testing import CliRunner
 
 import ape

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -1,8 +1,8 @@
 import json
 from pathlib import Path
 
-import pytest  # type: ignore
-from eth_account import Account  # type: ignore
+import pytest
+from eth_account import Account
 
 from ape.api import AccountAPI
 

--- a/tests/integration/cli/test_console.py
+++ b/tests/integration/cli/test_console.py
@@ -1,4 +1,4 @@
-import pytest  # type: ignore
+import pytest
 
 from ape import __all__
 

--- a/tests/integration/cli/test_misc.py
+++ b/tests/integration/cli/test_misc.py
@@ -1,4 +1,4 @@
-import pytest  # type: ignore
+import pytest
 
 
 # NOTE: test all the things without a direct test elsewhere


### PR DESCRIPTION
### What I did

Removed all unneeded `type: ignore` comments and configured `mypy` to warn on unused comments.
This is to keep the code base cleaner!

### How I did it

* Set `warn_unused_ignores = True` in `pyproject.toml` under `[tool.mypy]`
* Ran `mypy`
* Noticed all the errors now (from unneeded comments)
* Removed all the comments

### How to verify it

Passing build on CI/CD.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
