### PR TITLE
feat: chain manager

### DIFF
--- a/docs/methoddocs/managers.md
+++ b/docs/methoddocs/managers.md
@@ -16,6 +16,15 @@
     :members:
 ```
 
+## Chain
+
+```{eval-rst}
+.. automodule:: ape.managers.chain
+    :members:
+    :special-members:
+    :exclude-members: __repr__, __weakref__, __metaclass__
+```
+
 ## Config
 
 ```{eval-rst}

--- a/src/ape/__init__.py
+++ b/src/ape/__init__.py
@@ -54,7 +54,7 @@ Useful for development purposes, such as controlling the state of the blockchain
 Also handy for querying data about the chain and managing local caches.
 """
 
-accounts = _AccountManager(config, _converters, plugin_manager, networks, chain)  # type: ignore
+accounts = _AccountManager(config, _converters, plugin_manager, networks)  # type: ignore
 """Manages accounts for the current project. See :class:`ape.managers.accounts.AccountManager`."""
 
 Project = _partial(

--- a/src/ape/__init__.py
+++ b/src/ape/__init__.py
@@ -47,7 +47,14 @@ networks = _NetworkManager(config, plugin_manager)  # type: ignore
 
 _converters = _ConversionManager(config, plugin_manager, networks)  # type: ignore
 
-accounts = _AccountManager(config, _converters, plugin_manager, networks)  # type: ignore
+chain = _ChainManager(networks)  # type: ignore
+"""
+The current connected blockchain; requires an active provider.
+Useful for development purposes, such as controlling the state of the blockchain.
+Also handy for querying data about the chain and managing local caches.
+"""
+
+accounts = _AccountManager(config, _converters, plugin_manager, networks, chain)  # type: ignore
 """Manages accounts for the current project. See :class:`ape.managers.accounts.AccountManager`."""
 
 Project = _partial(
@@ -68,13 +75,6 @@ Contract = _partial(_Contract, networks=networks, converters=_converters)
 
 convert = _converters.convert
 """Conversion utility function. See :class:`ape.managers.converters.ConversionManager`."""
-
-chain = _ChainManager(networks)  # type: ignore
-"""
-The current connected blockchain; requires an active provider.
-Useful for development purposes, such as controlling the state of the blockchain.
-Also handy for querying data about the chain and managing local caches.
-"""
 
 
 __all__ = [

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -44,9 +44,6 @@ class AccountAPI(AddressAPI):
     def alias(self) -> Optional[str]:
         """
         A shortened-name for quicker access to the account.
-
-        Returns:
-            str (optional)
         """
         return None
 
@@ -56,7 +53,7 @@ class AccountAPI(AddressAPI):
         Sign a message.
 
         Args:
-          msg (SignableMessage): The message to sign.
+          msg (:class:`~ape.types.signatures.SignableMessage`): The message to sign.
             See these
             `docs <https://eth-account.readthedocs.io/en/stable/eth_account.html#eth_account.messages.SignableMessage>`__  # noqa: E501
             for more type information on this type.
@@ -137,9 +134,7 @@ class AccountAPI(AddressAPI):
         if not txn.signature:
             raise SignatureError("The transaction was not signed.")
 
-        receipt = self.provider.send_transaction(txn)
-        self.chain.account_history.append(receipt)
-        return receipt
+        return self.provider.send_transaction(txn)
 
     @cached_property
     def _convert(self) -> Callable:

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -137,7 +137,9 @@ class AccountAPI(AddressAPI):
         if not txn.signature:
             raise SignatureError("The transaction was not signed.")
 
-        return self.provider.send_transaction(txn)
+        receipt = self.provider.send_transaction(txn)
+        self._chain.account_history.append_transaction(txn)
+        return receipt
 
     @cached_property
     def _convert(self) -> Callable:

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -39,6 +39,7 @@ class AddressAPI:
     def provider(self, value: ProviderAPI):
         """
         Set the active provider if connected to one.
+
         Args:
             value (:class:`~ape.api.providers.ProviderAPI`): The provider to set.
         """

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -1,9 +1,9 @@
 from typing import List, Optional
 
+from ape.exceptions import AddressError
 from ape.types import AddressType
 from ape.utils import abstractdataclass, abstractmethod
 
-from ..exceptions import AddressError
 from .providers import ProviderAPI
 
 

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -35,6 +35,16 @@ class AddressAPI:
 
         return self._provider
 
+    @provider.setter
+    def provider(self, value: ProviderAPI):
+        """
+        Set the active provider if connected to one.
+        Args:
+            value (:class:`~ape.api.providers.ProviderAPI`): The provider to set.
+        """
+
+        self._provider = value
+
     @property
     @abstractmethod
     def address(self) -> AddressType:

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -1,10 +1,12 @@
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
-from ape.exceptions import AddressError
 from ape.types import AddressType
 from ape.utils import abstractdataclass, abstractmethod
 
 from .providers import ProviderAPI
+
+if TYPE_CHECKING:
+    from ape.managers.chain import ChainManager
 
 
 @abstractdataclass
@@ -13,7 +15,7 @@ class AddressAPI:
     A base address API class. All account-types subclass this type.
     """
 
-    _provider: Optional[ProviderAPI] = None
+    _chain: Optional["ChainManager"] = None
 
     @property
     def provider(self) -> ProviderAPI:
@@ -28,23 +30,7 @@ class AddressAPI:
             :class:`~ape.api.providers.ProviderAPI`
         """
 
-        if not self._provider:
-            raise AddressError(
-                f"Incorrectly implemented provider API for class {type(self).__name__}"
-            )
-
-        return self._provider
-
-    @provider.setter
-    def provider(self, value: ProviderAPI):
-        """
-        Set the active provider if connected to one.
-
-        Args:
-            value (:class:`~ape.api.providers.ProviderAPI`): The provider to set.
-        """
-
-        self._provider = value
+        return self._chain.provider
 
     @property
     @abstractmethod

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -19,9 +19,11 @@ class AddressAPI:
     def provider(self) -> ProviderAPI:
         """
         The current active provider if connected to one.
+
         Raises:
             :class:`~ape.exceptions.AddressError`: When there is no active
                provider at runtime.
+
         Returns:
             :class:`~ape.api.providers.ProviderAPI`
         """

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -1,13 +1,10 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import List, Optional
 
 from ape.types import AddressType
 from ape.utils import abstractdataclass, abstractmethod
 
 from ..exceptions import AddressError
 from .providers import ProviderAPI
-
-if TYPE_CHECKING:
-    from ape.managers.chain import ChainManager
 
 
 @abstractdataclass
@@ -16,34 +13,25 @@ class AddressAPI:
     A base address API class. All account-types subclass this type.
     """
 
-    _chain: Optional["ChainManager"] = None
-
-    @property
-    def chain(self):
-        """
-        The current active blockchain, if connected to one.
-
-        Raises:
-            :class:`~ape.exceptions.AddressError`: When there is no active
-               chain at runtime.
-        """
-
-        if not self._chain:
-            raise AddressError(
-                f"Incorrectly implemented provider API for class {type(self).__name__}. "
-                "Provider missing access to chain manager."
-            )
+    _provider: Optional[ProviderAPI] = None
 
     @property
     def provider(self) -> ProviderAPI:
         """
         The current active provider if connected to one.
-
         Raises:
             :class:`~ape.exceptions.AddressError`: When there is no active
                provider at runtime.
+        Returns:
+            :class:`~ape.api.providers.ProviderAPI`
         """
-        return self.chain.provider
+
+        if not self._provider:
+            raise AddressError(
+                f"Incorrectly implemented provider API for class {type(self).__name__}"
+            )
+
+        return self._provider
 
     @property
     @abstractmethod

--- a/src/ape/api/explorers.py
+++ b/src/ape/api/explorers.py
@@ -1,10 +1,10 @@
 from typing import Iterator, Optional
 
-from ape.api import ReceiptAPI
 from ape.types import AddressType, ContractType
 from ape.utils import abstractdataclass, abstractmethod
 
 from . import networks
+from .providers import ReceiptAPI
 
 
 @abstractdataclass

