### PR TITLE
docs: rename to method-docs TOC header to include "python"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@
 
 ```{eval-rst}
 .. toctree::
-   :caption: User API Reference
+   :caption: Python Reference
    :maxdepth: 1
 
    methoddocs/ape.md


### PR DESCRIPTION
### What I did

I think the last TOC section is not 100% clear on what it is.
This rename makes things super obvious I think.

### How I did it

Noticed this section was vague and thought about what a new user might think if we they were only looking for the python docs.

### How to verify it

Does this make sense to you? (Attachment)

<img width="288" alt="Screen Shot 2021-12-22 at 12 53 41" src="https://user-images.githubusercontent.com/19540978/147141566-c393f057-25cb-449d-ac19-52b2fc8de97d.png"> 

See how it matches the section above "CLI Reference"

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
