### PR TITLE
feat: allow configuring a global contracts path

### DIFF
--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -3,6 +3,22 @@
 An `ape-config.yaml` file allows you to configure ape. This guide serves as an index of the settings you can include 
 in an `ape-config.yaml` file.
 
+## Contracts Folder
+
+Specify a different path to your `contracts/` directory.
+This is useful when using a different naming convention, such as `src/` rather than `contracts/`.
+
+```yaml
+contracts_folder: src
+```
+
+You can also use an absolute path.
+This is useful for projects that compile contracts outside their directory.
+
+```yaml
+contracts_folder: "~/GlobalContracts"
+```
+
 ## Deployments
 
 Share import deployments to public networks with your teammates:

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -81,7 +81,7 @@ class CompilerManager:
             for path in paths_to_compile:
                 logger.info(f"Compiling '{self._get_contract_path(path)}'.")
 
-            base_path = self.config.PROJECT_FOLDER / Path("contracts")
+            base_path = self.config.contracts_folder
             compiled_contracts = self.registered_compilers[extension].compile(
                 paths_to_compile, base_path=base_path
             )
@@ -106,6 +106,6 @@ class CompilerManager:
 
     def _get_contract_path(self, path: Path):
         try:
-            return path.relative_to(self.config.PROJECT_FOLDER / "contracts")
+            return path.relative_to(self.config.contracts_folder)
         except ValueError:
             return path

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -75,9 +75,8 @@ class ConfigManager:
             contracts_folder_value = Path(user_config.pop("contracts_folder")).expanduser()
 
             # Attempt to resolve the path in the case it is relative to the project directory.
+            # NOTE: It is okay for this directory not to exist at this point.
             contracts_folder = Path(contracts_folder_value).resolve()
-            if not contracts_folder.exists() or not list(contracts_folder.iterdir()):
-                logger.warning(f"No sources file found in '{contracts_folder}'.")
         else:
             contracts_folder = self.PROJECT_FOLDER / "contracts"
 

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -76,8 +76,8 @@ class ConfigManager:
 
             # Attempt to resolve the path in the case it is relative to the project directory.
             contracts_folder = Path(contracts_folder_value).resolve()
-            if not contracts_folder.exists():
-                raise ConfigError(f"Contracts path '{contracts_folder}' does not exist.")
+            if not contracts_folder.exists() or not list(contracts_folder.iterdir()):
+                logger.warning(f"No sources file found in '{contracts_folder}'.")
         else:
             contracts_folder = self.PROJECT_FOLDER / "contracts"
 

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -44,6 +44,7 @@ class ConfigManager:
     PROJECT_FOLDER: Path
     name: str = ""
     version: str = ""
+    contracts_folder: Path = None  # type: ignore
     dependencies: Dict[str, str] = {}
     deployments: Dict[str, Dict[str, List[DeploymentConfig]]] = {}
     plugin_manager: PluginManager
@@ -63,6 +64,18 @@ class ConfigManager:
         # Top level config items
         self.name = user_config.pop("name", "")
         self.version = user_config.pop("version", "")
+
+        if "contracts_folder" in user_config:
+            contracts_folder_value = Path(user_config.pop("contracts_folder")).expanduser()
+
+            # Attempt to resolve the path in the case it is relative to the project directory.
+            contracts_folder = Path(contracts_folder_value).resolve()
+            if not contracts_folder.exists():
+                raise ConfigError(f"Contracts path '{contracts_folder}' does not exist.")
+        else:
+            contracts_folder = self.PROJECT_FOLDER / "contracts"
+
+        self.contracts_folder = contracts_folder
         self.dependencies = user_config.pop("dependencies", {})
 
         # Sanitize deployment addresses.

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -371,6 +371,40 @@ class ProjectManager:
 
         return self.load_contracts()
 
