### PR TITLE
feat: web3 provider base class

### DIFF
--- a/src/ape/api/__init__.py
+++ b/src/ape/api/__init__.py
@@ -10,6 +10,7 @@ from .providers import (
     TestProviderAPI,
     TransactionAPI,
     TransactionStatusEnum,
+    Web3Provider,
 )
 
 __all__ = [
@@ -20,6 +21,7 @@ __all__ = [
     "ContractInstance",
     "ContractLog",
     "ConverterAPI",
+    "create_network_type",
     "EcosystemAPI",
     "ExplorerAPI",
     "ProviderAPI",
@@ -31,5 +33,5 @@ __all__ = [
     "TestProviderAPI",
     "TransactionAPI",
     "TransactionStatusEnum",
-    "create_network_type",
+    "Web3Provider",
 ]

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -4,6 +4,7 @@ from typing import Iterator, List, Optional
 
 from dataclassy import as_dict
 from hexbytes import HexBytes
+from web3 import Web3
 
 from ape.logging import logger
 from ape.types import TransactionSignature
@@ -187,3 +188,88 @@ class TestProviderAPI(ProviderAPI):
     @abstractmethod
     def revert(self, snapshot_id: str):
         ...
+
+
+class Web3Provider(ProviderAPI):
+    """
+    A base provider that is web3 / RPC based.
+    """
+
+    _web3: Web3 = None  # type: ignore
+
+    def update_settings(self, new_settings: dict):
+        """
+        Update the provider settings and re-connect.
+        """
+        self.disconnect()
+        self.provider_settings.update(new_settings)
+        self.connect()
+
+    def estimate_gas_cost(self, txn: TransactionAPI) -> int:
+        """
+        Generates and returns an estimate of how much gas is necessary
+        to allow the transaction to complete.
+        The transaction will not be added to the blockchain.
+        """
+        txn_dict = txn.as_dict()
+        return self._web3.eth.estimate_gas(txn_dict)  # type: ignore
+
+    @property
+    def chain_id(self) -> int:
+        """
+        Returns the currently configured chain ID,
+        a value used in replay-protected transaction signing as introduced by EIP-155.
+        """
+        return self._web3.eth.chain_id
+
+    @property
+    def gas_price(self) -> int:
+        """
+        Returns the current price per gas in wei.
+        """
+        return self._web3.eth.generate_gas_price()
+
+    def get_nonce(self, address: str) -> int:
+        """q
+        Returns the number of transactions sent from an address.
+        """
+        return self._web3.eth.get_transaction_count(address)  # type: ignore
+
+    def get_balance(self, address: str) -> int:
+        """
+        Returns the balance of the account of a given address.
+        """
+        return self._web3.eth.get_balance(address)  # type: ignore
+
+    def get_code(self, address: str) -> bytes:
+        """
+        Returns code at a given address.
+        """
+        return self._web3.eth.get_code(address)  # type: ignore
+
+    def send_call(self, txn: TransactionAPI) -> bytes:
+        """
+        Executes a new message call immediately without creating a
+        transaction on the block chain.
+        """
+        return self._web3.eth.call(txn.as_dict())
+
+    def get_transaction(self, txn_hash: str) -> ReceiptAPI:
+        """
+        Returns the information about a transaction requested by transaction hash.
+        """
+        # TODO: Work on API that let's you work with ReceiptAPI and re-send transactions
+        receipt = self._web3.eth.wait_for_transaction_receipt(txn_hash)  # type: ignore
+        txn = self._web3.eth.get_transaction(txn_hash)  # type: ignore
+        return self.network.ecosystem.receipt_class.decode({**txn, **receipt})
+
+    def get_events(self, **filter_params) -> Iterator[dict]:
+        """
+        Returns an array of all logs matching a given set of filter parameters.
+        """
+        return iter(self._web3.eth.get_logs(filter_params))  # type: ignore
+
+    def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
+        txn_hash = self._web3.eth.send_raw_transaction(txn.encode())
+        receipt = self.get_transaction(txn_hash.hex())
+        return receipt

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -227,7 +227,7 @@ class Web3Provider(ProviderAPI):
         """
         Returns the current price per gas in wei.
         """
-        return self._web3.eth.generate_gas_price()
+        return self._web3.eth.generate_gas_price()  # type: ignore
 
     def get_nonce(self, address: str) -> int:
         """

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -192,7 +192,7 @@ class TestProviderAPI(ProviderAPI):
 
 class Web3Provider(ProviderAPI):
     """
-    A base provider that is web3 / RPC based.
+    A base provider that is web3 based.
     """
 
     _web3: Web3 = None  # type: ignore

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -230,7 +230,7 @@ class Web3Provider(ProviderAPI):
         return self._web3.eth.generate_gas_price()
 
     def get_nonce(self, address: str) -> int:
-        """q
+        """
         Returns the number of transactions sent from an address.
         """
         return self._web3.eth.get_transaction_count(address)  # type: ignore

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -70,7 +70,7 @@ def get_package_version(obj: Any) -> str:
     if hasattr(obj, "__version__"):
         return obj.__version__
 
-    # NOTE: In case were don't pass a module name
+    # NOTE: In case where don't pass a module name
     if not isinstance(obj, str):
         obj = obj.__name__
 

--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -1,6 +1,6 @@
 import shutil
 from pathlib import Path
-from typing import Dict, Iterator, Mapping, Optional, Union
+from typing import Dict, Mapping, Optional, Union
 from urllib.parse import urlparse
 
 from eth_utils import to_wei
@@ -18,7 +18,7 @@ from web3.types import NodeInfo
 
 from ape.api import ReceiptAPI, TransactionAPI
 from ape.api.config import ConfigItem
-from ape.api.providers import ProviderAPI
+from ape.api.providers import Web3Provider
 from ape.exceptions import (
     ContractLogicError,
     OutOfGasError,
@@ -140,8 +140,7 @@ class GethNotInstalledError(ConnectionError):
         )
 
 
-class GethProvider(ProviderAPI):
-    _web3: Web3 = None  # type: ignore
+class GethProvider(Web3Provider):
     _geth: Optional[EphemeralGeth] = None
 
     @property
@@ -150,6 +149,7 @@ class GethProvider(ProviderAPI):
 
     def connect(self):
         self._web3 = Web3(HTTPProvider(self.uri))
+        self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
 
         # Try to start an ephemeral geth process if no provider is running.
         if not self._web3.isConnected():
@@ -178,8 +178,6 @@ class GethProvider(ProviderAPI):
                 self._geth.disconnect()
                 raise ConnectionError("Unable to connect to locally running geth.")
 
-        self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
-
         def is_poa() -> bool:
             node_info: Mapping = self._node_info or {}
             chain_config = extract_nested_value(node_info, "protocols", "eth", "config")
@@ -200,13 +198,8 @@ class GethProvider(ProviderAPI):
             self._geth.disconnect()
             self._geth = None
 
-        # Must happen after geth.disconnect()
+        # Note: this must happen after geth.disconnect()
         self._web3 = None  # type: ignore
-
-    def update_settings(self, new_settings: dict):
-        self.disconnect()
-        self.provider_settings.update(new_settings)
-        self.connect()
 
     def estimate_gas_cost(self, txn: TransactionAPI) -> int:
         """
@@ -215,8 +208,7 @@ class GethProvider(ProviderAPI):
         The transaction will not be added to the blockchain.
         """
         try:
-            txn_dict = txn.as_dict()
-            return self._web3.eth.estimate_gas(txn_dict)  # type: ignore
+            return super().estimate_gas_cost(txn)
         except ValueError as err:
             tx_error = _get_vm_error(err)
 
@@ -229,21 +221,6 @@ class GethProvider(ProviderAPI):
             raise TransactionError(base_err=tx_error, message=message) from err
 
     @property
-    def chain_id(self) -> int:
-        """
-        Returns the currently configured chain ID,
-        a value used in replay-protected transaction signing as introduced by EIP-155.
-        """
-        return self._web3.eth.chain_id
-
-    @property
-    def gas_price(self):
-        """
-        Returns the current price per gas in wei.
-        """
-        return self._web3.eth.generate_gas_price()
-
-    @property
     def _node_info(self) -> Optional[NodeInfo]:
         try:
             return self._web3.geth.admin.node_info()
@@ -251,62 +228,20 @@ class GethProvider(ProviderAPI):
             # Unsupported API in user's geth.
             return None
 
-    def get_nonce(self, address: str) -> int:
-        """q
-        Returns the number of transactions sent from an address.
-        """
-        return self._web3.eth.get_transaction_count(address)  # type: ignore
-
-    def get_balance(self, address: str) -> int:
-        """
-        Returns the balance of the account of a given address.
-        """
-        return self._web3.eth.get_balance(address)  # type: ignore
-
-    def get_code(self, address: str) -> bytes:
-        """
-        Returns code at a given address.
-        """
-        return self._web3.eth.get_code(address)  # type: ignore
-
-    def send_call(self, txn: TransactionAPI) -> bytes:
-        """
-        Executes a new message call immediately without creating a
-        transaction on the block chain.
-        """
-        return self._web3.eth.call(txn.as_dict())
-
-    def get_transaction(self, txn_hash: str) -> ReceiptAPI:
-        """
-        Returns the information about a transaction requested by transaction hash.
-        """
-        # TODO: Work on API that let's you work with ReceiptAPI and re-send transactions
-        receipt = self._web3.eth.wait_for_transaction_receipt(txn_hash)  # type: ignore
-        txn = self._web3.eth.get_transaction(txn_hash)  # type: ignore
-        return self.network.ecosystem.receipt_class.decode({**txn, **receipt})
-
     def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
         """
         Creates a new message call transaction or a contract creation
         for signed transactions.
         """
         try:
-            txn_hash = self._web3.eth.send_raw_transaction(txn.encode())
+            receipt = super().send_transaction(txn)
         except ValueError as err:
             raise _get_vm_error(err) from err
-
-        receipt = self.get_transaction(txn_hash.hex())
 
         if txn.gas_limit is not None and receipt.ran_out_of_gas(txn.gas_limit):
             raise OutOfGasError()
 
         return receipt
-
-    def get_events(self, **filter_params) -> Iterator[dict]:
-        """
-        Returns an array of all logs matching a given set of filter parameters.
-        """
-        return iter(self._web3.eth.get_logs(filter_params))  # type: ignore
 
 
 def _get_vm_error(web3_value_error: ValueError) -> TransactionError:

--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -149,7 +149,6 @@ class GethProvider(Web3Provider):
 
     def connect(self):
         self._web3 = Web3(HTTPProvider(self.uri))
-        self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
 
         # Try to start an ephemeral geth process if no provider is running.
         if not self._web3.isConnected():
@@ -178,6 +177,8 @@ class GethProvider(Web3Provider):
                 self._geth.disconnect()
                 raise ConnectionError("Unable to connect to locally running geth.")
 
+        self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
+
         def is_poa() -> bool:
             node_info: Mapping = self._node_info or {}
             chain_config = extract_nested_value(node_info, "protocols", "eth", "config")
@@ -198,7 +199,7 @@ class GethProvider(Web3Provider):
             self._geth.disconnect()
             self._geth = None
 
-        # Note: this must happen after geth.disconnect()
+        # Must happen after geth.disconnect()
         self._web3 = None  # type: ignore
 
     def estimate_gas_cost(self, txn: TransactionAPI) -> int:

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -31,7 +31,7 @@ class LocalNetwork(TestProviderAPI):
         return self._web3.eth.chain_id
 
     @property
-    def gas_price(self):
+    def gas_price(self) -> int:
         # NOTE: Test chain doesn't care about gas prices
         return 0
 


### PR DESCRIPTION
### What I did

Creates a base class for providers that use web3 rpc.
I have a branch where hardhat will also use this base class (to help upgrade it and make it fit for ape-test)

### How I did it

Copy shared code to base class and put in Provider api module.

### How to verify it

- [x] Geth provider still works
- [ ] Check out my branch feat/use-new-baseclass in ape-hardhat and see that you can run tests and scripts and stuff using a version of the provider that uses this base class.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
