### PR TITLE
fix: Dockerfile not building for typing-extensions incorrect verions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 RUN apt-get update && apt-get upgrade --yes && apt-get install git python3.8 python3-pip --yes
 COPY . .
 # need to use typing-extensions<4 to deal with issue 387 bug: Docker will not build
-# todo: remove this line when 'trie' supports typing-extensions>4
+# TODO: Figure out a better solution or wait for it to resolve itself.
 RUN pip install typing-extensions==3.10.0.2
 RUN python3 ./setup.py install
 RUN ape plugins add solidity --yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:20.04
 RUN apt-get update && apt-get upgrade --yes && apt-get install git python3.8 python3-pip --yes
 COPY . .
+RUN pip install typing-extensions==3.10.0.2
 RUN python3 ./setup.py install
 RUN ape plugins add solidity --yes
 RUN ape plugins add vyper --yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:20.04
 RUN apt-get update && apt-get upgrade --yes && apt-get install git python3.8 python3-pip --yes
 COPY . .
+# need to use typing-extensions<4 to deal with issue 387 bug: Docker will not build
+# todo: remove this line when 'trie' supports typing-extensions>4
 RUN pip install typing-extensions==3.10.0.2
 RUN python3 ./setup.py install
 RUN ape plugins add solidity --yes


### PR DESCRIPTION
### What I did

fix an error with incorrect version of `typing-extensions` for a required dependency `'trie'`

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #387

### How I did it
added the line `RUN pip install typing-extensions==3.10.0.2` to the Dockerfile 

### How to verify it
Dockerfile now builds.

```
$ docker build .
$ docker images
REPOSITORY           TAG       IMAGE ID       CREATED          SIZE
<none>               <none>    07f16cf5e34a   47 minutes ago   586MB
$ docker run 07f16cf5e34a plugins list
Installed Plugins:
  vyper     0.1.0b1
  ens     0.1.0b2
  infura     0.1.0b2
  etherscan     0.1.0b1
  solidity     0.1.0b1
$ docker run -it 07f16cf5e34a console
In [1]:
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
