### PR TITLE
fix: issue preventing req confs from setting in test provider

### DIFF
--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -57,7 +57,9 @@ class LocalNetwork(TestProviderAPI, Web3Provider):
         except TransactionFailed as err:
             raise _get_vm_err(err) from err
 
-        receipt = self.get_transaction(txn_hash.hex())
+        receipt = self.get_transaction(
+            txn_hash.hex(), required_confirmations=txn.required_confirmations or 0
+        )
         if txn.gas_limit is not None and receipt.ran_out_of_gas:
             raise OutOfGasError()
 


### PR DESCRIPTION
### What I did

Noticed that I could not set `required_confirmations` in the `ape-test` provider whereas I could in the `ape-hardhat` provider. Thus, I realized we were not passing along the kwarg so I made it so.

### How I did it

Pass the kwarg for `required_confirmations` to the `get_transaction()` call, copied how it was happening in the web3 provider.

### How to verify it

Something like 

```
sender.transfer(receiver, "1 gwei", required_confirmations=3)
```

should not stall unless you are mining on another thread or something. But just by itself - it should hang forever waiting for confirmations.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
