### PR TITLE
docs: only go 1 level deep for guides in TOC

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 ```{eval-rst}
 .. toctree::
    :caption: User Guides
-   :maxdepth: 2
+   :maxdepth: 1
 
    userguides/quickstart
    userguides/plugins


### PR DESCRIPTION
### What I did

Make it only go one level deep for guides on the index page.

Before:
<img width="280" alt="Screen Shot 2021-12-20 at 13 55 49" src="https://user-images.githubusercontent.com/19540978/146825115-599e4131-3a8d-4425-9b2d-d4c3a3ec1e41.png">

After:
<img width="210" alt="Screen Shot 2021-12-20 at 13 56 19" src="https://user-images.githubusercontent.com/19540978/146825135-15b2af43-c6fd-4006-80c3-57316dbea6c8.png">

### How I did it

Change the max depth to 1

### How to verify it

build docs and check or just take my word for it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
