### PR TITLE
fix: issue where all plugins got counted as 1st class plugins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
-from os import path
+from pathlib import Path
 from typing import Dict
 
 from setuptools import find_packages, setup  # type: ignore
 
-here = path.abspath(path.dirname(__file__))
+here = Path(__file__).parent.absolute()
 packages_data: Dict = {}
-with open(path.join(here, "src", "ape", "__modules__.py"), encoding="utf8") as modules_file:
+with open(here / "src" / "ape" / "__modules__.py", encoding="utf8") as modules_file:
     exec(modules_file.read(), packages_data)
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
+from os import path
+from typing import Dict
+
 from setuptools import find_packages, setup  # type: ignore
+
+here = path.abspath(path.dirname(__file__))
+packages_data: Dict = {}
+with open(path.join(here, "src", "ape", "__modules__.py"), encoding="utf8") as modules_file:
+    exec(modules_file.read(), packages_data)
 
 extras_require = {
     "test": [  # `test` GitHub Action jobs uses this
@@ -94,19 +102,7 @@ setup(
     },
     python_requires=">=3.7,<3.10",
     extras_require=extras_require,
-    py_modules=[
-        "ape",
-        "ape_accounts",
-        "ape_compile",
-        "ape_console",
-        "ape_ethereum",
-        "ape_geth",
-        "ape_networks",
-        "ape_plugins",
-        "ape_run",
-        "ape_test",
-        "ape_pm",
-    ],
+    py_modules=packages_data["__modules__"],
     license="Apache-2.0",
     zip_safe=False,
     keywords="ethereum",

--- a/src/ape/__modules__.py
+++ b/src/ape/__modules__.py
@@ -1,0 +1,13 @@
+__modules__ = [
+    "ape",
+    "ape_accounts",
+    "ape_compile",
+    "ape_console",
+    "ape_ethereum",
+    "ape_geth",
+    "ape_networks",
+    "ape_plugins",
+    "ape_run",
+    "ape_test",
+    "ape_pm",
+]

--- a/src/ape_plugins/utils.py
+++ b/src/ape_plugins/utils.py
@@ -1,18 +1,15 @@
 import os
-from pathlib import Path
 from typing import Dict, Set, Tuple
 
 from github import Github
 
+from ape.__modules__ import __modules__
 from ape.exceptions import ConfigError
 from ape.logging import logger
 
-# Plugins included with ape core
-FIRST_CLASS_PLUGINS: Set[str] = {
-    d.name for d in Path(__file__).parent.parent.iterdir() if d.is_dir and d.name.startswith("ape_")
-}
-
 # Plugins maintained OSS by ApeWorX (and trusted)
+FIRST_CLASS_PLUGINS = set(__modules__)
+
 SECOND_CLASS_PLUGINS: Set[str] = set()
 
 # TODO: Should the github client be in core?


### PR DESCRIPTION
### What I did

fixes: #229 

### How I did it

Set `py_modules` from magic list in ape
Rely on same list in plugins plugin

### How to verify it

Install ape without using -e
Install plugin
Uninstall plugin

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
