### PR TITLE
docs: add missing method documentation for the types module 

### DIFF
--- a/docs/methoddocs/types.md
+++ b/docs/methoddocs/types.md
@@ -1,7 +1,33 @@
 # ape.types
 
+## Contracts
+
+```{eval-rst}
+.. automodule:: ape.types.contract
+    :members:
+    :show-inheritance:
+```
+
+## Manifest
+
+```{eval-rst}
+.. automodule:: ape.types.manifest
+    :members:
+    :show-inheritance:
+```
+
+
+## Miscellaneous
+
 ```{eval-rst}
 .. automodule:: ape.types
+    :members: BlockID, AddressType
+```
+
+## Signatures
+
+```{eval-rst}
+.. automodule:: ape.types.signatures
     :members:
     :show-inheritance:
 ```

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Union
 
-from eth_typing import ChecksumAddress as AddressType
+from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
 
 from .contract import ABI, Bytecode, Checksum, Compiler, ContractType, Source
@@ -17,9 +17,12 @@ else:
 
 BlockID = Union[str, int, HexBytes, Literal["earliest", "latest", "pending"]]
 """
-An ID that can match a block, such as the literals 'earliest', 'latest', or 'pending'
+An ID that can match a block, such as the literals ``"earliest"``, ``"latest"``, or ``"pending"``
 as well as a block number or hash (HexBytes).
 """
