### PR TITLE
refactor: create GitHub client

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -86,11 +86,16 @@ class ProjectManager:
     def sources_missing(self) -> bool:
         return not self.contracts_folder.exists() or not self.contracts_folder.iterdir()
 
-    @property
-    def extensions_with_missing_compilers(self) -> List[str]:
-        """All file extensions in the `contracts/` directory (recursively)
-        that do not correspond to a registered compiler."""
-        extensions = []
+    def extensions_with_missing_compilers(self, extensions: Optional[List[str]]) -> List[str]:
+        """
+        All file extensions in the `contracts/` directory (recursively)
+        that do not correspond to a registered compiler.
+
+        Args:
+            extensions: If provided, returns only extensions that
+                are in this list. Useful for checking against a sub-set of source files.
+        """
+        exts = []
 
         def _append_extensions_in_dir(directory: Path):
             for file in directory.iterdir():
@@ -98,13 +103,16 @@ class ProjectManager:
                     _append_extensions_in_dir(file)
                 elif (
                     file.suffix
-                    and file.suffix not in extensions
+                    and file.suffix not in exts
                     and file.suffix not in self.compilers.registered_compilers
                 ):
-                    extensions.append(file.suffix)
+                    exts.append(file.suffix)
 
         _append_extensions_in_dir(self.contracts_folder)
