### PR TITLE
fix: bug preventing changing the verbosity when using the console command

### DIFF
--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -6,6 +6,7 @@ import IPython  # type: ignore
 
 from ape import project as default_project
 from ape.cli import NetworkBoundCommand, ape_cli_context, network_option
+from ape.utils import _python_version
 from ape.version import version as ape_version  # type: ignore
 
 
@@ -39,7 +40,7 @@ def console(project=None, verbose=None, extra_locals=None):
 
     Are you ready to Ape, anon?
     """.format(
-            python_version=ape._python_version,
+            python_version=_python_version,
             ipython_version=IPython.__version__,
             ape_version=ape_version,
             project_path=project.path,

--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -1,4 +1,5 @@
 import faulthandler
+import io
 import logging
 
 import click
@@ -46,7 +47,11 @@ def console(project=None, verbose=None, extra_locals=None):
             project_path=project.path,
         )
 
-        faulthandler.enable()  # NOTE: In case we segfault
+        try:
+            faulthandler.enable()  # NOTE: In case we segfault
+        except io.UnsupportedOperation:
+            # Likely running in tests
+            pass
 
     namespace = {component: getattr(ape, component) for component in ape.__all__}
 

--- a/tests/integration/cli/test_console.py
+++ b/tests/integration/cli/test_console.py
@@ -10,3 +10,9 @@ from tests.integration.cli.utils import skip_projects
 def test_console(ape_cli, runner, item):
     result = runner.invoke(ape_cli, ["console"], input=f"{item}\nexit\n")
     assert result.exit_code == 0, result.output
+
+
+@skip_projects(["geth"])
+def test_console_verbose(ape_cli, runner):
+    result = runner.invoke(ape_cli, ["console", "-v", "debug"])
+    assert result.exit_code == 0, result.output

--- a/tests/integration/cli/test_console.py
+++ b/tests/integration/cli/test_console.py
@@ -8,11 +8,9 @@ from tests.integration.cli.utils import skip_projects
 @skip_projects(["geth"])
 @pytest.mark.parametrize("item", __all__)
 def test_console(ape_cli, runner, item):
-    result = runner.invoke(ape_cli, ["console"], input=f"{item}\nexit\n")
+    result = runner.invoke(ape_cli, ["console"], input=f"{item}\nexit\n", catch_exceptions=False)
     assert result.exit_code == 0, result.output
-
-
-@skip_projects(["geth"])
-def test_console_verbose(ape_cli, runner):
-    result = runner.invoke(ape_cli, ["console", "-v", "debug"])
+    result = runner.invoke(
+        ape_cli, ["console", "-v", "debug"], input=f"{item}\nexit\n", catch_exceptions=False
+    )
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
### What I did

Fix bug preventing the console from working with the `-v debug` flag.

### How I did it

Import the python version from `utils`.

### How to verify it

```bash
ape console -v debug
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
