### PR TITLE
fix: adhere to ethpm manifest compilation expectations

### DIFF
--- a/src/ape/api/compiler.py
+++ b/src/ape/api/compiler.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Set
+from typing import List, Optional, Set
 
 from ethpm_types import ContractType
 
@@ -40,15 +40,20 @@ class CompilerAPI:
         """
 
     @abstractmethod
-    def compile(self, contract_filepaths: List[Path]) -> List[ContractType]:
+    def compile(
+        self, contract_filepaths: List[Path], base_path: Optional[Path]
+    ) -> List[ContractType]:
         """
         Compile the given source files. All compiler plugins must implement this function.
 
         Args:
             contract_filepaths (List[pathlib.Path]): A list of source file paths to compile.
+            base_path (Optional[pathlib.Path]): Optionally provide the base path, such as
+              the project ``contracts/`` directory. Defaults to ``None``. When used with
+              ``ape compile`` in a project, gets set to the project's ``contracts/`` directory.
 
         Returns:
-            List[``ContractType``]
+            List[:class:`~ape.type.contract.ContractType`]
         """
 
     def __repr__(self) -> str:

--- a/src/ape/api/compiler.py
+++ b/src/ape/api/compiler.py
@@ -48,9 +48,9 @@ class CompilerAPI:
 
         Args:
             contract_filepaths (List[pathlib.Path]): A list of source file paths to compile.
-            base_path (Optional[pathlib.Path]): Optionally provide the base path, such as
-              the project ``contracts/`` directory. Defaults to ``None``. When used with
-              ``ape compile`` in a project, gets set to the project's ``contracts/`` directory.
+            base_path (Optional[pathlib.Path]): Optionally provide the base path, such as the
+              project ``contracts/`` directory. Defaults to ``None``. When using in a project
+              via ``ape compile``, gets set to the project's ``contracts/`` directory.
 
         Returns:
             List[:class:`~ape.type.contract.ContractType`]

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -106,6 +106,6 @@ class CompilerManager:
 
     def _get_contract_path(self, path: Path):
         try:
-            return path.relative_to(self.config.PROJECT_FOLDER)
+            return path.relative_to(self.config.PROJECT_FOLDER / "contracts")
         except ValueError:
             return path

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -81,7 +81,10 @@ class CompilerManager:
             for path in paths_to_compile:
                 logger.info(f"Compiling '{self._get_contract_path(path)}'.")
 
-            compiled_contracts = self.registered_compilers[extension].compile(paths_to_compile)
+            base_path = self.config.PROJECT_FOLDER / Path("contracts")
+            compiled_contracts = self.registered_compilers[extension].compile(
+                paths_to_compile, base_path=base_path
+            )
 
             for contract_type in compiled_contracts:
 

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -10,7 +10,7 @@ from ethpm_types.utils import compute_checksum
 from ape.contracts import ContractContainer
 from ape.exceptions import ProjectError
 from ape.managers.networks import NetworkManager
-from ape.utils import get_all_files_in_directory, github_client
+from ape.utils import get_all_files_in_directory, get_relative_path, github_client
 
 from .compilers import CompilerManager
 from .config import ConfigManager
@@ -187,8 +187,12 @@ class ProjectManager:
         files: List[Path] = []
         base_path = self.contracts_folder.parent
         for extension in self.compilers.registered_compilers:
-            src_files = self.contracts_folder.rglob("*" + extension)
-            files.extend([Path(str(s).split(str(base_path))[-1].strip("/")) for s in src_files])
+            files.extend(
+                map(
+                    lambda f: get_relative_path(f, base_path),
+                    self.contracts_folder.rglob("*" + extension),
+                )
+            )
 
         return files
 

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -173,14 +173,8 @@ class ProjectManager:
             List[pathlib.Path]: A list of a source file paths in the project.
         """
         files: List[Path] = []
-        base_path = self.contracts_folder
         for extension in self.compilers.registered_compilers:
-            files.extend(
-                map(
-                    lambda f: get_relative_path(f, base_path),
-                    self.contracts_folder.rglob("*" + extension),
-                )
-            )
+            files.extend(self.contracts_folder.rglob("*" + extension))
 
         return files
 
@@ -435,10 +429,10 @@ class ProjectManager:
 
     def _create_source_dict(self, contracts_paths: Collection[Path]) -> Dict[str, Source]:
         return {
-            str(source): Source(  # type: ignore
+            str(get_relative_path(source, self.contracts_folder)): Source(  # type: ignore
                 checksum=Checksum(  # type: ignore
                     algorithm="md5",
-                    hash=compute_checksum((self.contracts_folder / source).read_bytes()),
+                    hash=compute_checksum(source.read_bytes()),
                 ),
                 urls=[],
             )

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -293,7 +293,8 @@ class ProjectManager:
         }
 
         def file_needs_compiling(source: Path) -> bool:
-            path = str(source)
+            path = str(get_relative_path(source, self.contracts_folder))
+
             # New file added?
             if path not in cached_sources:
                 return True

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -282,6 +282,9 @@ class ProjectManager:
         if isinstance(file_paths, Path):
             file_paths = [file_paths]
 
+        if file_paths:
+            file_paths = [get_relative_path(f, self.contracts_folder) for f in file_paths]
+
         # Load a cached or clean manifest (to use for caching)
         manifest = use_cache and self.cached_manifest or PackageManifest()
         cached_sources = manifest.sources or {}

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -276,9 +276,6 @@ class ProjectManager:
         if isinstance(file_paths, Path):
             file_paths = [file_paths]
 
-        if file_paths:
-            file_paths = [get_relative_path(f, self.contracts_folder) for f in file_paths]
-
         # Load a cached or clean manifest (to use for caching)
         manifest = use_cache and self.cached_manifest or PackageManifest()
         cached_sources = manifest.sources or {}

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -185,8 +185,10 @@ class ProjectManager:
             List[pathlib.Path]: A list of a source file paths in the project.
         """
         files: List[Path] = []
+        base_path = self.contracts_folder.parent
         for extension in self.compilers.registered_compilers:
-            files.extend(self.contracts_folder.rglob("*" + extension))
+            src_files = self.contracts_folder.rglob("*" + extension)
+            files.extend([Path(str(s).split(str(base_path))[-1].strip("/")) for s in src_files])
 
         return files
 

--- a/src/ape_pm/__init__.py
+++ b/src/ape_pm/__init__.py
@@ -1,6 +1,11 @@
 from ape import plugins
 
-from .compiler import InterfaceCompiler
+from .compiler import InterfaceCompiler, InterfaceCompilerConfig
+
+
+@plugins.register(plugins.Config)
+def config_class():
+    return InterfaceCompilerConfig
 
 
 @plugins.register(plugins.CompilerPlugin)

--- a/src/ape_pm/__init__.py
+++ b/src/ape_pm/__init__.py
@@ -1,11 +1,6 @@
 from ape import plugins
 
-from .compiler import InterfaceCompiler, InterfaceCompilerConfig
-
-
-@plugins.register(plugins.Config)
-def config_class():
-    return InterfaceCompilerConfig
+from .compiler import InterfaceCompiler
 
 
 @plugins.register(plugins.CompilerPlugin)

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -5,11 +5,17 @@ from typing import List, Set
 from ethpm_types import ABI, ContractType
 from pydantic import parse_obj_as
 
-from ape.api import CompilerAPI
+from ape.api import CompilerAPI, ConfigItem
 from ape.exceptions import CompilerError
 
 
+class InterfaceCompilerConfig(ConfigItem):
+    base_path: Path = Path("contracts")
+
+
 class InterfaceCompiler(CompilerAPI):
+    config: InterfaceCompilerConfig
+
     @property
     def name(self) -> str:
         return "ethpm"
@@ -22,7 +28,8 @@ class InterfaceCompiler(CompilerAPI):
     def compile(self, filepaths: List[Path]) -> List[ContractType]:
         contract_types: List[ContractType] = []
         for path in filepaths:
-            with path.open() as f:
+            path_to_file = self.config.base_path / path
+            with path_to_file.open() as f:
                 data = json.load(f)
 
             if not isinstance(data, list):

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -5,17 +5,13 @@ from typing import List, Set
 from ethpm_types import ABI, ContractType
 from pydantic import parse_obj_as
 
-from ape.api import CompilerAPI, ConfigItem
+from ape.api import CompilerAPI
 from ape.exceptions import CompilerError
 
-
-class InterfaceCompilerConfig(ConfigItem):
-    contracts_path: Path = Path("contracts")
+CONTRACTS_DIRECTORY = Path("contracts")
 
 
 class InterfaceCompiler(CompilerAPI):
-    config: InterfaceCompilerConfig
-
     @property
     def name(self) -> str:
         return "ethpm"
@@ -28,7 +24,7 @@ class InterfaceCompiler(CompilerAPI):
     def compile(self, filepaths: List[Path]) -> List[ContractType]:
         contract_types: List[ContractType] = []
         for path in filepaths:
-            path_to_file = self.config.contracts_path / path
+            path_to_file = CONTRACTS_DIRECTORY / path
             with path_to_file.open() as f:
                 data = json.load(f)
 

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -1,14 +1,13 @@
 import json
 from pathlib import Path
-from typing import List, Set
+from typing import List, Optional, Set
 
 from ethpm_types import ABI, ContractType
 from pydantic import parse_obj_as
 
 from ape.api import CompilerAPI
 from ape.exceptions import CompilerError
-
-CONTRACTS_DIRECTORY = Path("contracts")
+from ape.utils import get_relative_path
 
 
 class InterfaceCompiler(CompilerAPI):
@@ -21,13 +20,19 @@ class InterfaceCompiler(CompilerAPI):
         #       ``compilers`` field. You should not do this with a real compiler plugin.
         return set()
 
-    def compile(self, filepaths: List[Path]) -> List[ContractType]:
+    def compile(
+        self, filepaths: List[Path], base_path: Optional[Path] = None
+    ) -> List[ContractType]:
         contract_types: List[ContractType] = []
         for path in filepaths:
-            path_to_file = CONTRACTS_DIRECTORY / path
-            with path_to_file.open() as f:
+            with path.open() as f:
                 data = json.load(f)
 
+            source_id = (
+                str(get_relative_path(path, base_path))
+                if base_path and path.is_absolute()
+                else str(path)
+            )
             if not isinstance(data, list):
                 raise CompilerError("Not a valid ABI interface JSON file.")
 
@@ -35,7 +40,7 @@ class InterfaceCompiler(CompilerAPI):
                 contract = ContractType(  # type: ignore
                     contractName=path.stem,
                     abi=parse_obj_as(List[ABI], data),
-                    sourceId=str(path),
+                    sourceId=source_id,
                 )
 
                 contract_types.append(contract)

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -10,7 +10,7 @@ from ape.exceptions import CompilerError
 
 
 class InterfaceCompilerConfig(ConfigItem):
-    base_path: Path = Path("contracts")
+    contracts_path: Path = Path("contracts")
 
 
 class InterfaceCompiler(CompilerAPI):
@@ -28,7 +28,7 @@ class InterfaceCompiler(CompilerAPI):
     def compile(self, filepaths: List[Path]) -> List[ContractType]:
         contract_types: List[ContractType] = []
         for path in filepaths:
-            path_to_file = self.config.base_path / path
+            path_to_file = self.config.contracts_path / path
             with path_to_file.open() as f:
                 data = json.load(f)
 

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -32,11 +32,19 @@ def test_no_compiler_for_extension(ape_cli, runner, project):
 @skip_projects(["empty-config", "no-config", "script", "unregistered-contracts", "test", "geth"])
 def test_compile(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["compile"])
+
+    if result.exception:
+        raise result.exception
+
     assert result.exit_code == 0, result.output
     # First time it compiles, it compiles fully
     for file in project.path.glob("contracts/**/*"):
         assert file.stem in result.output
     result = runner.invoke(ape_cli, ["compile"])
+
+    if result.exception:
+        raise result.exception
+
     assert result.exit_code == 0, result.output
     # First time it compiles, it caches
     for file in project.path.glob("contracts/**/*"):

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -31,20 +31,12 @@ def test_no_compiler_for_extension(ape_cli, runner, project):
 
 @skip_projects(["empty-config", "no-config", "script", "unregistered-contracts", "test", "geth"])
 def test_compile(ape_cli, runner, project):
-    result = runner.invoke(ape_cli, ["compile"])
-
-    if result.exception:
-        raise result.exception
-
+    result = runner.invoke(ape_cli, ["compile"], catch_exceptions=False)
     assert result.exit_code == 0, result.output
     # First time it compiles, it compiles fully
     for file in project.path.glob("contracts/**/*"):
         assert file.stem in result.output
-    result = runner.invoke(ape_cli, ["compile"])
-
-    if result.exception:
-        raise result.exception
-
+    result = runner.invoke(ape_cli, ["compile"], catch_exceptions=False)
     assert result.exit_code == 0, result.output
     # First time it compiles, it caches
     for file in project.path.glob("contracts/**/*"):
@@ -57,21 +49,23 @@ def test_compile(ape_cli, runner, project):
     ("Interface", "Interface.json", "contracts/Interface", "contracts/Interface.json"),
 )
 def test_compile_specified_contracts(ape_cli, runner, project, contract_path, clean_cache):
-    result = runner.invoke(ape_cli, ["compile", contract_path])
+    result = runner.invoke(ape_cli, ["compile", contract_path], catch_exceptions=False)
     assert result.exit_code == 0, result.output
-    assert "Compiling 'contracts/Interface.json'" in result.output
+    assert "Compiling 'Interface.json'" in result.output
 
 
 @skip_projects_except(["one-interface"])
 def test_compile_partial_extension_does_not_compile(ape_cli, runner, project, clean_cache):
-    result = runner.invoke(ape_cli, ["compile", "Interface.js"])  # Suffix to existing extension
+    result = runner.invoke(
+        ape_cli, ["compile", "Interface.js"], catch_exceptions=False
+    )  # Suffix to existing extension
     assert result.exit_code == 2, result.output
     assert "Error: Contract 'Interface.js' not found." in result.output
 
 
 @skip_projects_except([])
 def test_compile_contracts(ape_cli, runner, project):
-    result = runner.invoke(ape_cli, ["compile", "--size"])
+    result = runner.invoke(ape_cli, ["compile", "--size"], catch_exceptions=False)
     assert result.exit_code == 0, result.output
     # Still caches but displays bytecode size
     for file in project.path.glob("contracts/**/*"):


### PR DESCRIPTION
### What I did

Fix ethpm-type manifest related validation errors.
The source IDs were full OS paths and should be relevant to the project `contracts/` directory.
This PR  fixes that!

What it was before:

```json
{"sources": {"Users/Jules/Projects/ApeProject/contracts/Fund.sol": ...}, {"Users/Jules/Projects/ApeProject/contracts/nested/Foo.sol": ...}}}
```

What it is now:

```json
{"sources": {"Fund.sol": ...}, {"nested/Foo.sol": ...}}
```

### How I did it

Adjust PM compiler to set source ID as relevant from the `contracts/` directory. Since we don't have access to the `ProjectManager` in the `CompilerAPI`, I made the `base_path` a config property in the `ape-pm` plugin that defaults to `Path("contracts/"). Some other general tweaking to handle this.

### How to verify it

tests passing, make sure this makes sense too.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
