### PR TITLE
fix: upgrade IPython to prevent potential vulns

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         "requests>=2.25.1,<3.0",
         "importlib-metadata",
         "singledispatchmethod ; python_version<'3.8'",
-        "IPython>=7.25",
+        "IPython>=8.0.1",
         "pytest>=6.0,<7.0",
         "rich>=10.14,<11",
         "tqdm>=4.62.3,<5.0",

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         "requests>=2.25.1,<3.0",
         "importlib-metadata",
         "singledispatchmethod ; python_version<'3.8'",
-        "IPython>=8.0.1",
+        "IPython>=7.31.1",
         "pytest>=6.0,<7.0",
         "rich>=10.14,<11",
         "tqdm>=4.62.3,<5.0",


### PR DESCRIPTION
### What I did

Upgrade IPython to resolve vulnerability findings (CVE-2022-21699).

### How I did it

Noticed someone else did it and looked into it....

### How to verify it

```python
In [1]: import IPython

In [2]: IPython.__patched_cves__
Out[2]: {'CVE-2022-21699'}

In [3]: 'CVE-2022-21699' in IPython.__patched_cves__
Out[3]: True
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
