### PR TITLE
feat: align plugins and version number

### DIFF
--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -54,9 +54,14 @@ def _list(cli_ctx, display_all):
     installed_second_class_plugins_no_version = set()
     installed_third_class_plugins = set()
 
-    for name, plugin in plugin_manager.list_name_plugin():
-        version = get_package_version(name)
+    plugin_list = plugin_manager.list_name_plugin()
+    plugin_names = [p[0] for p in plugin_list]
+    longest_plugin_name = len(max(plugin_names, key=len))
+    space_buffer = 4
 
+    for name, _ in plugin_list:
+        version = get_package_version(name)
+        spacing = (longest_plugin_name - len(name) + space_buffer) * " "
         if name in CORE_PLUGINS:
             if not display_all:
                 continue  # NOTE: Skip 1st class plugins unless specified
@@ -64,11 +69,11 @@ def _list(cli_ctx, display_all):
             installed_first_class_plugins.add(name)
 
         elif name in github_client.available_plugins:
-            installed_second_class_plugins.add(f"{name}     {version}")
+            installed_second_class_plugins.add(f"{name}{spacing}{version}")
             installed_second_class_plugins_no_version.add(name)
 
         elif name not in CORE_PLUGINS or name not in github_client.available_plugins:
-            installed_third_class_plugins.add(f"{name}      {version})")
+            installed_third_class_plugins.add(f"{name}{spacing}{version})")
         else:
             cli_ctx.logger.error(f"{name} is not a plugin.")
 


### PR DESCRIPTION
### What I did

fixed spacing issue with the plugins list and version number

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #

### How I did it

used math and chris math minor to make the plugins list cleaner

### How to verify it

use the ape command `ape plugins list` to see the installed version numbers

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
