### PR TITLE
chore: move contracts into their own folder

### DIFF
--- a/src/ape/__init__.py
+++ b/src/ape/__init__.py
@@ -6,7 +6,7 @@ import sys as _sys
 from functools import partial as _partial
 from pathlib import Path as _Path
 
-from .api.contracts import _Contract
+from .contracts import _Contract
 from .managers.accounts import AccountManager as _AccountManager
 from .managers.compilers import CompilerManager as _CompilerManager
 from .managers.config import ConfigManager as _ConfigManager
@@ -57,7 +57,7 @@ project = Project(config.PROJECT_FOLDER)
 """The currently active project. See :class:`ape.managers.project.ProjectManager`."""
 
 Contract = _partial(_Contract, networks=networks, converters=_converters)
-"""User-facing class for instantiating contracts. See :class:`ape.api.contracts._Contract`."""
+"""User-facing class for instantiating contracts. See :class:`ape.contracts.base._Contract`."""
 
 convert = _converters.convert
 """Conversion utility function. See :class:`ape.managers.converters.ConversionManager`."""

--- a/src/ape/api/__init__.py
+++ b/src/ape/api/__init__.py
@@ -2,7 +2,6 @@ from .accounts import AccountAPI, AccountContainerAPI, TestAccountAPI, TestAccou
 from .address import Address, AddressAPI
 from .compiler import CompilerAPI
 from .config import ConfigDict, ConfigEnum, ConfigItem
-from .contracts import ContractInstance, ContractLog
 from .convert import ConverterAPI
 from .explorers import ExplorerAPI
 from .networks import EcosystemAPI, NetworkAPI, ProviderContextManager, create_network_type
@@ -32,8 +31,6 @@ __all__ = [
     "ConfigDict",
     "ConfigEnum",
     "ConfigItem",
-    "ContractInstance",
-    "ContractLog",
     "ConverterAPI",
     "create_network_type",
     "EcosystemAPI",

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -10,10 +10,10 @@ from ape.utils import cached_property
 
 from .address import AddressAPI
 from .base import abstractdataclass, abstractmethod
-from .contracts import ContractContainer, ContractInstance
 from .providers import ReceiptAPI, TransactionAPI, TransactionType
 
 if TYPE_CHECKING:
+    from ape.contracts import ContractContainer, ContractInstance
     from ape.managers.config import ConfigManager
 
 
@@ -136,7 +136,7 @@ class AccountAPI(AddressAPI):
 
         return self.call(txn, send_everything=value is None)
 
-    def deploy(self, contract: ContractContainer, *args, **kwargs) -> ContractInstance:
+    def deploy(self, contract: "ContractContainer", *args, **kwargs) -> "ContractInstance":
 
         txn = contract(*args, **kwargs)
         txn.sender = self.address

--- a/src/ape/contracts/__init__.py
+++ b/src/ape/contracts/__init__.py
@@ -1,0 +1,8 @@
+from .base import ContractContainer, ContractInstance, ContractLog, _Contract
+
+__all__ = [
+    "_Contract",
+    "ContractContainer",
+    "ContractInstance",
+    "ContractLog",
+]

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -2,13 +2,12 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from eth_utils import to_bytes
 
+from ape.api.address import Address, AddressAPI
+from ape.api.base import dataclass
+from ape.api.providers import ProviderAPI, ReceiptAPI, TransactionAPI
 from ape.exceptions import ArgumentsLengthError, ContractDeployError, TransactionError
 from ape.logging import logger
 from ape.types import ABI, AddressType, ContractType
-
-from .address import Address, AddressAPI
-from .base import dataclass
-from .providers import ProviderAPI, ReceiptAPI, TransactionAPI
 
 if TYPE_CHECKING:
     from ape.managers.converters import ConversionManager

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -5,7 +5,7 @@ from typing import Collection, Dict, List, Optional, Union
 import requests
 from dataclassy import dataclass
 
-from ape.api.contracts import ContractContainer
+from ape.contracts import ContractContainer
 from ape.exceptions import ProjectError
 from ape.managers.networks import NetworkManager
 from ape.types import Checksum, Compiler, ContractType, PackageManifest, Source

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -17,13 +17,13 @@ from ape.api import (
     BlockConsensusAPI,
     BlockGasAPI,
     ConfigItem,
-    ContractLog,
     EcosystemAPI,
     ReceiptAPI,
     TransactionAPI,
     TransactionStatusEnum,
     TransactionType,
 )
+from ape.contracts import ContractLog
 from ape.exceptions import DecodingError, OutOfGasError, SignatureError, TransactionError
 from ape.types import ABI, AddressType
 


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #298

Moved `contracts.py` out of the `api` folder and into their own folder `ape.contracts`.

### How I did it

Moved file to new `contracts` folder and refactored imports to work across the repo.

### How to verify it

Look at the new file structure.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