+
+AddressType = ChecksumAddress
+"""A type representing a checksummed address."""
 
 __all__ = [
     "ABI",

--- a/src/ape/types/contract.py
+++ b/src/ape/types/contract.py
@@ -353,6 +353,9 @@ class Source(SerializableType):
     :meth:`~ape.types.contract.Source.compute_checksum`.
     """
 
+    urls: List[str] = []
+    """The URLs by which to obtain the source, such as IPFS URLs."""
+
     content: Optional[str] = None
     # TODO This was probably done for solidity, needs files cached to disk for compiling
     # If processing a local project, code already exists, so no issue

--- a/src/ape/types/contract.py
+++ b/src/ape/types/contract.py
@@ -393,7 +393,7 @@ class Source(SerializableType):
 
     checksum: Optional[Checksum] = None
     """
-    The checksum of the source. Set by calling method
+    The checksum of the source. Set by calling the method
     :meth:`~ape.types.contract.Source.compute_checksum`.
     """
 

--- a/src/ape/types/contract.py
+++ b/src/ape/types/contract.py
@@ -103,8 +103,8 @@ class ABIType(SerializableType):
     @property
     def canonical_type(self) -> str:
         """
-        The lower-level type. For example, the type may be ``uint``
-        but at compile-time, gets replaces with ``uint256``.
+        The lower-level type. For example, the type may be ``uint`` in the code,
+        but at compile-time, it gets replaced with ``uint256``.
 
         Returns:
             str
@@ -125,13 +125,13 @@ class ABI(SerializableType):
     name: str = ""
     inputs: List[ABIType] = []
     """
-    A list of :class:`~ape.types.contract.ABIType` representing arguments
+    A list of :class:`~ape.types.contract.ABIType` instances representing arguments
     to the method.
     """
 
     outputs: List[ABIType] = []
     """
-    A list of :class:`~ape.types.contract.ABIType` representing return values
+    A list of :class:`~ape.types.contract.ABIType` instances representing return values
     from the method.
     """
 
@@ -279,7 +279,7 @@ class ContractType(FileMixin, SerializableType):
         """
         The fallback method of the contract, if it has one. A fallback method
         is external, has no name, arguments, or return value, and gets invoked
-        the user attempts to call a method that does not exist.
+        when the user attempts to call a method that does not exist.
         """
 
         for abi in self.abi:

--- a/src/ape/types/contract.py
+++ b/src/ape/types/contract.py
@@ -117,10 +117,10 @@ class ABIType(SerializableType):
     name: str = ""
     indexed: Optional[bool] = None
     type: Union[str, "ABIType"]
-    """The type, as defined in the contract, such as ``int``."""
+    """The type, as defined in the contract, such as ``int`` or ``bool``."""
 
     internalType: Optional[str] = None
-    """The real type used in the byte-code, such as ``uint256``."""
+    """The real type used in the byte-code, such as ``uint256`` or ``bool``."""
 
     @property
     def canonical_type(self) -> str:

--- a/src/ape/types/contract.py
+++ b/src/ape/types/contract.py
@@ -45,17 +45,6 @@ class Bytecode(SerializableType):
 
     @classmethod
     def from_dict(cls, params: Dict):
-        """
-        Create this class from a dictionary of its properties.
-        The dictionary keys must be the same name as the properties.
-
-        Args:
-            params (dict): A dictionary of properties.
-
-        Returns:
-            :class:`~ape.types.contract.Bytecode`
-        """
-
         params = deepcopy(params)
         update_list_params(params, "linkReferences", LinkReference)
         update_list_params(params, "linkDependencies", LinkDependency)
@@ -68,7 +57,7 @@ class ContractInstance(SerializableType):
     """
 
     contractType: str
-    """The name of the type of the smart-contract."""
+    """The name of the type of smart-contract."""
 
     address: str
     """The address of the smart-contract."""
@@ -84,17 +73,6 @@ class ContractInstance(SerializableType):
 
     @classmethod
     def from_dict(cls, params: Dict):
-        """
-        Create this class from a dictionary of its properties.
-        The dictionary keys must be the same name as the properties.
-
-        Args:
-            params (dict): A dictionary of properties.
-
-        Returns:
-            :class:`~ape.types.contract.Bytecode`
-        """
-
         params = deepcopy(params)
         update_params(params, "runtimeBytecode", Bytecode)
         return cls(**params)  # type: ignore
@@ -239,17 +217,6 @@ class ABI(SerializableType):
 
     @classmethod
     def from_dict(cls, params: Dict):
-        """
-        Create this class from a dictionary of its properties.
-        The dictionary keys must be the same name as the properties.
-
-        Args:
-            params (dict): A dictionary of properties.
-
-        Returns:
-            :class:`~ape.types.contract.ABI`
-        """
-
         params = deepcopy(params)
 
         # Handle ABI v1 fields (convert to ABI v2)
@@ -356,17 +323,6 @@ class ContractType(FileMixin, SerializableType):
 
     @classmethod
     def from_dict(cls, params: Dict):
-        """
-        Create this class from a dictionary of its properties.
-        The dictionary keys must be the same name as the properties.
-
-        Args:
-            params (dict): A dictionary of properties.
-
-        Returns:
-            :class:`~ape.types.contract.ContractType`
-        """
-
         params = deepcopy(params)
         update_list_params(params, "abi", ABI)
         update_params(params, "deploymentBytecode", Bytecode)
@@ -441,17 +397,6 @@ class Source(SerializableType):
 
     @classmethod
     def from_dict(cls, params: Dict):
-        """
-        Create this class from a dictionary of its properties.
-        The dictionary keys must be the same name as the properties.
-
-        Args:
-            params (dict): A dictionary of properties.
-
-        Returns:
-            :class:`~ape.types.contract.Checksum`
-        """
-
         params = deepcopy(params)
         update_params(params, "checksum", Checksum)
         return cls(**params)  # type: ignore

--- a/src/ape/types/contract.py
+++ b/src/ape/types/contract.py
@@ -44,7 +44,7 @@ class Bytecode(SerializableType):
         return self_str
 
     @classmethod
-    def from_dict(cls, params: Dict) -> "Bytecode":
+    def from_dict(cls, params: Dict):
         """
         Create this class from a dictionary of its properties.
         The dictionary keys must be the same name as the properties.
@@ -238,7 +238,7 @@ class ABI(SerializableType):
         return self.stateMutability not in ("view", "pure")
 
     @classmethod
-    def from_dict(cls, params: Dict) -> "ABI":
+    def from_dict(cls, params: Dict):
         """
         Create this class from a dictionary of its properties.
         The dictionary keys must be the same name as the properties.
@@ -355,7 +355,7 @@ class ContractType(FileMixin, SerializableType):
         return [abi for abi in self.abi if abi.type == "function" and abi.is_stateful]
 
     @classmethod
-    def from_dict(cls, params: Dict) -> "ContractType":
+    def from_dict(cls, params: Dict):
         """
         Create this class from a dictionary of its properties.
         The dictionary keys must be the same name as the properties.
@@ -440,7 +440,7 @@ class Source(SerializableType):
         )
 
     @classmethod