-        return extensions
+        if extensions:
+            exts = [e for e in exts if e in extensions]
+
+        return exts
 
     def lookup_path(self, key_contract_path: Path) -> Optional[Path]:
         """

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -195,7 +195,7 @@ def extract_nested_value(root: Mapping, *args: str) -> Optional[Dict]:
     return current_value
 
 
-class GitHubClient:
+class GithubClient:
     TOKEN_KEY = "GITHUB_ACCESS_TOKEN"
 
     def __init__(self):
@@ -223,7 +223,7 @@ class GitHubClient:
         }
 
 
-github_client = GitHubClient()
+github_client = GithubClient()
 
 
 __all__ = [

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -196,12 +196,13 @@ def extract_nested_value(root: Mapping, *args: str) -> Optional[Dict]:
 
 
 class GitHubClient:
+    TOKEN_KEY = "GITHUB_ACCESS_TOKEN"
+
     def __init__(self):
-        key = "GITHUB_ACCESS_TOKEN"
         token = None
-        self.has_auth = key in os.environ
+        self.has_auth = self.TOKEN_KEY in os.environ
         if self.has_auth:
-            token = os.environ[key]
+            token = os.environ[self.TOKEN_KEY]
 
         self._client = Github(login_or_token=token)
 
@@ -212,7 +213,7 @@ class GitHubClient:
     @cached_property
     def available_plugins(self) -> Set[str]:
         if not self.has_auth:
-            logger.warning("$GITHUB_ACCESS_TOKEN not set, unable to list all plugins.")
+            logger.warning(f"${self.TOKEN_KEY} not set, unable to list all plugins.")
             return Set()
 
         return {

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -214,7 +214,7 @@ class GithubClient:
     def available_plugins(self) -> Set[str]:
         if not self.has_auth:
             logger.warning(f"${self.TOKEN_KEY} not set, unable to list all plugins.")
-            return Set()
+            return set()
 
         return {
             repo.name.replace("-", "_")

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -38,15 +38,10 @@ def cli(cli_ctx, file_paths, use_cache, display_size):
         cli_ctx.logger.warning("No 'contracts/' directory detected")
         return
 
-    ext_with_missing_compilers = cli_ctx.project.extensions_with_missing_compilers
     ext_given = [p.suffix for p in file_paths if p]
+    ext_with_missing_compilers = cli_ctx.project.extensions_with_missing_compilers(ext_given)
     if ext_with_missing_compilers:
-        extensions = (
-            [e for e in ext_given if e in ext_with_missing_compilers]
-            if ext_given
-            else ext_with_missing_compilers
-        )
-        extensions_str = ", ".join(extensions)
+        extensions_str = ", ".join(ext_with_missing_compilers)
         message = f"No compilers detected for the following extensions: {extensions_str}"
         cli_ctx.logger.warning(message)
 

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -9,7 +9,7 @@ from ape.cli import ape_cli_context, skip_confirmation_option
 from ape.plugins import clean_plugin_name, plugin_manager
 from ape.utils import get_package_version, github_client
 from ape_plugins.utils import (
-    FIRST_CLASS_PLUGINS,
+    CORE_PLUGINS,
     extract_module_and_package_install_names,
     is_plugin_installed,
 )
@@ -57,17 +57,17 @@ def _list(cli_ctx, display_all):
     for name, plugin in plugin_manager.list_name_plugin():
         version = get_package_version(name)
 
-        if name in FIRST_CLASS_PLUGINS:
+        if name in CORE_PLUGINS:
             if not display_all:
-
                 continue  # NOTE: Skip 1st class plugins unless specified
-            installed_first_class_plugins.add(f"{name}")
+
+            installed_first_class_plugins.add(name)
 
         elif name in github_client.available_plugins:
             installed_second_class_plugins.add(f"{name}     {version}")
-            installed_second_class_plugins_no_version.add(f"{name}")
+            installed_second_class_plugins_no_version.add(name)
 
-        elif name not in FIRST_CLASS_PLUGINS or name not in github_client.available_plugins:
+        elif name not in CORE_PLUGINS or name not in github_client.available_plugins:
             installed_third_class_plugins.add(f"{name}      {version})")
         else:
             cli_ctx.logger.error(f"{name} is not a plugin.")
@@ -129,7 +129,7 @@ def add(cli_ctx, plugin, version, skip_confirmation):
     if version:
         plugin = f"{plugin}=={version}"
 
-    if plugin in FIRST_CLASS_PLUGINS:
+    if plugin in CORE_PLUGINS:
         cli_ctx.abort(f"Cannot add 1st class plugin '{plugin}'")
 
     elif is_plugin_installed(plugin):
@@ -180,7 +180,7 @@ def remove(cli_ctx, plugin, skip_confirmation):
     if not is_plugin_installed(plugin):
         cli_ctx.abort(f"Plugin '{plugin}' is not installed")
 
-    elif plugin in FIRST_CLASS_PLUGINS:
+    elif plugin in CORE_PLUGINS:
         cli_ctx.abort(f"Cannot remove 1st class plugin '{plugin}'")
 
     elif skip_confirmation or click.confirm(

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -7,10 +7,9 @@ import click
 from ape import config
 from ape.cli import ape_cli_context, skip_confirmation_option
 from ape.plugins import clean_plugin_name, plugin_manager
-from ape.utils import get_package_version
+from ape.utils import get_package_version, github_client
 from ape_plugins.utils import (
     FIRST_CLASS_PLUGINS,
-    SECOND_CLASS_PLUGINS,
     extract_module_and_package_install_names,
     is_plugin_installed,
 )
@@ -64,11 +63,11 @@ def _list(cli_ctx, display_all):
                 continue  # NOTE: Skip 1st class plugins unless specified
             installed_first_class_plugins.add(f"{name}")
 
-        elif name in SECOND_CLASS_PLUGINS:
+        elif name in github_client.available_plugins:
             installed_second_class_plugins.add(f"{name}     {version}")
             installed_second_class_plugins_no_version.add(f"{name}")
 
-        elif name not in FIRST_CLASS_PLUGINS or name not in SECOND_CLASS_PLUGINS:
+        elif name not in FIRST_CLASS_PLUGINS or name not in github_client.available_plugins:
             installed_third_class_plugins.add(f"{name}      {version})")
         else:
             cli_ctx.logger.error(f"{name} is not a plugin.")
@@ -80,7 +79,9 @@ def _list(cli_ctx, display_all):
         sections["Installed Core Plugins"] = [installed_first_class_plugins]
 
     # Second and Third Class Plugins
-    available_second = list(SECOND_CLASS_PLUGINS - installed_second_class_plugins_no_version)
+    available_second = list(
+        github_client.available_plugins - installed_second_class_plugins_no_version
+    )
 
     if installed_second_class_plugins:
         sections["Installed Plugins"] = [
@@ -101,7 +102,7 @@ def _list(cli_ctx, display_all):
             sections["Available Plugins"] = [available_second_output]
 
         else:
-            if SECOND_CLASS_PLUGINS:
+            if github_client.available_plugins:
                 click.echo("You have installed all the available Plugins\n")
 
     for i in range(0, len(sections)):
@@ -135,7 +136,7 @@ def add(cli_ctx, plugin, version, skip_confirmation):
         cli_ctx.abort(f"Plugin '{plugin}' already installed")
 
     elif (
-        plugin in SECOND_CLASS_PLUGINS
+        plugin in github_client.available_plugins
         or skip_confirmation
         or click.confirm(f"Install unknown 3rd party plugin '{plugin}'?")
     ):
@@ -154,7 +155,7 @@ def install(cli_ctx, skip_confirmation):
     for plugin in plugins:
         module_name, package_name = extract_module_and_package_install_names(plugin)
         if not is_plugin_installed(module_name) and (
-            module_name in SECOND_CLASS_PLUGINS
+            module_name in github_client.available_plugins
             or skip_confirmation
             or click.confirm(f"Install unknown 3rd party plugin '{package_name}'?")
         ):

--- a/src/ape_plugins/utils.py
+++ b/src/ape_plugins/utils.py
@@ -1,28 +1,12 @@
-import os
-from typing import Dict, Set, Tuple
-
-from github import Github
+from typing import Dict, Tuple
 
 from ape.__modules__ import __modules__
 from ape.exceptions import ConfigError
-from ape.logging import logger
 
 # Plugins maintained OSS by ApeWorX (and trusted)
 FIRST_CLASS_PLUGINS = set(__modules__)
 
-SECOND_CLASS_PLUGINS: Set[str] = set()
-
-# TODO: Should the github client be in core?
 # TODO: Handle failures with connecting to github (potentially cached on disk?)
-if "GITHUB_ACCESS_TOKEN" in os.environ:
-    author = Github(os.environ["GITHUB_ACCESS_TOKEN"]).get_organization("ApeWorX")
-
-    SECOND_CLASS_PLUGINS = {
-        repo.name.replace("-", "_") for repo in author.get_repos() if repo.name.startswith("ape-")
-    }
-
-else:
-    logger.warning("$GITHUB_ACCESS_TOKEN not set, unable to list all plugins")
 
 
 def is_plugin_installed(plugin: str) -> bool:

--- a/src/ape_plugins/utils.py
+++ b/src/ape_plugins/utils.py
@@ -4,9 +4,7 @@ from ape.__modules__ import __modules__
 from ape.exceptions import ConfigError
 
 # Plugins maintained OSS by ApeWorX (and trusted)
-FIRST_CLASS_PLUGINS = set(__modules__)
-
-# TODO: Handle failures with connecting to github (potentially cached on disk?)
+CORE_PLUGINS = {p for p in __modules__ if p != "ape"}
 
 
 def is_plugin_installed(plugin: str) -> bool:


### PR DESCRIPTION
### What I did

Working on dependencies, realizing sharing a GitHub client would be helpful.

This refactor does the following:

1. Creates a GitHub client in `ape.utils` (ideas on a better location for this?)
2. Moves some of the ext missing compiler logic to API, further keeping the `_cli.py` implementation smaller.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