+    def __getattr__(self, attr_name: str) -> ContractContainer:
+        """
+        Get a contract container from an existing contract type or dependency
+        name using ``.`` access.
+
+        Usage example::
+
+            from ape import project
+
+            contract = project.MyContract
+
+        Args:
+            attr_name (str): The name of the contract or dependency.
+
+        Returns:
+            :class:`~ape.contracts.ContractContainer`
+        """
+
+        contracts = self.load_contracts()
+        if attr_name in contracts:
+            contract_type = contracts[attr_name]
+        elif attr_name in self.dependencies:
+            contract_type = self.dependencies[attr_name]  # type: ignore
+        else:
+            # Fixes anomaly when accessing non-ContractType attributes.
+            # Returns normal attribute if exists. Raises 'AttributeError' otherwise.
+            return self.__getattribute__(attr_name)  # type: ignore
+
+        return ContractContainer(  # type: ignore
+            contract_type=contract_type,
+            _provider=self.networks.active_provider,
+            _converter=self.converter,
+        )
+
     @property
     def interfaces_folder(self) -> Path:
         """
@@ -423,40 +457,6 @@ class ProjectManager:
                 compilers.append(Compiler(compiler.name, version))  # type: ignore
 
         return compilers
-
-    def __getattr__(self, attr_name: str) -> ContractContainer:
-        """
-        Get a contract container from an existing contract type or dependency
-        name using ``.`` access.
-
-        Usage example::
-
-            from ape import project
-
-            contract = project.MyContract
-
-        Args:
-            attr_name (str): The name of the contract or dependency.
-
-        Returns:
-            :class:`~ape.contracts.ContractContainer`
-        """
-
-        contracts = self.load_contracts()
-        if attr_name in contracts:
-            contract_type = contracts[attr_name]
-        elif attr_name in self.dependencies:
-            contract_type = self.dependencies[attr_name]  # type: ignore
-        else:
-            # Fixes anomaly when accessing non-ContractType attributes.
-            # Returns normal attribute if exists. Raises 'AttributeError' otherwise.
-            return self.__getattribute__(attr_name)  # type: ignore
-
-        return ContractContainer(  # type: ignore
-            contract_type=contract_type,
-            _provider=self.networks.active_provider,
-            _converter=self.converter,
-        )
 
     def _create_source_dict(self, contracts_paths: Collection[Path]) -> Dict[str, Source]:
         return {

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -43,10 +43,34 @@ class ProjectManager:
     """
 
     path: Path
+    """The project path."""
+
     config: ConfigManager
+    """
+    A reference to :class:`~ape.managers.config.ConfigManager`, which
+    manages project and plugin configurations.
+    """
+
     converter: ConversionManager
+    """
+    A reference to the conversion utilities in
+    :class:`~ape.managers.converters.ConversionManager`.
+    """
+
     compilers: CompilerManager
+    """
+    The group of compiler plugins for compiling source files. See
+    :class:`~ape.managers.compilers.CompilerManager` for more information.
+    Call method :meth:`~ape.managers.project.ProjectManager.load_contracts` in this class
+    to more easily compile sources.
+    """
+
     networks: NetworkManager
+    """
+    The manager of networks, :class:`~ape.managers.networks.NetworkManager`.
+    To get the actie provide, use
+    :py:attr:`ape.managers.networks.NetworkManager.active_provider`.
+    """
 
     dependencies: Dict[str, PackageManifest] = dict()
 
@@ -424,7 +448,9 @@ class ProjectManager:
         elif attr_name in self.dependencies:
             contract_type = self.dependencies[attr_name]  # type: ignore
         else:
-            raise AttributeError(f"{self.__class__.__name__} has no attribute '{attr_name}'.")
+            # Fixes anomaly when accessing non-ContractType attributes.
+            # Returns normal attribute if exists. Raises 'AttributeError' otherwise.
+            return self.__getattribute__(attr_name)  # type: ignore
 
         return ContractContainer(  # type: ignore
             contract_type=contract_type,

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -164,7 +164,7 @@ class ProjectManager:
             pathlib.Path
         """
 
-        return self.path / "contracts"
+        return self.config.contracts_folder
 
     @property
     def sources(self) -> List[Path]:
@@ -347,38 +347,6 @@ class ProjectManager:
 
         return self.load_contracts()
 
-    def __getattr__(self, attr_name: str) -> ContractContainer:
-        """
-        Get a contract container from an existing contract type or dependency
-        name using ``.`` access.
-
-        Usage example::
-
-            from ape import project
-
-            contract = project.MyContract
-
-        Args:
-            attr_name (str): The name of the contract or dependency.
-
-        Returns:
-            :class:`~ape.contracts.ContractContainer`
-        """
-
-        contracts = self.load_contracts()
-        if attr_name in contracts:
-            contract_type = contracts[attr_name]
-        elif attr_name in self.dependencies:
-            contract_type = self.dependencies[attr_name]  # type: ignore
-        else:
-            raise AttributeError(f"{self.__class__.__name__} has no attribute '{attr_name}'.")
-
-        return ContractContainer(  # type: ignore
-            contract_type=contract_type,
-            _provider=self.networks.active_provider,
-            _converter=self.converter,
-        )
-
     @property
     def interfaces_folder(self) -> Path:
         """
@@ -431,6 +399,38 @@ class ProjectManager:
                 compilers.append(Compiler(compiler.name, version))  # type: ignore
 
         return compilers
+
+    def __getattr__(self, attr_name: str) -> ContractContainer:
+        """
+        Get a contract container from an existing contract type or dependency
+        name using ``.`` access.
+
+        Usage example::
+
+            from ape import project
+
+            contract = project.MyContract
+
+        Args:
+            attr_name (str): The name of the contract or dependency.
+
+        Returns:
+            :class:`~ape.contracts.ContractContainer`
+        """
+
+        contracts = self.load_contracts()
+        if attr_name in contracts:
+            contract_type = contracts[attr_name]
+        elif attr_name in self.dependencies:
+            contract_type = self.dependencies[attr_name]  # type: ignore
+        else:
+            raise AttributeError(f"{self.__class__.__name__} has no attribute '{attr_name}'.")
+
+        return ContractContainer(  # type: ignore
+            contract_type=contract_type,
+            _provider=self.networks.active_provider,
+            _converter=self.converter,
+        )
 
     def _create_source_dict(self, contracts_paths: Collection[Path]) -> Dict[str, Source]:
         return {

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -68,7 +68,7 @@ class ProjectManager:
     networks: NetworkManager
     """
     The manager of networks, :class:`~ape.managers.networks.NetworkManager`.
-    To get the actie provide, use
+    To get the active provide, use
     :py:attr:`ape.managers.networks.NetworkManager.active_provider`.
     """
 

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -35,8 +35,8 @@ def cli(cli_ctx, file_paths, use_cache, display_size):
     a project is loaded. You do not have to manually trigger a recompile.
     """
     if not file_paths and cli_ctx.project.sources_missing:
-        contracts_dir_name = cli_ctx.project.config.contracts_folder.name
-        cli_ctx.logger.warning(f"No contracts found in '{contracts_dir_name}/'.")
+        contracts_dir = cli_ctx.project.config.contracts_folder
+        cli_ctx.logger.warning(f"No source files found in '{contracts_dir}'.")
         return
 
     ext_given = [p.suffix for p in file_paths if p]

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -34,7 +34,8 @@ def cli(cli_ctx, file_paths, use_cache, display_size):
     Note that ape automatically recompiles any changed contracts each time
     a project is loaded. You do not have to manually trigger a recompile.
     """
-    if not file_paths and cli_ctx.project.sources_missing:
+    project = cli_ctx.project
+    if not file_paths and project.sources_missing:
         cli_ctx.logger.warning("No 'contracts/' directory detected")
         return
 

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -35,8 +35,7 @@ def cli(cli_ctx, file_paths, use_cache, display_size):
     a project is loaded. You do not have to manually trigger a recompile.
     """
     if not file_paths and cli_ctx.project.sources_missing:
-        contracts_dir_name = cli_ctx.project.config.contracts_folder.name
-        cli_ctx.logger.warning(f"No '{contracts_dir_name}/' directory detected")
+        cli_ctx.logger.warning("No 'contracts/' directory detected")
         return
 
     ext_given = [p.suffix for p in file_paths if p]

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -34,8 +34,7 @@ def cli(cli_ctx, file_paths, use_cache, display_size):
     Note that ape automatically recompiles any changed contracts each time
     a project is loaded. You do not have to manually trigger a recompile.
     """
-    project = cli_ctx.project
-    if not file_paths and project.sources_missing:
+    if not file_paths and cli_ctx.project.sources_missing:
         cli_ctx.logger.warning("No 'contracts/' directory detected")
         return
 

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -35,7 +35,8 @@ def cli(cli_ctx, file_paths, use_cache, display_size):
     a project is loaded. You do not have to manually trigger a recompile.
     """
     if not file_paths and cli_ctx.project.sources_missing:
-        cli_ctx.logger.warning("No 'contracts/' directory detected")
+        contracts_dir_name = cli_ctx.project.config.contracts_folder.name
+        cli_ctx.logger.warning(f"No '{contracts_dir_name}/' directory detected")
         return
 
     ext_given = [p.suffix for p in file_paths if p]

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -36,7 +36,7 @@ def cli(cli_ctx, file_paths, use_cache, display_size):
     """
     if not file_paths and cli_ctx.project.sources_missing:
         contracts_dir_name = cli_ctx.project.config.contracts_folder.name
-        cli_ctx.logger.warning(f"No '{contracts_dir_name}/' directory detected")
+        cli_ctx.logger.warning(f"No contracts found in '{contracts_dir_name}/'.")
         return
 
     ext_given = [p.suffix for p in file_paths if p]

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -86,8 +86,10 @@ def project_folder(request, config):
     copy_tree(project_source_dir.as_posix(), project_dest_dir.as_posix())
     previous_project_folder = config.PROJECT_FOLDER
     config.PROJECT_FOLDER = project_dest_dir
+    config.contracts_folder = project_dest_dir / "contracts"
     yield project_dest_dir
     config.PROJECT_FOLDER = previous_project_folder
+    config.contracts_folder = previous_project_folder / "contracts"
 
 
 @pytest.fixture

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -8,7 +8,7 @@ def test_compile_missing_contracts_dir(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["compile"])
     assert result.exit_code == 0, result.output
     assert "WARNING" in result.output
-    assert "No contracts found in 'contracts/'." in result.output
+    assert "No source files found in" in result.output
 
 
 @skip_projects_except(["unregistered-contracts"])

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -8,7 +8,7 @@ def test_compile_missing_contracts_dir(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["compile"])
     assert result.exit_code == 0, result.output
     assert "WARNING" in result.output
-    assert "No 'contracts/' directory detected" in result.output
+    assert "No contracts found in 'contracts/'." in result.output
 
 
 @skip_projects_except(["unregistered-contracts"])

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -15,7 +15,7 @@ def test_compile_missing_contracts_dir(ape_cli, runner, project):
 def test_missing_extensions(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["compile"])
     assert result.exit_code == 0, result.output
-    assert "WARNING: No compilers detected for the " "following extensions:" in result.output
+    assert "WARNING: No compilers detected for the following extensions:" in result.output
     assert ".test" in result.output
     assert ".foobar" in result.output
 
@@ -24,9 +24,7 @@ def test_missing_extensions(ape_cli, runner, project):
 def test_no_compiler_for_extension(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["compile", "contracts/Contract.test"])
     assert result.exit_code == 0, result.output
-    assert (
-        "WARNING: No compilers detected for the " "following extensions: .test"
-    ) in result.output
+    assert "WARNING: No compilers detected for the following extensions: .test" in result.output
 
 
 @skip_projects(["empty-config", "no-config", "script", "unregistered-contracts", "test", "geth"])


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #409 

### How I did it

Grab / create the path using the value from the conifg `contracts_folder:` property.
If the value does not exist, default to what it was before (`self.config.PROJECT_FOLDER / "contracts"`)

### How to verify it

* Create a project. Make things work as they did before.
* Set `contracts_folder: src` in your `ape-config.yaml` and rename `contracts/` to `src/`. Check that things still work. Recompile, etc.
* Renamed `src` back to `contracts`. Now, things should fail and it should not find your contracts.
* Create a global directory, like `$HOME/globalContracts`. Add contracts there. Set in your config the path to there (absolute). Notice things work - it compiles the global contracts.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