-    def from_dict(cls, params: Dict) -> "Checksum":
+    def from_dict(cls, params: Dict):
         """
         Create this class from a dictionary of its properties.
         The dictionary keys must be the same name as the properties.

--- a/src/ape/types/contract.py
+++ b/src/ape/types/contract.py
@@ -403,7 +403,7 @@ class Source(SerializableType):
     # If processing remote project, cache them in ape project data folder
     installPath: Optional[str] = None
     type: Optional[str] = None
-    """The type of the source, such as ``"interface"``."""
+    """The type of source, such as ``"interface"``."""
 
     license: Optional[str] = None
     """The license of the source, if one exists, such as the MIT license."""

--- a/src/ape/types/contract.py
+++ b/src/ape/types/contract.py
@@ -22,7 +22,13 @@ class LinkReference(SerializableType):
 
 
 class Bytecode(SerializableType):
+    """
+    Serializable data representing the byte-code of a smart-contract.
+    """
+
     bytecode: Optional[str] = None
+    """The raw byte-code ``str``."""
+
     linkReferences: Optional[List[LinkReference]] = None
     linkDependencies: Optional[List[LinkDependency]] = None
 
@@ -38,7 +44,18 @@ class Bytecode(SerializableType):
         return self_str
 
     @classmethod
-    def from_dict(cls, params: Dict):
+    def from_dict(cls, params: Dict) -> "Bytecode":
+        """
+        Create this class from a dictionary of its properties.
+        The dictionary keys must be the same name as the properties.
+
+        Args:
+            params (dict): A dictionary of properties.
+
+        Returns:
+            :class:`~ape.types.contract.Bytecode`
+        """
+
         params = deepcopy(params)
         update_list_params(params, "linkReferences", LinkReference)
         update_list_params(params, "linkDependencies", LinkDependency)
@@ -46,34 +63,75 @@ class Bytecode(SerializableType):
 
 
 class ContractInstance(SerializableType):
+    """
+    Serializable data representing a contract instance.
+    """
+
     contractType: str
+    """The name of the type of the smart-contract."""
+
     address: str
+    """The address of the smart-contract."""
+
     transaction: Optional[str] = None
+    """The deployment transaction-hash for the smart-contract."""
+
     block: Optional[str] = None
+    """The block containing the smart-contract deployment."""
+
     runtimeBytecode: Optional[Bytecode] = None
+    """The :class:`~ape.types.contract.Bytecode` of the smart-contract."""
 
     @classmethod
     def from_dict(cls, params: Dict):
+        """
+        Create this class from a dictionary of its properties.
+        The dictionary keys must be the same name as the properties.
+
+        Args:
+            params (dict): A dictionary of properties.
+
+        Returns:
+            :class:`~ape.types.contract.Bytecode`
+        """
+
         params = deepcopy(params)
         update_params(params, "runtimeBytecode", Bytecode)
         return cls(**params)  # type: ignore
 
 
 class Compiler(SerializableType):
+    """
+    Serializable data representing a compiler.
+    """
+
     name: str
     version: str
+    """The compiler version."""
+
     settings: Optional[str] = None
     contractTypes: Optional[List[str]] = None
 
 
 class ABIType(SerializableType):
-    name: str = ""  # NOTE: Tuples don't have names by default
+    name: str = ""
     indexed: Optional[bool] = None
     type: Union[str, "ABIType"]
+    """The type, as defined in the contract, such as ``int``."""
+
     internalType: Optional[str] = None
+    """The real type used in the byte-code, such as ``uint256``."""
 
     @property
     def canonical_type(self) -> str:
+        """
+        The lower-level type. For example, the type may be ``uint``
+        but at compile-time, gets replaces with ``uint256``.
+
+        Returns:
+            str
+        """
+
         if isinstance(self.type, str):
             return self.type
 
@@ -82,9 +140,23 @@ class ABIType(SerializableType):
 
 
 class ABI(SerializableType):
+    """
+    The "Application Binary Interface" as a serializable data-structure.
+    """
+
     name: str = ""
     inputs: List[ABIType] = []
+    """
+    A list of :class:`~ape.types.contract.ABIType` representing arguments
+    to the method.
+    """
+
     outputs: List[ABIType] = []
+    """
+    A list of :class:`~ape.types.contract.ABIType` representing return values
+    from the method.
+    """
+
     # ABI v2 Field
     # NOTE: Only functions have this field
     stateMutability: Optional[str] = None
@@ -94,12 +166,16 @@ class ABI(SerializableType):
     #       Would parse based on value of type here, so some indirection required
     #       Might make most sense to add to ``ContractType`` as a serde extension
     type: str
+    """The type of the ABI, such as ``"function"`` or ``"event"``."""
 
     @property
     def signature(self) -> str:
         """
         String representing the function/event signature, which includes the arg names and types,
