### PR TITLE
refactor: use transaction values from decoding rather than as new parameters

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -199,6 +199,7 @@ class ReceiptAPI:
     block_number: int
     gas_used: int
     gas_price: int
+    gas_limit: int
     logs: List[dict] = []
     contract_address: Optional[str] = None
     required_confirmations: int = 0
@@ -212,18 +213,19 @@ class ReceiptAPI:
     def __str__(self) -> str:
         return f"<{self.__class__.__name__} {self.txn_hash}>"
 
-    def raise_for_status(self, txn: TransactionAPI):
+    def raise_for_status(self):
         """
         Handle provider-specific errors regarding a non-successful
         :class:`~api.providers.TransactionStatusEnum`.
         """
 
-    def ran_out_of_gas(self, gas_limit: int) -> bool:
+    @property
+    def ran_out_of_gas(self) -> bool:
         """
         ``True`` when the transaction failed and used the
         same amount of gas as the given ``gas_limit``.
         """
-        return self.status == TransactionStatusEnum.FAILING and self.gas_used == gas_limit
+        return self.status == TransactionStatusEnum.FAILING and self.gas_used == self.gas_limit
 
     @classmethod
     @abstractmethod

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -150,12 +150,9 @@ class DynamicFeeTransaction(BaseTransaction):
 
 
 class Receipt(ReceiptAPI):
-    def raise_for_status(self, txn: TransactionAPI):
+    def raise_for_status(self):
         """
         Raise an error for the given transaction, if the transaction has failed.
-
-        Args:
-            txn (:class:`ape.api.providers.TransactionAPI`): The already-sent transaction to check.
 
         Raises:
             :class:`~ape.exceptions.OutOfGasError`: When the transaction failed
@@ -164,7 +161,7 @@ class Receipt(ReceiptAPI):
               failing status otherwise.
         """
 
-        if txn.gas_limit and self.ran_out_of_gas(txn.gas_limit):
+        if self.gas_limit and self.ran_out_of_gas:
             raise OutOfGasError()
         elif self.status != TransactionStatusEnum.NO_ERROR:
             txn_hash = HexBytes(self.txn_hash).hex()
@@ -180,6 +177,7 @@ class Receipt(ReceiptAPI):
             block_number=data["blockNumber"],
             gas_used=data["gasUsed"],
             gas_price=data["gasPrice"],
+            gas_limit=data.get("gas") or data.get("gasLimit"),
             logs=data["logs"],
             contract_address=data["contractAddress"],
             sender=data["from"],

--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -246,7 +246,7 @@ class GethProvider(Web3Provider, UpstreamProvider):
         except ValueError as err:
             raise _get_vm_error(err) from err
 
-        receipt.raise_for_status(txn)
+        receipt.raise_for_status()
         return receipt
 
 

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -57,7 +57,7 @@ class LocalNetwork(TestProviderAPI, Web3Provider):
             raise _get_vm_err(err) from err
 
         receipt = self.get_transaction(txn_hash.hex())
-        if txn.gas_limit is not None and receipt.ran_out_of_gas(txn.gas_limit):
+        if txn.gas_limit is not None and receipt.ran_out_of_gas:
             raise OutOfGasError()
 
         return receipt

--- a/tests/functional/ethereum/test_ecosystem.py
+++ b/tests/functional/ethereum/test_ecosystem.py
@@ -18,12 +18,11 @@ class TestBaseTransaction:
 class TestReceipt:
     def test_raise_for_status_out_of_gas_error(self, mocker):
         gas_limit = 100000
-        txn = BaseTransaction()
-        txn.gas_limit = gas_limit
         receipt = Receipt(
             provider=mocker.MagicMock(),
             txn_hash="",
             gas_used=gas_limit,
+            gas_limit=gas_limit,
             status=TransactionStatusEnum.FAILING,
             gas_price=0,
             block_number=0,
@@ -31,4 +30,4 @@ class TestReceipt:
             nonce=0,
         )
         with pytest.raises(OutOfGasError):
-            receipt.raise_for_status(txn)
+            receipt.raise_for_status()


### PR DESCRIPTION
### What I did

I think I initially made these changes, I was not as knowledgable about how a Receipt gets decodes using values from the transaction. Now that I am aware of this, I realize that this API does not make sense to ask for these parameters because it should already know them. How, this is a breaking change in the `ProviderAPI`. I think it is still okay for us to make this change so long that we update all the provider plugins as quick follow-ups / releases.

### How I did it

Remove transaction parameters from receipt API methods
Add needed attributes to Receipt API
Initialize properties during the decoding phase of the receipt using the transaction values.

### How to verify it

Things still work (make sure to use either the test or geth providers here)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
