### PR TITLE
feat: provider and account testing APIs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,6 @@ line_length = 100
 force_grid_wrap = 0
 include_trailing_comma = true
 known_third_party = ["IPython", "click", "dataclassy", "eth_abi", "eth_account", "eth_typing", "eth_utils", "github", "hexbytes", "hypothesis", "hypothesis_jsonschema", "importlib_metadata", "pluggy", "pytest", "requests", "setuptools", "web3", "yaml"]
-known_first_party = ["ape", "ape_accounts", "ape_console", "ape_ethereum", "ape_http", "ape_plugins"]
+known_first_party = ["ape", "ape_accounts", "ape_console", "ape_ethereum", "ape_http", "ape_plugins", "ape_test"]
 multi_line_output = 3
 use_parentheses = true

--- a/src/ape/api/__init__.py
+++ b/src/ape/api/__init__.py
@@ -1,10 +1,16 @@
-from .accounts import AccountAPI, AccountContainerAPI
+from .accounts import AccountAPI, AccountContainerAPI, TestAccountAPI, TestAccountContainerAPI
 from .address import Address, AddressAPI
 from .contracts import ContractInstance, ContractLog
 from .convert import ConverterAPI
 from .explorers import ExplorerAPI
 from .networks import EcosystemAPI, NetworkAPI, ProviderContextManager, create_network_type