--- a/src/ape/api/explorers.py
+++ b/src/ape/api/explorers.py
@@ -1,5 +1,6 @@
-from typing import Optional
+from typing import Iterator, Optional
 
+from ape.api import ReceiptAPI
 from ape.types import AddressType, ContractType
 from ape.utils import abstractdataclass, abstractmethod
 
@@ -48,8 +49,20 @@ class ExplorerAPI:
         Get the contract type for a given address if it has been published in an explorer.
 
         Args:
-            address (str): The contract address.
+            address (:class:`~ape.types.AddressType`): The contract address.
 
         Returns:
-            :class:`~ape.contracts.ContractType` if published, else ``None``.
+            Optional[:class:`~ape.contracts.ContractType`]: If not published, returns ``None``.
+        """
+
+    @abstractmethod
+    def get_account_transactions(self, address: AddressType) -> Iterator[ReceiptAPI]:
+        """
+        Get a list of list of transactions performed by an address.
+
+        Args:
+            address (:class:`~ape.types.AddressType`): The account address.
+
+        Returns:
+            Iterator[:class:`~ape.api.providers.ReceiptAPI`]
         """

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -345,6 +345,15 @@ class NetworkAPI:
 
         return self.config_manager.get_config(self.ecosystem.name)
 
+    @cached_property
+    def network_config(self) -> ConfigItem:
+        """
+        The configuration of the network. See :class:`~ape.managers.config.ConfigManager`
+        for more information on plugin configurations.
+        """
+
+        return self.config.get(self.name, {})  # type: ignore
+
     @property
     def chain_id(self) -> int:
         """
@@ -391,11 +400,25 @@ class NetworkAPI:
         Returns:
             int
         """
-        try:
-            return self.config[self.name]["required_confirmations"]
-        except KeyError:
-            # Is likely a 'development' network.
-            return 0
+        return self.network_config.get("required_confirmations", 0)  # type: ignore
+
+    @property
+    def approximate_block_time(self) -> int:
+        """
+        The approximate amount of time it takes for a new block to get mined to the chain.
+        Configure in your ``ape-config.yaml`` file via.
+
+        Config example::
+
+            ethereum:
+              mainnet:
+                approximxate_block_time: 15
+
+        Returns:
+            int
+        """
+
+        return self.network_config.get("approximate_block_time", 0)  # type: ignore
 
     @cached_property
     def explorer(self) -> Optional["ExplorerAPI"]:

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -346,12 +346,7 @@ class NetworkAPI:
         return self.config_manager.get_config(self.ecosystem.name)
 
     @cached_property
-    def network_config(self) -> ConfigItem:
-        """
-        The configuration of the network. See :class:`~ape.managers.config.ConfigManager`
-        for more information on plugin configurations.
-        """
-
+    def _network_config(self) -> ConfigItem:
         return self.config.get(self.name, {})  # type: ignore
 
     @property
@@ -400,13 +395,13 @@ class NetworkAPI:
         Returns:
             int
         """
-        return self.network_config.get("required_confirmations", 0)  # type: ignore
+        return self._network_config.get("required_confirmations", 0)  # type: ignore
 
     @property
     def approximate_block_time(self) -> int:
         """
         The approximate amount of time it takes for a new block to get mined to the chain.
-        Configure in your ``ape-config.yaml`` file via.
+        Configure in your ``ape-config.yaml`` file.
 
         Config example::
 
@@ -418,7 +413,7 @@ class NetworkAPI:
             int
         """
 
-        return self.network_config.get("approximate_block_time", 0)  # type: ignore
+        return self._network_config.get("approximate_block_time", 0)  # type: ignore
 
     @cached_property
     def explorer(self) -> Optional["ExplorerAPI"]:

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -407,7 +407,7 @@ class NetworkAPI:
 
             ethereum:
               mainnet:
-                approximxate_block_time: 15
+                block_time: 15
 
         Returns:
             int

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -398,7 +398,7 @@ class NetworkAPI:
         return self._network_config.get("required_confirmations", 0)  # type: ignore
 
     @property
-    def approximate_block_time(self) -> int:
+    def block_time(self) -> int:
         """
         The approximate amount of time it takes for a new block to get mined to the chain.
         Configure in your ``ape-config.yaml`` file.
@@ -413,7 +413,7 @@ class NetworkAPI:
             int
         """
 
-        return self._network_config.get("approximate_block_time", 0)  # type: ignore
+        return self._network_config.get("block_time", 0)  # type: ignore
 
     @cached_property
     def explorer(self) -> Optional["ExplorerAPI"]:

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -200,6 +200,7 @@ class ReceiptAPI:
     contract_address: Optional[str] = None
     required_confirmations: int = 0
     sender: str
+    receiver: str
     nonce: int
 
     def __post_init__(self):

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -404,9 +404,7 @@ class ProviderAPI:
     def chain_id(self) -> int:
         """
         The blockchain ID.
-
-        Returns:
-            int: The value of the blockchain ID.
+        See `ChainList <https://chainlist.org/>`__ for a comprehensive list of IDs.
         """
 
     @abstractmethod
@@ -462,24 +460,18 @@ class ProviderAPI:
     @abstractmethod
     def gas_price(self) -> int:
         """
-        The price for what it costs to transact.
-
-        Returns:
-            int
+        The price for what it costs to transact
+        (pre-`EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__).
         """
 
     @property
     def priority_fee(self) -> int:
         """
-        A miner tip to incentivize them
-        to include your transaction in a block.
+        A miner tip to incentivize them to include your transaction in a block.
 
         Raises:
             NotImplementedError: When the provider does not implement
               `EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__ typed transactions.
-
-        Returns:
-            int: The value of the fee.
         """
         raise NotImplementedError("priority_fee is not implemented by this provider")
 
@@ -494,9 +486,6 @@ class ProviderAPI:
         Raises:
             NotImplementedError: When this provider does not implement
               `EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__.
-
-        Returns:
-            int
         """
         raise NotImplementedError("base_fee is not implemented by this provider")
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -588,6 +588,17 @@ class TestProviderAPI(ProviderAPI):
             snapshot_id (str): The snapshot ID.
         """
 
+    def sleep(self, seconds: int) -> int:
+        """
+        Increase the time of the chain.
+
+        Args:
+            seconds (int): Seconds to move the chain into the future.
+
+        Returns:
+            int: The new current timestamp.
+        """
+
 
 class Web3Provider(ProviderAPI):
     """

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -483,8 +483,7 @@ class ProviderAPI:
     @property
     def base_fee(self) -> int:
         """
-        The minimum value required to get your transaction
-        included on the next block.
+        The minimum value required to get your transaction included on the next block.
         Only providers that implement `EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__
         will use this property.
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -557,6 +557,10 @@ class ProviderAPI:
             Iterator[dict]: A dictionary of events.
         """
 
+    def _try_track_receipt(self, receipt: ReceiptAPI):
+        if self._chain:
+            self._chain.account_history.append(receipt)
+
 
 class TestProviderAPI(ProviderAPI):
     """
@@ -674,10 +678,7 @@ class Web3Provider(ProviderAPI):
             else self.network.required_confirmations
         )
         receipt = self.get_transaction(txn_hash.hex(), required_confirmations=req_confs)
-
-        if self._chain:
-            self._chain.account_history.append(receipt)
-
+        self._try_track_receipt(receipt)
         return receipt
 
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -588,17 +588,6 @@ class TestProviderAPI(ProviderAPI):
             snapshot_id (str): The snapshot ID.
         """
 
-    def sleep(self, seconds: int) -> int:
-        """
-        Increase the time of the chain.
-
-        Args:
-            seconds (int): Seconds to move the chain into the future.
-
-        Returns:
-            int: The new current timestamp.
-        """
-
 
 class Web3Provider(ProviderAPI):
     """

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1,7 +1,7 @@
 import time
 from enum import Enum, IntEnum
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional
+from typing import TYPE_CHECKING, Dict, Iterator, List, Optional
 
 from dataclassy import as_dict
 from eth_typing import HexStr
@@ -17,6 +17,9 @@ from ape.utils import abstractdataclass, abstractmethod
 
 from . import networks
 from .config import ConfigItem
