### PR TITLE
feat: contract CLI options

### DIFF
--- a/src/ape/cli/__init__.py
+++ b/src/ape/cli/__init__.py
@@ -4,6 +4,7 @@ from ape.cli.commands import NetworkBoundCommand
 from ape.cli.options import (
     account_option_that_prompts_when_not_given,
     ape_cli_context,
+    contract_type_option,
     network_option,
     skip_confirmation_option,
 )
@@ -12,17 +13,18 @@ from ape.cli.utils import Abort
 
 __all__ = [
     "Abort",
-    "Alias",
-    "AccountAliasPromptChoice",
     "account_option_that_prompts_when_not_given",
+    "AccountAliasPromptChoice",
+    "Alias",
     "AllFilePaths",
     "ape_cli_context",
+    "contract_type_option",
     "existing_alias_argument",
-    "NetworkBoundCommand",
+    "get_user_selected_account",
     "network_option",
+    "NetworkBoundCommand",
     "non_existing_alias_argument",
     "Path",
     "PromptChoice",
-    "get_user_selected_account",
     "skip_confirmation_option",
 ]

--- a/src/ape/cli/__init__.py
+++ b/src/ape/cli/__init__.py
@@ -4,7 +4,7 @@ from ape.cli.commands import NetworkBoundCommand
 from ape.cli.options import (
     account_option_that_prompts_when_not_given,
     ape_cli_context,
-    contract_type_option,
+    contract_option,
     network_option,
     skip_confirmation_option,
 )
@@ -18,7 +18,7 @@ __all__ = [
     "Alias",
     "AllFilePaths",
     "ape_cli_context",
-    "contract_type_option",
+    "contract_option",
     "existing_alias_argument",
     "get_user_selected_account",
     "network_option",

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -123,7 +123,7 @@ def _load_contracts(ctx, param, value) -> Optional[Union[ContractType, List[Cont
     return [create_contract(c) for c in value] if is_multiple else create_contract(value)
 
 
-def contract_type_option(help=None, required=False, multiple=False):
+def contract_option(help=None, required=False, multiple=False):
     """
     Contract(s) from the current project.
     If you pass ``multiple=True``, you will get a list of contract types from the callback.

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -1,9 +1,13 @@
+from typing import List, Optional, Union
+
 import click
 
-from ape import networks
+from ape import networks, project
 from ape.cli.choices import AccountAliasPromptChoice, NetworkChoice
 from ape.cli.utils import Abort
+from ape.exceptions import ContractError
 from ape.logging import LogLevel, logger
+from ape.types import ContractType
 
 
 class ApeCliContextObject:
@@ -98,4 +102,33 @@ def account_option_that_prompts_when_not_given():
         "--account",
         type=AccountAliasPromptChoice(),
         callback=_account_callback,
+    )
+
+
+def _load_contracts(ctx, param, value) -> Optional[Union[ContractType, List[ContractType]]]:
+    if not value:
+        return None
+
+    if len(project.contracts) == 0:
+        raise ContractError("Project has no contracts.")
+
+    is_multiple = isinstance(value, (tuple, list))
+
+    def create_contract(contract_name: str) -> ContractType:
+        if contract_name not in project.contracts:
+            raise ContractError(f"No contract named '{value}'")
+
+        return project.contracts[contract_name]
+
+    return [create_contract(c) for c in value] if is_multiple else create_contract(value)
+
+
+def contract_type_option(help=None, required=False, multiple=False):
+    """
+    Contract(s) from the current project.
+    If you pass ``multiple=True``, you will get a list of contract types from the callback.
+    """
+    help = help or "The name of a contract in the current project"
+    return click.option(
+        "--contract", help=help, required=required, callback=_load_contracts, multiple=multiple
     )

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -112,6 +112,8 @@ def _load_contracts(ctx, param, value) -> Optional[Union[ContractType, List[Cont
     if len(project.contracts) == 0:
         raise ContractError("Project has no contracts.")
 
+    # If the user passed in `multiple=True`, then `value` is a list,
+    # and therefore we should also return a list.
     is_multiple = isinstance(value, (tuple, list))
 
     def create_contract(contract_name: str) -> ContractType:


### PR DESCRIPTION
### What I did

Creates a new custom `ape.cli.option` for contract.
* The contract type _must_ be a contract within the current project
* The command fails in the arg collection stage when not in a project with the given contract (which is before starting up a network!).

Use case:

So you want to make a custom command that queries logs for a given contract. You have a provider like Infura and you have the compiled ABI etc. This makes it easy to pass in a CLI option for specifying the contract type.

### How I did it

Custom click option in the cli module using `from ape import projects`.

### How to verify it

```python
import click
import json
from ape.cli import contract_option

@click.group()
def cli():
    pass


@cli.command()
@contract_option(help="The name of the contract to dump the ABI from.", required=True)
def abi(contract):
    abi_dict = {"abi": [abi.to_dict() for abi in contract.abi]}
    output = json.dumps(abi_dict, indent=4)
    click.echo(output)


@cli.command()
@contract_option(help="The name of the contracts to list the extensions for.", multiple=True, required=True)
def list_ext(contract):
    exts = []
    for con in contract:
        ext = str(con.sourceId).split(".")[-1]
        exts.append(ext)

    click.echo(f"The given contracts have the following extensions: {exts}")
```

run the first one like `ape jules abi --contract Vault`. It should dump the vault source abi.

run the second one like `abi jules list-ext --contract Vault --contract Fund`. It should list the extensions `[.vy, .sol]`

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
