### PR TITLE
docs: document the CLI utilities

### DIFF
--- a/src/ape/cli/arguments.py
+++ b/src/ape/cli/arguments.py
@@ -19,10 +19,22 @@ def _require_non_existing_alias(value):
 
 
 def existing_alias_argument(account_type: Optional[Type[AccountAPI]] = None):
+    """
+    A ``click.argument`` for an existing account alias.
+
+    Args:
+        account_type (type[:class:`~ape.api.accounts.AccountAPI`], optional):
+          If given, limits the type of account the user may choose from.
+    """
+
     return click.argument("alias", type=Alias(account_type=account_type))
 
 
 def non_existing_alias_argument():
+    """
+    A ``click.argument`` for an account alias that does not yet exist in ape.
+    """
+
     return click.argument(
         "alias", callback=lambda ctx, param, value: _require_non_existing_alias(value)
     )
@@ -48,6 +60,14 @@ def _create_contracts_paths(ctx, param, value):
 
 
 def contract_file_paths_argument():
+    """
+    A ``click.argument`` representing contract source file paths.
+    This argument takes 0-to-many values.
+
+    The return type from the callback is a flattened list of
+    source file-paths.
+    """
+
     return click.argument(
         "file_paths",
         nargs=-1,

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -14,7 +14,8 @@ def _get_account_by_type(account_type: Optional[Type[AccountAPI]] = None) -> Lis
 
 
 class Alias(click.Choice):
-    """Wraps ``click.Choice`` to load account aliases for the active project at runtime.
+    """
+    A ``click.Choice`` for loading account aliases for the active project at runtime.
 
     Provide an ``account_type`` to limit the type of account to choose from.
     Defaults to all account types in ``choices()``.
@@ -30,6 +31,13 @@ class Alias(click.Choice):
 
     @property
     def choices(self) -> List[str]:  # type: ignore
+        """
+        The aliases available to choose from.
+
+        Returns:
+            list[str]: A list of account aliases the user may choose from.
+        """
+
         options = _get_account_by_type(self._account_type)
         return [a.alias for a in options if a.alias is not None]
 
@@ -43,6 +51,10 @@ class PromptChoice(click.ParamType):
         self.choices = choices
 
     def print_choices(self):
+        """
+        Echo the choices to the terminal.
+        """
+
         choices = dict(enumerate(self.choices, 0))
         for choice in choices:
             click.echo(f"{choice}. {choices[choice]}")
@@ -70,14 +82,20 @@ def get_user_selected_account(
     account_type: Optional[Type[AccountAPI]] = None, prompt_message: Optional[str] = None
 ) -> AccountAPI:
     """
-    Prompts the user to pick from their accounts
-    and returns that account. Optionally filter the accounts
-    by type.
+    Prompt the user to pick from their accounts and return that account.
+    Use this method if you want to prompt users to select accounts _outside_
+    of CLI options. For CLI options, use
+    :meth:`~ape.cli.options.account_option_that_prompts_when_not_given`.
 
-    Use this method if you want to prompt users to select
-    accounts _outside_ of CLI options. For CLI options,
-    use :meth:`ape.cli.options.account_option_that_prompts_when_not_given`.
+    Args:
+        account_type (type[:class:`~ape.api.accounts.AccountAPI`], optional):
+          If given, the user may only select an account of this type.
+        prompt_message (str, optional): Customize the prompt message.
+
+    Returns:
+        :class:`~ape.api.accounts.AccountAPI`
     """
+
     if account_type and (type(account_type) != type or not issubclass(account_type, AccountAPI)):
         raise AccountsError(f"Cannot return accounts with type '{account_type}'.")
 
@@ -110,6 +128,13 @@ class AccountAliasPromptChoice(PromptChoice):
 
     @property
     def choices(self) -> List[str]:
+        """
+        All the account aliases.
+
+        Returns:
+            list[str]: A list of all the account aliases.
+        """
+
         return [
             a.alias
             for a in _get_account_by_type(self._account_type)
@@ -120,6 +145,7 @@ class AccountAliasPromptChoice(PromptChoice):
         """
         Returns the selected account.
         """
+
         if not self.choices:
             raise AccountsError("No accounts found.")
         elif len(self.choices) == 1:
@@ -133,7 +159,9 @@ class AccountAliasPromptChoice(PromptChoice):
 
 
 class NetworkChoice(click.Choice):
-    """Wraps ``click.Choice`` to provide network choice defaults for the active project."""
+    """
+    A ``click.Choice`` to provide network choice defaults for the active project.
+    """
 
     def __init__(self, case_sensitive=True):
         super().__init__(list(networks.network_choices), case_sensitive)
@@ -143,6 +171,11 @@ class NetworkChoice(click.Choice):
 
 
 class OutputFormat(Enum):
+    """
+    Various output format types to use for outputting data
+    to the user.
+    """
+
     TREE = "TREE"
     YAML = "YAML"
 
@@ -150,8 +183,15 @@ class OutputFormat(Enum):
 def output_format_choice(options: List[OutputFormat] = None) -> Choice:
     """
     Returns a ``click.Choice()`` type for the given options.
-    If
+
+    Args:
+        options (list[:class:`~ape.choices.OutputFormat`], optional):
+          Limit the formats to accept. Defaults to allowing all formats.
+
+    Returns:
+        :class:`click.Choice`
     """
+
     options = options or [o for o in OutputFormat]
 
     # Uses `str` form of enum for CLI choices.

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -144,6 +144,9 @@ class AccountAliasPromptChoice(PromptChoice):
     def get_user_selected_account(self) -> AccountAPI:
         """
         Returns the selected account.
+
+        Returns:
+            :class:`~ape.apo.accounts.AccountAPI`
         """
 
         if not self.choices:

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -172,8 +172,9 @@ class NetworkChoice(click.Choice):
 
 class OutputFormat(Enum):
     """
-    Various output format types to use for outputting data
-    to the user.
+    An enum representing output formats, such as ``TREE`` or ``YAML``.
+    Use this to select a subset of common output formats to use
+    when creating a :meth:`~ape.cli.choices.output_format_choice`.
     """
 
     TREE = "TREE"

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -146,7 +146,7 @@ class AccountAliasPromptChoice(PromptChoice):
         Returns the selected account.
 
         Returns:
-            :class:`~ape.apo.accounts.AccountAPI`
+            :class:`~ape.api.accounts.AccountAPI`
         """
 
         if not self.choices:

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -178,7 +178,10 @@ class OutputFormat(Enum):
     """
 
     TREE = "TREE"
+    """A rich text tree view of the data."""
+
     YAML = "YAML"
+    """A standard .yaml format of the data."""
 
 
 def output_format_choice(options: List[OutputFormat] = None) -> Choice:

--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -7,7 +7,8 @@ from ape import networks
 
 
 class NetworkBoundCommand(click.Command):
-    """A command that uses the network option.
+    """
+    A command that uses the :meth:`~ape.cli.options.network_option`.
     It will automatically set the network for the duration of the command execution.
     """
 

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -18,7 +18,7 @@ from ape.types import ContractType
 
 class ApeCliContextObject:
     """
-    A ``click`` context object class. Use via ``@ape_cli_context()``.
+    A ``click`` context object class. Use via :meth:`~ape.cli.options.ape_cli_context()`.
     It provides common CLI utilities for ape, such as logging or
     access to the managers.
     """

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -12,20 +12,31 @@ from ape.cli.choices import (
 from ape.cli.utils import Abort
 from ape.exceptions import ContractError
 from ape.logging import LogLevel, logger
+from ape.managers.project import ProjectManager
 from ape.types import ContractType
 
 
 class ApeCliContextObject:
-    """A class that can be auto-imported into a plugin ``click.command()``
-    via ``@ape_cli_context()``. It can help do common CLI tasks such as log
-    messages to the user or abort execution."""
+    """
+    A ``click`` context object class. Use via ``@ape_cli_context()``.
+    It provides common CLI utilities for ape, such as logging or
+    access to the managers.
+    """
 
     def __init__(self):
         self.logger = logger
         self._project = None
 
     @property
-    def project(self):
+    def project(self) -> ProjectManager:
+        """
+        A class representing the project that is active at runtime.
+        (This is the same object as from ``from ape import project``).
+
+        Returns:
+            :class:`~ape.managers.project.ProjectManager`
+        """
+
         if not self._project:
             from ape import project
 
@@ -35,6 +46,15 @@ class ApeCliContextObject:
 
     @staticmethod
     def abort(msg: str, base_error: Exception = None):
+        """
+        End execution of the current command invocation.
+
+        Args:
+            msg (str): A message to output to the terminal.
+            base_error (Exception, optional): Optionally provide
+              an error to preserve the exception stack.
+        """
+
         if base_error:
             logger.error(msg)
             raise Abort(msg) from base_error
@@ -73,6 +93,12 @@ def verbosity_option(cli_logger):
 
 
 def ape_cli_context():
+    """
+    A ``click`` context object with helpful utilities.
+    Use in your commands to get access to common utility features,
+    such as logging or accessing managers.
+    """
+
     def decorator(f):
         f = verbosity_option(logger)(f)
         f = click.make_pass_decorator(ApeCliContextObject, ensure=True)(f)
@@ -82,6 +108,15 @@ def ape_cli_context():
 
 
 def network_option(default: str = networks.default_ecosystem.name):
+    """
+    A ``click.option`` for specifying a network.
+
+    Args:
+        default (str): Optionally, change which network to
+          use as the default. Defaults to how ``ape`` normally
+          selects a default network.
+    """
+
     return click.option(
         "--network",
         type=NetworkChoice(case_sensitive=False),
@@ -93,6 +128,13 @@ def network_option(default: str = networks.default_ecosystem.name):
 
 
 def skip_confirmation_option(help=""):
+    """
+    A ``click.option`` for skipping confirmation (``--yes``).
+
+    Args:
+        help (str): CLI option help text. Defaults to ``""``.
+    """
+
     return click.option(
         "-y",
         "--yes",
@@ -106,6 +148,7 @@ def skip_confirmation_option(help=""):
 def _account_callback(ctx, param, value):
     if param and not value:
         return param.type.get_user_selected_account()
+
     return value
 
 
@@ -114,6 +157,7 @@ def account_option_that_prompts_when_not_given():
     Accepts either the account alias or the account number.
     If not given anything, it will prompt the user to select an account.
     """
+
     return click.option(
         "--account",
         type=AccountAliasPromptChoice(),
@@ -146,6 +190,7 @@ def contract_option(help=None, required=False, multiple=False):
     Contract(s) from the current project.
     If you pass ``multiple=True``, you will get a list of contract types from the callback.
     """
+
     help = help or "The name of a contract in the current project"
     return click.option(
         "--contract", help=help, required=required, callback=_load_contracts, multiple=multiple
@@ -153,6 +198,13 @@ def contract_option(help=None, required=False, multiple=False):
 
 
 def output_format_option(default: OutputFormat = OutputFormat.TREE):
+    """
+    A ``click.option`` for specifying a format to use when outputting data.
+
+    Args:
+        default (:class:`~ape.cli.choices.OutputFormat`): Defaults to ``TREE`` format.
+    """
+
     return click.option(
         "--format",
         "output_format",

--- a/src/ape/cli/utils.py
+++ b/src/ape/cli/utils.py
@@ -4,7 +4,11 @@ from ape.logging import logger
 
 
 class Abort(click.ClickException):
-    """Wrapper around a CLI exception"""
+    """
+    A wrapper around a CLI exception. When you raise this error,
+    the error is nicely printed to the terminal. This is
+    useful for all user-facing errors.
+    """
 
     def __init__(self, message):
         if not message.endswith("."):
@@ -13,5 +17,8 @@ class Abort(click.ClickException):
         super().__init__(message)
 
     def show(self, file=None):
-        """Override default ``show`` to print CLI errors in red text."""
+        """
+        Override default ``show`` to print CLI errors in red text.
+        """
+
         logger.error(self.format_message())


### PR DESCRIPTION
### What I did

Add missing doc strs to the `ape.cli` namespace.

### How I did it

Lots of revising.

### How to verify it

Lots of reading (audience for these particular docs would be plugin writers probably).

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
