### PR TITLE
fix: ensure the correct type when signing a message using eth-account

### DIFF
--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -4,6 +4,7 @@ from typing import Iterator, Optional
 
 import click
 from eth_account import Account as EthAccount  # type: ignore
+from eth_utils import to_bytes
 
 from ape.api import AccountAPI, AccountContainerAPI, TransactionAPI
 from ape.convert import to_address
@@ -131,11 +132,19 @@ class KeyfileAccount(AccountAPI):
             return None
 
         signed_msg = EthAccount.sign_message(msg, self.__key)
-        return MessageSignature(v=signed_msg.v, r=signed_msg.r, s=signed_msg.s)  # type: ignore
+        return MessageSignature(  # type: ignore
+            v=signed_msg.v,
+            r=to_bytes(signed_msg.r),
+            s=to_bytes(signed_msg.s),
+        )
 
     def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:
         if self.locked and not click.confirm(f"{txn}\n\nSign: "):
             return None
 
         signed_txn = EthAccount.sign_transaction(txn.as_dict(), self.__key)
-        return TransactionSignature(v=signed_txn.v, r=signed_txn.r, s=signed_txn.s)  # type: ignore
+        return TransactionSignature(  # type: ignore
+            v=signed_txn.v,
+            r=to_bytes(signed_txn.r),
+            s=to_bytes(signed_txn.s),
+        )

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -2,6 +2,7 @@ from typing import Iterator, List, Optional
 
 from eth_account import Account as EthAccount  # type: ignore
 from eth_account.messages import SignableMessage
+from eth_utils import to_bytes
 
 from ape.api import TestAccountAPI, TestAccountContainerAPI, TransactionAPI
 from ape.convert import to_address
@@ -50,8 +51,16 @@ class TestAccount(TestAccountAPI):
 
     def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
         signed_msg = EthAccount.sign_message(msg, self._private_key)
-        return MessageSignature(v=signed_msg.v, r=signed_msg.r, s=signed_msg.s)  # type: ignore
+        return MessageSignature(  # type: ignore
+            v=signed_msg.v,
+            r=to_bytes(signed_msg.r),
+            s=to_bytes(signed_msg.s),
+        )
 
     def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:
         signed_txn = EthAccount.sign_transaction(txn.as_dict(), self._private_key)
-        return TransactionSignature(v=signed_txn.v, r=signed_txn.r, s=signed_txn.s)  # type: ignore
+        return TransactionSignature(  # type: ignore
+            v=signed_txn.v,
+            r=to_bytes(signed_txn.r),
+            s=to_bytes(signed_txn.s),
+        )


### PR DESCRIPTION
### What I did
Noticed that when you sign a message using eth-account, it does not return `r` and `s` in the signature the same as with signing a transaction