### PR TITLE
fix: bug preventing from solidity dependencies to work properly

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -36,7 +36,7 @@ def new_dir(path: Path) -> Path:
 
 def build_docs(path: Path) -> Path:
     path = new_dir(path)
-    run("sphinx-build", "docs", path)
+    run("sphinx-build", "docs", str(path))
     return path
 
 

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 from dataclassy import dataclass
 from ethpm_types import ContractType
@@ -56,7 +56,9 @@ class CompilerManager:
 
         return registered_compilers
 
-    def compile(self, contract_filepaths: List[Path]) -> Dict[str, ContractType]:
+    def compile(
+        self, contract_filepaths: List[Path], base_path: Optional[Path] = None
+    ) -> Dict[str, ContractType]:
         """
         Invoke :meth:`ape.ape.compiler.CompilerAPI.compile` for each of the given files.
         For example, use the `ape-solidity plugin <https://github.com/ApeWorX/ape-solidity>`__
@@ -81,11 +83,10 @@ class CompilerManager:
             for path in paths_to_compile:
                 logger.info(f"Compiling '{self._get_contract_path(path)}'.")
 
-            base_path = self.config.PROJECT_FOLDER / Path("contracts")
+            base_path = base_path or self.config.PROJECT_FOLDER / Path("contracts")
             compiled_contracts = self.registered_compilers[extension].compile(
                 paths_to_compile, base_path=base_path
             )
-
             for contract_type in compiled_contracts:
 
                 if contract_type.name in contract_types_dict:

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -50,6 +50,12 @@ class ConfigManager:
     _plugin_configs_by_project: Dict[str, Dict[str, ConfigItem]] = {}
 
     @property
+    def packages_folder(self) -> Path:
+        path = self.DATA_FOLDER / "packages"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    @property
     def _plugin_configs(self) -> Dict[str, ConfigItem]:
         # This property is cached per active project.
         project_name = self.PROJECT_FOLDER.stem

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -124,6 +124,14 @@ class ConfigManager:
     def __repr__(self):
         return "<ConfigManager>"
 
+    def load(self) -> "ConfigManager":
+        """
+        Load the user config file and return this class.
+        """
+
+        _ = self._plugin_configs
+        return self
+
     def get_config(self, plugin_name: str) -> ConfigItem:
         """
         Get a plugin config.

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -68,8 +68,14 @@ class ProjectManager:
 
     def _extract_dependency_manifest(self, name: str, download_path: str) -> PackageManifest:
         target_path = self.config.packages_folder / name
-        target_path.mkdir(exist_ok=True, parents=True)
         manifest_file_path = target_path / "manifest.json"
+
+        # Handles migrating older ape when we cached the entire project
+        # rather than just the manifest file.
+        if target_path.exists() and not manifest_file_path.exists():
+            shutil.rmtree(target_path)
+
+        target_path.mkdir(exist_ok=True, parents=True)
 
         manifest_dict = None
         if manifest_file_path.exists():

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -9,6 +9,7 @@ from typing import Collection, Dict, List, Optional, Union
 import requests
 from dataclassy import dataclass
 from ethpm_types import Checksum, Compiler, ContractType, PackageManifest, Source
+from ethpm_types.manifest import PackageName
 from ethpm_types.utils import compute_checksum
 
 from ape.contracts import ContractContainer
@@ -119,7 +120,7 @@ class ProjectManager:
                     if s.name not in ("package.json", "package-lock.json")
                     and s.suffix in self.compilers.registered_compilers
                 ]
