### PR TITLE
chore: cast props to int when needed in Block decode class

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -217,15 +217,23 @@ class BlockConsensus(BlockConsensusAPI):
         )  # type: ignore
 
 
+def _get_int(data: Dict, key: str) -> Optional[int]:
+    number = data.get("number")
+    if number is not None and isinstance(number, str) and number.isnumeric():
+        number = int(number)
+
+    return number
+
+
 class Block(BlockAPI):
     @classmethod
     def decode(cls, data: Dict) -> BlockAPI:
         return cls(  # type: ignore
             gas_data=BlockGasFee.decode(data),
             consensus_data=BlockConsensus.decode(data),
-            number=int(data["number"]),
-            size=int(data["size"]) if "size" in data else None,
-            timestamp=int(data["timestamp"]) if "timestamp" in data else None,
+            number=_get_int(data, "number"),
+            size=_get_int(data, "size"),
+            timestamp=_get_int(data, "timestamp"),
             hash=data.get("hash"),
             parent_hash=data.get("hash"),
         )

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -223,9 +223,9 @@ class Block(BlockAPI):
         return cls(  # type: ignore
             gas_data=BlockGasFee.decode(data),
             consensus_data=BlockConsensus.decode(data),
-            number=data["number"],
-            size=data.get("size"),
-            timestamp=data.get("timestamp"),
+            number=int(data["number"]),
+            size=int(data["size"]) if "size" in data else None,
+            timestamp=int(data["timestamp"]) if "timestamp" in data else None,
             hash=data.get("hash"),
             parent_hash=data.get("hash"),
         )


### PR DESCRIPTION
### What I did

Sometimes, for whatever reason, these are `str` instead of `int`.
This makes them always `int`.

### How I did it

cast to `int` if present else `None`

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