-from .providers import ProviderAPI, ReceiptAPI, TransactionAPI, TransactionStatusEnum
+from .providers import (
+    ProviderAPI,
+    ReceiptAPI,
+    TestProviderAPI,
+    TransactionAPI,
+    TransactionStatusEnum,
+)
 
 __all__ = [
     "AccountAPI",
@@ -20,6 +26,9 @@ __all__ = [
     "ProviderContextManager",
     "NetworkAPI",
     "ReceiptAPI",
+    "TestAccountAPI",
+    "TestAccountContainerAPI",
+    "TestProviderAPI",
     "TransactionAPI",
     "TransactionStatusEnum",
     "create_network_type",

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -75,7 +75,8 @@ class AccountAPI(AddressAPI):
 
         if txn.total_transfer_value > self.balance:
             raise AccountsError(
-                "Transfer value meets or exceeds account balance. "
+                "Transfer value meets or exceeds account balance.\n"
+                "Are you using the correct provider/account combination?\n"
                 f"(transfer_value={txn.total_transfer_value}, balance={self.balance})."
             )
 
@@ -202,3 +203,19 @@ class AccountContainerAPI:
     def _verify_unused_alias(self, account):
         if account.alias and account.alias in self.aliases:
             raise AliasAlreadyInUseError(account.alias)
+
+
+class TestAccountContainerAPI(AccountContainerAPI):
+    """
+    Test account containers for ``ape test`` should implement
+    this API instead of ``AccountContainerAPI`` directly. This
+    is how they show up in the ``accounts`` test fixture.
+    """
+
+
+class TestAccountAPI(AccountAPI):
+    """
+    Test accounts for ``ape test`` should implement this API
+    instead of ``AccountAPI`` directly. This is how they show
+    up in the ``accounts`` test fixture.
+    """

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -94,6 +94,13 @@ class ReceiptAPI:
     def __str__(self) -> str:
         return f"<{self.__class__.__name__} {self.txn_hash}>"
 
+    def ran_out_of_gas(self, gas_limit: int) -> bool:
+        """
+        Returns ``True`` when the transaction failed and used the
+        same amount of gas as the given ``gas_limit``.
+        """
+        return self.status == TransactionStatusEnum.FAILING and self.gas_used == gas_limit
+
     @classmethod
     @abstractmethod
     def decode(cls, data: dict) -> "ReceiptAPI":
@@ -165,4 +172,18 @@ class ProviderAPI:
 
     @abstractmethod
     def get_events(self, **filter_params) -> Iterator[dict]:
+        ...
+
+
+class TestProviderAPI(ProviderAPI):
+    """
+    An API for providers that have development functionality, such as snapshotting.
+    """
+
+    @abstractmethod
+    def snapshot(self) -> str:
+        ...
+
+    @abstractmethod
+    def revert(self, snapshot_id: str):
         ...

--- a/src/ape/cli/utils.py
+++ b/src/ape/cli/utils.py
@@ -6,6 +6,12 @@ from ape.logging import logger
 class Abort(click.ClickException):
     """Wrapper around a CLI exception"""
 
+    def __init__(self, message):
+        if not message.endswith("."):
+            message = f"{message}."
+
+        super().__init__(message)
+
     def show(self, file=None):
         """Override default ``show`` to print CLI errors in red text."""
         logger.error(self.format_message())

--- a/src/ape/plugins/__init__.py
+++ b/src/ape/plugins/__init__.py
@@ -113,8 +113,9 @@ class PluginManager:
                         yield clean_plugin_name(plugin_name), result
 
                     else:
+                        api_name = result.__name__ if hasattr(result, "__name__") else result
                         logger.warning(
-                            f"'{result.__name__}' from '{plugin_name}' is not fully implemented"
+                            f"'{api_name}' from '{plugin_name}' is not fully implemented."
                         )
 
             elif valid_impl(results):

--- a/src/ape_networks/_cli.py
+++ b/src/ape_networks/_cli.py
@@ -1,6 +1,7 @@
 import click
 
 from ape import networks
+from ape.cli import ape_cli_context
 
 
 @click.group(short_help="Manage networks")
@@ -11,5 +12,6 @@ def cli():
 
 
 @cli.command(name="list", short_help="List registered networks")
-def _list():
+@ape_cli_context()
+def _list(cli_ctx):
     click.echo(networks.networks_yaml)

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -71,7 +71,7 @@ def cli(cli_ctx, scripts, interactive, network):
     the exports from the ``ape`` top-level package (similar to how the console works)
     """
     if not scripts:
-        cli_ctx.abort("Must provide at least one script name or path")
+        cli_ctx.abort("Must provide at least one script name or path.")
 
     scripts_folder = config.PROJECT_FOLDER / "scripts"
 
@@ -84,10 +84,10 @@ def cli(cli_ctx, scripts, interactive, network):
             script_file = Path(name).resolve()
 
         elif not scripts_folder.exists():
-            cli_ctx.abort("No `scripts/` directory detected to run script")
+            cli_ctx.abort("No 'scripts/' directory detected to run script.")
 
         elif name not in available_scripts:
-            cli_ctx.abort(f"No script named '{name}' detected in scripts folder")
+            cli_ctx.abort(f"No script named '{name}' detected in scripts folder.")
 
         else:
             script_file = available_scripts[name]

--- a/src/ape_test/__init__.py
+++ b/src/ape_test/__init__.py
@@ -1,5 +1,6 @@
 from ape import plugins
 from ape.api.config import ConfigItem
+from ape_test.accounts import TestAccount, TestAccountContainer
 
 from .providers import LocalNetwork
 
@@ -12,6 +13,11 @@ class Config(ConfigItem):
 @plugins.register(plugins.Config)
 def config_class():
     return Config
+
+
+@plugins.register(plugins.AccountPlugin)
+def account_types():
+    return TestAccountContainer, TestAccount
 
 
 @plugins.register(plugins.ProviderPlugin)

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 from typing import Iterator, List, Optional
 
 from eth_account import Account as EthAccount  # type: ignore
@@ -7,7 +6,7 @@ from eth_account.messages import SignableMessage
 from ape.api import TestAccountAPI, TestAccountContainerAPI, TransactionAPI
 from ape.convert import to_address
 from ape.types import AddressType, MessageSignature, TransactionSignature
-from ape.utils import GeneratedDevAccount, generate_dev_accounts
+from ape.utils import GeneratedDevAccount, cached_property, generate_dev_accounts
 
 
 class TestAccountContainer(TestAccountContainerAPI):

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -1,0 +1,58 @@
+from functools import cached_property
+from typing import Iterator, List, Optional
+
+from eth_account import Account as EthAccount  # type: ignore
+from eth_account.messages import SignableMessage
+
+from ape.api import TestAccountAPI, TestAccountContainerAPI, TransactionAPI
+from ape.convert import to_address
+from ape.types import AddressType, MessageSignature, TransactionSignature
+from ape.utils import GeneratedDevAccount, generate_dev_accounts
+
+
+class TestAccountContainer(TestAccountContainerAPI):
+    @property
+    def config(self):
+        return self.config_manager.get_config("test")
+
+    @cached_property
+    def _dev_accounts(self) -> List[GeneratedDevAccount]:
+        mnemonic = self.config["mnemonic"]
+        return generate_dev_accounts(mnemonic)
+
+    @property
+    def aliases(self) -> Iterator[str]:
+        for index in range(0, len(self)):
+            yield f"dev_{index}"
+
+    def __len__(self) -> int:
+        return len(self._dev_accounts)
+
+    def __iter__(self) -> Iterator[TestAccountAPI]:
+        for index in range(0, len(self)):
+            account = self._dev_accounts[index]
+            yield TestAccount(
+                self, _index=index, _address=account.address, _private_key=account.private_key
+            )  # type: ignore
+
+
+class TestAccount(TestAccountAPI):
+    _index: int
+    _address: str
+    _private_key: str
+
+    @property
+    def alias(self) -> str:
+        return f"dev_{self._index}"
+
+    @property
+    def address(self) -> AddressType:
+        return to_address(self._address)
+
+    def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
+        signed_msg = EthAccount.sign_message(msg, self._private_key)
+        return MessageSignature(v=signed_msg.v, r=signed_msg.r, s=signed_msg.s)  # type: ignore
+
+    def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:
+        signed_txn = EthAccount.sign_transaction(txn.as_dict(), self._private_key)
+        return TransactionSignature(v=signed_txn.v, r=signed_txn.r, s=signed_txn.s)  # type: ignore

--- a/tests/functional/api/test_accounts.py
+++ b/tests/functional/api/test_accounts.py
@@ -65,7 +65,9 @@ class TestAccountAPI:
             test_account_api_can_sign.call(mock_transaction)
 
         expected = (
-            "Transfer value meets or exceeds account balance. (transfer_value=1000000, balance=0)."
+            "Transfer value meets or exceeds account balance.\n"
+            "Are you using the correct provider/account combination?\n"
+            "(transfer_value=1000000, balance=0)."
         )
         assert str(err.value) == expected
 

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -31,11 +31,17 @@ def project(project_folder):
     ape.project = previous_project
 
 
+class ApeCliRunner(CliRunner):
+    def invoke_using_test_network(self, cli, args, input=None):
+        args.extend(("--network", "::test"))
+        return self.invoke(cli, args, input=input)
+
+
 @pytest.fixture
 def runner(project_folder):
     previous_cwd = str(Path.cwd())
     os.chdir(str(project_folder))
-    runner = CliRunner()
+    runner = ApeCliRunner()
     yield runner
     os.chdir(previous_cwd)
 

--- a/tests/integration/cli/test_console.py
+++ b/tests/integration/cli/test_console.py
@@ -7,4 +7,4 @@ from ape import __all__
 @pytest.mark.parametrize("item", __all__)
 def test_console(ape_cli, runner, item):
     result = runner.invoke_using_test_network(ape_cli, ["console"], input=f"{item}\nexit\n")
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output

--- a/tests/integration/cli/test_console.py
+++ b/tests/integration/cli/test_console.py
@@ -6,5 +6,5 @@ from ape import __all__
 # NOTE: We export `__all__` into the IPython session that the console runs in
 @pytest.mark.parametrize("item", __all__)
 def test_console(ape_cli, runner, item):
-    result = runner.invoke(ape_cli, "console", input=f"{item}\nexit\n")
+    result = runner.invoke_using_test_network(ape_cli, ["console"], input=f"{item}\nexit\n")
     assert result.exit_code == 0

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -9,7 +9,7 @@ def test_run(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["run", BAD_COMMAND])
     assert result.exit_code == 1
     if not (project.path / "scripts").exists():
-        assert "No `scripts/` directory detected to run script" in result.output
+        assert "No 'scripts/' directory detected to run script" in result.output
 
     else:
         assert f"No script named '{BAD_COMMAND}' detected in scripts folder" in result.output

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -3,7 +3,7 @@ BAD_COMMAND = "not-a-name"
 
 def test_run(ape_cli, runner, project):
     result = runner.invoke_using_test_network(ape_cli, ["run"])
-    assert result.exit_code == 1
+    assert result.exit_code == 1, result.output
     assert "Must provide at least one script name or path" in result.output
 
     result = runner.invoke_using_test_network(ape_cli, ["run", BAD_COMMAND])
@@ -16,4 +16,4 @@ def test_run(ape_cli, runner, project):
 
     for script_file in (project.path / "scripts").glob("*.py"):
         result = runner.invoke_using_test_network(ape_cli, ["run", script_file.stem])
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -2,11 +2,11 @@ BAD_COMMAND = "not-a-name"
 
 
 def test_run(ape_cli, runner, project):
-    result = runner.invoke(ape_cli, ["run"])
+    result = runner.invoke_using_test_network(ape_cli, ["run"])
     assert result.exit_code == 1
     assert "Must provide at least one script name or path" in result.output
 
-    result = runner.invoke(ape_cli, ["run", BAD_COMMAND])
+    result = runner.invoke_using_test_network(ape_cli, ["run", BAD_COMMAND])
     assert result.exit_code == 1
     if not (project.path / "scripts").exists():
         assert "No 'scripts/' directory detected to run script" in result.output
@@ -15,7 +15,5 @@ def test_run(ape_cli, runner, project):
         assert f"No script named '{BAD_COMMAND}' detected in scripts folder" in result.output
 
     for script_file in (project.path / "scripts").glob("*.py"):
-        result = runner.invoke(
-            ape_cli, ["run", script_file.stem, "--network", "ethereum:development:test"]
-        )
+        result = runner.invoke_using_test_network(ape_cli, ["run", script_file.stem])
         assert result.exit_code == 0


### PR DESCRIPTION
Make sure you have this account added in ape: `0xdd23ca549a97cb330b011aebb674730df8b14acaee42d211ab45692699ab8ba5`

Start up a geth, (e.g. check out this repo: https://github.com/unparalleled-js/hdpath-geth and run `make`)

Run the deploy script from my demo project (Use a demo project, e.g. https://github.com/unparalleled-js/ape-demo-project) `ape run deploy`, select the account you added. It should run.

Now, run the same script with the test provider, `ape run deploy --network ::test`. It should automatically use the test account at index 0 and work.


### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