+
+if TYPE_CHECKING:
+    from ape.managers.chain import ChainManager
 
 
 class TransactionType(Enum):
@@ -359,6 +362,8 @@ class ProviderAPI:
     plugin or the `ape-hardhat <https://github.com/ApeWorX/ape-hardhat>`__ plugin.
     """
 
+    _chain: Optional["ChainManager"] = None
+
     name: str
     """The name of the provider (should be the plugin name)."""
 
@@ -669,6 +674,10 @@ class Web3Provider(ProviderAPI):
             else self.network.required_confirmations
         )
         receipt = self.get_transaction(txn_hash.hex(), required_confirmations=req_confs)
+
+        if self._chain:
+            self._chain.account_history.append(receipt)
+
         return receipt
 
 
@@ -683,7 +692,4 @@ class UpstreamProvider(ProviderAPI):
         """
         The str used by downstream providers to connect to this one.
         For example, the URL for HTTP-based providers.
-
-        Returns:
-            str
         """

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -216,4 +216,4 @@ class UnknownSnapshotError(ChainError):
             # Is block hash
             snapshot_id = humanize_hash(snapshot_id)  # type: ignore
 
-        super().__init__(f"Unknown snapshot ID '{str(snapshot_id)}'.")
+        super().__init__(f"Unknown snapshot ID '{snapshot_id}'.")

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -216,4 +216,4 @@ class UnknownSnapshotError(ChainError):
             # Is block hash
             snapshot_id = humanize_hash(snapshot_id)  # type: ignore
 
-        super().__init__(f"Unknown snapshot ID '{snapshot_id}'.")
+        super().__init__(f"Unknown snapshot ID '{str(snapshot_id)}'.")

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -226,4 +226,5 @@ class AccountManager:
         return any(address in container for container in self.containers.values())
 
     def _inject_provider(self, account: AccountAPI):
-        account._provider = self.network_manager.active_provider
+        if self.network_manager.active_provider is not None:
+            account.provider = self.network_manager.active_provider

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -7,7 +7,6 @@ from ape.api.accounts import AccountAPI, AccountContainerAPI, TestAccountAPI
 from ape.types import AddressType
 from ape.utils import cached_property, singledispatchmethod
 
-from .chain import ChainManager
 from .config import ConfigManager
 from .converters import ConversionManager
 from .networks import NetworkManager
@@ -34,7 +33,6 @@ class AccountManager:
     converters: ConversionManager
     plugin_manager: PluginManager
     network_manager: NetworkManager
-    chain_manager: ChainManager
 
     @cached_property
     def containers(self) -> Dict[str, AccountContainerAPI]:

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -91,7 +91,7 @@ class AccountManager:
         accounts_with_type = []
         for account in self:
             if isinstance(account, type_):
-                self._inject_chain(account)
+                self._inject_provider(account)
                 accounts_with_type.append(account)
 
         return accounts_with_type
@@ -109,7 +109,7 @@ class AccountManager:
     def __iter__(self) -> Iterator[AccountAPI]:
         for container in self.containers.values():
             for account in container:
-                self._inject_chain(account)
+                self._inject_provider(account)
                 yield account
 
     def __repr__(self) -> str:
@@ -141,7 +141,7 @@ class AccountManager:
 
             container = container_type(None, account_type, self.config)
             for account in container:
-                self._inject_chain(account)
+                self._inject_provider(account)
                 accounts.append(account)
 
         return accounts
@@ -162,7 +162,7 @@ class AccountManager:
 
         for account in self:
             if account.alias and account.alias == alias:
-                self._inject_chain(account)
+                self._inject_provider(account)
                 return account
 
         raise IndexError(f"No account with alias '{alias}'.")
@@ -187,7 +187,7 @@ class AccountManager:
 
         for idx, account in enumerate(self.__iter__()):
             if account_id == idx:
-                self._inject_chain(account)
+                self._inject_provider(account)
                 return account
 
         raise IndexError(f"No account at index '{account_id}'.")
@@ -209,7 +209,7 @@ class AccountManager:
         for container in self.containers.values():
             if account_id in container:
                 account = container[account_id]
-                self._inject_chain(account)
+                self._inject_provider(account)
                 return account
 
         raise IndexError(f"No account with address '{account_id}'.")
@@ -227,5 +227,5 @@ class AccountManager:
 
         return any(address in container for container in self.containers.values())
 
-    def _inject_chain(self, account: AccountAPI):
-        account._chain = self.chain_manager
+    def _inject_provider(self, account: AccountAPI):
+        account._provider = self.network_manager.active_provider

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -54,8 +54,7 @@ class BlockContainer:
         return self.height + 1
 
     def __iter__(self) -> Iterator[BlockAPI]:
-        for i in range(len(self)):
-            yield self._get_block(i)
+        return self.range()
 
     @property
     def head(self) -> BlockAPI:
@@ -64,6 +63,13 @@ class BlockContainer:
     @property
     def height(self) -> int:
         return self.head.number
+
+    def range(self, start: int = 0, end: int = None) -> Iterator[BlockAPI]:
+        if end is None:
+            end = len(self)
+
+        for i in range(start, end):
+            yield self._get_block(i)
 
     def _get_block(self, block_id: BlockID) -> BlockAPI:
         return self._provider.get_block(block_id)

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -256,15 +256,14 @@ class ChainManager:
     _networks: NetworkManager
     _snapshots: List[SnapshotID] = []
     _chain_id_map: Dict[str, int] = {}
+    _time_offset: int = 0
 
     account_history: AccountHistory = AccountHistory()
     """A mapping of transactions from the active session to the account responsible."""
 
     def __repr__(self) -> str:
-        try:
-            return f"<ChainManager (chain_id={self.chain_id})>"
-        except ProviderNotConnectedError:
-            return "<ChainManager (disconnected)>"
+        props = f"id={self.chain_id}" if self._networks.active_provider else "disconnected"
+        return f"<ChainManager ({props})>"
 
     @property
     def provider(self) -> ProviderAPI:
@@ -331,7 +330,18 @@ class ChainManager:
         The current epoch time of the chain, as an ``int``.
         """
 
-        return int(time.time())
+        return int(time.time() + self._time_offset)
+
+    def sleep(self, seconds: int):
+        """
+        Increase the time (development-chains only).
+
+        Args:
+            seconds (int): Seconds to move the chain into the future.
+        """
+
+        test_provider = self._get_test_provider("sleep")
+        self._time_offset = test_provider.sleep(seconds)
 
     def snapshot(self) -> SnapshotID:
         """

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -152,6 +152,7 @@ class ChainManager:
         if not provider:
             raise ProviderNotConnectedError()
 
+        provider._chain = self
         return provider
 
     @property

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -134,8 +134,7 @@ class BlockContainer(_ConnectedChain):
     ) -> Iterator[BlockAPI]:
         """
         Poll new blocks. Optionally set a start block to include historical blocks.
-        **NOTE**: This is a deamon method; it does not terminate unless an exception
-        occurrs.
+        **NOTE**: This is a daemon method; it does not terminate unless an exception occurrs.
 
         Usage example::
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -173,8 +173,13 @@ class BlockContainer(_ConnectedChain):
                     "Try adjusting the required network confirmations."
                 )
             elif confirmable_block_number > latest_confirmed_block_number:
-                block = self._get_block(confirmable_block_number)
-                yield block
+                # Yield all missed confirmable blocks
+                new_blocks_count = confirmable_block_number - latest_confirmed_block_number
+                for i in range(new_blocks_count):
+                    block_num = latest_confirmed_block_number + i
+                    block = self._get_block(block_num)
+                    yield block
+
                 has_yielded = True
                 latest_confirmed_block_number = confirmable_block_number
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -330,8 +330,7 @@ class ChainManager(_ConnectedChain):
     @property
     def gas_price(self) -> int:
         """
-        The price for what it costs to transact
-        (pre-`EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__).
+        The price for what it costs to transact.
         """
 
         return self.provider.gas_price

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -50,7 +50,7 @@ class BlockContainer:
             int
         """
 
-        return self._provider.get_block("latest").number
+        return self._provider.get_block("latest").number + 1
 
 
 @dataclass

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -152,7 +152,6 @@ class ChainManager:
         if not provider:
             raise ProviderNotConnectedError()
 
-        provider._chain = self
         return provider
 
     @property

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -269,6 +269,7 @@ class ChainManager(ConnectedChain):
 
     _snapshots: List[SnapshotID] = []
     _chain_id_map: Dict[str, int] = {}
+    _account_history_map: Dict[int, AccountHistory] = {}
 
     @property
     def blocks(self) -> BlockContainer:
@@ -282,7 +283,11 @@ class ChainManager(ConnectedChain):
         """
         A mapping of transactions from the active session to the account responsible.
         """
-        return AccountHistory(self._networks)  # type: ignore
+        if self.chain_id not in self._account_history_map:
+            history = AccountHistory(self._networks)  # type: ignore
+            self._account_history_map[self.chain_id] = history
+
+        return self._account_history_map[self.chain_id]
 
     @property
     def chain_id(self) -> int:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -143,10 +143,11 @@ class BlockContainer(_ConnectedChain):
                 print(f"New block found: number={new_block.number}")
 
         Args:
-            start (Optional[int]): The block number to start with. Defaults to the block
-              of the ``+1`` the current block number when this method was called.
+            start (Optional[int]): The block number to start with. Defaults to the pending
+              block number.
             required_confirmations (Optional[int]): The amount of confirmations to wait
-              before yielding the block. The more confirmations, the less likely a reorg will occur.
+              before yielding the block. The more confirmations, the less likely a reorg
+                will occur.
 
         Returns:
             Iterator[:class:`~ape.api.providers.BlockAPI`]

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -104,7 +104,7 @@ class ChainManager:
         Returns:
             :class:`~ape.types.SnapshotID`: The snapshot ID.
         """
-        provider = self._get_test_provider("snapshot")
+        provider = self._get_test_provider(TestProviderAPI.snapshot.__name__)
         snapshot_id = provider.snapshot()
 
         if snapshot_id not in self._snapshots:
@@ -127,7 +127,7 @@ class ChainManager:
             snapshot_id (Optional[:class:`~ape.types.SnapshotID`]): The snapshot ID. Defaults
               to the most recent snapshot ID.
         """
-        provider = self._get_test_provider("restore")
+        provider = self._get_test_provider(TestProviderAPI.revert.__name__)
         if not self._snapshots:
             raise ChainError("There are no snapshots to revert to.")
         elif snapshot_id is None:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -5,7 +5,7 @@ from dataclassy import dataclass
 
 from ape.api import AddressAPI, BlockAPI, ProviderAPI, ReceiptAPI, TestProviderAPI
 from ape.exceptions import ChainError, ProviderNotConnectedError, UnknownSnapshotError
-from ape.types import AddressType, SnapshotID
+from ape.types import AddressType, BlockID, SnapshotID
 
 from .networks import NetworkManager
 
@@ -54,13 +54,19 @@ class BlockContainer:
         return self.height + 1
 
     def __iter__(self) -> Iterator[BlockAPI]:
-        for i in range(self.height):
-            yield self[i]
-        return (self[i] for i in range(self.height))
+        for i in range(len(self)):
+            yield self._get_block(i)
+
+    @property
+    def head(self) -> BlockAPI:
+        return self._get_block("latest")
 
     @property
     def height(self) -> int:
-        return self._provider.get_block("latest").number
+        return self.head.number
+
+    def _get_block(self, block_id: BlockID) -> BlockAPI:
+        return self._provider.get_block(block_id)
 
 
 class AccountHistory:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -54,21 +54,49 @@ class BlockContainer:
         return self.height + 1
 
     def __iter__(self) -> Iterator[BlockAPI]:
+        """
+        Iterate over all the current blocks.
+
+        Returns:
+            Iterator[:class:`~ape.api.providers.BlockAPI`]
+        """
+
         return self.range()
 
     @property
     def head(self) -> BlockAPI:
+        """
+        The latest block.
+        """
+
         return self._get_block("latest")
 
     @property
     def height(self) -> int:
+        """
+        The latest block number.
+        """
+
         return self.head.number
 
-    def range(self, start: int = 0, end: int = None) -> Iterator[BlockAPI]:
-        if end is None:
-            end = len(self)
+    def range(self, start: int = 0, stop: int = None) -> Iterator[BlockAPI]:
+        """
+        Iterate over blocks. Works similarly to python ``range()``.
 
-        for i in range(start, end):
+        Args:
+            start (int): The first block, by number, to include in the range.
+              Defaults to 0.
+            stop (int): The block number to stop before. Also the total
+             number of blocks to get.
+
+        Returns:
+            Iterator[:class:`~ape.api.providers.BlockAPI`]
+        """
+
+        if stop is None:
+            stop = len(self)
+
+        for i in range(start, stop):
             yield self._get_block(i)
 
     def _get_block(self, block_id: BlockID) -> BlockAPI:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -146,7 +146,7 @@ class BlockContainer(_ConnectedChain):
 
         Args:
             start (Optional[int]): The block number to start with. Defaults to the block
-              of the ``+1`` the current block number.
+              of the ``+1`` the current block number when this method was called.
             required_confirmations (Optional[int]): The amount of confirmations to wait
               before yielding the block. The more confirmations, the less likely a reorg will occur.
             poll_wait_interval (int): The amount of seconds to wait before checking for

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -121,8 +121,7 @@ class ChainManager:
             NotImplementedError: When the active provider does not support
               snapshotting.
             :class:`~ape.exceptions.UnknownSnapshotError`: When the snapshot ID is not cached.
-            :class:`~ape.exceptions.ChainError`: When the snapshot ID does not exist or there are
-              no snapshot IDs to select from.
+            :class:`~ape.exceptions.ChainError`: When there are no snapshot IDs to select from.
 
         Args:
             snapshot_id (Optional[:class:`~ape.types.SnapshotID`]): The snapshot ID. Defaults

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -116,6 +116,12 @@ class BlockContainer(ConnectedChain):
                 f"'stop={stop}' cannot be greater than the chain length ({len(self)}). "
                 f"Use '{self.poll_blocks.__name__}()' to wait for future blocks."
             )
+        elif stop < start:
+            raise ValueError(f"stop '{stop}' cannot be less than start '{start}'.")
+        elif stop < 0:
+            raise ValueError(f"start '{start}' cannot be negative.")
+        elif start < 0:
+            raise ValueError(f"stop '{stop}' cannot be negative.")
 
         for i in range(start, stop):
             yield self._get_block(i)

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -221,7 +221,7 @@ class AccountHistory(_ConnectedChain):
             [r for r in explorer.get_account_transactions(address_key)] if explorer else []
         )
         for receipt in explorer_receipts:
-            if receipt.txn_hash not in self._map.get(address_key, []):
+            if receipt.txn_hash not in [r.txn_hash for r in self._map.get(address_key, [])]:
                 self.append(receipt)
 
         return self._map.get(address_key, [])

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -126,7 +126,7 @@ class ChainManager:
 
         Args:
             snapshot_id (Optional[:class:`~ape.types.SnapshotID`]): The snapshot ID. Defaults
-            to the most recent snapshot ID.
+              to the most recent snapshot ID.
         """
         provider = self._get_test_provider()
         if not self._snapshots:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -164,7 +164,7 @@ class BlockContainer(_ConnectedChain):
             yield from self.range(start, latest_confirmed_block_number + 1)
             has_yielded = True
 
-        time.sleep(self.provider.network.approximate_block_time)
+        time.sleep(self.provider.network.block_time)
 
         while True:
             confirmable_block_number = self.height - required_confirmations
@@ -184,7 +184,7 @@ class BlockContainer(_ConnectedChain):
                 has_yielded = True
                 latest_confirmed_block_number = confirmable_block_number
 
-            time.sleep(self.provider.network.approximate_block_time)
+            time.sleep(self.provider.network.block_time)
 
     def _get_block(self, block_id: BlockID) -> BlockAPI:
         return self.provider.get_block(block_id)

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -148,7 +148,7 @@ class BlockContainer(_ConnectedChain):
             start (Optional[int]): The block number to start with. Defaults to the block
               of the ``+1`` the current block number.
             required_confirmations (Optional[int]): The amount of confirmations to wait
