### PR TITLE
feat: ability to initialize contract objects with an address

### DIFF
--- a/src/ape/__init__.py
+++ b/src/ape/__init__.py
@@ -58,7 +58,7 @@ _converters = _ConversionManager(config, plugin_manager, networks)  # type: igno
 accounts = _AccountManager(config, _converters, plugin_manager, networks)  # type: ignore
 """Manages accounts for the current project. See :class:`ape.managers.accounts.AccountManager`."""
 
-Project = _partial(_ProjectManager, config=config, compilers=compilers)
+Project = _partial(_ProjectManager, config=config, compilers=compilers, networks=networks)
 """User-facing class for instantiating Projects (in addition to the currently
 active ``project``). See :class:`ape.managers.project.ProjectManager`."""
 

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -5,13 +5,7 @@ import click
 
 from ape.exceptions import AccountsError, AliasAlreadyInUseError, SignatureError
 from ape.logging import logger
-from ape.types import (
-    AddressType,
-    ContractType,
-    MessageSignature,
-    SignableMessage,
-    TransactionSignature,
-)
+from ape.types import AddressType, MessageSignature, SignableMessage, TransactionSignature
 from ape.utils import cached_property
 
 from .address import AddressAPI
@@ -137,13 +131,9 @@ class AccountAPI(AddressAPI):
 
         return self.call(txn, send_everything=value is None)
 
-    def deploy(self, contract_type: ContractType, *args, **kwargs) -> ContractInstance:
-        c = ContractContainer(  # type: ignore
-            _provider=self.provider,
-            _contract_type=contract_type,
-        )
+    def deploy(self, contract: ContractContainer, *args, **kwargs) -> ContractInstance:
 
-        txn = c(*args, **kwargs)
+        txn = contract(*args, **kwargs)
         txn.sender = self.address
         receipt = self.call(txn)
 
@@ -151,12 +141,12 @@ class AccountAPI(AddressAPI):
             raise AccountsError(f"'{receipt.txn_hash}' did not create a contract.")
 
         address = click.style(receipt.contract_address, bold=True)
-        logger.success(f"Contract '{contract_type.contractName}' deployed to: {address}")
+        logger.success(f"Contract '{contract._contract_type.contractName}' deployed to: {address}")
 
         return ContractInstance(  # type: ignore
             _provider=self.provider,
             _address=receipt.contract_address,
-            _contract_type=contract_type,
+            _contract_type=contract._contract_type,
         )
 
 

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -141,12 +141,12 @@ class AccountAPI(AddressAPI):
             raise AccountsError(f"'{receipt.txn_hash}' did not create a contract.")
 
         address = click.style(receipt.contract_address, bold=True)
-        logger.success(f"Contract '{contract._contract_type.contractName}' deployed to: {address}")
+        logger.success(f"Contract '{contract.contract_type.contractName}' deployed to: {address}")
 
         return ContractInstance(  # type: ignore
             _provider=self.provider,
             _address=receipt.contract_address,
-            _contract_type=contract._contract_type,
+            _contract_type=contract.contract_type,
         )
 
 

--- a/src/ape/api/contracts.py
+++ b/src/ape/api/contracts.py
@@ -234,8 +234,8 @@ class ContractInstance(AddressAPI):
 
 @dataclass
 class ContractContainer:
-    _provider: ProviderAPI
     _contract_type: ContractType
+    _provider: Optional[ProviderAPI]
 
     def __repr__(self) -> str:
         return f"<{self._contract_type.contractName}>"

--- a/src/ape/api/contracts.py
+++ b/src/ape/api/contracts.py
@@ -234,41 +234,39 @@ class ContractInstance(AddressAPI):
 
 @dataclass
 class ContractContainer:
-    _contract_type: ContractType
+    contract_type: ContractType
     _provider: Optional[ProviderAPI]
+    # _provider is only None when a user is not connected to a provider.
 
     def __repr__(self) -> str:
-        return f"<{self._contract_type.contractName}>"
+        return f"<{self.contract_type.contractName}>"
 
     def at(self, address: str) -> ContractInstance:
         return ContractInstance(  # type: ignore
             _address=address,
             _provider=self._provider,
-            _contract_type=self._contract_type,
+            _contract_type=self.contract_type,
         )
 
     @property
     def _deployment_bytecode(self) -> bytes:
-        if (
-            self._contract_type.deploymentBytecode
-            and self._contract_type.deploymentBytecode.bytecode
-        ):
-            return to_bytes(hexstr=self._contract_type.deploymentBytecode.bytecode)
+        if self.contract_type.deploymentBytecode and self.contract_type.deploymentBytecode.bytecode:
+            return to_bytes(hexstr=self.contract_type.deploymentBytecode.bytecode)
 
         else:
             return b""
 
     @property
     def _runtime_bytecode(self) -> bytes:
-        if self._contract_type.runtimeBytecode and self._contract_type.runtimeBytecode.bytecode:
-            return to_bytes(hexstr=self._contract_type.runtimeBytecode.bytecode)
+        if self.contract_type.runtimeBytecode and self.contract_type.runtimeBytecode.bytecode:
+            return to_bytes(hexstr=self.contract_type.runtimeBytecode.bytecode)
 
         else:
             return b""
 
     def __call__(self, *args, **kwargs) -> TransactionAPI:
         constructor = ContractConstructor(  # type: ignore
-            abi=self._contract_type.constructor,
+            abi=self.contract_type.constructor,
             provider=self._provider,
             deployment_bytecode=self._deployment_bytecode,
         )

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -5,7 +5,9 @@ from typing import Dict, List, Optional
 import requests
 from dataclassy import dataclass
 
+from ape.api.contracts import ContractContainer
 from ape.exceptions import ProjectError
+from ape.managers.networks import NetworkManager
 from ape.types import Checksum, Compiler, ContractType, PackageManifest, Source
 from ape.utils import compute_checksum
 
@@ -18,6 +20,7 @@ class ProjectManager:
     path: Path
     config: ConfigManager
     compilers: CompilerManager
+    networks: NetworkManager
 
     dependencies: Dict[str, PackageManifest] = dict()
 
@@ -209,12 +212,18 @@ class ProjectManager:
 
     def __getattr__(self, attr_name: str):
         contracts = self.load_contracts()
+        contract_type = None
+
         if attr_name in contracts:
-            return contracts[attr_name]
+            contract_type = contracts[attr_name]
         elif attr_name in self.dependencies:
-            return self.dependencies[attr_name]
+            contract_type = self.dependencies[attr_name]  # type: ignore
         else:
             raise AttributeError(f"{self.__class__.__name__} has no attribute '{attr_name}'.")
+
+        return ContractContainer(  # type: ignore
+            _contract_type=contract_type, _provider=self.networks.active_provider
+        )
 
     @property
     def interfaces_folder(self) -> Path:

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -222,7 +222,7 @@ class ProjectManager:
             raise AttributeError(f"{self.__class__.__name__} has no attribute '{attr_name}'.")
 
         return ContractContainer(  # type: ignore
-            _contract_type=contract_type, _provider=self.networks.active_provider
+            contract_type=contract_type, _provider=self.networks.active_provider
         )
 
     @property


### PR DESCRIPTION
### What I did

fixes: #290 

Update the process for retrieving/initializing a  previously deployed contract to be more UX friendly.

### How I did it

Modify  `__getattr__(...)` in `ProjectManager` to return a `ContractContainer` instead of a `ContractType` and refactored `deploy(...)`

### How to verify it

```python
contract = project.Fund("0x274b028b03A250cA03644E6c578D81f019eE1323")
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