-        and output names (if any) and type(s)
+        and output names (if any) and type(s).
+
+        Returns:
+            str
         """
         name = self.name if (self.type == "function" or self.type == "event") else self.type
 
@@ -127,7 +203,10 @@ class ABI(SerializableType):
     @property
     def selector(self) -> str:
         """
-        String representing the function selector, used to compute ``method_id`` and ``event_id``.
+        A string representing the function selector, used to compute ``method_id`` and ``event_id``.
+
+        Returns:
+            str
         """
         name = self.name if (self.type == "function" or self.type == "event") else self.type
         input_names = ",".join(i.canonical_type for i in self.inputs)
@@ -135,18 +214,42 @@ class ABI(SerializableType):
 
     @property
     def is_event(self) -> bool:
+        """
+        ``True`` when this ABI refers to an event.
+        """
+
         return self.anonymous is not None
 
     @property
     def is_payable(self) -> bool:
+        """
+        ``True`` when this ABI refers to a payable function.
+        """
+
         return self.stateMutability == "payable"
 
     @property
     def is_stateful(self) -> bool:
+        """
+        ``True`` when this ABI refers to a function that may alter the state
+        of the contract, such as updating a list.
+        """
+
         return self.stateMutability not in ("view", "pure")
 
     @classmethod
-    def from_dict(cls, params: Dict):
+    def from_dict(cls, params: Dict) -> "ABI":
+        """
+        Create this class from a dictionary of its properties.
+        The dictionary keys must be the same name as the properties.
+
+        Args:
+            params (dict): A dictionary of properties.
+
+        Returns:
+            :class:`~ape.types.contract.ABI`
+        """
+
         params = deepcopy(params)
 
         # Handle ABI v1 fields (convert to ABI v2)
@@ -172,6 +275,12 @@ class ABI(SerializableType):
 
 
 class ContractType(FileMixin, SerializableType):
+    """
+    A serializable type representing the type of a contract.
+    For example, if you define your contract as ``contract MyContract`` (in Solidity),
+    then ``MyContract`` would be the type.
+    """
+
     _keep_fields_: Set[str] = {"abi"}
     _skip_fields_: Set[str] = {"contractName"}
     contractName: str
@@ -185,6 +294,13 @@ class ContractType(FileMixin, SerializableType):
 
     @property
     def constructor(self) -> Optional[ABI]:
+        """
+        The constructor of the contract, if it has one. For example,
+        your smart-contract (in Solidity) may define a ``constructor() public {}``.
+        This property contains information about the parameters needed to initialize
+        a contract.
+        """
+
         for abi in self.abi:
             if abi.type == "constructor":
                 return abi
@@ -193,6 +309,12 @@ class ContractType(FileMixin, SerializableType):
 
     @property
     def fallback(self) -> Optional[ABI]:
+        """
+        The fallback method of the contract, if it has one. A fallback method
+        is external, has no name, arguments, or return value, and gets invoked
+        the user attempts to call a method that does not exist.
+        """
+
         for abi in self.abi:
             if abi.type == "fallback":
                 return abi
@@ -201,18 +323,50 @@ class ContractType(FileMixin, SerializableType):
 
     @property
     def events(self) -> List[ABI]:
+        """
+        The events defined in a smart contract.
+
+        Returns:
+            list[:class:`~ape.types.contract.ABI`]
+        """
+
         return [abi for abi in self.abi if abi.type == "event"]
 
     @property
     def calls(self) -> List[ABI]:
+        """
+        The call-methods (read-only method, non-payable methods) defined in a smart contract.
+
+        Returns:
+            list[:class:`~ape.types.contract.ABI`]
+        """
+
         return [abi for abi in self.abi if abi.type == "function" and not abi.is_stateful]
 
     @property
     def transactions(self) -> List[ABI]:
+        """
+        The transaction-methods (stateful or payable methods) defined in a smart contract.
+
+        Returns:
+            list[:class:`~ape.types.contract.ABI`]
+        """
+
         return [abi for abi in self.abi if abi.type == "function" and abi.is_stateful]
 
     @classmethod
-    def from_dict(cls, params: Dict):
+    def from_dict(cls, params: Dict) -> "ContractType":
+        """
+        Create this class from a dictionary of its properties.
+        The dictionary keys must be the same name as the properties.
+
+        Args:
+            params (dict): A dictionary of properties.
+
+        Returns:
+            :class:`~ape.types.contract.ContractType`
+        """
+
         params = deepcopy(params)
         update_list_params(params, "abi", ABI)
         update_params(params, "deploymentBytecode", Bytecode)
@@ -221,23 +375,40 @@ class ContractType(FileMixin, SerializableType):
 
 
 class Checksum(SerializableType):
+    """
+    A serializable type representing a checksum.
+    """
+
     algorithm: str
+    """The algorithm used to compute the checksum, such as ``"md5"``."""
+
     hash: str
+    """The hash ``str``."""
 
 
 class Source(SerializableType):
+    """
+    A serializable type representing source material.
+    """
+
     checksum: Optional[Checksum] = None
-    urls: List[str] = []
+    """
+    The checksum of the source. Set by calling method
+    :meth:`~ape.types.contract.Source.compute_checksum`.
+    """
+
     content: Optional[str] = None
     # TODO This was probably done for solidity, needs files cached to disk for compiling
     # If processing a local project, code already exists, so no issue
     # If processing remote project, cache them in ape project data folder
     installPath: Optional[str] = None
     type: Optional[str] = None
+    """The type of the source, such as ``"interface"``."""
+
     license: Optional[str] = None
+    """The license of the source, if one exists, such as the MIT license."""
 
     def load_content(self):
-        """Loads resource at ``urls`` into ``content``."""
         if len(self.urls) == 0:
             return
 
@@ -248,6 +419,14 @@ class Source(SerializableType):
         """
         Compute the checksum if ``content`` exists but ``checksum`` doesn't
         exist yet. Or compute the checksum regardless if ``force`` is ``True``.
