### PR TITLE
feat: show contract address on deployment

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Iterator, List, Optional, Type, Union
 
+import click
+
 from ape.exceptions import AccountsError, AliasAlreadyInUseError, SignatureError
+from ape.logging import logger
 from ape.types import (
     AddressType,
     ContractType,
@@ -147,6 +150,9 @@ class AccountAPI(AddressAPI):
 
         if not receipt.contract_address:
             raise AccountsError(f"'{receipt.txn_hash}' did not create a contract.")
+
+        address = click.style(receipt.contract_address, bold=True)
+        logger.success(f"Contract '{contract_type.contractName}' deployed to: {address}")
 
         return ContractInstance(  # type: ignore
             _provider=self.provider,


### PR DESCRIPTION
### What I did

When deploying a contract, show the contract address as a SUCCESS message (also bolden the address)

### How I did it

click and logger

### How to verify it

Deploy a contract, you should see some stuff like this (this is a local dev env, so not a real address):
<img width="862" alt="Screen Shot 2021-11-23 at 10 36 27" src="https://user-images.githubusercontent.com/19540978/143065575-ee14cbf5-2f92-41b2-8fe7-64e21976efba.png">

