### PR TITLE
fix: handle when there is not a message in a contract revert

### DIFF
--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -67,6 +67,8 @@ class TransactionError(ContractError):
     Raised when issues occur related to transactions.
     """
 
+    DEFAULT_MESSAGE = "Tranaction failed."
+
     def __init__(
         self,
         base_err: Optional[Exception] = None,
@@ -75,7 +77,7 @@ class TransactionError(ContractError):
     ):
         self.base_err = base_err
         if not message:
-            message = str(base_err) if base_err else "Tranaction Failed"
+            message = str(base_err) if base_err else self.DEFAULT_MESSAGE
 
         self.message = message
         self.code = code
@@ -96,7 +98,7 @@ class ContractLogicError(VirtualMachineError):
     such as from an assert/require statement.
     """
 
-    def __init__(self, revert_message: str):
+    def __init__(self, revert_message: Optional[str] = None):
         super().__init__(message=revert_message)
 
     @property

--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -243,7 +243,11 @@ def _get_vm_error(web3_value_error: ValueError) -> TransactionError:
     if isinstance(web3_value_error, Web3ContractLogicError):
         # This happens from `assert` or `require` statements.
         message = str(web3_value_error).split(":")[-1].strip()
-        return ContractLogicError(message)
+        if message == "execution reverted":
+            # Reverted without an error message
+            raise ContractLogicError()
+
+        return ContractLogicError(revert_message=message)
 
     if not len(web3_value_error.args):
         return VirtualMachineError(base_err=web3_value_error)

--- a/src/ape_test/contextmanagers.py
+++ b/src/ape_test/contextmanagers.py
@@ -1,6 +1,6 @@
 from typing import Optional, Type
 
-from ape.exceptions import ContractLogicError
+from ape.exceptions import ContractLogicError, TransactionError
 
 
 class RevertsContextManager:
@@ -21,10 +21,16 @@ class RevertsContextManager:
 
         actual = exc_value.revert_message
 
+        # Validate the expected revert message if given one.
         if self.expected_message is not None and self.expected_message != actual:
-            raise AssertionError(
-                f"Expected revert message '{self.expected_message}' but got '{actual}'."
-            )
+            assertion_error_prefix = f"Expected revert message '{self.expected_message}'"
+
+            if actual == TransactionError.DEFAULT_MESSAGE:
+                # The transaction failed without a revert message
+                # but the user is expecting one.
+                raise AssertionError(f"{assertion_error_prefix} but there was none.")
+
+            raise AssertionError(f"{assertion_error_prefix} but got '{actual}'.")
 
         # Returning True causes the expected exception not to get raised
         # and the test to pass

--- a/tests/functional/http/test_providers.py
+++ b/tests/functional/http/test_providers.py
@@ -70,3 +70,24 @@ class TestEthereumProvider:
             provider.send_transaction(mock_transaction)
 
         assert str(err.value) == _TEST_REVERT_REASON
+
+    def test_send_transaction_no_revert_message(
+        self, mock_web3, mock_network_api, mock_config_item, mock_transaction
+    ):
+        provider = GethProvider(
+            name="test",
+            network=mock_network_api,
+            config=mock_config_item,
+            provider_settings={},
+            data_folder=Path("."),
+            request_header="",
+        )
+        provider._web3 = mock_web3
+        mock_network_api.ecosystem.receipt_class = _create_mock_receipt()
+        test_err = Web3ContractLogicError("execution reverted")
+        mock_web3.eth.send_raw_transaction.side_effect = test_err
+
+        with pytest.raises(ContractLogicError) as err:
+            provider.send_transaction(mock_transaction)
+
+        assert str(err.value) == TransactionError.DEFAULT_MESSAGE


### PR DESCRIPTION
### What I did

* Fixes issue where if a contract reverts with no error message, the `reverts` context manager did not have a specific enough error message. I noticed this while working on `ape hardhat`.
* Fixes issue where the `geth` provider wrongly considered the default error message the contract's revert message.

In general, this work handles the case when there is no revert message in contract reverts. That got missed before.

### How I did it

Detect if error was raised without a contract error message. Don't specify `revert_message` in the custom exception when that happened. Make `revert_message` an optional argument in the custom exception.

### How to verify it

Make a call to a contract that reverts without an error message. Example:

```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.6.0;

contract Fund {
    bool public enabled;

    constructor() public {
        enabled = true;
    }

    modifier isOn() {
        require(enabled);
        _;
    }

    function changeOnStatus(bool newValue) public onlyOwner {
        enabled = newValue;
    }

    function fund() public payable isOn {
        require(msg.value > 0, "Fund amount must be greater than 0.");
    }
```



Add a test that tests this functionality and call `reverts` without specifying a revert message:

```python
    contract = owner.deploy(project.Fund)
    contract.changeOnStatus(False, sender=owner)

    with ape.reverts():
        contract.fund(value=100000000, sender=funder)
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
