### PR TITLE
docs: use raises keyword in method docs where apt

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -75,6 +75,9 @@ class AccountAPI(AddressAPI):
         """
         Make a transaction call.
 
+        Raises:
+            :class:`~ape.exceptions.AccountsError`: When the nonce is invalid.
+
         Args:
             txn (:class:`~ape.api.providers.TransactionAPI`): The transaction to submit in a call.
             send_everything (bool): ``True`` will send the value difference from balance and fee.
@@ -239,6 +242,9 @@ class AccountContainerAPI:
         """
         Get an account by address.
 
+        Raises:
+            IndexError: When there is no account, locally, with the given address.
+
         Returns:
             :class:`~ape.api.accounts.AccountAPI`
         """
@@ -251,6 +257,9 @@ class AccountContainerAPI:
     def append(self, account: AccountAPI):
         """
         Add an account to the container.
+
+        Raises:
+            :class:`~ape.exceptions.AccountsError`: When the account already is in the container.
 
         Args:
             account (:class:`~ape.api.accounts.AccountAPI`): The account to add.
@@ -270,7 +279,9 @@ class AccountContainerAPI:
     def remove(self, account: AccountAPI):
         """
         Delete an account.
-        Must be known to ``ape`` or else raises :class:`~ape.exceptions.AccountsError`.
+
+        Raises:
+            :class:`~ape.exceptions.AccountsError`: When the account is not known to ``ape``.
 
         Args:
             account (:class:`~ape.accounts.AccountAPI`): The account to remove.
@@ -285,7 +296,9 @@ class AccountContainerAPI:
     def __delitem__(self, address: AddressType):
         """
         Delete an account.
-        Must be overriden or else raises ``NotImplementedError``.
+
+        Raises:
+            NotImplementError: When this is not overridden in a plugin.
 
         Args:
             address: (address :class:`~ape.types.AddressType`):
@@ -297,7 +310,9 @@ class AccountContainerAPI:
     def __contains__(self, address: AddressType) -> bool:
         """
         Check if the address is an existing account in ``ape``.
-        Must be a valid address or else raises ``IndexError``.
+
+        Raises:
+            IndexError: When the given account address is not in this container.
 
         Args:
             address :class:`~ape.types.AddressType`: An account address.

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -243,7 +243,7 @@ class AccountContainerAPI:
         Get an account by address.
 
         Raises:
-            IndexError: When there is no account, locally, with the given address.
+            IndexError: When there is no local account with the given address.
 
         Returns:
             :class:`~ape.api.accounts.AccountAPI`
@@ -259,7 +259,7 @@ class AccountContainerAPI:
         Add an account to the container.
 
         Raises:
-            :class:`~ape.exceptions.AccountsError`: When the account already is in the container.
+            :class:`~ape.exceptions.AccountsError`: When the account is already in the container.
 
         Args:
             account (:class:`~ape.api.accounts.AccountAPI`): The account to add.

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -298,7 +298,7 @@ class AccountContainerAPI:
         Delete an account.
 
         Raises:
-            NotImplementError: When this is not overridden in a plugin.
+            NotImplementError: When not overridden within a plugin.
 
         Args:
             address: (address :class:`~ape.types.AddressType`):

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -19,8 +19,10 @@ class AddressAPI:
     def provider(self) -> ProviderAPI:
         """
         The current active provider if connected to one.
-        If there is no active provider at runtime, then this raises an
-        :class:`~ape.exceptions.AddressError`.
+
+        Raises:
+            :class:`~ape.exceptions.AddressError`: When there is no active
+             provider at runtime.
 
         Returns:
             :class:`~ape.api.providers.ProviderAPI`

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -22,7 +22,7 @@ class AddressAPI:
 
         Raises:
             :class:`~ape.exceptions.AddressError`: When there is no active
-             provider at runtime.
+               provider at runtime.
 
         Returns:
             :class:`~ape.api.providers.ProviderAPI`

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -114,6 +114,10 @@ class EcosystemAPI:
         """
         Get a network by name.
 
+        Raises:
+            :class:`~ape.exceptions.NetworkNotFoundError`:
+              When there is no network with the given name.
+
         Args:
             network_name (str): The name of the network to retrieve.
 
@@ -131,6 +135,10 @@ class EcosystemAPI:
 
             from ape import networks
             mainnet = networks.ecosystem.mainnet
+
+        Raises:
+            :class:`~ape.exceptions.NetworkNotFoundError`:
+              When there is no network with the given name.
 
         Args:
             network_name (str): The name of the network to retrieve.

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -65,18 +65,17 @@ class TransactionAPI:
 
         See :class:`~ape_ethereum.ecosystem.StaticFeeTransaction` and
         :class:`~ape_ethereum.ecosystem.DynamicFeeTransaction` as examples.
+
+        Raises:
+            NotImplementedError: When setting in a class that did not override the setter.
+
+        Returns:
+            int
         """
         return 0
 
     @max_fee.setter
     def max_fee(self, value: int):
