### PR TITLE
refactor: use _compat.py module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,5 @@ exclude =
 per-file-ignores =
     # Need signal handler before imports
     src/ape/__init__.py: E402
+    # Need for imports that seem unused, imported for compat reasons.
+    src/ape/_compat.py: F401

--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -5,15 +5,11 @@ from typing import Any, Dict
 import click
 import yaml
 
+from ape._compat import metadata
 from ape.cli import Abort, ape_cli_context
 from ape.exceptions import ApeException
 from ape.logging import logger
 from ape.plugins import clean_plugin_name
-
-try:
-    from importlib import metadata  # type: ignore
-except ImportError:
-    import importlib_metadata as metadata  # type: ignore
 
 _DIFFLIB_CUT_OFF = 0.6
 

--- a/src/ape/_compat.py
+++ b/src/ape/_compat.py
@@ -1,0 +1,13 @@
+import sys
+
+# We can remove this once we stop supporting python3.7.
+if sys.version_info >= (3, 8):
+    from functools import cached_property  # type: ignore
+    from functools import singledispatchmethod  # type: ignore
+    from importlib import metadata  # type: ignore
+    from typing import Literal
+else:
+    import importlib_metadata as metadata  # type: ignore
+    from backports.cached_property import cached_property  # type: ignore
+    from singledispatchmethod import singledispatchmethod  # type: ignore
+    from typing_extensions import Literal

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Callable, Iterator, List, Optional, Type, Unio
 
 import click
 
+from ape._compat import cached_property
 from ape.exceptions import AccountsError, AliasAlreadyInUseError, SignatureError
 from ape.logging import logger
 from ape.types import (
@@ -12,7 +13,6 @@ from ape.types import (
     SignableMessage,
     TransactionSignature,
 )
-from ape.utils import cached_property
 
 from .address import AddressAPI
 from .base import abstractdataclass, abstractmethod

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -4,9 +4,9 @@ from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Type
 
 from pluggy import PluginManager  # type: ignore
 
+from ape._compat import cached_property
 from ape.exceptions import NetworkError, NetworkNotFoundError
 from ape.types import ABI, AddressType
-from ape.utils import cached_property
 
 from .base import abstractdataclass, abstractmethod, dataclass
 from .config import ConfigItem

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -3,9 +3,9 @@ from typing import Dict, Iterator, List, Type
 from dataclassy import dataclass
 from pluggy import PluginManager  # type: ignore
 
+from ape._compat import cached_property, singledispatchmethod
 from ape.api.accounts import AccountAPI, AccountContainerAPI, TestAccountAPI
 from ape.types import AddressType
-from ape.utils import cached_property, singledispatchmethod
 
 from .config import ConfigManager
 from .converters import ConversionManager

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -3,12 +3,12 @@ from typing import Dict, List, Set
 
 from dataclassy import dataclass
 
+from ape._compat import cached_property
 from ape.api.compiler import CompilerAPI
 from ape.exceptions import CompilerError
 from ape.logging import logger
 from ape.plugins import PluginManager
 from ape.types import ContractType
-from ape.utils import cached_property
 
 from .config import ConfigManager
 

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -4,12 +4,12 @@ from dataclassy import dataclass
 from eth_utils import is_checksum_address, is_hex, is_hex_address, to_checksum_address
 from hexbytes import HexBytes
 
+from ape._compat import cached_property
 from ape.api import AddressAPI, ConverterAPI
 from ape.exceptions import ConversionError
 from ape.logging import logger
 from ape.plugins import PluginManager
 from ape.types import AddressType
-from ape.utils import cached_property
 
 from .config import ConfigManager
 from .networks import NetworkManager

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -4,9 +4,9 @@ import yaml
 from dataclassy import dataclass
 from pluggy import PluginManager  # type: ignore
 
+from ape._compat import cached_property
 from ape.api import EcosystemAPI, ProviderAPI, ProviderContextManager
 from ape.exceptions import NetworkError
-from ape.utils import cached_property
 
 from .config import ConfigManager
 

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -15,16 +15,6 @@ from importlib_metadata import PackageNotFoundError, packages_distributions, ver
 
 from ape.logging import logger
 
-try:
-    from functools import cached_property  # type: ignore
-except ImportError:
-    from backports.cached_property import cached_property  # type: ignore
-
-try:
-    from functools import singledispatchmethod  # type: ignore
-except ImportError:
-    from singledispatchmethod import singledispatchmethod  # type: ignore
-
 
 @lru_cache(maxsize=None)
 def get_distributions():
@@ -195,7 +185,6 @@ def extract_nested_value(root: Mapping, *args: str) -> Optional[Dict]:
 
 
 __all__ = [
-    "cached_property",
     "deep_merge",
     "expand_environment_variables",
     "extract_nested_value",
@@ -204,5 +193,4 @@ __all__ = [
     "GeneratedDevAccount",
     "generate_dev_accounts",
     "load_config",
-    "singledispatchmethod",
 ]

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -3,10 +3,11 @@ from typing import Iterator, List, Optional
 from eth_account import Account as EthAccount  # type: ignore
 from eth_account.messages import SignableMessage
 
+from ape._compat import cached_property
 from ape.api import TestAccountAPI, TestAccountContainerAPI, TransactionAPI
 from ape.convert import to_address
 from ape.types import AddressType, MessageSignature, TransactionSignature
-from ape.utils import GeneratedDevAccount, cached_property, generate_dev_accounts
+from ape.utils import GeneratedDevAccount, generate_dev_accounts
 
 
 class TestAccountContainer(TestAccountContainerAPI):


### PR DESCRIPTION
### What I did

Create compat module to prevent people from using our compat methods from `ape.utils`. Also, easier to track and delete the code when necessary. Keeps it protected and isolated basically and makes more sense when importing, such as `Literal` from the `typing` module.

### How I did it

Move all compat methods to new module `ape._compat.py`

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
