### PR TITLE
fix: chain id for goerli

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -34,7 +34,7 @@ NETWORKS = {
     "ropsten": (3, 3),
     "kovan": (42, 42),
     "rinkeby": (4, 4),
-    "goerli": (420, 420),
+    "goerli": (5, 5),
 }
 
 


### PR DESCRIPTION
### What I did

Use correct chain ID for goerli

### How I did it

changed it

### How to verify it

I used this list to verify: https://besu.hyperledger.org/en/stable/Concepts/NetworkID-And-ChainID/
when typing `goerli` in chain list, it shows Optimism for some reason, probably how this happened.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
