### PR TITLE
fix: bug preventing str-type when specifying transaction types.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@
    userguides/quickstart
    userguides/projects
    userguides/plugins
+   userguides/transactions
 ```
 
 ```{eval-rst}

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -21,7 +21,7 @@ def deploy():
     return account.deploy(project.MyContract)
 ```
 
-## Dynamic Fee Transactions
+## Dynamic-Fee Transactions
 
 Before [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559), all transactions used a `gas_price`.
 After the London fork of Etheruem, the `gas_price` got broken up into two values, `max_fee` and `max_priority_fee`.
@@ -51,7 +51,11 @@ the value returned from the
 [ProviderAPI.base_fee](../methoddocs/api.html?highlight=accountapi#ape.api.providers.ProviderAPI.base_fee) method
 property.
 
-## Static Fee Transactions
+## Static-Fee Transactions
+
+Static-fee transactions are the transactions that Ethereum used before the London-fork
+(before [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)).
+**However, some applications may still require using static-fee transactions.**
 
 One way to use a static-fee transaction is by specifying the `gas_price` as a key-value argument:
 
@@ -59,9 +63,12 @@ One way to use a static-fee transaction is by specifying the `gas_price` as a ke
 contract.fundMyContract(value="1 gwei", gas_price="100 gwei")
 ```
 
-Another way to use a static-fee transaction (without having to provide `gas_price`) is to set the key-value
+**NOTE**: Miners prioritize static-fee transactions based on the highest `gas_price`.
+
+Another way to use a static-fee transactions (without having to provide `gas_price`) is to set the key-value
 argument `type` equal to `0x00`.
 
 ```python
 contract.fundMyContract(value="1 gwei", type="0x0")
 ```
+

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -23,7 +23,7 @@ def deploy():
 
 ## Dynamic Fee Transactions
 
-Before [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)), all transaction used a `gas_price`. After the London fork
+Before [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)), all transactions used a `gas_price`. After the London fork
 of Etheruem, the `gas_price` got broken up into two values `max_fee` and `max_priority_fee`. The `ape` platform supports
 both types of transactions. By default, transactions use the dynamic fee model. Making contract calls without specifying
 any additional `kwargs` will use a dynamic-fee transaction.

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -24,7 +24,7 @@ def deploy():
 ## Dynamic Fee Transactions
 
 Before [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)), all transactions used a `gas_price`. After the London fork