-              before yielding the block.
+              before yielding the block. The more confirmations, the less likely a reorg will occur.
             poll_wait_interval (int): The amount of seconds to wait before checking for
               new blocks. Defaults to ``2``.
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -116,7 +116,8 @@ class BlockContainer:
     ) -> Iterator[BlockAPI]:
         """
         Poll new blocks. Optionally set a start block to include historical blocks.
-        **NOTE**: This is a deamon method; it does not terminate.
+        **NOTE**: This is a deamon method; it does not terminate unless an exception
+        occurrs.
 
         Usage example::
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -195,10 +195,15 @@ class AccountHistory(ConnectedChain):
         """
 
         address_key: AddressType = self._convert(address, AddressType)
-        transactions = self._map.get(address_key, [])
+        explorer = self.provider.network.explorer
+        explorer_receipts = (
+            [r for r in explorer.get_account_transactions(address_key)] if explorer else []
+        )
+        for receipt in explorer_receipts:
+            if receipt.txn_hash not in self._map.get(address_key, []):
+                self.append(receipt)
 
-        # TODO: Use explorerAPI to get more transaction if possible
-        return transactions
+        return self._map.get(address_key, [])
 
     def __iter__(self) -> Iterator[AddressType]:
         """

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -138,6 +138,39 @@ class ChainManager:
 
         return provider
 
+    @property
+    def chain_id(self) -> int:
+        """
+        The blockchain ID.
+        See `ChainList <https://chainlist.org/>`__ for a comprehensive list of IDs.
+        """
+
+        return self.provider.chain_id
+
+    @property
+    def gas_price(self) -> int:
+        """
+        The price for what it costs to transact
+        (pre-`EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__).
+        """
+
+        return self.provider.gas_price
+
+    @property
+    def base_fee(self) -> int:
+        """
+        The minimum value required to get your transaction
+        included on the next block.
+        Only providers that implement `EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__
+        will use this property.
+
+        Raises:
+            NotImplementedError: When this provider does not implement
+              `EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__.
+        """
+
+        return self.provider.base_fee
+
     def snapshot(self) -> SnapshotID:
         """
         Record the current state of the blockchain with intent to later

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -40,7 +40,7 @@ class BlockContainer:
             :class:`~ape.api.providers.BlockAPI`
         """
         if block_number < 0:
-            block_number = self.height + 1 + block_number
+            block_number = len(self) + block_number
 
         return self._get_block(block_number)
 
@@ -121,10 +121,10 @@ class BlockContainer:
 
         Usage example::
 
-                from ape import chain
+            from ape import chain
 
-                for new_block in chain.blocks.poll_blocks():
-                    print(f"New block found: number={new_block.number}")
+            for new_block in chain.blocks.poll_blocks():
+                print(f"New block found: number={new_block.number}")
 
         Args:
             start (Optional[int]): The block number to start with. Defaults to the block

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -180,7 +180,7 @@ class AccountHistory:
 
         Returns:
             List[:class:`~ape.api.providers.TransactionAPI`]: The list of transactions. If there
-            are no recorded transactions, returns the empty list.
+            are no recorded transactions, returns an empty list.
         """
         address_key: AddressType = _convert(address, AddressType)
         return self._map.get(address_key, [])
@@ -195,7 +195,8 @@ class AccountHistory:
 
         Args:
             txn_receipt (:class:`~ape.api.providers.ReceiptAPI`): The transaction receipt to append.
-              **NOTE**: The receipt is accessible in the list returned from container[sender].
+              **NOTE**: The receipt is accessible in the list returned from
+              :meth:`~ape.managers.chain.AccountHistory.__getitem__`.
         """
         address = _convert(txn_receipt.sender, AddressType)
         if address not in self._map:
@@ -222,7 +223,6 @@ class ChainManager:
 
     _networks: NetworkManager
     _snapshots: List[SnapshotID] = []
-    _time_offset: int = 0
     _chain_id_map: Dict[str, int] = {}
 
     account_history: AccountHistory = AccountHistory()
@@ -282,8 +282,7 @@ class ChainManager:
     @property
     def base_fee(self) -> int:
         """
-        The minimum value required to get your transaction
-        included on the next block.
+        The minimum value required to get your transaction included on the next block.
         Only providers that implement `EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__
         will use this property.
 
@@ -300,7 +299,7 @@ class ChainManager:
         The current epoch time of the chain, as an ``int``.
         """
 
-        return int(time.time() + self._time_offset)
+        return int(time.time())
 
     def snapshot(self) -> SnapshotID:
         """

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -17,7 +17,7 @@ class ConnectedChain:
     _networks: NetworkManager
 
     @property
-    def _provider(self) -> ProviderAPI:
+    def provider(self) -> ProviderAPI:
         if not self._networks.active_provider:
             raise ProviderNotConnectedError()
 
@@ -94,7 +94,7 @@ class BlockContainer(ConnectedChain):
 
     @property
     def _network_confirmations(self) -> int:
-        return self._provider.network.required_confirmations
+        return self.provider.network.required_confirmations
 
     def range(self, start: int = 0, stop: Optional[int] = None) -> Iterator[BlockAPI]:
         """
@@ -166,7 +166,7 @@ class BlockContainer(ConnectedChain):
             time.sleep(self._poll_wait_interval)
 
     def _get_block(self, block_id: BlockID) -> BlockAPI:
-        return self._provider.get_block(block_id)
+        return self.provider.get_block(block_id)
 
 
 class AccountHistory(ConnectedChain):
@@ -295,9 +295,9 @@ class ChainManager(ConnectedChain):
         See `ChainList <https://chainlist.org/>`__ for a comprehensive list of IDs.
         """
 
-        network_name = self._provider.network.name
+        network_name = self.provider.network.name
         if network_name not in self._chain_id_map:
-            self._chain_id_map[network_name] = self._provider.chain_id
+            self._chain_id_map[network_name] = self.provider.chain_id
 
         return self._chain_id_map[network_name]
 
@@ -308,7 +308,7 @@ class ChainManager(ConnectedChain):
         (pre-`EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__).
         """
 
-        return self._provider.gas_price
+        return self.provider.gas_price
 
     @property
     def base_fee(self) -> int:
@@ -322,7 +322,7 @@ class ChainManager(ConnectedChain):
               `EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__.
         """
 
-        return self._provider.base_fee
+        return self.provider.base_fee
 
     @property
     def pending_timestamp(self) -> int:
@@ -384,7 +384,7 @@ class ChainManager(ConnectedChain):
         self.account_history.revert_to_block(self.blocks.height)
 
     def _get_test_provider(self, method_name: str) -> TestProviderAPI:
-        provider = self._provider
+        provider = self.provider
         if not isinstance(provider, TestProviderAPI):
             raise NotImplementedError(
                 f"Provider '{provider.name}' does not support method '{method_name}'."

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -238,7 +238,7 @@ class AccountHistory(_ConnectedChain):
 
     def items(self) -> Iterator[Tuple[AddressType, List[ReceiptAPI]]]:
         """
-        Iterate through the list of address-types to list of transactions.
+        Iterate through the list of address-types to list of transaction receipts.
 
         Returns:
             Iterator[Tuple[:class:`~ape.types.AddressType`, :class:`~ape.api.providers.ReceiptAPI`]]
@@ -251,7 +251,7 @@ class AccountHistory(_ConnectedChain):
 
         Raises:
             :class:`~ape.exceptions.ChainError`: When trying to append a transaction
-              that is already in the list.
+              receipt that is already in the list.
 
         Args:
             txn_receipt (:class:`~ape.api.providers.ReceiptAPI`): The transaction receipt to append.

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -215,6 +215,7 @@ class ChainManager:
     _networks: NetworkManager
     _snapshots: List[SnapshotID] = []
     _time_offset: int = 0
+    _chain_id_map: Dict[str, int] = {}
 
     account_history: AccountHistory = AccountHistory()
     """A mapping of transactions from the active session to the account responsible."""
@@ -255,7 +256,11 @@ class ChainManager:
         See `ChainList <https://chainlist.org/>`__ for a comprehensive list of IDs.
         """
 
-        return self.provider.chain_id
+        network_name = self.provider.network.name
+        if network_name not in self._chain_id_map:
+            self._chain_id_map[network_name] = self.provider.chain_id
+
+        return self._chain_id_map[network_name]
 
     @property
     def gas_price(self) -> int:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -93,7 +93,7 @@ class BlockContainer(ConnectedChain):
         return self.head.number
 
     @property
-    def _network_confirmations(self) -> int:
+    def network_confirmations(self) -> int:
         return self.provider.network.required_confirmations
 
     def range(self, start: int = 0, stop: Optional[int] = None) -> Iterator[BlockAPI]:
@@ -141,7 +141,7 @@ class BlockContainer(ConnectedChain):
             Iterator[:class:`~ape.api.providers.BlockAPI`]
         """
         if required_confirmations is None:
-            required_confirmations = self._network_confirmations
+            required_confirmations = self.network_confirmations
 
         # Get number of last block with the necessary amount of confirmations.
         latest_confirmed_block_number = self.height - required_confirmations

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -118,6 +118,13 @@ class BlockContainer:
         Poll new blocks. Optionally set a start block to include historical blocks.
         **NOTE**: This is a deamon method; it does not terminate.
 
+        Usage example::
+
+                from ape import chain
+
+                for new_block in chain.blocks.poll_blocks():
+                    print(f"New block found: number={new_block.number}")
+
         Args:
             start (Optional[int]): The block number to start with. Defaults to the block
               of the ``+1`` the current block number.

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -104,7 +104,7 @@ class ChainManager:
         Returns:
             :class:`~ape.types.SnapshotID`: The snapshot ID.
         """
-        provider = self._get_test_provider()
+        provider = self._get_test_provider("snapshot")
         snapshot_id = provider.snapshot()
 
         if snapshot_id not in self._snapshots:
@@ -127,7 +127,7 @@ class ChainManager:
             snapshot_id (Optional[:class:`~ape.types.SnapshotID`]): The snapshot ID. Defaults
               to the most recent snapshot ID.
         """
-        provider = self._get_test_provider()
+        provider = self._get_test_provider("restore")
         if not self._snapshots:
             raise ChainError("There are no snapshots to revert to.")
         elif snapshot_id is None:
@@ -140,9 +140,11 @@ class ChainManager:
 
         provider.revert(snapshot_id)
 
-    def _get_test_provider(self) -> TestProviderAPI:
+    def _get_test_provider(self, method_name: str) -> TestProviderAPI:
         provider = self.provider
         if not isinstance(provider, TestProviderAPI):
-            raise NotImplementedError(f"Provider '{provider.name}' does not support snapshotting.")
+            raise NotImplementedError(
+                f"Provider '{provider.name}' does not support method '{method_name}'."
+            )
 
         return provider

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -13,7 +13,7 @@ from .networks import NetworkManager
 
 
 @dataclass
-class ConnectedChain:
+class _ConnectedChain:
     _networks: NetworkManager
 
     @property
@@ -24,7 +24,7 @@ class ConnectedChain:
         return self._networks.active_provider
 
 
-class BlockContainer(ConnectedChain):
+class BlockContainer(_ConnectedChain):
     """
     A list of blocks on the chain.
 
@@ -185,7 +185,7 @@ class BlockContainer(ConnectedChain):
         return self.provider.get_block(block_id)
 
 
-class AccountHistory(ConnectedChain):
+class AccountHistory(_ConnectedChain):
     """
     A container mapping account addresses to the transaction from the active session.
     """
@@ -277,7 +277,7 @@ class AccountHistory(ConnectedChain):
         }
 
 
-class ChainManager(ConnectedChain):
+class ChainManager(_ConnectedChain):
     """
     A class for managing the state of the active blockchain.
     Also handy for querying data about the chain and managing local caches.

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -238,4 +238,4 @@ class ConversionManager:
             if converter.is_convertible(value):
                 return converter.convert(value)
 
-        raise ConversionError(f"No conversion registered to handle '{value}'.")
+        raise ConversionError(f"No convert registered to handle '{value}'.")

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -238,4 +238,4 @@ class ConversionManager:
             if converter.is_convertible(value):
                 return converter.convert(value)
 
-        raise ConversionError(f"No convert registered to handle '{value}'.")
+        raise ConversionError(f"No conversion registered to handle '{value}'.")

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -28,12 +28,23 @@ class NetworkManager:
 
     config: ConfigManager
     plugin_manager: PluginManager
-    active_provider: Optional[ProviderAPI] = None
+    _active_provider: Optional[ProviderAPI] = None
     _default: Optional[str] = None
     _ecosystems_by_project: Dict[str, Dict[str, EcosystemAPI]] = {}
 
     def __repr__(self):
         return f"<NetworkManager, active_provider={self.active_provider}>"
+
+    @property
+    def active_provider(self) -> Optional[ProviderAPI]:
+        return self._active_provider
+
+    @active_provider.setter
+    def active_provider(self, new_value: ProviderAPI):
+        from ape import chain
+
+        new_value._chain = chain
+        self._active_provider = new_value
 
     @property
     def ecosystems(self) -> Dict[str, EcosystemAPI]:

--- a/src/ape/plugins/converter.py
+++ b/src/ape/plugins/converter.py
@@ -8,7 +8,7 @@ from .pluggy_patch import PluginType, hookspec
 class ConversionPlugin(PluginType):
     """
     A plugin for converting values. The `ape-ens <https://github.com/ApeWorX/ape-ens>`__
-    plugin is an example of a convert-plugin.
+    plugin is an example of a conversion-plugin.
     """
 
     @hookspec

--- a/src/ape/plugins/converter.py
+++ b/src/ape/plugins/converter.py
@@ -8,7 +8,7 @@ from .pluggy_patch import PluginType, hookspec
 class ConversionPlugin(PluginType):
     """
     A plugin for converting values. The `ape-ens <https://github.com/ApeWorX/ape-ens>`__
-    plugin is an example of a conversion-plugin.
+    plugin is an example of a convert-plugin.
     """
 
     @hookspec

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -1,5 +1,5 @@
 import sys
-from typing import NewType, Union
+from typing import Union
 
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
@@ -31,7 +31,7 @@ providers when using this feature, so there should not be confusion over this ty
 cases.
 """
 
-AddressType = NewType("AddressType", ChecksumAddress)  # type: ignore
+AddressType = ChecksumAddress  # type: ignore
 """A type representing a checksummed address."""
 
 __all__ = [

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Union
+from typing import TypeAlias, Union
 
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
@@ -31,7 +31,7 @@ providers when using this feature, so there should not be confusion over this ty
 cases.
 """
 
-AddressType = ChecksumAddress
+AddressType: TypeAlias = ChecksumAddress
 """A type representing a checksummed address."""
 
 __all__ = [

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -479,7 +479,6 @@ also abstract (meaning it has methods that **must** be implemented or else
 errors will occur. This class cannot be instantiated on its own.
 """
 
-
 __all__ = [
     "abstractdataclass",
     "abstractmethod",

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -480,18 +480,11 @@ errors will occur. This class cannot be instantiated on its own.
 """
 
 
-def convert(*args, **kwargs):
-    from ape import convert
-
-    return convert(*args, **kwargs)
-
-
 __all__ = [
     "abstractdataclass",
     "abstractmethod",
     "AbstractDataClassMeta",
     "cached_property",
-    "convert",
     "dataclass",
     "deep_merge",
     "expand_environment_variables",

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -479,11 +479,19 @@ also abstract (meaning it has methods that **must** be implemented or else
 errors will occur. This class cannot be instantiated on its own.
 """
 
+
+def convert(*args, **kwargs):
+    from ape import convert
+
+    return convert(*args, **kwargs)
+
+
 __all__ = [
     "abstractdataclass",
     "abstractmethod",
     "AbstractDataClassMeta",
     "cached_property",
+    "convert",
     "dataclass",
     "deep_merge",
     "expand_environment_variables",

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -40,25 +40,15 @@ NETWORKS = {
 class NetworkConfig(ConfigItem):
     required_confirmations: int = 0
     default_provider: str = "geth"
-    approximate_block_time: int = 0
+    block_time: int = 0
 
 
 class EthereumConfig(ConfigItem):
-    mainnet: NetworkConfig = NetworkConfig(
-        required_confirmations=7, approximate_block_time=13
-    )  # type: ignore
-    ropsten: NetworkConfig = NetworkConfig(
-        required_confirmations=12, approximate_block_time=15
-    )  # type: ignore
-    kovan: NetworkConfig = NetworkConfig(
-        required_confirmations=3, approximate_block_time=4
-    )  # type: ignore
-    rinkeby: NetworkConfig = NetworkConfig(
-        required_confirmations=3, approximate_block_time=15
-    )  # type: ignore
-    goerli: NetworkConfig = NetworkConfig(
-        required_confirmations=10, approximate_block_time=15
-    )  # type: ignore
+    mainnet: NetworkConfig = NetworkConfig(required_confirmations=7, block_time=13)  # type: ignore
+    ropsten: NetworkConfig = NetworkConfig(required_confirmations=12, block_time=15)  # type: ignore
+    kovan: NetworkConfig = NetworkConfig(required_confirmations=3, block_time=4)  # type: ignore
+    rinkeby: NetworkConfig = NetworkConfig(required_confirmations=3, block_time=15)  # type: ignore
+    goerli: NetworkConfig = NetworkConfig(required_confirmations=10, block_time=15)  # type: ignore
     development: NetworkConfig = NetworkConfig(default_provider="test")  # type: ignore
 
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -182,6 +182,7 @@ class Receipt(ReceiptAPI):
             logs=data["logs"],
             contract_address=data["contractAddress"],
             sender=data["from"],
+            receiver=data["to"],
             nonce=data["nonce"],
         )
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -170,20 +170,27 @@ class Receipt(ReceiptAPI):
 
     @classmethod
     def decode(cls, data: dict) -> ReceiptAPI:
+        status = data.get("status")
+        if status:
+            if isinstance(status, str) and status.isnumeric():
+                status = int(status)
+
+            status = TransactionStatusEnum(status)
+
         return cls(  # type: ignore
-            provider=data["provider"],
+            provider=data.get("provider"),
             required_confirmations=data.get("required_confirmations", 0),
             txn_hash=data["hash"],
-            status=TransactionStatusEnum(data["status"]),
+            status=status,
             block_number=data["blockNumber"],
             gas_used=data["gasUsed"],
             gas_price=data["gasPrice"],
             gas_limit=data.get("gas") or data.get("gasLimit"),
-            logs=data["logs"],
-            contract_address=data["contractAddress"],
+            logs=data.get("logs"),
+            contract_address=data.get("contractAddress"),
             sender=data["from"],
             receiver=data["to"],
-            nonce=data["nonce"],
+            nonce=data.get("nonce"),
         )
 
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -40,17 +40,26 @@ NETWORKS = {
 class NetworkConfig(ConfigItem):
     required_confirmations: int = 0
     default_provider: str = "geth"
+    approximate_block_time: int = 0
 
 
 class EthereumConfig(ConfigItem):
-    mainnet: NetworkConfig = NetworkConfig(required_confirmations=7)  # type: ignore
-    ropsten: NetworkConfig = NetworkConfig(required_confirmations=12)  # type: ignore
-    kovan: NetworkConfig = NetworkConfig(required_confirmations=3)  # type: ignore
-    rinkeby: NetworkConfig = NetworkConfig(required_confirmations=3)  # type: ignore
-    goerli: NetworkConfig = NetworkConfig(required_confirmations=10)  # type: ignore
-    development: NetworkConfig = NetworkConfig(
-        required_confirmations=0, default_provider="test"
+    mainnet: NetworkConfig = NetworkConfig(
+        required_confirmations=7, approximate_block_time=13
     )  # type: ignore
+    ropsten: NetworkConfig = NetworkConfig(
+        required_confirmations=12, approximate_block_time=15
+    )  # type: ignore
+    kovan: NetworkConfig = NetworkConfig(
+        required_confirmations=3, approximate_block_time=4
+    )  # type: ignore
+    rinkeby: NetworkConfig = NetworkConfig(
+        required_confirmations=3, approximate_block_time=15
+    )  # type: ignore
+    goerli: NetworkConfig = NetworkConfig(
+        required_confirmations=10, approximate_block_time=15
+    )  # type: ignore
+    development: NetworkConfig = NetworkConfig(default_provider="test")  # type: ignore
 
 
 class BaseTransaction(TransactionAPI):

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -46,9 +46,9 @@ class NetworkConfig(ConfigItem):
 class EthereumConfig(ConfigItem):
     mainnet: NetworkConfig = NetworkConfig(required_confirmations=7, block_time=13)  # type: ignore
     ropsten: NetworkConfig = NetworkConfig(required_confirmations=12, block_time=15)  # type: ignore
-    kovan: NetworkConfig = NetworkConfig(required_confirmations=3, block_time=4)  # type: ignore
-    rinkeby: NetworkConfig = NetworkConfig(required_confirmations=3, block_time=15)  # type: ignore
-    goerli: NetworkConfig = NetworkConfig(required_confirmations=10, block_time=15)  # type: ignore
+    kovan: NetworkConfig = NetworkConfig(required_confirmations=2, block_time=4)  # type: ignore
+    rinkeby: NetworkConfig = NetworkConfig(required_confirmations=2, block_time=15)  # type: ignore
+    goerli: NetworkConfig = NetworkConfig(required_confirmations=2, block_time=15)  # type: ignore
     development: NetworkConfig = NetworkConfig(default_provider="test")  # type: ignore
 
 

--- a/src/ape_test/fixtures.py
+++ b/src/ape_test/fixtures.py
@@ -22,7 +22,7 @@ class PytestApeFixtures:
         self._project = project
         self._chain = chain
 
-    @pytest.fixture
+    @pytest.fixture(scope="session")
     def accounts(self) -> List[TestAccountAPI]:
         return self._accounts.test_accounts
 

--- a/src/ape_test/fixtures.py
+++ b/src/ape_test/fixtures.py
@@ -26,7 +26,7 @@ class PytestApeFixtures:
     def accounts(self) -> List[TestAccountAPI]:
         return self._accounts.test_accounts
 
-    @pytest.fixture
+    @pytest.fixture(scope="session")
     def chain(self) -> ChainManager:
         return self._chain
 

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -73,6 +73,10 @@ class LocalNetwork(TestProviderAPI, Web3Provider):
             if current_hash != snapshot_id:
                 return self._tester.revert_to_snapshot(snapshot_id)
 
+    def sleep(self, seconds: int) -> int:
+        new_timestamp = self.get_block("latest").timestamp + seconds
+        return self._tester.time_travel(new_timestamp)
+
 
 def _get_vm_err(web3_err: TransactionFailed) -> ContractLogicError:
     err_message = str(web3_err).split("execution reverted: ")[-1] or None

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -73,10 +73,6 @@ class LocalNetwork(TestProviderAPI, Web3Provider):
             if current_hash != snapshot_id:
                 return self._tester.revert_to_snapshot(snapshot_id)
 
-    def sleep(self, seconds: int) -> int:
-        new_timestamp = self.get_block("latest").timestamp + seconds
-        return self._tester.time_travel(new_timestamp)
-
 
 def _get_vm_err(web3_err: TransactionFailed) -> ContractLogicError:
     err_message = str(web3_err).split("execution reverted: ")[-1] or None

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -61,6 +61,7 @@ class LocalNetwork(TestProviderAPI, Web3Provider):
         if txn.gas_limit is not None and receipt.ran_out_of_gas:
             raise OutOfGasError()
 
+        self._try_track_receipt(receipt)
         return receipt
 
     def snapshot(self) -> SnapshotID:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,11 @@ def networks():
 
 
 @pytest.fixture(scope="session")
+def chain():
+    yield ape.chain
+
+
+@pytest.fixture(scope="session")
 def project_folder(config):
     yield config.PROJECT_FOLDER
 

--- a/tests/functional/conversion/test_ether.py
+++ b/tests/functional/conversion/test_ether.py
@@ -38,7 +38,7 @@ def test_no_registered_converter():
     with pytest.raises(ConversionError) as err:
         convert(value="something", type=ChecksumAddress)
 
-    assert str(err.value) == "No conversion registered to handle 'something'."
+    assert str(err.value) == "No convert registered to handle 'something'."
 
 
 def test_lists():

--- a/tests/functional/conversion/test_ether.py
+++ b/tests/functional/conversion/test_ether.py
@@ -38,7 +38,7 @@ def test_no_registered_converter():
     with pytest.raises(ConversionError) as err:
         convert(value="something", type=ChecksumAddress)
 
-    assert str(err.value) == "No convert registered to handle 'something'."
+    assert str(err.value) == "No conversion registered to handle 'something'."
 
 
 def test_lists():

--- a/tests/functional/ethereum/test_ecosystem.py
+++ b/tests/functional/ethereum/test_ecosystem.py
@@ -27,6 +27,7 @@ class TestReceipt:
             gas_price=0,
             block_number=0,
             sender="",
+            receiver="",
             nonce=0,
         )
         with pytest.raises(OutOfGasError):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -31,6 +31,12 @@ def pytest_runtest_protocol(item, nextitem):
 
 
 @pytest.fixture
+def networks_connected_to_tester():
+    with networks.parse_network_choice("::test"):
+        yield networks
+
+
+@pytest.fixture
 def ethereum(networks_connected_to_tester):
     return networks_connected_to_tester.ethereum
 

--- a/tests/integration/test_chain.py
+++ b/tests/integration/test_chain.py
@@ -1,78 +1,70 @@
 import pytest
 
 from ape.exceptions import ChainError
-from ape.managers.chain import ChainManager
 
 
 @pytest.fixture
-def chain_manager(networks):
-    manager = ChainManager(networks)
-    return manager
-
-
-@pytest.fixture
-def chain_manager_up_5_blocks(chain_manager, sender, receiver):
-    snapshot_id = chain_manager.snapshot()
+def chain_up_5_blocks(chain, sender, receiver):
+    snapshot_id = chain.snapshot()
     for i in range(5):
         sender.transfer(receiver, "1 wei")
 
-    yield chain_manager
-    chain_manager.restore(snapshot_id)
+    yield chain
+    chain.restore(snapshot_id)
 
 
-def test_snapshot_and_restore(chain_manager, sender, receiver):
+def test_snapshot_and_restore(chain, sender, receiver):
     initial_balance = receiver.balance  # Initial balance at block 0.
     end_range = 5
     snapshot_ids = []
 
     for i in range(end_range):
-        snapshot_id = chain_manager.snapshot()
+        snapshot_id = chain.snapshot()
         snapshot_ids.append(snapshot_id)
         sender.transfer(receiver, "1 wei")  # Advance a block by transacting
 
-    assert chain_manager.blocks[-1].number == end_range
+    assert chain.blocks[-1].number == end_range
 
     # Show that we can also provide the snapshot ID as an argument.
-    chain_manager.restore(snapshot_ids[2])
-    assert chain_manager.blocks[-1].number == 2
+    chain.restore(snapshot_ids[2])
+    assert chain.blocks[-1].number == 2
 
     # Head back to the initial block.
-    while chain_manager.blocks[-1].number != 0:
-        chain_manager.restore()
+    while chain.blocks[-1].number != 0:
+        chain.restore()
 
-    assert chain_manager.blocks[-1].number == 0
+    assert chain.blocks[-1].number == 0
     assert receiver.balance == initial_balance
 
 
-def test_snapshot_and_restore_unknown_snapshot_id(chain_manager, sender, receiver):
-    _ = chain_manager.snapshot()
+def test_snapshot_and_restore_unknown_snapshot_id(chain, sender, receiver):
+    _ = chain.snapshot()
     sender.transfer(receiver, "1 wei")
-    snapshot_id_2 = chain_manager.snapshot()
+    snapshot_id_2 = chain.snapshot()
     sender.transfer(receiver, "1 wei")
-    snapshot_id_3 = chain_manager.snapshot()
+    snapshot_id_3 = chain.snapshot()
     sender.transfer(receiver, "1 wei")
 
     # After restoring to the second ID, the third ID is now invalid.
-    chain_manager.restore(snapshot_id_2)
+    chain.restore(snapshot_id_2)
 
     with pytest.raises(ChainError) as err:
-        chain_manager.restore(snapshot_id_3)
+        chain.restore(snapshot_id_3)
 
     assert "Unknown snapshot ID" in str(err.value)
 
 
-def test_snapshot_and_restore_no_snapshots(chain_manager, sender, receiver):
+def test_snapshot_and_restore_no_snapshots(chain, sender, receiver):
     with pytest.raises(ChainError) as err:
-        chain_manager.restore("{}")
+        chain.restore("{}")
 
     assert "There are no snapshots to revert to." in str(err.value)
 
 
-def test_account_history(sender, receiver, chain_manager):
-    history = chain_manager.account_history
-    assert not history[sender]
+def test_account_history(sender, receiver, chain):
+    assert not chain.account_history[sender]
     receipt = sender.transfer(receiver, "1 wei")
-    transactions_from_cache = history[sender]
+    transactions_from_cache = chain.account_history[sender]
     assert len(transactions_from_cache) == 1
 
     txn = transactions_from_cache[0]
@@ -80,9 +72,9 @@ def test_account_history(sender, receiver, chain_manager):
     assert txn.receiver == receipt.receiver == receiver
 
 
-def test_iterate_blocks(chain_manager_up_5_blocks):
+def test_iterate_blocks(chain_up_5_blocks):
     expected_number_of_blocks = 6  # Including the 0th start block
-    blocks = [b for b in chain_manager_up_5_blocks.blocks]
+    blocks = [b for b in chain_up_5_blocks.blocks]
     assert len(blocks) == expected_number_of_blocks
 
     expected_number = 0
@@ -91,9 +83,9 @@ def test_iterate_blocks(chain_manager_up_5_blocks):
         expected_number += 1
 
 
-def test_blocks_range(chain_manager_up_5_blocks):
+def test_blocks_range(chain_up_5_blocks):
     expected_number_of_blocks = 3  # Expecting blocks [0, 1, 2]
-    blocks = [b for b in chain_manager_up_5_blocks.blocks.range(stop=3)]
+    blocks = [b for b in chain_up_5_blocks.blocks.range(stop=3)]
     assert len(blocks) == expected_number_of_blocks
 
     expected_number = 0

--- a/tests/integration/test_chain.py
+++ b/tests/integration/test_chain.py
@@ -55,6 +55,7 @@ def test_snapshot_and_restore_unknown_snapshot_id(chain, sender, receiver):
 
 
 def test_snapshot_and_restore_no_snapshots(chain, sender, receiver):
+    chain._snapshots = []  # Ensure empty (gets set in test setup)
     with pytest.raises(ChainError) as err:
         chain.restore("{}")
 

--- a/tests/integration/test_chain.py
+++ b/tests/integration/test_chain.py
@@ -56,3 +56,15 @@ def test_snapshot_and_restore_no_snapshots(chain_manager, sender, receiver):
         chain_manager.restore("{}")
 
     assert "There are no snapshots to revert to." in str(err.value)
+
+
+def test_account_history(sender, receiver, chain_manager):
+    history = chain_manager.account_history
+    assert not history[sender]
+    receipt = sender.transfer(receiver, "1 wei")
+    transactions_from_cache = history[sender]
+    assert len(transactions_from_cache) == 1
+
+    txn = transactions_from_cache[0]
+    assert txn.sender == receipt.sender == sender
+    assert txn.receiver == receipt.receiver == receiver


### PR DESCRIPTION
### What I did

fixes: #129
^ Note there are several other related to chain manager, such adding mining support. This work is just to initialize the chain manager as well as swap out the snapshotting login in `ape_test` using the chain manager rather than the `ProviderAPI` alone.

### How I did it

* Create new class ChainManager, a top-level object that takes the `NetworksManager`.
* The chain manager raises an error when not connected to a provider.
* The chain manager keeps track of a "snapshot stack"

### How to verify it

See the new test module `tests/integration/test_chain.py`.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
