### PR TITLE
fix: pin typing extensions dependency to fix docker build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
         "singledispatchmethod ; python_version<'3.8'",
         "IPython>=7.25",
         "pytest>=6.0,<7.0",
+        "typing-extensions>=3.10,<4.0.0",
         "web3[tester]>=5.24.0,<6.0.0",
     ],
     entry_points={


### PR DESCRIPTION
### What I did

fix issue where docker image was not building

### How I did it

https://pypi.org/project/typing-extensions/ 

^ this happened on the same day, is the culprit
Some loose dependency out there broke us..  I am not sure.

### How to verify it

Docker should now build locally. and hopefully in CI.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
