### PR TITLE
refactor: remove incorrectly used property 'is_valid' from the transaction API

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -10,7 +10,7 @@ from hexbytes import HexBytes
 from tqdm import tqdm  # type: ignore
 from web3 import Web3
 
-from ape.exceptions import ProviderError, TransactionError
+from ape.exceptions import TransactionError
 from ape.logging import logger
 from ape.types import BlockID, TransactionSignature
 from ape.utils import abstractdataclass, abstractmethod
@@ -52,10 +52,6 @@ class TransactionAPI:
 
     signature: Optional[TransactionSignature] = None
 
-    def __post_init__(self):
-        if not self.is_valid:
-            raise ProviderError("Transaction is not valid.")
-
     @property
     def max_fee(self) -> int:
         """
@@ -86,13 +82,6 @@ class TransactionAPI:
         to submit the transaction.
         """
         return self.value + self.max_fee
-
-    @property
-    @abstractmethod
-    def is_valid(self):
-        """
-        Check if the transaction is valid.
-        """
 
     @abstractmethod
     def encode(self) -> bytes:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -50,9 +50,6 @@ class EthereumConfig(ConfigItem):
 
 
 class BaseTransaction(TransactionAPI):
-    def is_valid(self) -> bool:
-        return False
-
     def as_dict(self) -> dict:
         data = super().as_dict()
 


### PR DESCRIPTION
### What I did

Remove unneeded method and check.

The `is_valid` method always returns `False` and is not used correctly. The "check" that happens verifies the truthiness of the method existing, it does not call the method or anything, and thus the checked result is always `True` (false positive).

At the same time, there is no implementation or explanation of this property. It should be removed if it not needed or else it should be implemented properly. Since we are getting by without it, I opted for removing here. Let me know otherwise!

### How I did it

I was documenting these methods and noticed the docs did not really say what `is_valid` means. Then, I noticed it was not getting called correctly. Then, I noticed it was never actually getting set o

### How to verify it

This PR should have no effect on anything.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