-                manifest.name = name.lower().replace("_", "").replace("-", "")
+                manifest.name = PackageName(name.lower().replace("_", "-"))
                 manifest.sources = self._create_source_dict(sources, base_path=temp_contracts_path)
                 manifest.contract_types = self.compilers.compile(
                     sources, base_path=temp_contracts_path

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -83,7 +83,7 @@ class ProjectManager:
             manifest_dict = self._download_manifest(name, download_path, manifest_file_path)
 
         if "name" not in manifest_dict:
-            manifest_dict["name"] = name.replace("_", "").replace("-", "")
+            manifest_dict["name"] = name.replace("_", "-")
 
         return PackageManifest(**manifest_dict)
 

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -189,6 +189,8 @@ class ProjectManager:
             List[pathlib.Path]: A list of a source file paths in the project.
         """
         files: List[Path] = []
+        if not self.contracts_folder.exists():
+            return files
 
         for extension in self.compilers.registered_compilers:
             files.extend(self.contracts_folder.glob(f"*{extension}"))

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -65,8 +65,7 @@ class ProjectManager:
         return "<ProjectManager>"
 
     def _extract_manifest(self, name: str, download_path: str) -> PackageManifest:
-        dependencies_path = self.contracts_folder / ".dependencies"
-        target_path = dependencies_path / name
+        target_path = self._dependencies_folder / name
         target_path.mkdir(exist_ok=True, parents=True)
 
         if download_path.startswith("https://") or download_path.startswith("http://"):
@@ -197,7 +196,7 @@ class ProjectManager:
                 d
                 for d in self.contracts_folder.iterdir()
                 if d.is_dir()
-                if d.name != ".dependencies"
+                if d.name != self._dependencies_folder.name
             ]:
                 files.extend(sub_contract_dir.glob(f"*{extension}"))
 
@@ -211,6 +210,10 @@ class ProjectManager:
         """
 
         return not self.contracts_folder.exists() or not self.contracts_folder.iterdir()
+
+    @property
+    def _dependencies_folder(self) -> Path:
+        return self.contracts_folder / ".dependencies"
 
     def extensions_with_missing_compilers(self, extensions: Optional[List[str]]) -> List[str]:
         """

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -190,8 +190,16 @@ class ProjectManager:
             List[pathlib.Path]: A list of a source file paths in the project.
         """
         files: List[Path] = []
+
         for extension in self.compilers.registered_compilers:
-            files.extend(self.contracts_folder.rglob("*" + extension))
+            files.extend(self.contracts_folder.glob(f"*{extension}"))
+            for sub_contract_dir in [
+                d
+                for d in self.contracts_folder.iterdir()
+                if d.is_dir()
+                if d.name != ".dependencies"
+            ]:
+                files.extend(sub_contract_dir.glob(f"*{extension}"))
 
         return files
 

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -65,7 +65,7 @@ class ProjectManager:
         return "<ProjectManager>"
 
     def _extract_manifest(self, name: str, download_path: str) -> PackageManifest:
-        target_path = self._dependencies_folder / name
+        target_path = self._dependencies_cache_folder / name
         target_path.mkdir(exist_ok=True, parents=True)
 
         if download_path.startswith("https://") or download_path.startswith("http://"):
@@ -198,7 +198,7 @@ class ProjectManager:
                 d
                 for d in self.contracts_folder.iterdir()
                 if d.is_dir()
-                if d.name != self._dependencies_folder.name
+                if d.name != self._dependencies_cache_folder.name
             ]:
                 files.extend(sub_contract_dir.glob(f"*{extension}"))
 
@@ -214,8 +214,8 @@ class ProjectManager:
         return not self.contracts_folder.exists() or not self.contracts_folder.iterdir()
 
     @property
-    def _dependencies_folder(self) -> Path:
-        return self.contracts_folder / ".dependencies"
+    def _dependencies_cache_folder(self) -> Path:
+        return self.contracts_folder / ".cache"
 
     def extensions_with_missing_compilers(self, extensions: Optional[List[str]]) -> List[str]:
         """

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -120,6 +120,7 @@ class ProjectManager:
                     if s.name not in ("package.json", "package-lock.json")
                     and s.suffix in self.compilers.registered_compilers
                 ]
+
                 manifest.name = PackageName(name.lower().replace("_", "-"))
                 manifest.sources = self._create_source_dict(sources, base_path=temp_contracts_path)
                 manifest.contract_types = self.compilers.compile(

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -6,7 +6,7 @@ from ethpm_types import ABI, ContractType
 from pydantic import parse_obj_as
 
 from ape.api import CompilerAPI
-from ape.exceptions import CompilerError
+from ape.logging import logger
 from ape.utils import get_relative_path
 
 
@@ -34,7 +34,7 @@ class InterfaceCompiler(CompilerAPI):
                 else str(path)
             )
             if not isinstance(data, list):
-                raise CompilerError("Not a valid ABI interface JSON file.")
+                logger.warning(f"Not a valid ABI interface JSON file (sourceID={source_id}).")
 
             else:
                 contract = ContractType(  # type: ignore


### PR DESCRIPTION
### What I did

fixes: #150 (not pushed yet)
Issue preventing dependencies from working correctly.
https://github.com/ApeWorX/ape-solidity/pull/20

A change that is part of this and something we wanted is that now, when we download a dependency from Github, instead of caching all the files, we only cache the manifest.

In `ape-solidity` (PR Linked above), we then de-compile the files from the manifest and put them in the `contracts/.cache` directory. Since only `solidity` needs this, it makes sense that it happens in the plugin.

### How I did it

Moves dependencies to `<project>/contracts/.dependencies` folder. Reason: This way, are in the base-path, which seems to be needed.  We still do the mapping (basically ignoring `.dependencies` part). This feels a lot like `remix`.### How to verify it

`simple-nft` project

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
