### PR TITLE
fix: issue preventing scripts from having the same name as a package

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -1,4 +1,6 @@
 import json
+import sys
+from importlib import import_module
 from pathlib import Path
 from typing import Collection, Dict, List, Optional, Union
 
@@ -12,6 +14,7 @@ from ape.exceptions import ProjectError
 from ape.managers.networks import NetworkManager
 from ape.utils import get_all_files_in_directory, get_relative_path, github_client
 
+from ..logging import logger
 from .compilers import CompilerManager
 from .config import ConfigManager
 from .converters import ConversionManager
@@ -440,6 +443,67 @@ class ProjectManager:
             )
             for source in contracts_paths
         }
+
+    def run_script(self, name: str, interactive: bool = False):
+        """
+        Run a script from the project ``scripts/`` directory.
+
+        Args:
+            name (str): The script name.
+            interactive (bool): Whether to launch the console as well. Defaults to ``False``.
+        """
+        # Generate the lookup based on all the scripts defined in the project's ``scripts/`` folder
+        # NOTE: If folder does not exist, this will be empty (same as if there are no files)
+        available_scripts = {p.stem: p.resolve() for p in self.scripts_folder.glob("*.py")}
+
+        if Path(name).exists():
+            script_file = Path(name).resolve()
+
+        elif not self.scripts_folder.exists():
+            raise ProjectError("No 'scripts/' directory detected to run script.")
+
+        elif name not in available_scripts:
+            raise ProjectError(f"No script named '{name}' detected in scripts folder.")
+
+        else:
+            script_file = self.scripts_folder / name
+
+        script_path = get_relative_path(script_file, Path.cwd())
+        script_parts = script_path.parts[:-1]
+
+        if any(p == ".." for p in script_parts):
+            raise ProjectError("Cannot execute script from outside current directory")
+
+        # Add to Python path so we can search for the given script to import
+        sys.path.append(str(script_path.parent.resolve()))
+
+        # Load the python module to find our hook functions
+        try:
+            py_module = import_module(script_path.stem)
+        except Exception as err:
+            logger.error_from_exception(err, f"Exception while executing script: {script_path}")
+            sys.exit(1)
+
+        finally:
+            # Undo adding the path to make sure it's not permanent
+            sys.path.remove(str(script_path.parent.resolve()))
+
+        # Execute the hooks
+        if hasattr(py_module, "cli"):
+            # TODO: Pass context to ``cli`` before calling it
+            py_module.cli()  # type: ignore
+
+        elif hasattr(py_module, "main"):
+            # NOTE: ``main()`` accepts no arguments
+            py_module.main()  # type: ignore
+
+        else:
+            raise ProjectError("No `main` or `cli` method detected")
+
+        if interactive:
+            from ape_console._cli import console
+
+            return console()
 
     # @property
     # def meta(self) -> PackageMeta:

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -11,10 +11,10 @@ from ethpm_types.utils import compute_checksum
 
 from ape.contracts import ContractContainer
 from ape.exceptions import ProjectError
+from ape.logging import logger
 from ape.managers.networks import NetworkManager
 from ape.utils import get_all_files_in_directory, get_relative_path, github_client
 
-from ..logging import logger
 from .compilers import CompilerManager
 from .config import ConfigManager
 from .converters import ConversionManager

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -1,8 +1,8 @@
 import json
 import sys
-from importlib import import_module, reload
+from importlib import import_module
 from pathlib import Path
-from typing import Any, Collection, Dict, List, Optional, Union
+from typing import Collection, Dict, List, Optional, Union
 
 import requests
 from dataclassy import dataclass
@@ -49,7 +49,6 @@ class ProjectManager:
     networks: NetworkManager
 
     dependencies: Dict[str, PackageManifest] = dict()
-    _import_cache: Dict[str, Any] = {}
 
     def __post_init__(self):
         if isinstance(self.path, str):
@@ -482,13 +481,7 @@ class ProjectManager:
         # Load the python module to find our hook functions
         try:
             import_str = ".".join(self.scripts_folder.absolute().parts[1:] + (script_path.stem,))
-            if import_str in self._import_cache:
-                reload(self._import_cache[import_str])
-            else:
-                self._import_cache[import_str] = import_module(import_str)
-
-            py_module = self._import_cache[import_str]
-
+            py_module = import_module(import_str)
         except Exception as err:
             logger.error_from_exception(err, f"Exception while executing script: {script_path}")
             sys.exit(1)

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -475,11 +475,14 @@ class ProjectManager:
             raise ProjectError("Cannot execute script from outside current directory")
 
         # Add to Python path so we can search for the given script to import
-        sys.path.append(str(script_path.parent.resolve()))
+        scripts_path = str(script_path.parent.resolve())
+        sys.path.append(scripts_path)
 
         # Load the python module to find our hook functions
         try:
-            py_module = import_module(script_path.stem)
+            import_str = ".".join(self.scripts_folder.absolute().parts[1:] + (script_path.stem,))
+            print(import_str)
+            py_module = import_module(import_str, package="scripts")
         except Exception as err:
             logger.error_from_exception(err, f"Exception while executing script: {script_path}")
             sys.exit(1)

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -1,52 +1,9 @@
-import sys
-from importlib import import_module
-from pathlib import Path
-
 import click
 
-from ape import config
+from ape import project
 from ape.cli import NetworkBoundCommand, ape_cli_context, network_option
-from ape.utils import get_relative_path
-from ape_console._cli import console
 
 # TODO: Migrate this to a CLI toolkit under ``ape``
