### PR TITLE
feat: test config that includes mnemonic and number of accounts

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Callable, Iterator, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Callable, Iterator, List, Optional, Type, Union
 
 from ape.types import (
     AddressType,
@@ -15,6 +15,9 @@ from .address import AddressAPI
 from .base import abstractdataclass, abstractmethod
 from .contracts import ContractContainer, ContractInstance
 from .providers import ReceiptAPI, TransactionAPI
+
+if TYPE_CHECKING:
+    from ape.managers.config import ConfigManager
 
 
 # NOTE: AddressAPI is a dataclass already
@@ -134,6 +137,7 @@ class AccountAPI(AddressAPI):
 class AccountContainerAPI:
     data_folder: Path
     account_type: Type[AccountAPI]
+    config_manager: "ConfigManager"
 
     @property
     @abstractmethod

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -32,7 +32,7 @@ class AccountManager:
         for plugin_name, (container_type, account_type) in self.plugin_manager.account_types:
             accounts_folder = data_folder / plugin_name
             accounts_folder.mkdir(exist_ok=True)
-            containers[plugin_name] = container_type(accounts_folder, account_type)
+            containers[plugin_name] = container_type(accounts_folder, account_type, self.config)
 
         return containers
 

--- a/src/ape_test/__init__.py
+++ b/src/ape_test/__init__.py
@@ -1,6 +1,17 @@
 from ape import plugins
+from ape.api.config import ConfigItem
 
 from .providers import LocalNetwork
+
+
+class Config(ConfigItem):
+    mnemonic: str = "test test test test test test test test test test test junk"
+    number_of_accounts: int = 10
+
+
+@plugins.register(plugins.Config)
+def config_class():
+    return Config
 
 
 @plugins.register(plugins.ProviderPlugin)


### PR DESCRIPTION
### What I did

Creating a config for the test plugin for setting a mnemonic and the number of accounts. This work is also present on the testing wip PR (#215), so it will help focus that PR.

Using this, I can create a testing account and provider setup, which I can open a PR for after this (also work present on the testing wip PR). And I have tested that setup with both geth and ethtester.

I know @lost-theory was working on this, let me know if you want to merge.

### How I did it

Added a config api implementation to the test plugin with the required fields

### How to verify it

Verify using the #215 if you want

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
