### PR TITLE
docs: general revisions and fixes

### DIFF
--- a/docs/methoddocs/utils.md
+++ b/docs/methoddocs/utils.md
@@ -4,4 +4,5 @@
 .. automodule:: ape.utils
     :members:
     :show-inheritance:
+    :exclude-members: abstractmethod, dataclass
 ```

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -29,7 +29,7 @@ class AccountAPI(AddressAPI):
         Display methods to IPython on ``a.[TAB]`` tab completion.
 
         Returns:
-            list[str]: Method names that IPython uses for tab completion.
+            List[str]: Method names that IPython uses for tab completion.
         """
         return list(super(AddressAPI, self).__dir__()) + [
             "alias",
@@ -44,16 +44,22 @@ class AccountAPI(AddressAPI):
     def alias(self) -> Optional[str]:
         """
         A shortened-name for quicker access to the account.
+
+        Returns:
+            str (optional)
         """
         return None
 
     @abstractmethod
     def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
         """
-        Signs the given message.
+        Sign a message.
 
         Args:
-          msg (:class:`~eth_account.messages.SignableMessage`): The message to sign.
+          msg (SignableMessage): The message to sign.
+            See these
+            `docs <https://eth-account.readthedocs.io/en/stable/eth_account.html#eth_account.messages.SignableMessage>`__  # noqa: E501
+            for more type information on this type.
 
         Returns:
           :class:`~ape.types.signatures.MessageSignature` (optional): The signed message.
@@ -62,7 +68,7 @@ class AccountAPI(AddressAPI):
     @abstractmethod
     def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:
         """
-        Signs the given transaction.
+        Sign a transaction.
 
         Args:
           txn (:class:`~ape.api.providers.TransactionAPI`): The transaction to sign.
@@ -76,7 +82,10 @@ class AccountAPI(AddressAPI):
         Make a transaction call.
 
         Raises:
-            :class:`~ape.exceptions.AccountsError`: When the nonce is invalid.
+            :class:`~ape.exceptions.AccountsError`: When the nonce is invalid or the sender does
+              not have enough funds.
+            :class:`~ape.exceptions.TransactionError`: When the required confirmations are negative.
+            :class:`~ape.exceptions.SignatureError`: When the user does not sign the transaction.
 
         Args:
             txn (:class:`~ape.api.providers.TransactionAPI`): The transaction to submit in a call.
@@ -170,18 +179,15 @@ class AccountAPI(AddressAPI):
 
     def deploy(self, contract: "ContractContainer", *args, **kwargs) -> "ContractInstance":
         """
-        Create a smart contract on the blockchain.
-
-        Method Limitations:
-            The smart contract must compile before deploying.
-            A provider must be active.
+        Create a smart contract on the blockchain. The smart contract must compile before
+        deploying and a provider must be active.
 
         Args:
             contract (:class:`~ape.contracts.ContractContainer`):
                 The type of contract to deploy.
 
         Returns:
-            :class:`~ape.contracts.ContractInstance`
+            :class:`~ape.contracts.ContractInstance`: An instance of the deployed contract.
         """
 
         txn = contract(*args, **kwargs)
@@ -206,7 +212,8 @@ class AccountAPI(AddressAPI):
 @abstractdataclass
 class AccountContainerAPI:
     """
-    An API class for managing accounts.
+    An API class representing a collection of :class:`~ape.api.accounts.AccountAPI`
+    instances.
     """
 
     data_folder: Path
@@ -217,10 +224,10 @@ class AccountContainerAPI:
     @abstractmethod
     def aliases(self) -> Iterator[str]:
         """
-        List all available aliases.
+        Iterate over all available aliases.
 
         Returns:
-            iter[str]: List of aliases.
+            Iterator[str]
         """
 
     @abstractmethod
@@ -235,7 +242,7 @@ class AccountContainerAPI:
         Iterate over all accounts.
 
         Returns:
-            iter[:class:`~ape.api.accounts.AccountAPI`]
+            Iterator[:class:`~ape.api.accounts.AccountAPI`]
         """
 
     def __getitem__(self, address: AddressType) -> AccountAPI:
@@ -301,7 +308,7 @@ class AccountContainerAPI:
             NotImplementError: When not overridden within a plugin.
 
         Args:
-            address: (address :class:`~ape.types.AddressType`):
+            address (address :class:`~ape.types.AddressType`):
                         The address of the account to delete.
 
         """
@@ -315,7 +322,7 @@ class AccountContainerAPI:
             IndexError: When the given account address is not in this container.
 
         Args:
-            address :class:`~ape.types.AddressType`: An account address.
+            address (:class:`~ape.types.AddressType`): An account address.
 
         Returns:
             bool: ``True`` if ``ape`` manages the account with the given address.
@@ -342,15 +349,15 @@ class AccountContainerAPI:
 
 class TestAccountContainerAPI(AccountContainerAPI):
     """
-    Test account containers for ``ape test`` should implement
-    this API instead of ``AccountContainerAPI`` directly. This
-    is how they show up in the ``accounts`` test fixture.
+    Test account containers for ``ape test`` (such containers that generate accounts using
+    :class:`~ape.utils.GeneratedDevAccounts`) should implement this API instead of
+    ``AccountContainerAPI`` directly. This is how they show up in the ``accounts`` test fixture.
     """
 
 
 class TestAccountAPI(AccountAPI):
     """
-    Test accounts for ``ape test`` should implement this API
-    instead of ``AccountAPI`` directly. This is how they show
-    up in the ``accounts`` test fixture.
+    Test accounts for ``ape test`` (such accounts that use
+    :class:`~ape.utils.GeneratedDevAccounts`) should implement this API
+    instead of ``AccountAPI`` directly. This is how they show up in the ``accounts`` test fixture.
     """

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -58,8 +58,7 @@ class AccountAPI(AddressAPI):
         Args:
           msg (SignableMessage): The message to sign.
             See these
-            # noqa: E501
-            `docs <https://eth-account.readthedocs.io/en/stable/eth_account.html#eth_account.messages.SignableMessage>`__
+            `docs <https://eth-account.readthedocs.io/en/stable/eth_account.html#eth_account.messages.SignableMessage>`__  # noqa: E501
             for more type information on this type.
 
         Returns:

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -58,7 +58,8 @@ class AccountAPI(AddressAPI):
         Args:
           msg (SignableMessage): The message to sign.
             See these
-            `docs <https://eth-account.readthedocs.io/en/stable/eth_account.html#eth_account.messages.SignableMessage>`__  # noqa: E501
+            # noqa: E501
+            `docs <https://eth-account.readthedocs.io/en/stable/eth_account.html#eth_account.messages.SignableMessage>`__
             for more type information on this type.
 
         Returns:

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -74,7 +74,7 @@ class AddressAPI:
         Display methods to IPython on ``a.[TAB]`` tab completion.
 
         Returns:
-            list[str]: Method names that IPython uses for tab completion.
+            List[str]: Method names that IPython uses for tab completion.
         """
         return [
             "address",

--- a/src/ape/api/compiler.py
+++ b/src/ape/api/compiler.py
@@ -10,10 +10,16 @@ from .config import ConfigItem
 @abstractdataclass
 class CompilerAPI:
     """
-    Compiler plugins, such as for languages like Solidity or Vyper, implement this API.
+    Compiler plugins, such as for languages like
+    `Solidity <https://docs.soliditylang.org/en/v0.8.11/>`__ or
+    `Vyper <https://vyper.readthedocs.io/en/stable/>`__, implement this API.
+    See the repository for the `ape-solidity <https://github.com/ApeWorX/ape-solidity>`__ plugin or
+    the `ape-vyper <https://github.com/ApeWorX/ape-vyper>`__ plugin as example implementations of
+    this API.
     """
 
     config: ConfigItem
+    """The :class:`ape.api.config.ConfigItem` for this compiler plugin."""
 
     @property
     @abstractmethod
@@ -26,23 +32,22 @@ class CompilerAPI:
         Retrieve the set of available compiler versions for this plugin to compile ``all_paths``.
 
         Args:
-            all_paths (list[pathlib.Path]): The list of paths.
+            all_paths (List[pathlib.Path]): The list of paths.
 
         Returns:
-            set[str]: A set of available compiler versions.
+            Set[str]: A set of available compiler versions.
         """
 
     @abstractmethod
     def compile(self, contract_filepaths: List[Path]) -> List[ContractType]:
         """
-        Compile the source given ``pkg_manifest``.
-        All compiler plugins must implement this function.
+        Compile the given source files. All compiler plugins must implement this function.
 
         Args:
-            contract_filepaths (list[pathlib.Path]): A list of source file paths to compile.
+            contract_filepaths (List[pathlib.Path]): A list of source file paths to compile.
 
         Returns:
-            list[:class:`~ape.type.contract.ContractType`]
+            List[:class:`~ape.type.contract.ContractType`]
         """
 
     def __repr__(self) -> str:

--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -8,8 +8,8 @@ from ape.utils import dataclass
 class ConfigEnum(str, Enum):
     """
     A configuration `Enum <https://docs.python.org/3/library/enum.html>`__ type.
-    Set this to limit the values of a config item to be a limited set, such
-    colors ``"RED"``, ``"BLUE"``, ``"GREEN"``, rather than an arbitrary ``str``.
+    Use this to limit the values of a config item, such as colors ``"RED"``, ``"BLUE"``,
+    ``"GREEN"``, rather than any arbitrary ``str``.
     """
 
 

--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -6,7 +6,11 @@ from ape.utils import dataclass
 
 
 class ConfigEnum(str, Enum):
-    pass
+    """
+    A configuration `Enum <https://docs.python.org/3/library/enum.html>`__ type.
+    Set this to limit the values of a config item to be a limited set, such
+    colors ``"RED"``, ``"BLUE"``, ``"GREEN"``, rather than an arbitrary ``str``.
+    """
 
 
 @dataclass(slots=True, kwargs=True)

--- a/src/ape/api/convert.py
+++ b/src/ape/api/convert.py
@@ -34,7 +34,7 @@ class ConverterAPI(Generic[ConvertedType]):
     @abstractmethod
     def convert(self, value: Any) -> ConvertedType:
         """
-        Implements any conversion logic on `value` to produce `ABIType`.
-
-        Must throw if not convertible.
+        Convert the given value to the type specified as the generic for this class.
+        Implementations of this API must throw a :class:`~ape.exceptions.ConversionError`
+        when the item fails to convert properly.
         """

--- a/src/ape/api/explorers.py
+++ b/src/ape/api/explorers.py
@@ -9,7 +9,8 @@ from . import networks
 @abstractdataclass
 class ExplorerAPI:
     """
-    An Explorer must work with a particular Network in a particular Ecosystem.
+    An API class representing a blockchain explorer for a particular network
+    in a particular ecosystem.
     """
 
     name: str  # Plugin name
@@ -22,7 +23,8 @@ class ExplorerAPI:
         Get an address URL, such as for a transaction.
 
         Args:
-            address (str): The address to get the URL for.
+            address (:class:`~ape.types.AddressType`): The address to
+              get the URL for.
 
         Returns:
             str
@@ -49,5 +51,5 @@ class ExplorerAPI:
             address (str): The contract address.
 
         Returns:
-            class:`~ape.contracts.ContractType` if published, else ``None``.
+            :class:`~ape.contracts.ContractType` if published, else ``None``.
         """

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -74,7 +74,7 @@ class EcosystemAPI:
         A dictionary of network names mapped to their API implementation.
 
         Returns:
-            dict[str, :class:`~ape.api.networks.NetworkAPI`]
+            Dict[str, :class:`~ape.api.networks.NetworkAPI`]
         """
 
         networks = {}
@@ -106,7 +106,7 @@ class EcosystemAPI:
         Iterate over the set of all valid network names in the ecosystem.
 
         Returns:
-            iter[str]
+            Iterator[str]
         """
         yield from self.networks
 
@@ -423,7 +423,7 @@ class NetworkAPI:
         The providers of the network, such as Infura, Alchemy, or Geth.
 
         Returns:
-            dict[str, partial[:class:`~ape.api.providers.ProviderAPI`]]
+            Dict[str, partial[:class:`~ape.api.providers.ProviderAPI`]]
         """
 
         providers = {}

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -350,7 +350,8 @@ class NetworkAPI:
         """
         The ID of the blockchain.
 
-        **NOTE**: Unless overridden, returns same as :meth:`ape.api.providers.ProviderAPI.chain_id`.
+        **NOTE**: Unless overridden, returns same as
+        :py:attr:`ape.api.providers.ProviderAPI.chain_id`.
 
         Returns:
             int

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -372,7 +372,8 @@ class NetworkAPI:
         """
         The ID of the network.
 
-        **NOTE**: Unless overridden, returns same as :meth:`~ape.api.networks.NetworkAPI.chain_id`.
+        **NOTE**: Unless overridden, returns same as
+        :py:attr:`~ape.api.networks.NetworkAPI.chain_id`.
 
         Returns:
             int

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -22,7 +22,7 @@ from .config import ConfigItem
 class TransactionType(Enum):
     """
     Transaction enumerables type constants defined by
-    `EIP-2718` <https://eips.ethereum.org/EIPS/eip-2718>`__.
+    `EIP-2718 <https://eips.ethereum.org/EIPS/eip-2718>`__.
     """
 
     STATIC = "0x0"

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -53,7 +53,6 @@ class TransactionAPI:
     signature: Optional[TransactionSignature] = None
 
     def __post_init__(self):
-        breakpoint()
         if not self.is_valid:
             raise ProviderError("Transaction is not valid.")
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -53,6 +53,7 @@ class TransactionAPI:
     signature: Optional[TransactionSignature] = None
 
     def __post_init__(self):
+        breakpoint()
         if not self.is_valid:
             raise ProviderError("Transaction is not valid.")
 
@@ -183,14 +184,15 @@ class ConfirmationsProgressBar:
 @abstractdataclass
 class ReceiptAPI:
     """
-    An Abstract class to represent :class:`~ape.api.providers.ReceiptAPI`.
-    It contains information about the transaction
-    such as the status and required confirmations.
+    An abstract class to represent a transaction receipt. The receipt
+    contains information about the transaction, such as the status
+    and required confirmations.
 
-    NOTE: Use a ``required_confirmations`` of ``0`` in your transaction
+    **NOTE**: Use a ``required_confirmations`` of ``0`` in your transaction
     to not wait for confirmations.
 
-    A receipt is returned after making a contract or account transfers.
+    Get a receipt by making transactions in ``ape``, such as interacting with
+    a :class:`ape.contracts.base.ContractInstance`.
     """
 
     provider: "ProviderAPI"
@@ -220,8 +222,14 @@ class ReceiptAPI:
 
     def ran_out_of_gas(self, gas_limit: int) -> bool:
         """
-        ``True`` when the transaction failed and used the
-        same amount of gas as the given ``gas_limit``.
+        Check if a transaction has ran out of gas and failed.
+
+        Args:
+            gas_limit (int): The gas limit of the transaction.
+
+        Returns:
+            bool:  ``True`` when the transaction failed and used the
+            same amount of gas as the given ``gas_limit``.
         """
         return self.status == TransactionStatusEnum.FAILING and self.gas_used == gas_limit
 
@@ -352,21 +360,33 @@ class BlockAPI:
 @abstractdataclass
 class ProviderAPI:
     """
-    A provider must work with a particular network in a particular ecosystem.
-    An abstraction of a connection to the Ethereum Network.
+    An abstraction of a connection to a network in an ecosystem. Example ``ProviderAPI``
+    implementations include the `ape-infura <https://github.com/ApeWorX/ape-infura>`__
+    plugin or the `ape-hardhat <https://github.com/ApeWorX/ape-hardhat>`__ plugin.
     """
 
-    name: str  # Plugin name
+    name: str
+    """The name of the provider (should be the plugin name)."""
+
     network: networks.NetworkAPI
+    """A reference to the network this provider provides."""
+
     config: ConfigItem
+    """The provider's configuration."""
+
     provider_settings: dict
+    """The settings for the provider, as overrides to the configuration."""
+
     data_folder: Path
+    """The path to the  ``.ape`` directory."""
+
     request_header: str
+    """A header to set on HTTP/RPC requests."""
 
     @abstractmethod
     def connect(self):
         """
-        Connect a to a provider, such as start up a process or create an HTTP connection.
+        Connect a to a provider, such as start-up a process or create an HTTP connection.
         """
 
     @abstractmethod
@@ -475,7 +495,11 @@ class ProviderAPI:
         The minimum value required to get your transaction
         included on the next block.
         Only providers that implement `EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__
-        will use this property, otherwise will raise ``NotImplementedError``.
+        will use this property.
+
+        Raises:
+            NotImplementedError: When this provider does not implement
+              `EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__.
 
         Returns:
             int
@@ -543,7 +567,7 @@ class ProviderAPI:
                 ex: logs certains or types.
 
         Returns:
-            iter[dict]: A dictionary of events.
+            Iterator[dict]: A dictionary of events.
         """
 
 
@@ -724,7 +748,7 @@ class Web3Provider(ProviderAPI):
                 ex: logs certains or types.
 
         Returns:
-            iter[dict]: A dictionary of events.
+            Iterator[dict]: A dictionary of events.
 
         """
         return iter(self._web3.eth.get_logs(filter_params))  # type: ignore

--- a/src/ape/cli/arguments.py
+++ b/src/ape/cli/arguments.py
@@ -23,7 +23,7 @@ def existing_alias_argument(account_type: Optional[Type[AccountAPI]] = None):
     A ``click.argument`` for an existing account alias.
 
     Args:
-        account_type (type[:class:`~ape.api.accounts.AccountAPI`], optional):
+        account_type (Type[:class:`~ape.api.accounts.AccountAPI`], optional):
           If given, limits the type of account the user may choose from.
     """
 

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -35,7 +35,7 @@ class Alias(click.Choice):
         The aliases available to choose from.
 
         Returns:
-            list[str]: A list of account aliases the user may choose from.
+            List[str]: A list of account aliases the user may choose from.
         """
 
         options = _get_account_by_type(self._account_type)
@@ -132,7 +132,7 @@ class AccountAliasPromptChoice(PromptChoice):
         All the account aliases.
 
         Returns:
-            list[str]: A list of all the account aliases.
+            List[str]: A list of all the account aliases.
         """
 
         return [
@@ -192,7 +192,7 @@ def output_format_choice(options: List[OutputFormat] = None) -> Choice:
     Returns a ``click.Choice()`` type for the given options.
 
     Args:
-        options (list[:class:`~ape.choices.OutputFormat`], optional):
+        options (List[:class:`~ape.choices.OutputFormat`], optional):
           Limit the formats to accept. Defaults to allowing all formats.
 
     Returns:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -219,7 +219,7 @@ class ContractInstance(AddressAPI):
         Display methods to IPython on ``c.[TAB]`` tab completion.
 
         Returns:
-            list[str]
+            List[str]
         """
         return list(super(AddressAPI, self).__dir__()) + [
             abi.name for abi in self._contract_type.abi

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -68,7 +68,7 @@ class AccountManager:
         :meth:`~ape.managers.accounts.AccountManager.load`.
 
         Returns:
-            iter[str]
+            Iterator[str]
         """
 
         for container in self.containers.values():
@@ -79,11 +79,11 @@ class AccountManager:
         Get a list of accounts by their type.
 
         Args:
-            type_ (type[:class:`~ape.api.accounts.AccountAPI`]): The type of account
+            type_ (Type[:class:`~ape.api.accounts.AccountAPI`]): The type of account
               to get.
 
         Returns:
-            list[:class:`~ape.api.accounts.AccountAPI`]
+            List[:class:`~ape.api.accounts.AccountAPI`]
         """
 
         accounts_with_type = []
@@ -130,7 +130,7 @@ class AccountManager:
                ...
 
         Returns:
-            list[:class:`~ape.api.accounts.TestAccountAPI`]
+            List[:class:`~ape.api.accounts.TestAccountAPI`]
         """
         accounts = []
         for plugin_name, (container_type, account_type) in self.plugin_manager.account_types:

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -40,7 +40,7 @@ class CompilerManager:
         :class:`~ape.api.compiler.CompilerAPI` instance.
 
         Returns:
-            dict[str, :class:`~ape.api.compiler.CompilerAPI`]: The mapping of file-extensions
+            Dict[str, :class:`~ape.api.compiler.CompilerAPI`]: The mapping of file-extensions
             to compiler API classes.
         """
 
@@ -67,11 +67,11 @@ class CompilerManager:
               extension as well as when there is a contract-type collision across compilers.
 
         Args:
-            contract_filepaths (list[pathlib.Path]): The list of files to compile,
+            contract_filepaths (List[pathlib.Path]): The list of files to compile,
               as ``pathlib.Path`` objects.
 
         Returns:
-            dict[str, :class:`~ape.types.contract.ContractType`]: A mapping of
+            Dict[str, :class:`~ape.types.contract.ContractType`]: A mapping of
             contract names to their type.
         """
 

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -151,7 +151,7 @@ class NetworkManager:
         """
         Get a :class:`~ape.api.providers.ProviderAPI` from a network choice.
         A network choice is any value returned from
-        :meth:`~ape.managers.networks.NetworkManager.network_choices`. Use the
+        :py:attr:`~ape.managers.networks.NetworkManager.network_choices`. Use the
         CLI command ``ape networks list`` to list all the possible network
         combinations.
 
@@ -161,7 +161,7 @@ class NetworkManager:
 
         Args:
             network_choice (str, optional): The network choice
-              (see :meth:`~ape.managers.networks.NetworkManager.network_choices`).
+              (see :py:attr:`~ape.managers.networks.NetworkManager.network_choices`).
               Defaults to the default ecosystem, network, and provider combination.
             provider_settings (dict, optional): Settings for the provider. Defaults to None.
 
@@ -217,12 +217,12 @@ class NetworkManager:
         """
         Parse a network choice into a context manager for managing a temporary
         connection to a provider. See
-        :meth:`~ape.managers.networks.NetworkManager.network_choices` for all
+        :py:attr:`~ape.managers.networks.NetworkManager.network_choices` for all
         available choices (or use CLI command ``ape networks list``).
 
         Args:
             network_choice (str, optional): The network choice
-              (see :meth:`~ape.managers.networks.NetworkManager.network_choices`).
+              (see :py:attr:`~ape.managers.networks.NetworkManager.network_choices`).
               Defaults to the default ecosystem, network, and provider combination.
             provider_settings (dict, optional): Settings for the provider. Defaults to None.
 

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -58,7 +58,7 @@ class NetworkManager:
         All the managed ecosystems in ``ape``, as an iterable.
 
         Returns:
-            iter[:class:`~ape.api.networks.EcosystemAPI`]
+            Iterator[:class:`~ape.api.networks.EcosystemAPI`]
         """
 
         yield from self.ecosystems
@@ -118,7 +118,7 @@ class NetworkManager:
         combinations.
 
         Returns:
-            iter[str]: An iterator over all the network-choice possibilities.
+            Iterator[str]: An iterator over all the network-choice possibilities.
         """
         for ecosystem_name, ecosystem in self.ecosystems.items():
             yield ecosystem_name

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -179,7 +179,7 @@ class ProjectManager:
         Excludes files with extensions that don't have a registered compiler.
 
         Returns:
-            list[pathlib.Path]: A list of a source file paths in the project.
+            List[pathlib.Path]: A list of a source file paths in the project.
         """
         files: List[Path] = []
         for extension in self.compilers.registered_compilers:
@@ -202,11 +202,11 @@ class ProjectManager:
         that do not correspond to a registered compiler.
 
         Args:
-            extensions (list[str], optional): If provided, returns only extensions that
+            extensions (List[str], optional): If provided, returns only extensions that
                 are in this list. Useful for checking against a subset of source files.
 
         Returns:
-            list[str]: A list of file extensions found in the ``contracts/`` directory
+            List[str]: A list of file extensions found in the ``contracts/`` directory
             that do not have associated compilers installed.
         """
         exts = []
@@ -271,14 +271,14 @@ class ProjectManager:
         scripts or tests in ``ape``, such as from ``ape run`` or ``ape test``.
 
         Args:
-            file_paths (list[pathlib.Path] or pathlib.Path], optional):
+            file_paths (List[pathlib.Path] or pathlib.Path], optional):
               Provide one or more contract file-paths to load. If excluded,
               will load all the contracts.
             use_cache (bool, optional): Set to ``False`` to force a re-compile.
               Defaults to ``True``.
 
         Returns:
-            dict[str, :class:`~ape.types.contract.ContractType`]: A dictionary of contract names
+            Dict[str, :class:`~ape.types.contract.ContractType`]: A dictionary of contract names
             to their types for each compiled contract.
         """
 
@@ -341,7 +341,7 @@ class ProjectManager:
         See :meth:`~ape.managers.project.ProjectManager.load_contracts` for more information.
 
         Returns:
-            dict[str, :class:`~ape.types.contract.ContractType`]
+            Dict[str, :class:`~ape.types.contract.ContractType`]
         """
 
         return self.load_contracts()
@@ -417,7 +417,7 @@ class ProjectManager:
         A list of objects representing the raw-data specifics of a compiler.
 
         Returns:
-            list[:class:`~ape.types.contract.Compiler`]
+            List[:class:`~ape.types.contract.Compiler`]
         """
 
         compilers = []

--- a/src/ape/types/contract.py
+++ b/src/ape/types/contract.py
@@ -294,7 +294,7 @@ class ContractType(FileMixin, SerializableType):
         The events defined in a smart contract.
 
         Returns:
-            list[:class:`~ape.types.contract.ABI`]
+            List[:class:`~ape.types.contract.ABI`]
         """
 
         return [abi for abi in self.abi if abi.type == "event"]
@@ -305,7 +305,7 @@ class ContractType(FileMixin, SerializableType):
         The call-methods (read-only method, non-payable methods) defined in a smart contract.
 
         Returns:
-            list[:class:`~ape.types.contract.ABI`]
+            List[:class:`~ape.types.contract.ABI`]
         """
 
         return [abi for abi in self.abi if abi.type == "function" and not abi.is_stateful]
@@ -316,7 +316,7 @@ class ContractType(FileMixin, SerializableType):
         The transaction-methods (stateful or payable methods) defined in a smart contract.
 
         Returns:
-            list[:class:`~ape.types.contract.ABI`]
+            List[:class:`~ape.types.contract.ABI`]
         """
 
         return [abi for abi in self.abi if abi.type == "function" and abi.is_stateful]

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -227,6 +227,18 @@ def compute_checksum(source: bytes, algorithm: str = "md5") -> str:
 
 
 GeneratedDevAccount = collections.namedtuple("GeneratedDevAccount", ("address", "private_key"))
+"""
+An account key-pair generated using a test mnemonic. Set the test ``mnemonic``
+in your ``ape-config.yaml`` file under the ``test`` section. Access your test
+accounts using :meth:`~ape.managers.accounts.AccountManager.test_accounts`.
+
+Config example::
+
+    test:
+      mnemonic: test test test test test test test test test test test junk
+      number_of_accounts: 10
+
+"""
 
 
 def generate_dev_accounts(
@@ -241,11 +253,12 @@ def generate_dev_accounts(
 
     Args:
         mnemonic (str): mnemonic phrase or seed words.
-        number_of_accounts: Number of accounts
+        number_of_accounts (int): Number of accounts. Defaults to ``10``.
         hd_path_format (str): Hard Wallets/HD Keys derivation path format.
+          Defaults to ``"m/44'/60'/0'/{}"``.
 
     Returns:
-        list[:class:`~ape.utils.GeneratedDevAccount`]: List of development accounts.
+        List[:class:`~ape.utils.GeneratedDevAccount`]: List of development accounts.
     """
     seed = seed_from_mnemonic(mnemonic, "")
     accounts = []
@@ -261,8 +274,15 @@ def generate_dev_accounts(
 
 def gas_estimation_error_message(tx_error: Exception) -> str:
     """
-    Use this method in ``ProviderAPI`` implementations when error handling
-    transaction errors. This is to have a consistent experience across providers.
+    Get an error message containing the given error and an explanation of how the
+    gas estimation failed, as in :class:`ape.api.providers.ProviderAPI` implementations.
+
+    Args:
+        tx_error (Exception): The error that occurred when trying to estimate gas.
+
+    Returns:
+        str: An error message explaining that the gas failed and that the transaction
+        will likely revert.
     """
     return (
         f"Gas estimation failed: '{tx_error}'. This transaction will likely revert. "
@@ -272,7 +292,13 @@ def gas_estimation_error_message(tx_error: Exception) -> str:
 
 def extract_nested_value(root: Mapping, *args: str) -> Optional[Dict]:
     """
-    Dig through a nested ``Dict`` gives the keys to use in order as arguments.
+    Dig through a nested ``dict`` using the given keys and return the
+    last-found object.
+
+    Usage example::
+
+            >>> extract_nested_value({"foo": {"bar": {"test": "VALUE"}}}, "foo", "bar", "test")
+            'VALUE'
 
     Args:
         root (dict): Nested keys to form arguments.
@@ -410,12 +436,19 @@ def get_all_files_in_directory(path: Path) -> List[Path]:
     """
     Returns all the files in a directory structure.
 
-    For example: Given a dir structure like
+    For example, given a director structure like::
+
         dir_a: dir_b, file_a, file_b
         dir_b: file_c
 
-      and you provide the path to `dir_a`, it will return a list containing
-      the Paths to `file_a`, `file_b` and `file_c`.
+    and you provide the path to ``dir_a``, it will return a list containing
+    the Paths to ``file_a``, ``file_b`` and ``file_c``.
+
+    Args:
+        path (pathlib.Path): A directory containing files of interest.
+
+    Returns:
+        List[pathlib.Path]: A list of files in the given directory.
     """
     if path.is_dir():
         return list(path.rglob("*.*"))

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -443,13 +443,13 @@ def get_all_files_in_directory(path: Path) -> List[Path]:
     """
     Returns all the files in a directory structure.
 
-    For example, given a director structure like::
+    For example, given a directory structure like::
 
         dir_a: dir_b, file_a, file_b
         dir_b: file_c
 
     and you provide the path to ``dir_a``, it will return a list containing
-    the Paths to ``file_a``, ``file_b`` and ``file_c``.
+    the paths to ``file_a``, ``file_b`` and ``file_c``.
 
     Args:
         path (pathlib.Path): A directory containing files of interest.

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -77,7 +77,14 @@ def get_relative_path(target: Path, anchor: Path) -> Path:
     """
     Compute the relative path of ``target`` relative to ``anchor``,
     which may or may not share a common ancestor.
-    NOTE: Both paths must be absolute
+    **NOTE**: Both paths must be absolute.
+
+    Args:
+        target (pathlib.Path): The path we are interested in.
+        anchor (pathlib.Path): The path we are starting from.
+
+    Returns:
+        pathlib.Path: The new path to the target path from the anchor path.
     """
     if not target.is_absolute():
         raise ValueError("'target' must be an absolute path.")
@@ -139,10 +146,10 @@ USER_AGENT = f"Ape/{__version__} (Python/{_python_version})"
 
 def deep_merge(dict1, dict2) -> Dict:
     """
-    Return a new dictionary by merging two dictionaries recursively.
+    Merge two dictionaries recursively.
 
     Returns:
-        dict
+        dict: The result of the merge as a new dictionary.
     """
 
     result = deepcopy(dict1)
@@ -228,9 +235,9 @@ def compute_checksum(source: bytes, algorithm: str = "md5") -> str:
 
 GeneratedDevAccount = collections.namedtuple("GeneratedDevAccount", ("address", "private_key"))
 """
-An account key-pair generated using a test mnemonic. Set the test ``mnemonic``
+An account key-pair generated from the test mnemonic. Set the test mnemonic
 in your ``ape-config.yaml`` file under the ``test`` section. Access your test
-accounts using :meth:`~ape.managers.accounts.AccountManager.test_accounts`.
+accounts using the :py:attr:`~ape.managers.accounts.AccountManager.test_accounts` property.
 
 Config example::
 
@@ -247,7 +254,7 @@ def generate_dev_accounts(
     hd_path_format="m/44'/60'/0'/{}",
 ) -> List[GeneratedDevAccount]:
     """
-    Create accounts from the configured test mnemonic.
+    Create accounts from the given test mnemonic.
     Use these accounts (or the mnemonic) in chain-genesis
     for testing providers.
 
@@ -372,7 +379,7 @@ class GithubClient:
         The available ``ape`` plugins, found from looking at the ``ApeWorx`` Github organization.
 
         Returns:
-            set[str]: The plugin names.
+            Set[str]: The plugin names.
         """
         return {
             repo.name.replace("-", "_")
@@ -457,13 +464,19 @@ def get_all_files_in_directory(path: Path) -> List[Path]:
 
 
 class AbstractDataClassMeta(DataClassMeta, ABCMeta):
-    pass
+    """
+    A `data class <https://docs.python.org/3/library/dataclasses.html>`__ that
+    is also abstract (meaning it has methods that **must** be implemented in a
+    sub-class or else errors will occur). This class cannot be instantiated
+    on its own.
+    """
 
 
 abstractdataclass = partial(dataclass, kwargs=True, meta=AbstractDataClassMeta)
 """
-A class with abstract properties that cannot be subclassed on its own.
-ex: API classes
+A `data class <https://docs.python.org/3/library/dataclasses.html>`__ that is
+also abstract (meaning it has methods that **must** be implemented or else
+errors will occur. This class cannot be instantiated on its own.
 """
 
 __all__ = [


### PR DESCRIPTION
### What I did

* Switched `:meth:` to `:py:attr:` for `@property` based methods (removes `()` from HTML link output)
* Switch to using `typing` modules types instead of `sphinx` native types where applicable (so `Iterator[str]` instead of `iter[str]`)
* Removes docs from `Web3Provider` so that it uses the base `ProviderAPI` class docs (removes a lot duplication)
* General documentation revising, format fixes, and additions!

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
