### PR TITLE
fix: add missing error handling for VM-related contract logic errors in calls

### DIFF
--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -72,7 +72,7 @@ class TransactionError(ContractError):
     Raised when issues occur related to transactions.
     """
 
-    DEFAULT_MESSAGE = "Tranaction failed."
+    DEFAULT_MESSAGE = "Transaction failed."
 
     def __init__(
         self,

--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -210,11 +210,6 @@ class GethProvider(Web3Provider, UpstreamProvider):
         self._web3 = None  # type: ignore
 
     def estimate_gas_cost(self, txn: TransactionAPI) -> int:
-        """
-        Generates and returns an estimate of how much gas is necessary
-        to allow the transaction to complete.
-        The transaction will not be added to the blockchain.
-        """
         try:
             return super().estimate_gas_cost(txn)
         except ValueError as err:
@@ -236,11 +231,13 @@ class GethProvider(Web3Provider, UpstreamProvider):
             # Unsupported API in user's geth.
             return None
 
+    def send_call(self, txn: TransactionAPI) -> bytes:
+        try:
+            return super().send_call(txn)
+        except ValueError as err:
+            raise _get_vm_error(err) from err
+
     def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
-        """
-        Creates a new message call transaction or a contract creation
-        for signed transactions.
-        """
         try:
             receipt = super().send_transaction(txn)
         except ValueError as err:

--- a/src/ape_test/contextmanagers.py
+++ b/src/ape_test/contextmanagers.py
@@ -16,7 +16,8 @@ class RevertsContextManager:
 
         if not isinstance(exc_value, ContractLogicError):
             raise AssertionError(
-                f"Transaction did not revert.\nHowever, an exception occurred: {exc_value}"
+                f"Transaction did not revert.\n"
+                f"However, an exception of type {type(exc_value)} occurred: {exc_value}"
             ) from exc_value
 
         actual = exc_value.revert_message

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -47,7 +47,13 @@ class LocalNetwork(TestProviderAPI, Web3Provider):
         data = txn.as_dict()
         if "gas" not in data or data["gas"] == 0:
             data["gas"] = int(1e12)
-        return self._web3.eth.call(data)
+
+        try:
+            return self._web3.eth.call(data)
+        except ValidationError as err:
+            raise VirtualMachineError(base_err=err) from err
+        except TransactionFailed as err:
+            raise _get_vm_err(err) from err
 
     def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
         try:
@@ -82,4 +88,7 @@ class LocalNetwork(TestProviderAPI, Web3Provider):
 
 def _get_vm_err(web3_err: TransactionFailed) -> ContractLogicError:
     err_message = str(web3_err).split("execution reverted: ")[-1] or None
+    if err_message == "b''":
+        err_message = None
+
     return ContractLogicError(revert_message=err_message)


### PR DESCRIPTION
### What I did

* Handle ContractLogic VM-errors in `ape-geth` and `ape-test` when making contracts calls. It was happening in transactions before but never in calls.
* Issue where we did not properly detect an empty revert message in `ape-test` because the message was `"b''"`.
* Other small fixes, like spelling

### How I did it

* Copy logic from `send_transaction()`
* Handle odd case in `ape-test` when empty revert message

### How to verify it

```vyper
# @version 0.3.2


@view
@external
def valuation(tokenId: uint256):
    assert tokenId > 0
```

and a test

```python
import ape


def test_no_portfolio(accounts):
    a = accounts[0]
    empty = a.deploy(ape.project.empty)
    with ape.reverts():
        empty.valuation(0)
```

```bash
ape test --network ::test
ape test --network ::geth
ape test --network ::hardhat
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
