### PR TITLE
fix: keep type info for all ape packages up-to-date

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,16 +108,7 @@ setup(
     keywords="ethereum",
     packages=find_packages("src"),
     package_dir={"": "src"},
-    package_data={
-        "ape": ["py.typed"],
-        "ape_accounts": ["py.typed"],
-        "ape_compile": ["py.typed"],
-        "ape_ethereum": ["py.typed"],
-        "ape_geth": ["py.typed"],
-        "ape_run": ["py.typed"],
-        "ape_test": ["py.typed"],
-        "ape_pm": ["py.typed"],
-    },
+    package_data={p: ["py.typed"] for p in packages_data["__modules__"]},
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
### What I did

Adds missing packages to packages_data.. Fixes issue where not all packages had their typing including.
Makes it so it goes off the universal source of truth, so it should not happen in the future!

### How I did it

Noticed package_data. Noticed it was missing some packages. Noticed we could use the same source as truth as `py_modules`.

### How to verify it

Install ape, both editable mode and not, make sure it installs expectedly.
Shouldn't need type ignore anymore if was importing from these missing modules? (not exactly sure)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