-        """
-        Set the max fee.
-        Must be overriden or else raises `NotImplementedError`.
-
-        Args:
-            value (int): The number of the fee
-        """
         raise NotImplementedError("Max fee is not settable by default.")
 
     @property
@@ -624,8 +623,9 @@ class Web3Provider(ProviderAPI):
         """
         The current base fee from the latest block.
 
-        NOTE: If your chain does not support base_fees (EIP-1559),
-        this method will raise a ``NotImplementedError``.
+        Raises:
+            NotImplementedError: When your chain does not support base_fees
+              (`EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__)
         """
         block = self.get_block("latest")
 
@@ -686,6 +686,9 @@ class Web3Provider(ProviderAPI):
     def get_transaction(self, txn_hash: str, required_confirmations: int = 0) -> ReceiptAPI:
         """
         The information about a transaction requested by transaction hash.
+
+        Raises:
+            :class:`~ape.exceptions.TransactionError`: When the required confirmations is negative.
 
         Args:
             txn_hash (str): The hash of the transaction to retrieve.

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -625,7 +625,7 @@ class Web3Provider(ProviderAPI):
 
         Raises:
             NotImplementedError: When your chain does not support base_fees
-              (`EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__)
+              (`EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__).
         """
         block = self.get_block("latest")
 

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -189,6 +189,9 @@ def contract_option(help=None, required=False, multiple=False):
     """
     Contract(s) from the current project.
     If you pass ``multiple=True``, you will get a list of contract types from the callback.
+
+    Raises:
+        :class:`~ape.exceptions.ContractError`: In the callback when it fails to load the contracts.
     """
 
     help = help or "The name of a contract in the current project"

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -148,6 +148,9 @@ class AccountManager:
         """
         Get an account by its alias.
 
+        Raises:
+            IndexError: When there is no local accounts with the given alias.
+
         Returns:
             :class:`~ape.api.accounts.AccountAPI`
         """
@@ -160,7 +163,7 @@ class AccountManager:
                 self._inject_provider(account)
                 return account
 
-        raise IndexError(f"No account with alias `{alias}`.")
+        raise IndexError(f"No account with alias '{alias}'.")
 
     @singledispatchmethod
     def __getitem__(self, account_id) -> AccountAPI:
@@ -192,6 +195,9 @@ class AccountManager:
         """
         Get an account by address.
 
+        Raises:
+            IndexError: When there is no local account with the given address.
+
         Returns:
             :class:`~ape.api.accounts.AccountAPI`
         """
@@ -204,7 +210,7 @@ class AccountManager:
                 self._inject_provider(account)
                 return account
 
-        raise IndexError(f"No account with address `{account_id}`.")
+        raise IndexError(f"No account with address '{account_id}'.")
 
     def __contains__(self, address: AddressType) -> bool:
         """

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -149,7 +149,7 @@ class AccountManager:
         Get an account by its alias.
 
         Raises:
-            IndexError: When there is no local accounts with the given alias.
+            IndexError: When there is no local account with the given alias.
 
         Returns:
             :class:`~ape.api.accounts.AccountAPI`

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -51,11 +51,8 @@ class CompilerManager:
             compiler = compiler_class(config=config)
 
             for extension in extensions:
-
-                if extension in registered_compilers:
-                    raise CompilerError(f"Compiler for '{extension}' is already registered.")
-
-                registered_compilers[extension] = compiler
+                if extension not in registered_compilers:
+                    registered_compilers[extension] = compiler
 
         return registered_compilers
 
@@ -64,6 +61,10 @@ class CompilerManager:
         Invoke :meth:`ape.ape.compiler.CompilerAPI.compile` for each of the given files.
         For example, use the `ape-solidity plugin <https://github.com/ApeWorX/ape-solidity>`__
         to compile ``'.sol'`` files.
+
+        Raises:
+            :class:`~ape.exceptions.CompilerError`: When there is no compiler found for the given
+              extension as well as when there is a contract-type collision across compilers.
 
         Args:
             contract_filepaths (list[pathlib.Path]): The list of files to compile,

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -161,8 +161,10 @@ class ConversionManager:
         Convert the given value to the given type. This method accesses
         all :class:`~ape.api.convert.ConverterAPI` instances known to
         `ape`` and selects the appropriate one, so long that it exists.
-        Raises a :class:`~ape.exceptions.ConversionError` when there is not
-        a registered converter for the given arguments.
+
+        Raises:
+            :class:`~ape.exceptions.ConversionError`: When there is not a registered
+              converter for the given arguments.
 
         Args:
             value (any): The value to convert.

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -67,6 +67,10 @@ class NetworkManager:
         """
         Get an ecosystem by name.
 
