### PR TITLE
feat: handle iterable args

### DIFF
--- a/src/ape/__init__.py
+++ b/src/ape/__init__.py
@@ -49,7 +49,13 @@ _converters = _ConversionManager(config, plugin_manager, networks)  # type: igno
 accounts = _AccountManager(config, _converters, plugin_manager, networks)  # type: ignore
 """Manages accounts for the current project. See :class:`ape.managers.accounts.AccountManager`."""
 
-Project = _partial(_ProjectManager, config=config, compilers=compilers, networks=networks)
+Project = _partial(
+    _ProjectManager,
+    config=config,
+    compilers=compilers,
+    networks=networks,
+    converter=_converters,
+)
 """User-facing class for instantiating Projects (in addition to the currently
 active ``project``). See :class:`ape.managers.project.ProjectManager`."""
 

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -200,10 +200,12 @@ class AccountAPI(AddressAPI):
         address = click.style(receipt.contract_address, bold=True)
         logger.success(f"Contract '{contract.contract_type.contractName}' deployed to: {address}")
 
+        from ape import _converters
         from ape.contracts import ContractInstance
 
         return ContractInstance(  # type: ignore
             _provider=self.provider,
+            _converter=_converters,
             _address=receipt.contract_address,
             _contract_type=contract.contract_type,
         )

--- a/src/ape/api/convert.py
+++ b/src/ape/api/convert.py
@@ -5,6 +5,7 @@ from ape.utils import abstractdataclass, abstractmethod
 from .config import ConfigItem
 
 if TYPE_CHECKING:
+    from ape.managers.converters import ConversionManager
     from ape.managers.networks import NetworkManager
 
 ConvertedType = TypeVar("ConvertedType")
@@ -17,6 +18,8 @@ class ConverterAPI(Generic[ConvertedType]):
 
     # NOTE: In case we need access to a network e.g. ENS
     networks: "NetworkManager"
+
+    converter: "ConversionManager"
 
     @abstractmethod
     def is_convertible(self, value: Any) -> bool:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -36,6 +36,7 @@ class ContractConstructor:
     deployment_bytecode: bytes
     abi: Optional[ABI]
     provider: ProviderAPI
+    converter: "ConversionManager"
 
     def __post_init__(self):
         if len(self.deployment_bytecode) == 0:
@@ -67,6 +68,7 @@ class ContractCall:
     abi: ABI
     address: AddressType
     provider: ProviderAPI
+    converter: "ConversionManager"
 
     def __repr__(self) -> str:
         return self.abi.signature
@@ -97,6 +99,7 @@ class ContractCall:
 @dataclass
 class ContractCallHandler:
     provider: ProviderAPI
+    converter: "ConversionManager"
     address: AddressType
     abis: List[ABI]
 
@@ -130,6 +133,7 @@ class ContractTransaction:
     abi: ABI
     address: AddressType
     provider: ProviderAPI
+    converter: "ConversionManager"
 
     def __repr__(self) -> str:
         return self.abi.signature
@@ -151,6 +155,7 @@ class ContractTransaction:
 @dataclass
 class ContractTransactionHandler:
     provider: ProviderAPI
+    converter: "ConversionManager"
     address: AddressType
     abis: List[ABI]
 
@@ -179,6 +184,7 @@ class ContractLog:
 @dataclass
 class ContractEvent:
     provider: ProviderAPI
+    converter: "ConversionManager"
     address: str
     abis: List[ABI]
     cached_logs: List[ContractLog] = []
