### PR TITLE
docs: fix path versioning issue / filter out betas

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -63,16 +63,17 @@ def main():
         if not tag:
             raise DocsBuildError("Unable to find release tag.")
 
-        build_dir = DOCS_BUILD_PATH / tag
-        build_docs(build_dir)
+        if "beta" not in tag and "alpha" not in tag:
+            build_dir = DOCS_BUILD_PATH / tag
+            build_docs(build_dir)
 
-        # Clean-up unnecessary extra 'fonts/' directories to save space.
-        # There should still be one in 'latest/'
-        for font_dirs in build_dir.glob("**/fonts"):
-            if font_dirs.exists():
-                shutil.rmtree(font_dirs)
+            # Clean-up unnecessary extra 'fonts/' directories to save space.
+            # There should still be one in 'latest/'
+            for font_dirs in build_dir.glob("**/fonts"):
+                if font_dirs.exists():
+                    shutil.rmtree(font_dirs)
 
-        shutil.copytree(build_dir, STABLE_PATH)
+            shutil.copytree(build_dir, STABLE_PATH)
 
     # Set up the redirect at /index.html
     with open(DOCS_BUILD_PATH / "index.html", "w") as f:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ def fixpath(path: str) -> str:
     new = f"/{project}/latest/_static"
 
     if suffix:
-        new = str(Path(new) / suffix)
+        new = str(Path(new) / suffix.lstrip("/"))
 
     return new
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ def fixpath(path: str) -> str:
     new = f"/{project}/latest/_static"
 
     if suffix:
-        new = f"{new}/{suffix}"
+        new = str(Path(new) / suffix)
 
     return new
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,8 +88,14 @@ def get_versions() -> List[str]:
         return []
 
     versions = [
-        d.name for d in build_dir.iterdir() if d.is_dir and re.match(r"v\d+.?\d?.?\d?", d.stem)
+        d.name
+        for d in build_dir.iterdir()
+        if d.is_dir
+        and re.match(r"v\d+.?\d?.?\d?", d.stem)
+        and "beta" not in d.name
+        and "alpha" not in d.name
     ]
+
     return versions
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@
 ```{eval-rst}
 .. toctree::
    :caption: CLI Reference
+   :maxdepth: 1
 
    commands/accounts.rst
    commands/compile.rst


### PR DESCRIPTION
### What I did

* Fix path issue causing versioning system not to work right
* Filter out beta and alpha from versioning system
* Keep CLI TOC nested to 1 level to match the other and look cleaner.

### How I did it

Using path lib to sanitize the path (a leading slash was causing issues)

### How to verify it

Build docs locally
Copy "latest" folder and create fake folders next to it for "stable", "v0.1.0.beta.1" and "v0.1.0". The beta should be filtered out.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
