### PR TITLE
feat: add string address encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ version.py
 
 # Ape stuff
 .build/
+
+# VS Code
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,3 @@ version.py
 
 # Ape stuff
 .build/
-
-# VS Code
-.vscode

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -13,6 +13,23 @@ if TYPE_CHECKING:
     from ape.managers.networks import NetworkManager
 
 
+def _encode_address_args(*args):
+    """
+    Helper for encoding Ape AddressAPI to underlying address for ABI use
+    """
+    return [arg.address if isinstance(arg, AddressAPI) else arg for arg in args]
+
+
+def _encode_address_kwargs(**kwargs):
+    """
+    Helper for encoding Ape AddressAPI to underlying address for ABI use
+    """
+    return {
+        key: value.address if isinstance(value, AddressAPI) else value
+        for key, value in kwargs.items()
+    }
+
+
 @dataclass
 class ContractConstructor:
     deployment_bytecode: bytes
@@ -28,20 +45,20 @@ class ContractConstructor:
 
     def encode(self, *args, **kwargs) -> TransactionAPI:
         return self.provider.network.ecosystem.encode_deployment(
-            self.deployment_bytecode, self.abi, *args, **kwargs
+            self.deployment_bytecode,
+            self.abi,
+            *_encode_address_args(*args),
+            **_encode_address_kwargs(**kwargs),
         )
 
     def __call__(self, *args, **kwargs) -> ReceiptAPI:
         if "sender" in kwargs:
             sender = kwargs["sender"]
-            kwargs["sender"] = sender.address
-
             txn = self.encode(*args, **kwargs)
             return sender.call(txn)
 
-        else:
-            txn = self.encode(*args, **kwargs)
-            return self.provider.send_transaction(txn)
+        txn = self.encode(*args, **kwargs)
+        return self.provider.send_transaction(txn)
 
 
 @dataclass
@@ -55,15 +72,12 @@ class ContractCall:
 
     def encode(self, *args, **kwargs) -> TransactionAPI:
         return self.provider.network.ecosystem.encode_transaction(
-            self.address, self.abi, *args, **kwargs
+            self.address, self.abi, *_encode_address_args(*args), **_encode_address_kwargs(**kwargs)
         )
 
     def __call__(self, *args, **kwargs) -> Any:
         txn = self.encode(*args, **kwargs)
         txn.chain_id = self.provider.network.chain_id
-
-        if "sender" in kwargs and not isinstance(kwargs["sender"], str):
-            txn.sender = kwargs["sender"].address
 
         raw_output = self.provider.send_call(txn)
         tuple_output = self.provider.network.ecosystem.decode_calldata(  # type: ignore
@@ -75,9 +89,8 @@ class ContractCall:
         if len(tuple_output) < 2:
             return tuple_output[0] if len(tuple_output) == 1 else None
 
-        else:
-            # TODO: Handle struct output
-            return tuple_output
+        # TODO: Handle struct output
+        return tuple_output
 
 
 @dataclass
@@ -122,20 +135,16 @@ class ContractTransaction:
 
     def encode(self, *args, **kwargs) -> TransactionAPI:
         return self.provider.network.ecosystem.encode_transaction(
-            self.address, self.abi, *args, **kwargs
+            self.address, self.abi, *_encode_address_args(*args), **_encode_address_kwargs(**kwargs)
         )
 
     def __call__(self, *args, **kwargs) -> ReceiptAPI:
-
         if "sender" in kwargs:
             sender = kwargs["sender"]
-            kwargs["sender"] = sender.address
-
             txn = self.encode(*args, **kwargs)
             return sender.call(txn)
 
-        else:
-            raise TransactionError(message="Must specify a `sender`.")
+        raise TransactionError(message="Must specify a `sender`.")
 
 
 @dataclass

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -14,16 +14,12 @@ if TYPE_CHECKING:
 
 
 def _encode_address_args(*args):
-    """
-    Helper for encoding Ape AddressAPI to underlying address for ABI use
-    """
+    # Convert higher level address types to str
     return [arg.address if isinstance(arg, AddressAPI) else arg for arg in args]
 
 
 def _encode_address_kwargs(**kwargs):
-    """
-    Helper for encoding Ape AddressAPI to underlying address for ABI use
-    """
+    # Convert higher level address types to str
     return {
         key: value.address if isinstance(value, AddressAPI) else value
         for key, value in kwargs.items()


### PR DESCRIPTION
### What I did

fixes: #310
Update logic to encode `AddressAPI` objects as their underlying address value [str]

### How I did it

Private helper method called in several `Contract encode` methods

### How to verify it

Old behavior:
```python
contract.mint(receiver.address, 0, sender=owner)
```

New behavior:
```python
contract.mint(receiver, 0, sender=owner)
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