@@ -199,6 +205,7 @@ class ContractInstance(AddressAPI):
     """
 
     _address: AddressType
+    _converter: "ConversionManager"
     _contract_type: ContractType
 
     def __repr__(self) -> str:
@@ -256,6 +263,7 @@ class ContractInstance(AddressAPI):
 
             kwargs = {
                 "provider": self.provider,
+                "converter": self._converter,
                 "address": self.address,
                 "abis": selected_abis,
             }
@@ -298,6 +306,8 @@ class ContractContainer:
     _provider: Optional[ProviderAPI]
     # _provider is only None when a user is not connected to a provider.
 
+    _converter: "ConversionManager"
+
     def __repr__(self) -> str:
         return f"<{self.contract_type.contractName}>"
 
@@ -324,6 +334,7 @@ class ContractContainer:
         return ContractInstance(  # type: ignore
             _address=address,
             _provider=self._provider,
+            _converter=self._converter,
             _contract_type=self.contract_type,
         )
 
@@ -347,6 +358,7 @@ class ContractContainer:
         constructor = ContractConstructor(  # type: ignore
             abi=self.contract_type.constructor,
             provider=self._provider,
+            converter=self._converter,
             deployment_bytecode=self._deployment_bytecode,
         )
         return constructor.encode(*args, **kwargs)
@@ -388,6 +400,7 @@ def _Contract(
         return ContractInstance(  # type: ignore
             _address=converted_address,
             _provider=provider,
+            _converter=converters,
             _contract_type=contract_type,
         )
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -54,6 +54,7 @@ class ContractConstructor:
         )
 
     def __call__(self, *args, **kwargs) -> ReceiptAPI:
+        args = self.converter.convert(args, tuple)
         if "sender" in kwargs:
             sender = kwargs["sender"]
             txn = self.encode(*args, **kwargs)
@@ -74,11 +75,13 @@ class ContractCall:
         return self.abi.signature
 
     def encode(self, *args, **kwargs) -> TransactionAPI:
+        args = self.converter.convert(args, tuple)
         return self.provider.network.ecosystem.encode_transaction(
             self.address, self.abi, *_encode_address_args(*args), **_encode_address_kwargs(**kwargs)
         )
 
     def __call__(self, *args, **kwargs) -> Any:
+        args = self.converter.convert(args, tuple)
         txn = self.encode(*args, **kwargs)
         txn.chain_id = self.provider.network.chain_id
 
@@ -108,6 +111,7 @@ class ContractCallHandler:
         return abis[-1].signature
 
     def __call__(self, *args, **kwargs) -> Any:
+        args = self.converter.convert(args, tuple)
         selected_abi = _select_abi(self.abis, args)
         if not selected_abi:
             raise ArgumentsLengthError()
@@ -139,11 +143,13 @@ class ContractTransaction:
         return self.abi.signature
 
     def encode(self, *args, **kwargs) -> TransactionAPI:
+        args = self.converter.convert(args, tuple)
         return self.provider.network.ecosystem.encode_transaction(
             self.address, self.abi, *_encode_address_args(*args), **_encode_address_kwargs(**kwargs)
         )
 
     def __call__(self, *args, **kwargs) -> ReceiptAPI:
+        args = self.converter.convert(args, tuple)
         if "sender" in kwargs:
             sender = kwargs["sender"]
             txn = self.encode(*args, **kwargs)
@@ -164,6 +170,7 @@ class ContractTransactionHandler:
         return abis[-1].signature
 
     def __call__(self, *args, **kwargs) -> ReceiptAPI:
+        args = self.converter.convert(args, tuple)
         selected_abi = _select_abi(self.abis, args)
         if not selected_abi:
             raise ArgumentsLengthError()
@@ -355,6 +362,7 @@ class ContractContainer:
             return b""
 
     def __call__(self, *args, **kwargs) -> TransactionAPI:
+        args = self._converter.convert(args, tuple)
         constructor = ContractConstructor(  # type: ignore
             abi=self.contract_type.constructor,
             provider=self._provider,

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -120,6 +120,7 @@ class ContractCallHandler:
             abi=selected_abi,
             address=self.address,
             provider=self.provider,
+            converter=self.converter,
         )(*args, **kwargs)
 
 
@@ -179,6 +180,7 @@ class ContractTransactionHandler:
             abi=selected_abi,
             address=self.address,
             provider=self.provider,
+            converter=self.converter,
         )(*args, **kwargs)
 
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -41,6 +41,7 @@ class ContractConstructor:
         return self.abi.signature if self.abi else "constructor()"
 
     def encode(self, *args, **kwargs) -> TransactionAPI:
+        args = self.converter.convert(args, tuple)
         return self.provider.network.ecosystem.encode_deployment(
             self.deployment_bytecode, self.abi, *args, **_encode_address_kwargs(**kwargs)
         )

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -18,11 +18,6 @@ if TYPE_CHECKING:
     from ape.managers.networks import NetworkManager
 
 
-def _encode_address_args(*args):
-    # Convert higher level address types to str
-    return [arg.address if isinstance(arg, AddressAPI) else arg for arg in args]
-
-
 def _encode_address_kwargs(**kwargs):
     # Convert higher level address types to str
     return {
@@ -47,10 +42,7 @@ class ContractConstructor:
 
     def encode(self, *args, **kwargs) -> TransactionAPI:
         return self.provider.network.ecosystem.encode_deployment(
-            self.deployment_bytecode,
-            self.abi,
-            *_encode_address_args(*args),
-            **_encode_address_kwargs(**kwargs),
+            self.deployment_bytecode, self.abi, *args, **_encode_address_kwargs(**kwargs)
         )
 
     def __call__(self, *args, **kwargs) -> ReceiptAPI:
@@ -77,7 +69,7 @@ class ContractCall:
     def encode(self, *args, **kwargs) -> TransactionAPI:
         args = self.converter.convert(args, tuple)
         return self.provider.network.ecosystem.encode_transaction(
-            self.address, self.abi, *_encode_address_args(*args), **_encode_address_kwargs(**kwargs)
+            self.address, self.abi, *args, **_encode_address_kwargs(**kwargs)
         )
 
     def __call__(self, *args, **kwargs) -> Any:
@@ -146,7 +138,7 @@ class ContractTransaction:
     def encode(self, *args, **kwargs) -> TransactionAPI:
         args = self.converter.convert(args, tuple)
         return self.provider.network.ecosystem.encode_transaction(
-            self.address, self.abi, *_encode_address_args(*args), **_encode_address_kwargs(**kwargs)
+            self.address, self.abi, *args, **_encode_address_kwargs(**kwargs)
         )
 
     def __call__(self, *args, **kwargs) -> ReceiptAPI:

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -130,6 +130,9 @@ class ListTupleConverter(ConverterAPI):
                         conversion_found = True
                         break
 
+                if conversion_found:
+                    break
+
             if not conversion_found:
                 # NOTE: If no conversions found, just insert the original
                 converted_value.append(v)

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Any, Dict, List, Type
 
 from dataclassy import dataclass
@@ -123,6 +124,7 @@ class ConversionManager:
             AddressType: [address_api_converter, hex_address_converter],
             bytes: [hex_converter],
             int: [],
+            Decimal: [],
         }
 
         for plugin_name, (conversion_type, converter_class) in self.plugin_manager.converters:

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -97,8 +97,7 @@ hex_address_converter = HexAddressConverter(None, None, None)  # type: ignore
 
 class ListTupleConverter(ConverterAPI):
     """
