### PR TITLE
fix: warn when unprocessed config items instead of error

### DIFF
--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -110,11 +110,13 @@ class ConfigManager:
 
             configs[plugin_name] = config
 
-        if len(user_config.keys()) > 0:
+        remaining_keys = list(user_config.keys())
+
+        if len(remaining_keys) > 0:
+            remaining_keys_str = ", ".join(remaining_keys)
             logger.warning(
-                "Not all config items have been processed yet. "
-                "If warning persists after 'ape plugins install', "
-                "there are unrecognized config keys."
+                f"Unprocessed plugin config(s): {remaining_keys_str}. "
+                "Plugins may not be installed yet or may be mis-spelled."
             )
 
         self._plugin_configs_by_project[project_name] = configs

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -110,8 +110,7 @@ class ConfigManager:
 
             configs[plugin_name] = config
 
-        remaining_keys = list(user_config.keys())
-
+        remaining_keys = user_config.keys()
         if len(remaining_keys) > 0:
             remaining_keys_str = ", ".join(remaining_keys)
             logger.warning(

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -7,6 +7,7 @@ from dataclassy import dataclass
 from ape.api import ConfigDict, ConfigItem
 from ape.convert import to_address
 from ape.exceptions import ConfigError
+from ape.logging import logger
 from ape.plugins import PluginManager
 from ape.utils import load_config
 
@@ -110,7 +111,11 @@ class ConfigManager:
             configs[plugin_name] = config
 
         if len(user_config.keys()) > 0:
-            raise ConfigError("Unprocessed config items.")
+            logger.warning(
+                "Not all config items have been processed yet. "
+                "If warning persists after 'ape plugins install', "
+                "there are unrecognized config keys."
+            )
 
         self._plugin_configs_by_project[project_name] = configs
         return configs

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -115,7 +115,7 @@ class ConfigManager:
             remaining_keys_str = ", ".join(remaining_keys)
             logger.warning(
                 f"Unprocessed plugin config(s): {remaining_keys_str}. "
-                "Plugins may not be installed yet or may be mis-spelled."
+                "Plugins may not be installed yet or keys may be mis-spelled."
             )
 
         self._plugin_configs_by_project[project_name] = configs

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -230,7 +230,7 @@ def install(cli_ctx, skip_confirmation, upgrade):
             else:
                 cli_ctx.logger.warning(
                     f"{module_name} is already installed. "
-                    f"Use the '--upgrade' option if you want to update '{plugin}'"
+                    f"Use the '--upgrade' option if you want to update '{module_name}'"
                 )
 
         if not is_plugin_installed(module_name) and (

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -168,7 +168,7 @@ def add(cli_ctx, plugin, version, skip_confirmation, upgrade):
             if result == 0 and is_plugin_installed(plugin):
                 cli_ctx.logger.success(f"Plugin '{plugin}' has been upgraded.")
             else:
-                cli_ctx.logger.error(f"Failed to add '{plugin}'.")
+                cli_ctx.logger.error(f"Error occurs when updating '{plugin}'.")
                 sys.exit(1)
         else:
             cli_ctx.logger.warning(
@@ -191,7 +191,7 @@ def add(cli_ctx, plugin, version, skip_confirmation, upgrade):
         if result == 0 and is_plugin_installed(plugin):
             cli_ctx.logger.success(f"Plugin '{plugin}' has been added.")
         else:
-            cli_ctx.logger.error(f"Failed to add '{plugin}'.")
+            cli_ctx.logger.error(f"Errors occurred when adding '{plugin}'.")
             sys.exit(1)
 
 
@@ -225,7 +225,7 @@ def install(cli_ctx, skip_confirmation, upgrade):
                 if result == 0 and is_plugin_installed(module_name):
                     cli_ctx.logger.success(f"Plugin '{module_name}' has been upgraded.")
                 else:
-                    cli_ctx.logger.error(f"Failed to upgrade '{module_name}'.")
+                    cli_ctx.logger.error(f"Errors occurred when upgrading '{module_name}'.")
                     any_install_failed = True
             else:
                 cli_ctx.logger.warning(
@@ -250,7 +250,7 @@ def install(cli_ctx, skip_confirmation, upgrade):
             if result == 0 and plugin_got_installed:
                 cli_ctx.logger.success(f"Plugin '{module_name}' has been added.")
             else:
-                cli_ctx.logger.error(f"Failed to add '{package_name}'.")
+                cli_ctx.logger.error(f"Errors occurred when adding '{package_name}'.")
                 any_install_failed = True
     if any_install_failed:
         sys.exit(1)


### PR DESCRIPTION
### What I did

fixes: #400 
Fixes issue preventing you to use an `ape-config.yaml` to install plugins when that config file contains keys that those plugins use.

Additionally made some small fixes I noticed in `ape plugins li

### How I did it

Change error to logger warning

### How to verify it

`ape plugins install`
`ape plugins uninstall`

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
