### PR TITLE
feat: plugin feature will display available and installed plugins

### DIFF
--- a/src/ape_plugins/utils.py
+++ b/src/ape_plugins/utils.py
@@ -22,7 +22,7 @@ if "GITHUB_ACCESS_TOKEN" in os.environ:
     }
 
 else:
-    logger.warning("$GITHUB_ACCESS_TOKEN not set, skipping 2nd class plugins")
+    logger.warning("$GITHUB_ACCESS_TOKEN not set, unable to list all plugins")
 
 
 def is_plugin_installed(plugin: str) -> bool:


### PR DESCRIPTION
### What I did
I created sets of plugins delineated by first, second, and third class and then had subsets of installed and available plugins.
 
fixes: PR #211 
#211  was a branch created from sabotages branch


### How I did it : 
This feature allows ``` ape plugins list, ape plugins list -a ``` to show installed and available First and Second class plugins to install. 

### How to verify it: 
You can verify by running the ``` ape plugins list, ape plugins list -a ```  commands

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [x] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
