### PR TITLE
fix: make account option 0-index based

### DIFF
--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -42,7 +42,7 @@ class PromptChoice(click.ParamType):
         self.choices = choices
 
     def print_choices(self):
-        choices = dict(enumerate(self.choices, 1))
+        choices = dict(enumerate(self.choices, 0))
         for choice in choices:
             click.echo(f"{choice}. {choices[choice]}")
         click.echo()
@@ -52,7 +52,7 @@ class PromptChoice(click.ParamType):
     ) -> Optional[Any]:
         # noinspection PyBroadException
         try:
-            choice_index = int(value) - 1
+            choice_index = int(value)
             if choice_index < 0:
                 self.fail("Invalid choice", param=param)
 


### PR DESCRIPTION
### What I did

Make the accounts option selector 0 based.
Reason:  `--account 0` is more in line with how users are probably familiar with indexing their accounts.

The reason I didn't do this initially is because the prompt approach I thought looked weird:

```
0. hardhat_0
1. ganache_1
2. ganache_0
3. geth_dev_1
```

However, I now think it is better to start from 0.

### How I did it

See code, pretty straightforward

### How to verify it

Instructions from this PR: https://github.com/ApeWorX/ape/pull/196
Except it starts from 0 instead of 1.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