-    A converter that converts any tuple or list of items
-    :class:`~ape.types.AddressType`.
+    A converter that converts all items in a tuple or list recursively.
     """
 
     def is_convertible(self, value: Any) -> bool:

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -22,8 +22,8 @@ class HexConverter(ConverterAPI):
     A converter that converts ``str`` to ``HexBytes``.
     """
 
-    def is_convertible(self, value: str) -> bool:
-        return is_hex(value)
+    def is_convertible(self, value: Any) -> bool:
+        return isinstance(value, str) and is_hex(value)
 
     def convert(self, value: str) -> bytes:
         """
@@ -74,7 +74,7 @@ class HexAddressConverter(ConverterAPI):
     :class:`~ape.types.AddressType`.
     """
 
-    def is_convertible(self, value: str) -> bool:
+    def is_convertible(self, value: Any) -> bool:
         return isinstance(value, str) and is_hex_address(value) and not is_checksum_address(value)
 
     def convert(self, value: str) -> AddressType:

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -39,7 +39,7 @@ class HexConverter(ConverterAPI):
         return HexBytes(value)
 
 
-hex_converter = HexConverter(None, None)  # type: ignore
+hex_converter = HexConverter(None, None, None)  # type: ignore
 
 
 class AddressAPIConverter(ConverterAPI):
@@ -65,7 +65,7 @@ class AddressAPIConverter(ConverterAPI):
         return value.address
 
 
-address_api_converter = AddressAPIConverter(None, None)  # type: ignore
+address_api_converter = AddressAPIConverter(None, None, None)  # type: ignore
 
 
 class HexAddressConverter(ConverterAPI):
@@ -128,7 +128,7 @@ class ConversionManager:
         }
 
         for plugin_name, (conversion_type, converter_class) in self.plugin_manager.converters:
-            converter = converter_class(self.config.get_config(plugin_name), self.networks)
+            converter = converter_class(self.config.get_config(plugin_name), self.networks, self)
 
             if conversion_type not in converters:
                 options = ", ".join([t.__name__ for t in converters])

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from dataclassy import dataclass
 from eth_utils import is_checksum_address, is_hex, is_hex_address, to_checksum_address
@@ -102,17 +102,17 @@ class ListTupleConverter(ConverterAPI):
     """
 
     def is_convertible(self, value: Any) -> bool:
-        return isinstance(value, list) or isinstance(value, tuple)
+        return isinstance(value, (list, tuple))
 
-    def convert(self, value: Union[list, tuple]) -> Union[list, tuple]:
+    def convert(self, value: Union[List, Tuple]) -> Union[List, Tuple]:
         """
         Convert the items inside the given list or tuple.
 
         Args:
-            value (``list`` or ``tuple``): The collection to convert.
+            value (Union[List, Tuple]): The collection to convert.
 
         Returns:
-            ``list`` or ``tuple`` (depending on input)
+            Union[list, tuple]: Depending on the input
         """
 
         converted_value: List[Any] = []
@@ -136,13 +136,11 @@ class ListTupleConverter(ConverterAPI):
                     raise ConversionError(f"Unsupported ABI Type: {v.__class__}")
 
             # Try all of them to see if one converts it over (only use first one)
+            conversion_found = False
             for check_fn, convert_fn in map(lambda c: (c.is_convertible, c.convert), converters):
                 if check_fn(v):
                     converted_value.append(convert_fn(v))
                     conversion_found = True
-                    break
-
-                if conversion_found:
                     break
 
             if not conversion_found:

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -13,6 +13,7 @@ from ape.utils import compute_checksum, get_all_files_in_directory, github_clien
 
 from .compilers import CompilerManager
 from .config import ConfigManager
+from .converters import ConversionManager
 
 
 def _create_source_dict(contracts_paths: Collection[Path]) -> Dict[str, Source]:
@@ -51,6 +52,7 @@ class ProjectManager:
 
     path: Path
     config: ConfigManager
+    converter: ConversionManager
     compilers: CompilerManager
     networks: NetworkManager
 
@@ -374,7 +376,9 @@ class ProjectManager:
             raise AttributeError(f"{self.__class__.__name__} has no attribute '{attr_name}'.")
 
         return ContractContainer(  # type: ignore
-            contract_type=contract_type, _provider=self.networks.active_provider
+            contract_type=contract_type,
+            _provider=self.networks.active_provider,
+            _converter=self.converter,
         )
 
     @property

--- a/tests/functional/conversion/test_ether.py
+++ b/tests/functional/conversion/test_ether.py
@@ -39,3 +39,7 @@ def test_no_registered_converter():
         convert(value="something", type=ChecksumAddress)
 
     assert str(err.value) == "No conversion registered to handle 'something'."
+
+
+def test_lists():
+    assert convert(["1 ether"], list) == [int(1e18)]

--- a/tests/functional/conversion/test_ether.py
+++ b/tests/functional/conversion/test_ether.py
@@ -28,7 +28,7 @@ def test_bad_type():
     with pytest.raises(ConversionError) as err:
         convert(value="something", type=float)
 
-    expected = "Type '<class 'float'>' must be one of [ChecksumAddress, bytes, int]."
+    expected = "Type '<class 'float'>' must be one of [ChecksumAddress, bytes, int, Decimal]."
     assert str(err.value) == expected
 
 

--- a/tests/functional/conversion/test_ether.py
+++ b/tests/functional/conversion/test_ether.py
@@ -28,7 +28,9 @@ def test_bad_type():
     with pytest.raises(ConversionError) as err:
         convert(value="something", type=float)
 
-    expected = "Type '<class 'float'>' must be one of [ChecksumAddress, bytes, int, Decimal]."
+    expected = (
+        "Type '<class 'float'>' must be one of [ChecksumAddress, bytes, int, Decimal, list, tuple]."
+    )
     assert str(err.value) == expected
 
 


### PR DESCRIPTION
### What I did
Added support to `ConversionManager` for handling `tuple` and `list` conversions (e.g. recursively applying conversions)

fixes: #376

### How I did it

### How to verify it

### Checklist

- [x] Add integration support to `ape.contracts` ABI arg processing
- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
