### PR TITLE
fix: bug preventing setting default networks from working

### DIFF
--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -13,5 +13,6 @@ class NetworkBoundCommand(click.Command):
     """
 
     def invoke(self, ctx: Context) -> Any:
-        with networks.parse_network_choice(ctx.params["network"]):
+        value = ctx.params["network"]
+        with networks.parse_network_choice(value):
             super().invoke(ctx)

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -208,7 +208,8 @@ class NetworkManager:
         """
 
         if network_choice is None:
-            return self.default_ecosystem["development"].get_provider(
+            default_network = self.default_ecosystem.default_network
+            return self.default_ecosystem[default_network].get_provider(
                 provider_settings=provider_settings
             )
 
@@ -224,7 +225,8 @@ class NetworkManager:
             ecosystem = self.__getattr__(selections[0] or self.default_ecosystem.name)
             # By default, the "development" network should be specified for
             # any ecosystem (this should not correspond to a production chain)
-            return ecosystem["development"].get_provider(provider_settings=provider_settings)
+            default_network = ecosystem.default_network
+            return ecosystem[default_network].get_provider(provider_settings=provider_settings)
 
         elif len(selections) == 2:
             # Only ecosystem and network were specified, not provider


### PR DESCRIPTION
### What I did

Bug preventing setting default networks from working correctly.

### How I did it

Tried to use mainnet fork and struggles.

### How to verify it

This config should work now:

```yaml

ethereum:
  default_network: mainnet-fork
  mainnet-fork:
    default_provider: hardhat

hardhat:
  mainnet_fork:
    upstream_provider: alchemy
```

^ default network is `ethereum:mainnet-fork:hardhat` and upstreams to `alchemy`.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