-
-
-def _run_script(cli_ctx, script_path, interactive=False):
-    script_path = get_relative_path(script_path, Path.cwd())
-    script_parts = script_path.parts[:-1]
-
-    if any(p == ".." for p in script_parts):
-        cli_ctx.abort("Cannot execute script from outside current directory")
-
-    # Add to Python path so we can search for the given script to import
-    sys.path.append(str(script_path.parent.resolve()))
-
-    # Load the python module to find our hook functions
-    try:
-        py_module = import_module(script_path.stem)
-    except Exception as err:
-        cli_ctx.logger.error_from_exception(err, f"Exception while executing script: {script_path}")
-        sys.exit(1)
-
-    finally:
-        # Undo adding the path to make sure it's not permanent
-        sys.path.remove(str(script_path.parent.resolve()))
-
-    # Execute the hooks
-    if hasattr(py_module, "cli"):
-        # TODO: Pass context to ``cli`` before calling it
-        py_module.cli()
-
-    elif hasattr(py_module, "main"):
-        # NOTE: ``main()`` accepts no arguments
-        py_module.main()
-
-    else:
-        cli_ctx.abort("No `main` or `cli` method detected")
-
-    if interactive:
-        return console()
 
 
 @click.command(cls=NetworkBoundCommand, short_help="Run scripts from the `scripts` folder")
@@ -73,24 +30,5 @@ def cli(cli_ctx, scripts, interactive, network):
     if not scripts:
         cli_ctx.abort("Must provide at least one script name or path.")
 
-    scripts_folder = config.PROJECT_FOLDER / "scripts"
-
-    # Generate the lookup based on all the scripts defined in the project's ``scripts/`` folder
-    # NOTE: If folder does not exist, this will be empty (same as if there are no files)
-    available_scripts = {p.stem: p.resolve() for p in scripts_folder.glob("*.py")}
-
     for name in scripts:
-        if Path(name).exists():
-            script_file = Path(name).resolve()
-
-        elif not scripts_folder.exists():
-            cli_ctx.abort("No 'scripts/' directory detected to run script.")
-
-        elif name not in available_scripts:
-            cli_ctx.abort(f"No script named '{name}' detected in scripts folder.")
-
-        else:
-            script_file = available_scripts[name]
-
-        # noinspection PyUnboundLocalVariable
-        _run_script(cli_ctx, script_file, interactive)
+        project.run_script(name, interactive)

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -1,6 +1,5 @@
 import click
 
-from ape import project
 from ape.cli import NetworkBoundCommand, ape_cli_context, network_option
 
 
@@ -31,4 +30,4 @@ def cli(cli_ctx, scripts, interactive, network):
         cli_ctx.abort("Must provide at least one script name or path.")
 
     for name in scripts:
-        project.run_script(name, interactive)
+        cli_ctx.project.run_script(name, interactive)

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -3,8 +3,6 @@ import click
 from ape import project
 from ape.cli import NetworkBoundCommand, ape_cli_context, network_option
 
-# TODO: Migrate this to a CLI toolkit under ``ape``
-
 
 @click.command(cls=NetworkBoundCommand, short_help="Run scripts from the `scripts` folder")
 @click.argument("scripts", nargs=-1)
@@ -27,6 +25,8 @@ def cli(cli_ctx, scripts, interactive, network):
     will be injected dynamically during script execution. The dynamically injected objects are
     the exports from the ``ape`` top-level package (similar to how the console works)
     """
+    _ = network  # Not used directly but required.
+
     if not scripts:
         cli_ctx.abort("Must provide at least one script name or path.")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ import pytest
 import ape
 
 # NOTE: Ensure that we don't use local paths for these
-ape.config.DATA_FOLDER = Path(mkdtemp())
-ape.config.PROJECT_FOLDER = Path(mkdtemp())
+ape.config.DATA_FOLDER = Path(mkdtemp()).resolve()
+ape.config.PROJECT_FOLDER = Path(mkdtemp()).resolve()
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/cli/projects/script/scripts/site.py
+++ b/tests/integration/cli/projects/script/scripts/site.py
@@ -1,0 +1,4 @@
+def main():
+    # This script proves that we are allowed to have scripts
+    # with the same name as a built-in site package, e.g. `site.py`.
+    assert True

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -1,4 +1,4 @@
-from .utils import skip_projects
+from .utils import skip_projects, skip_projects_except
 
 BAD_COMMAND = "not-a-name"
 
@@ -10,19 +10,25 @@ def test_run_no_scripts_dir(ape_cli, runner, project):
     assert "No 'scripts/' directory detected to run script" in result.output
 
 
-@skip_projects(
-    ["empty-config", "no-config", "one-interface", "unregistered-contracts", "test", "geth"]
-)
-def test_run(ape_cli, runner, project):
+@skip_projects_except(["script"])
+def test_run_no_argument(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["run"])
     assert result.exit_code == 1, result.output
     assert "Must provide at least one script name or path" in result.output
 
+
+@skip_projects_except(["script"])
+def test_run_unknown_script(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["run", BAD_COMMAND])
     assert result.exit_code == 1
     assert f"No script named '{BAD_COMMAND}' detected in scripts folder" in result.output
 
-    for script_file in (project.path / "scripts").glob("*.py"):
+
+@skip_projects(
+    ["empty-config", "no-config", "one-interface", "unregistered-contracts", "test", "geth"]
+)
+def test_run(ape_cli, runner, project):
+    for script_file in project.scripts_folder.glob("*.py"):
         if script_file.stem == "__init__":
             continue
 


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #396 

Fix bug preventing scripts to have names like `site.py` because `site` is a built-in python package.

### How I did it

Copied brownie.
`brownie` seems to register the user's full path, cache imports, and import the module via its full-path.

### How to verify it

Are able to run scripts with names such as `site.py`.
Are able to run any scripts you could before.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