+
+        Raises:
+            ValueError: When the content is not yet loaded.
+
+        Args:
+            algorithm (str, optional): The algorithm to use when computing the checksum.
+              Defaults to ``"md5"``.
+            force (bool, optional): Set to ``True`` to force a re-check. Defaults to ``False``.
         """
         if self.checksum and not force:
             return  # skip recalculating
@@ -261,7 +440,18 @@ class Source(SerializableType):
         )
 
     @classmethod
-    def from_dict(cls, params: Dict):
+    def from_dict(cls, params: Dict) -> "Checksum":
+        """
+        Create this class from a dictionary of its properties.
+        The dictionary keys must be the same name as the properties.
+
+        Args:
+            params (dict): A dictionary of properties.
+
+        Returns:
+            :class:`~ape.types.contract.Checksum`
+        """
+
         params = deepcopy(params)
         update_params(params, "checksum", Checksum)
         return cls(**params)  # type: ignore

--- a/src/ape/types/manifest.py
+++ b/src/ape/types/manifest.py
@@ -62,7 +62,7 @@ class PackageManifest(FileMixin, SerializableType):
             raise AttributeError(f"{self.__class__.__name__} has no attribute '{attr_name}'.")
 
     @classmethod
-    def from_dict(cls, params: Dict) -> "PackageManifest":
+    def from_dict(cls, params: Dict):
         """
         Create this class from a dictionary of its properties.
         The dictionary keys must be the same name as the properties.