+        Raises:
+            :class:`~ape.exceptions.NetworkError`: When the given ecosystem name is
+              unknown.
+
         Args:
             ecosystem_name (str): The name of the ecosystem to get.
 
@@ -150,6 +154,10 @@ class NetworkManager:
         :meth:`~ape.managers.networks.NetworkManager.network_choices`. Use the
         CLI command ``ape networks list`` to list all the possible network
         combinations.
+
+        Raises:
+            :class:`~ape.exceptions.NetworkError`: When the given network choice does not
+              match any known network.
 
         Args:
             network_choice (str, optional): The network choice
@@ -250,6 +258,9 @@ class NetworkManager:
     def set_default_ecosystem(self, ecosystem_name: str):
         """
         Change the default ecosystem.
+
+        Raises:
+            :class:`~ape.exceptions.NetworkError`: When the given ecosystem name is unknown.
 
         Args:
             ecosystem_name (str): The name of the ecosystem to set

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -37,6 +37,9 @@ class ProjectManager:
     Use ``ape.project`` to reference the current project and ``ape.Project`` to reference
     this class uninitialized.
 
+    Raises:
+        :class:`~ape.exceptions.ProjectError`: When the project's dependencies are invalid.
+
     Usage example::
 
         from ape import project  # "project" is the ProjectManager for the active project
@@ -99,7 +102,8 @@ class ProjectManager:
 
             if not package_contracts_path.exists():
                 raise ProjectError(
-                    "Dependency does not have a support structure. Expecting 'contracts/' path."
+                    "Dependency does not have a supported file structure. "
+                    "Expecting 'contracts/' path."
                 )
 
             manifest = PackageManifest()

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -155,8 +155,7 @@ class Receipt(ReceiptAPI):
         Raise an error for the given transaction, if the transaction has failed.
 
         Args:
-            txn (:class:`ape.api.providers.TransactionAPI`): The sent-transaction to
-              check the status of.
+            txn (:class:`ape.api.providers.TransactionAPI`): The already-sent transaction to check.
 
         Raises:
             :class:`~ape.exceptions.OutOfGasError`: When the transaction failed

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -152,12 +152,19 @@ class DynamicFeeTransaction(BaseTransaction):
 class Receipt(ReceiptAPI):
     def raise_for_status(self, txn: TransactionAPI):
         """
-        Raises :class`~ape.exceptions.OutOfGasError` when the
-        transaction failed and consumed all the gas.
+        Raise an error for the given transaction if the transaction has failed.
 
-        Raises :class:`~ape.exceptions.TransactionError`
-        when the transaction has a failing status otherwise.
+        Args:
+            txn (:class:`ape.api.providers.TransactionAPI`): The sent-transaction to
+              check the status of.
+
+        Raises:
+            :class:`~ape.exceptions.OutOfGasError`: When the transaction failed
+              and ran out of gas.
+            :class:`~ape.exceptions.TransactionError`: When the transaction has a
+              failing status otherwise.
         """
+
         if txn.gas_limit and self.ran_out_of_gas(txn.gas_limit):
             raise OutOfGasError()
         elif self.status != TransactionStatusEnum.NO_ERROR:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -152,7 +152,7 @@ class DynamicFeeTransaction(BaseTransaction):
 class Receipt(ReceiptAPI):
     def raise_for_status(self, txn: TransactionAPI):
         """
-        Raise an error for the given transaction if the transaction has failed.
+        Raise an error for the given transaction, if the transaction has failed.
 
         Args:
             txn (:class:`ape.api.providers.TransactionAPI`): The sent-transaction to


### PR DESCRIPTION
### What I did

Uses `Raises:` sphinx keyword whenever possible.
This makes things look more nice and organized on the site and makes use of the sphinx feature.

### How I did it

Find places where we mention what a method raises and replace it with this syntax.
Find other places where we don't mention it and add it.

### How to verify it

read through docs
build and see what I mean by the sytnax.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
