### PR TITLE
feat: allow setting the pending timestamp from top-level 'chain' class

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -589,12 +589,15 @@ class TestProviderAPI(ProviderAPI):
         """
 
     @abstractmethod
-    def increase_time(self, seconds: int):
+    def fast_forward_time(self, new_timestamp: int) -> int:
         """
         Increase the time into the future for testing purposes.
 
         Args:
-            seconds (int): The amount of seconds to increase time.
+            new_timestamp (int): The timestamp to set.
+
+        Returns:
+            int: The new timestamp.
         """
 
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -588,6 +588,15 @@ class TestProviderAPI(ProviderAPI):
             snapshot_id (str): The snapshot ID.
         """
 
+    @abstractmethod
+    def increase_time(self, seconds: int):
+        """
+        Increase the time into the future for testing purposes.
+
+        Args:
+            seconds (int): The amount of seconds to increase time.
+        """
+
 
 class Web3Provider(ProviderAPI):
     """

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -297,6 +297,7 @@ class ChainManager(_ConnectedChain):
     _chain_id_map: Dict[str, int] = {}
     _block_container_map: Dict[int, BlockContainer] = {}
     _account_history_map: Dict[int, AccountHistory] = {}
+    _time_offset = 0
 
     @property
     def blocks(self) -> BlockContainer:
@@ -359,9 +360,22 @@ class ChainManager(_ConnectedChain):
     def pending_timestamp(self) -> int:
         """
         The current epoch time of the chain, as an ``int``.
+        Set the timestamp to fast-forward time into the future.
+
+        Usage example::
+
+            from ape import chain
+
+            chain.pending_timestamp += 3600
         """
 
-        return int(time.time())
+        return int(time.time() + self._time_offset)
+
+    @pending_timestamp.setter
+    def pending_timestamp(self, new_value: int):
+        provider = self._get_test_provider(TestProviderAPI.fast_forward_time.__name__)
+        new_timestamp = provider.fast_forward_time(new_value)
+        self._time_offset = new_timestamp - self.pending_timestamp
 
     def __repr__(self) -> str:
         props = f"id={self.chain_id}" if self._networks.active_provider else "disconnected"

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -73,10 +73,8 @@ class LocalNetwork(TestProviderAPI, Web3Provider):
             if current_hash != snapshot_id:
                 return self._tester.revert_to_snapshot(snapshot_id)
 
-    def increase_time(self, seconds: int):
-        current_timestamp = self.get_block("latest").timestamp
-        requested_timestamp = current_timestamp + seconds
-        self._tester.time_travel(requested_timestamp)
+    def fast_forward_time(self, new_timestamp: int) -> int:
+        return self._tester.time_travel(new_timestamp)
 
 
 def _get_vm_err(web3_err: TransactionFailed) -> ContractLogicError:

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -73,6 +73,11 @@ class LocalNetwork(TestProviderAPI, Web3Provider):
             if current_hash != snapshot_id:
                 return self._tester.revert_to_snapshot(snapshot_id)
 
+    def increase_time(self, seconds: int):
+        current_timestamp = self.get_block("latest").timestamp
+        requested_timestamp = current_timestamp + seconds
+        self._tester.time_travel(requested_timestamp)
+
 
 def _get_vm_err(web3_err: TransactionFailed) -> ContractLogicError:
     err_message = str(web3_err).split("execution reverted: ")[-1] or None

--- a/tests/integration/test_chain.py
+++ b/tests/integration/test_chain.py
@@ -105,3 +105,10 @@ def test_blocks_range_too_high_stop(chain_at_block_5):
         f"'stop={len_plus_1}' cannot be greater than the chain length (6). "
         f"Use 'poll_blocks()' to wait for future blocks."
     )
+
+
+def test_set_pending_timestamp(chain):
+    start_timestamp = chain.pending_timestamp
+    chain.pending_timestamp += 3600
+    new_timestamp = chain.pending_timestamp
+    assert new_timestamp - start_timestamp == 3600


### PR DESCRIPTION
### What I did

Allows setting the pending timestamp

### How I did it

Copied brownie and used the `eth-tester` method `time_travel()`

### How to verify it

Does my test make sense?

Usage example:

```python
from ape import chain

chain.pending_timestamp += 3600
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