--- a/src/ape/types/manifest.py
+++ b/src/ape/types/manifest.py
@@ -20,6 +20,13 @@ class PackageMeta(SerializableType):
 
 
 class PackageManifest(FileMixin, SerializableType):
+    """
+    Content referring to a complete smart-contract package.
+    The manifest contains everything needed to "share" a package.
+    Use manifests to publish your project as well as use other projects locally,
+    whether as dependencies or just in scripts.
+    """
+
     # NOTE: Must not override this key
     manifest: str = "ethpm/3"
     # NOTE: ``name`` and ``version`` should appear together
@@ -55,7 +62,18 @@ class PackageManifest(FileMixin, SerializableType):
             raise AttributeError(f"{self.__class__.__name__} has no attribute '{attr_name}'.")
 
     @classmethod
-    def from_dict(cls, params: Dict):
+    def from_dict(cls, params: Dict) -> "PackageManifest":
+        """
+        Create this class from a dictionary of its properties.
+        The dictionary keys must be the same name as the properties.
+
+        Args:
+            params (dict): A dictionary of properties.
+
+        Returns:
+            :class:`~ape.types.manifest.PackageManifest`
+        """
+
         params = deepcopy(params)
         update_params(params, "meta", PackageMeta)
         update_dict_params(params, "sources", Source)

--- a/src/ape/types/manifest.py
+++ b/src/ape/types/manifest.py
@@ -63,17 +63,6 @@ class PackageManifest(FileMixin, SerializableType):
 
     @classmethod
     def from_dict(cls, params: Dict):
-        """
-        Create this class from a dictionary of its properties.
-        The dictionary keys must be the same name as the properties.
-
-        Args:
-            params (dict): A dictionary of properties.
-
-        Returns:
-            :class:`~ape.types.manifest.PackageManifest`
-        """
-
         params = deepcopy(params)
         update_params(params, "meta", PackageMeta)
         update_dict_params(params, "sources", Source)

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -28,11 +28,15 @@ class _Signature:
 
 
 class MessageSignature(_Signature):
-    pass
+    """
+    A ECDSA signature (vrs) of a message.
+    """
 
 
 class TransactionSignature(_Signature):
-    pass
+    """
+    A ECDSA signature (vrs) of a transaction.
+    """
 
 
 _ = SignableMessage


### PR DESCRIPTION
### What I did

Makes the `ape.types` method-docs more usable.

**The will fix some of the broken links in the docs**

### How I did it

* Add missing docs
* Organize docs

Note, this module in general seems to need some work. I purposely did not document some of these methods / attributes.

### How to verify it

Build docs and check it out.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
