### PR TITLE
fix: handle none args or inputs

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -126,9 +126,11 @@ class ContractCallHandler:
 
 
 def _select_abi(abis, args):
+    args = args or []
     selected_abi = None
     for abi in abis:
-        if len(args) == len(abi.inputs):
+        inputs = abi.inputs or []
+        if len(args) == len(inputs):
             selected_abi = abi
 
     return selected_abi


### PR DESCRIPTION
### What I did

fixes: #424

### How I did it

Coerce args **and** `abi.inputs` to empty list when they are `None`.

### How to verify it

```python
from ape_tokens import tokens
yfi = tokens["YFI"]
yfi.decimals()  # <---   Outputs '18'
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
