### PR TITLE
fix: make all cli options callable

### DIFF
--- a/src/ape/cli/arguments.py
+++ b/src/ape/cli/arguments.py
@@ -18,6 +18,7 @@ def existing_alias_argument(account_type: Optional[Type[AccountAPI]] = None):
     return click.argument("alias", type=Alias(account_type=account_type))
 
 
-non_existing_alias_argument = click.argument(
-    "alias", callback=lambda ctx, param, value: _require_non_existing_alias(value)
-)
+def non_existing_alias_argument():
+    return click.argument(
+        "alias", callback=lambda ctx, param, value: _require_non_existing_alias(value)
+    )

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -61,14 +61,15 @@ def ape_cli_context():
     return decorator
 
 
-network_option = click.option(
-    "--network",
-    type=NetworkChoice(case_sensitive=False),
-    default=networks.default_ecosystem.name,
-    help="Override the default network and provider. (see ``ape networks list`` for options)",
-    show_default=True,
-    show_choices=False,
-)
+def network_option():
+    return click.option(
+        "--network",
+        type=NetworkChoice(case_sensitive=False),
+        default=networks.default_ecosystem.name,
+        help="Override the default network and provider. (see ``ape networks list`` for options)",
+        show_default=True,
+        show_choices=False,
+    )
 
 
 def skip_confirmation_option(help=""):

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -42,7 +42,7 @@ def _list(cli_ctx, all):
 
 
 @cli.command(short_help="Create a new keyfile account with a random private key")
-@non_existing_alias_argument
+@non_existing_alias_argument()
 @ape_cli_context()
 def generate(cli_ctx, alias):
     path = container.data_folder.joinpath(f"{alias}.json")
@@ -64,7 +64,7 @@ def generate(cli_ctx, alias):
 
 # Different name because `import` is a keyword
 @cli.command(name="import", short_help="Add a new keyfile account by entering a private key")
-@non_existing_alias_argument
+@non_existing_alias_argument()
 @ape_cli_context()
 def _import(cli_ctx, alias):
     path = container.data_folder.joinpath(f"{alias}.json")

--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -14,7 +14,7 @@ from ape.version import version as ape_version  # type: ignore
     short_help="Load the console",
     context_settings=dict(ignore_unknown_options=True),
 )
-@network_option
+@network_option()
 @ape_cli_context()
 def cli(cli_ctx, network):
     """Opens a console for the local project."""

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -59,7 +59,7 @@ def _run_script(cli_ctx, script_path, interactive=False):
     help="Drop into interactive console session after running",
 )
 @ape_cli_context()
-@network_option
+@network_option()
 def cli(cli_ctx, scripts, interactive, network):
     """
     NAME - Path or script name (from ``scripts/`` folder)


### PR DESCRIPTION
### What I did

There were a few arguments and cli options that were not callable.
We should make them callable from now on because:

1. we can document them
2. we can add parameters without it being a breaking change, so more resilient 

**Believe it or not, this will help make my testing branches smaller as I had to do this fro networks option**

### How I did it

Looked for options and arguments that were not callable and wrapped them in a definition statement and changed all their usages.

### How to verify it

N/a

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