-of Etheruem, the `gas_price` got broken up into two values, `max_fee` and `max_priority_fee`. The `ape` platform
+of Etheruem, the `gas_price` got broken up into two values, `max_fee` and `max_priority_fee`. The `ape` framework
 supports both types of transactions. By default, transactions use the dynamic fee model. Making contract calls without
 specifying any additional `kwargs` will use a dynamic-fee transaction.
 

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -46,7 +46,7 @@ The `max_priority_fee` cannot exceed the `max_fee`, as the `max_fee` includes bo
 The `max_priority_fee`, when omitted, defaults to the return value from the
 [ProviderAPI.priority_fee](../methoddocs/api.html?highlight=accountapi#ape.api.providers.ProviderAPI.priority_fee)
 method property.
-The `max_fee`, when omitted, defaults to the `priority_fee` (which get it's default applied beforehand) plus the latest
+The `max_fee`, when omitted, defaults to the `priority_fee` (which gets its default applied beforehand) plus the latest
 the value returned from the
 [ProviderAPI.base_fee](../methoddocs/api.html?highlight=accountapi#ape.api.providers.ProviderAPI.base_fee) method
 property.
@@ -65,10 +65,9 @@ contract.fundMyContract(value="1 gwei", gas_price="100 gwei")
 
 **NOTE**: Miners prioritize static-fee transactions based on the highest `gas_price`.
 
-Another way to use a static-fee transactions (without having to provide `gas_price`) is to set the key-value
+Another way to use a static-fee transaction (without having to provide `gas_price`) is to set the key-value
 argument `type` equal to `0x00`.
 
 ```python
 contract.fundMyContract(value="1 gwei", type="0x0")
 ```
-

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -1,0 +1,60 @@
+# Making Transactions
+
+Regardless of how you are using `ape`, you will likely be making transactions. There are some types of transactions
+you can make with `ape`. A simple example is deploying a contract.
+
+## Deployment
+
+Deploying a smart contract is a unique type of transaction where we don't necessarily care about the receipt as much
+as we care about the contract instance. That is why the return value from a
+[ContractInstance](../methoddocs/api.html?highlight=accountapi#ape.api.accounts.AccountAPI.deploy) is a
+[ContractInstance](../methoddocs/contracts.html?highlight=contractinstance#ape.contracts.base.ContractInstance).
+
+The following example demonstrates a simple deployment script:
+
+```python
+from ape import accounts, project
+
+
+def deploy():
+    account = accounts.load("MyAccount")
+    return account.deploy(project.MyContract)
+```
+
+## Dynamic Fee Transactions
+
+Before [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)), all transaction used a `gas_price`. After the London fork
+of Etheruem, the `gas_price` got broken up into two values `max_fee` and `max_priority_fee`. The `ape` platform supports
+both types of transactions. By default, transactions use the dynamic fee model. Making contract calls without specifying
+any additional `kwargs` will use a dynamic-fee transaction.
+
+Calling certain methods on a deployed-contract is a way to transact.
+
+```python
+contract = deploy()  # Example from above, that returns a contract instance.
+contract.fundMyContract(value="1 gwei")  # Assuming there is a method named 'fundMyContract' on MyContract.
+```
+
+In the example above, the call to `fundMyContract()` invokes a dynamic-fee transaction. To have more control of the 
+fee-values, you can specify the `max_fee` and the `max_priority_fee`.
+
+```python
+contract = deploy()  # Example from above, that returns a contract instance.
+contract.fundMyContract(value="1 gwei", max_priorty_fee=50000000000, max_fee=100000000000)
+```
+
+## Static Fee Transactions
+
+To use the original static fee transactions, you can merely specify a `type="0x0"`.
+
+```python
+contract = deploy()  # Example from above, that returns a contract instance.
+contract.fundMyContract(value="1 gwei", type="0x0")
+```
+
+Also, specifying a `gas_price` will automatically trigger the usage of a static-fee transaction.
+
+```python
+contract = deploy()  # Example from above, that returns a contract instance.
+contract.fundMyContract(value="1 gwei", gas_price=
+```

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -1,7 +1,7 @@
 # Making Transactions
 
-Regardless of how you are using `ape`, you will likely be making transactions. There are various types of transactions
-you can make with `ape`. A simple example is deploying a contract.
+Regardless of how you are using `ape`, you will likely be making transactions.
+There are various types of transactions you can make with `ape`. A simple example is deploying a contract.
 
 ## Deployment
 
@@ -23,10 +23,10 @@ def deploy():
 
 ## Dynamic Fee Transactions
 
-Before [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)), all transactions used a `gas_price`. After the London fork
-of Etheruem, the `gas_price` got broken up into two values, `max_fee` and `max_priority_fee`. The `ape` framework
-supports both types of transactions. By default, transactions use the dynamic fee model. Making contract calls without
-specifying any additional `kwargs` will use a dynamic-fee transaction.
+Before [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)), all transactions used a `gas_price`.
+After the London fork of Etheruem, the `gas_price` got broken up into two values, `max_fee` and `max_priority_fee`.
+The `ape` framework supports both types of transactions. By default, transactions use the dynamic fee model.
+Making contract calls without specifying any additional `kwargs` will use a dynamic-fee transaction.
 
 Calling certain methods on a deployed-contract is one way to transact.
 
@@ -35,8 +35,8 @@ contract = deploy()  # Example from above, that returns a contract instance.
 contract.fundMyContract(value="1 gwei")  # Assuming there is a method named 'fundMyContract' on MyContract.
 ```
 
-In the example above, the call to `fundMyContract()` invokes a dynamic-fee transaction. To have more control of the 
-fee-values, you can specify the `max_fee`, the `max_priority_fee`, or both.
+In the example above, the call to `fundMyContract()` invokes a dynamic-fee transaction.
+To have more control of the fee-values, you can specify the `max_fee`, the `max_priority_fee`, or both.
 
 ```python
 contract.fundMyContract(value="1 gwei", max_priority_fee="50 gwei", max_fee="100 gwei")

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -71,3 +71,5 @@ argument `type` equal to `0x00`.
 ```python
 contract.fundMyContract(value="1 gwei", type="0x0")
 ```
+
+When declaring `type="0x0"` and _not_ specifying a `gas_price`, the `gas_price` gets set using the provider's estimation.

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -36,7 +36,7 @@ contract.fundMyContract(value="1 gwei")  # Assuming there is a method named 'fun
 ```
 
 In the example above, the call to `fundMyContract()` invokes a dynamic-fee transaction. To have more control of the 
-fee-values, you can specify the `max_fee` and the `max_priority_fee`.
+fee-values, you can specify the `max_fee`, the `max_priority_fee`, or both.
 
 ```python
 contract = deploy()  # Example from above, that returns a contract instance.

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -42,6 +42,15 @@ To have more control of the fee-values, you can specify the `max_fee`, the `max_
 contract.fundMyContract(value="1 gwei", max_priority_fee="50 gwei", max_fee="100 gwei")
 ```
 
+The `max_priority_fee` cannot exceed the `max_fee`, as the `max_fee` includes both the base fee and the priority fee.
+The `max_priority_fee`, when omitted, defaults to the return value from the
+[ProviderAPI.priority_fee](../methoddocs/api.html?highlight=accountapi#ape.api.providers.ProviderAPI.priority_fee)
+method property.
+The `max_fee`, when omitted, defaults to the `priority_fee` (which get it's default applied beforehand) plus the latest
+the value returned from the
+[ProviderAPI.priority_fee](../methoddocs/api.html?highlight=accountapi#ape.api.providers.ProviderAPI.base_fee) method
+property.
+
 ## Static Fee Transactions
 
 One way to use a static-fee transaction is by specifying the `gas_price` as a key-value argument:
@@ -56,4 +65,3 @@ argument `type` equal to `0x00`.
 ```python
 contract.fundMyContract(value="1 gwei", type="0x0")
 ```
-

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -45,7 +45,7 @@ contract.fundMyContract(value="1 gwei", max_priority_fee="50 gwei", max_fee="100
 
 ## Static Fee Transactions
 
-To use the original static fee transactions, you can merely specify a `type="0x0"`.
+To use the original static fee transactions without having to specify `gas_price`, you just have to specify `type="0x0"`.
 
 ```python
 contract = deploy()  # Example from above, that returns a contract instance.

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -40,7 +40,7 @@ fee-values, you can specify the `max_fee` and the `max_priority_fee`.
 
 ```python
 contract = deploy()  # Example from above, that returns a contract instance.
-contract.fundMyContract(value="1 gwei", max_priorty_fee=50000000000, max_fee=100000000000)
+contract.fundMyContract(value="1 gwei", max_priority_fee="50 gwei", max_fee="100 gwei")
 ```
 
 ## Static Fee Transactions

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -56,5 +56,5 @@ Also, specifying a `gas_price` will automatically trigger the usage of a static-
 
 ```python
 contract = deploy()  # Example from above, that returns a contract instance.
-contract.fundMyContract(value="1 gwei", gas_price=100000000000)
+contract.fundMyContract(value="1 gwei", gas_price="100 gwei")
 ```

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -23,7 +23,7 @@ def deploy():
 
 ## Dynamic Fee Transactions
 
-Before [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)), all transactions used a `gas_price`.
+Before [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559), all transactions used a `gas_price`.
 After the London fork of Etheruem, the `gas_price` got broken up into two values, `max_fee` and `max_priority_fee`.
 The `ape` framework supports both types of transactions. By default, transactions use the dynamic-fee model.
 Making contract calls without specifying any additional `kwargs` will use a dynamic-fee transaction.
@@ -48,7 +48,7 @@ The `max_priority_fee`, when omitted, defaults to the return value from the
 method property.
 The `max_fee`, when omitted, defaults to the `priority_fee` (which get it's default applied beforehand) plus the latest
 the value returned from the
-[ProviderAPI.priority_fee](../methoddocs/api.html?highlight=accountapi#ape.api.providers.ProviderAPI.base_fee) method
+[ProviderAPI.base_fee](../methoddocs/api.html?highlight=accountapi#ape.api.providers.ProviderAPI.base_fee) method
 property.
 
 ## Static Fee Transactions

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -24,11 +24,11 @@ def deploy():
 ## Dynamic Fee Transactions
 
 Before [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)), all transactions used a `gas_price`. After the London fork
-of Etheruem, the `gas_price` got broken up into two values `max_fee` and `max_priority_fee`. The `ape` platform supports
-both types of transactions. By default, transactions use the dynamic fee model. Making contract calls without specifying
-any additional `kwargs` will use a dynamic-fee transaction.
+of Etheruem, the `gas_price` got broken up into two values, `max_fee` and `max_priority_fee`. The `ape` platform
+supports both types of transactions. By default, transactions use the dynamic fee model. Making contract calls without
+specifying any additional `kwargs` will use a dynamic-fee transaction.
 
-Calling certain methods on a deployed-contract is a way to transact.
+Calling certain methods on a deployed-contract is one way to transact.
 
 ```python
 contract = deploy()  # Example from above, that returns a contract instance.
@@ -39,22 +39,21 @@ In the example above, the call to `fundMyContract()` invokes a dynamic-fee trans
 fee-values, you can specify the `max_fee`, the `max_priority_fee`, or both.
 
 ```python
-contract = deploy()  # Example from above, that returns a contract instance.
 contract.fundMyContract(value="1 gwei", max_priority_fee="50 gwei", max_fee="100 gwei")
 ```
 
 ## Static Fee Transactions
 
-To use the original static fee transactions without having to specify `gas_price`, you just have to specify `type="0x0"`.
+One way to use a static-fee transaction is by specifying the `gas_price` as a key-value argument:
 
 ```python
-contract = deploy()  # Example from above, that returns a contract instance.
+contract.fundMyContract(value="1 gwei", gas_price="100 gwei")
+```
+
+Another way to use a static-fee transaction (without having to provide `gas_price`) is to set the key-value
+argument `type` equal to `0x00`.
+
+```python
 contract.fundMyContract(value="1 gwei", type="0x0")
 ```
 
-Also, specifying a `gas_price` will automatically trigger the usage of a static-fee transaction.
-
-```python
-contract = deploy()  # Example from above, that returns a contract instance.
-contract.fundMyContract(value="1 gwei", gas_price="100 gwei")
-```

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -1,13 +1,13 @@
 # Making Transactions
 
-Regardless of how you are using `ape`, you will likely be making transactions. There are some types of transactions
+Regardless of how you are using `ape`, you will likely be making transactions. There are various types of transactions
 you can make with `ape`. A simple example is deploying a contract.
 
 ## Deployment
 
 Deploying a smart contract is a unique type of transaction where we don't necessarily care about the receipt as much
-as we care about the contract instance. That is why the return value from a
-[ContractInstance](../methoddocs/api.html?highlight=accountapi#ape.api.accounts.AccountAPI.deploy) is a
+as we care about the contract instance. That is why the return value from
+[the deploy method](../methoddocs/api.html?highlight=accountapi#ape.api.accounts.AccountAPI.deploy) is a
 [ContractInstance](../methoddocs/contracts.html?highlight=contractinstance#ape.contracts.base.ContractInstance).
 
 The following example demonstrates a simple deployment script:
@@ -56,5 +56,5 @@ Also, specifying a `gas_price` will automatically trigger the usage of a static-
 
 ```python
 contract = deploy()  # Example from above, that returns a contract instance.
-contract.fundMyContract(value="1 gwei", gas_price=
+contract.fundMyContract(value="1 gwei", gas_price=100000000000)
 ```

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -25,7 +25,7 @@ def deploy():
 
 Before [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)), all transactions used a `gas_price`.
 After the London fork of Etheruem, the `gas_price` got broken up into two values, `max_fee` and `max_priority_fee`.
-The `ape` framework supports both types of transactions. By default, transactions use the dynamic fee model.
+The `ape` framework supports both types of transactions. By default, transactions use the dynamic-fee model.
 Making contract calls without specifying any additional `kwargs` will use a dynamic-fee transaction.
 
 Calling certain methods on a deployed-contract is one way to transact.

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -25,8 +25,8 @@ class TransactionType(Enum):
     `EIP-2718 <https://eips.ethereum.org/EIPS/eip-2718>`__.
     """
 
-    STATIC = "0x0"
-    DYNAMIC = "0x2"  # EIP-1559
+    STATIC = "0x00"
+    DYNAMIC = "0x02"  # EIP-1559
 
 
 @abstractdataclass

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -35,7 +35,6 @@ class HexConverter(ConverterAPI):
         Returns:
             bytes
         """
-
         return HexBytes(value)
 
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -311,7 +311,7 @@ class Ethereum(EcosystemAPI):
             if type_kwarg == "0x00":
                 type_kwarg = "0x0"
 
-            version_str = str(add_0x_prefix(HexStr(str(type_kwarg))))
+            version_str = add_0x_prefix(HexStr(type_kwarg))
             version = TransactionType(version_str)
         elif "gas_price" in kwargs:
             version = TransactionType.STATIC

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -302,8 +302,7 @@ class Ethereum(EcosystemAPI):
             type_kwarg = kwargs["type"]
             if type_kwarg is None:
                 type_kwarg = TransactionType.DYNAMIC.value
-
-            if isinstance(type_kwarg, int):
+            elif isinstance(type_kwarg, int):
                 type_kwarg = str(type_kwarg)
             elif isinstance(type_kwarg, HexBytes):
                 type_kwarg = type_kwarg.hex()

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -296,8 +296,19 @@ class Ethereum(EcosystemAPI):
         Returns a tranaction using the given constructor kwargs.
         """
         if "type" in kwargs:
-            type_arg = HexStr(str(kwargs["type"]))
-            version_str = str(add_0x_prefix(type_arg))
+            type_kwarg = kwargs["type"]
+
+            if isinstance(type_kwarg, int):
+                type_kwarg = HexStr(str(type_kwarg))
+            elif isinstance(type_kwarg, HexBytes):
+                type_kwarg = HexStr(type_kwarg.hex())
+            elif isinstance(type_kwarg, bytes):
+                type_kwarg = type_kwarg.decode()
+
+            if type_kwarg == "0x00":
+                type_kwarg = "0x0"
+
+            version_str = str(add_0x_prefix(str(type_kwarg)))
             version = TransactionType(version_str)
         elif "gas_price" in kwargs:
             version = TransactionType.STATIC

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -293,22 +293,25 @@ class Ethereum(EcosystemAPI):
 
     def create_transaction(self, **kwargs) -> TransactionAPI:
         """
-        Returns a tranaction using the given constructor kwargs.
+        Returns a transaction using the given constructor kwargs.
+
+        Returns:
+            :class:`~ape.api.providers.TransactionAPI`
         """
         if "type" in kwargs:
             type_kwarg = kwargs["type"]
 
             if isinstance(type_kwarg, int):
-                type_kwarg = HexStr(str(type_kwarg))
+                type_kwarg = str(type_kwarg)
             elif isinstance(type_kwarg, HexBytes):
-                type_kwarg = HexStr(type_kwarg.hex())
+                type_kwarg = type_kwarg.hex()
             elif isinstance(type_kwarg, bytes):
                 type_kwarg = type_kwarg.decode()
 
             if type_kwarg == "0x00":
                 type_kwarg = "0x0"
 
-            version_str = str(add_0x_prefix(str(type_kwarg)))
+            version_str = str(add_0x_prefix(HexStr(str(type_kwarg))))
             version = TransactionType(version_str)
         elif "gas_price" in kwargs:
             version = TransactionType.STATIC

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -302,16 +302,16 @@ class Ethereum(EcosystemAPI):
             type_kwarg = kwargs["type"]
             if type_kwarg is None:
                 type_kwarg = TransactionType.DYNAMIC.value
-            elif isinstance(type_kwarg, str):
-                suffix = type_kwarg.replace("0x", "")
-                if len(suffix) == 1:
-                    type_kwarg = f"{type_kwarg.rstrip(suffix)}0{suffix}"
             elif isinstance(type_kwarg, int):
                 type_kwarg = f"0{type_kwarg}"
             elif isinstance(type_kwarg, HexBytes):
                 type_kwarg = type_kwarg.hex()
             elif isinstance(type_kwarg, bytes):
                 type_kwarg = type_kwarg.decode()
+
+            suffix = type_kwarg.replace("0x", "")
+            if len(suffix) == 1:
+                type_kwarg = f"{type_kwarg.rstrip(suffix)}0{suffix}"
 
             version_str = add_0x_prefix(HexStr(type_kwarg))
             version = TransactionType(version_str)

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -302,15 +302,16 @@ class Ethereum(EcosystemAPI):
             type_kwarg = kwargs["type"]
             if type_kwarg is None:
                 type_kwarg = TransactionType.DYNAMIC.value
+            elif isinstance(type_kwarg, str):
+                suffix = type_kwarg.replace("0x", "")
+                if len(suffix) == 1:
+                    type_kwarg = f"{type_kwarg.rstrip(suffix)}0{suffix}"
             elif isinstance(type_kwarg, int):
-                type_kwarg = str(type_kwarg)
+                type_kwarg = f"0{type_kwarg}"
             elif isinstance(type_kwarg, HexBytes):
                 type_kwarg = type_kwarg.hex()
             elif isinstance(type_kwarg, bytes):
                 type_kwarg = type_kwarg.decode()
-
-            if type_kwarg == "0x00":
-                type_kwarg = "0x0"
 
             version_str = add_0x_prefix(HexStr(type_kwarg))
             version = TransactionType(version_str)

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -300,6 +300,8 @@ class Ethereum(EcosystemAPI):
         """
         if "type" in kwargs:
             type_kwarg = kwargs["type"]
+            if type_kwarg is None:
+                type_kwarg = TransactionType.DYNAMIC.value
 
             if isinstance(type_kwarg, int):
                 type_kwarg = str(type_kwarg)

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -304,10 +304,8 @@ class Ethereum(EcosystemAPI):
                 type_kwarg = TransactionType.DYNAMIC.value
             elif isinstance(type_kwarg, int):
                 type_kwarg = f"0{type_kwarg}"
-            elif isinstance(type_kwarg, HexBytes):
-                type_kwarg = type_kwarg.hex()
             elif isinstance(type_kwarg, bytes):
-                type_kwarg = type_kwarg.decode()
+                type_kwarg = type_kwarg.hex()
 
             suffix = type_kwarg.replace("0x", "")
             if len(suffix) == 1:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,16 @@ from ape import networks
 
 
 @pytest.fixture
-def eth_tester_provider():
+def networks_connected_to_tester():
     with networks.parse_network_choice("::test"):
-        yield networks.active_provider
+        yield networks
+
+
+@pytest.fixture
+def eth_tester_provider(networks_connected_to_tester):
+    yield networks_connected_to_tester.active_provider
+
+
+@pytest.fixture
+def ethereum(networks_connected_to_tester):
+    return networks_connected_to_tester.ethereum

--- a/tests/integration/test_ethereum.py
+++ b/tests/integration/test_ethereum.py
@@ -4,17 +4,13 @@ from hexbytes import HexBytes
 from ape.api import TransactionType
 
 
-@pytest.mark.parametrize(
-    "type_kwarg", (0, "0x0", b"0", b"0x0", b"0x00", "0", HexBytes("0x0"), HexBytes("0x00"))
-)
+@pytest.mark.parametrize("type_kwarg", (0, "0x0", b"\x00", "0", HexBytes("0x0"), HexBytes("0x00")))
 def test_create_static_fee_transaction(ethereum, type_kwarg):
     txn = ethereum.create_transaction(type=type_kwarg)
     assert txn.type == TransactionType.STATIC.value
 
 
-@pytest.mark.parametrize(
-    "type_kwarg", (None, 2, "0x02", b"0x02", b"2", "2", "02", HexBytes("0x02"))
-)
+@pytest.mark.parametrize("type_kwarg", (None, 2, "0x02", b"\x02", "2", "02", HexBytes("0x02")))
 def test_create_dynamic_fee_transaction(ethereum, type_kwarg):
     txn = ethereum.create_transaction(type=type_kwarg)
     assert txn.type == TransactionType.DYNAMIC.value

--- a/tests/integration/test_ethereum.py
+++ b/tests/integration/test_ethereum.py
@@ -5,7 +5,7 @@ from ape.api import TransactionType
 
 
 @pytest.mark.parametrize(
-    "type_kwarg", (0, "0x0", b"0x0", b"0x00", "0", HexBytes("0x0"), HexBytes("0x00"))
+    "type_kwarg", (0, "0x0", b"0", b"0x0", b"0x00", "0", HexBytes("0x0"), HexBytes("0x00"))
 )
 def test_create_static_fee_transaction(ethereum, type_kwarg):
     txn = ethereum.create_transaction(type=type_kwarg)

--- a/tests/integration/test_ethereum.py
+++ b/tests/integration/test_ethereum.py
@@ -12,7 +12,9 @@ def test_create_static_fee_transaction(ethereum, type_kwarg):
     assert txn.type == TransactionType.STATIC.value
 
 
-@pytest.mark.parametrize("type_kwarg", (None, 2, "0x02", b"0x02", "2", "02", HexBytes("0x02")))
+@pytest.mark.parametrize(
+    "type_kwarg", (None, 2, "0x02", b"0x02", b"2", "2", "02", HexBytes("0x02"))
+)
 def test_create_dynamic_fee_transaction(ethereum, type_kwarg):
     txn = ethereum.create_transaction(type=type_kwarg)
     assert txn.type == TransactionType.DYNAMIC.value

--- a/tests/integration/test_ethereum.py
+++ b/tests/integration/test_ethereum.py
@@ -1,0 +1,15 @@
+import pytest
+
+from ape.api import TransactionType
+
+
+@pytest.mark.parametrize("type_kwarg", (0, "0x0", b"0x0", "0"))
+def test_create_static_fee_transaction(ethereum, type_kwarg):
+    txn = ethereum.create_transaction(type=type_kwarg)
+    assert txn.type == TransactionType.STATIC.value
+
+
+@pytest.mark.parametrize("type_kwarg", (None, 2, "0x2", b"0x2", "2"))
+def test_create_dynamic_fee_transaction(ethereum, type_kwarg):
+    txn = ethereum.create_transaction(type=type_kwarg)
+    assert txn.type == TransactionType.DYNAMIC.value

--- a/tests/integration/test_ethereum.py
+++ b/tests/integration/test_ethereum.py
@@ -1,15 +1,18 @@
 import pytest
+from hexbytes import HexBytes
 
 from ape.api import TransactionType
 
 
-@pytest.mark.parametrize("type_kwarg", (0, "0x0", b"0x0", "0"))
+@pytest.mark.parametrize(
+    "type_kwarg", (0, "0x0", b"0x0", b"0x00", "0", HexBytes("0x0"), HexBytes("0x00"))
+)
 def test_create_static_fee_transaction(ethereum, type_kwarg):
     txn = ethereum.create_transaction(type=type_kwarg)
     assert txn.type == TransactionType.STATIC.value
 
 
-@pytest.mark.parametrize("type_kwarg", (None, 2, "0x2", b"0x2", "2"))
+@pytest.mark.parametrize("type_kwarg", (None, 2, "0x02", b"0x02", "2", "02", HexBytes("0x02")))
 def test_create_dynamic_fee_transaction(ethereum, type_kwarg):
     txn = ethereum.create_transaction(type=type_kwarg)
     assert txn.type == TransactionType.DYNAMIC.value


### PR DESCRIPTION
### What I did

Fixes regression where we were not longer able to specify `type="0x0"` for static fee transactions.
Adds Transactions guide.

### How I did it

handle hexbytes differently than bytes

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
