### PR TITLE
refactor: remove dataclassy from managers

### DIFF
--- a/src/ape/__init__.py
+++ b/src/ape/__init__.py
@@ -22,6 +22,7 @@ from .utils import USER_AGENT
 plugin_manager = _PluginManager()
 """Manages plugins for the current project. See :class:`ape.plugins.PluginManager`."""
 
+_ConfigManager.plugin_manager = plugin_manager
 config = _ConfigManager(
     # Store all globally-cached files
     data_folder=_Path.home().joinpath(".ape"),
@@ -31,40 +32,50 @@ config = _ConfigManager(
     },
     # What we are considering to be the starting project directory
     project_folder=_Path.cwd(),
-    plugin_manager=plugin_manager,
 )
 """The active configs for the current project. See :class:`ape.managers.config.ConfigManager`."""
 
 # Main types we export for the user
 
-compilers = _CompilerManager(config=config, plugin_manager=plugin_manager)
+_CompilerManager.config = config
+_CompilerManager.plugin_manager = plugin_manager
+compilers = _CompilerManager()
 """Manages compilers for the current project. See
 :class:`ape.managers.compilers.CompilerManager`."""
 
-networks = _NetworkManager(config=config, plugin_manager=plugin_manager)
+_NetworkManager.config = config
+_NetworkManager.plugin_manager = plugin_manager
+networks = _NetworkManager()
 """Manages the networks for the current project. See
 :class:`ape.managers.networks.NetworkManager`."""
 
-_converters = _ConversionManager(config=config, plugin_manager=plugin_manager, networks=networks)
+_ConversionManager.config = config
+_ConversionManager.plugin_manager = plugin_manager
+_ConversionManager.networks = networks
+_converters = _ConversionManager()
 
-chain = _ChainManager(networks=networks, converters=_converters)
+_ChainManager._networks = networks
+_ChainManager._converters = _converters
+chain = _ChainManager()
 """
 The current connected blockchain; requires an active provider.
 Useful for development purposes, such as controlling the state of the blockchain.
 Also handy for querying data about the chain and managing local caches.
 """
 
-accounts = _AccountManager(
-    config=config, converters=_converters, plugin_manager=plugin_manager, network_manager=networks
-)
+_AccountManager.config = config
+_AccountManager.converters = _converters
+_AccountManager.plugin_manager = plugin_manager
+_AccountManager.network_manager = networks
+accounts = _AccountManager()
 """Manages accounts for the current project. See :class:`ape.managers.accounts.AccountManager`."""
 
+_ProjectManager.config = config
+_ProjectManager.compilers = compilers
+_ProjectManager.networks = networks
+_ProjectManager.converter = _converters
 Project = _partial(
     _ProjectManager,
-    config=config,
-    compilers=compilers,
-    networks=networks,
-    converter=_converters,
 )
 """User-facing class for instantiating Projects (in addition to the currently
 active ``project``). See :class:`ape.managers.project.ProjectManager`."""

--- a/src/ape/__init__.py
+++ b/src/ape/__init__.py
@@ -13,7 +13,7 @@ from .managers.compilers import CompilerManager as _CompilerManager
 from .managers.config import ConfigManager as _ConfigManager
 from .managers.converters import ConversionManager as _ConversionManager
 from .managers.networks import NetworkManager as _NetworkManager
-from .managers.project import ProjectManager as _ProjectManager
+from .managers.project import ProjectManager as Project
 from .plugins import PluginManager as _PluginManager
 from .utils import USER_AGENT
 
@@ -70,13 +70,10 @@ _AccountManager.network_manager = networks
 accounts = _AccountManager()
 """Manages accounts for the current project. See :class:`ape.managers.accounts.AccountManager`."""
 
-_ProjectManager.config = config
-_ProjectManager.compilers = compilers
-_ProjectManager.networks = networks
-_ProjectManager.converter = _converters
-Project = _partial(
-    _ProjectManager,
-)
+Project.config = config
+Project.compilers = compilers
+Project.networks = networks
+Project.converter = _converters
 """User-facing class for instantiating Projects (in addition to the currently
 active ``project``). See :class:`ape.managers.project.ProjectManager`."""
 

--- a/src/ape/__init__.py
+++ b/src/ape/__init__.py
@@ -22,39 +22,41 @@ from .utils import USER_AGENT
 plugin_manager = _PluginManager()
 """Manages plugins for the current project. See :class:`ape.plugins.PluginManager`."""
 
-config = _ConfigManager(  # type: ignore
+config = _ConfigManager(
     # Store all globally-cached files
-    DATA_FOLDER=_Path.home().joinpath(".ape"),
+    data_folder=_Path.home().joinpath(".ape"),
     # NOTE: For all HTTP requests we make
-    REQUEST_HEADER={
+    request_header={
         "User-Agent": USER_AGENT,
     },
     # What we are considering to be the starting project directory
-    PROJECT_FOLDER=_Path.cwd(),
+    project_folder=_Path.cwd(),
     plugin_manager=plugin_manager,
 )
 """The active configs for the current project. See :class:`ape.managers.config.ConfigManager`."""
 
 # Main types we export for the user
 
-compilers = _CompilerManager(config, plugin_manager)  # type: ignore
+compilers = _CompilerManager(config=config, plugin_manager=plugin_manager)
 """Manages compilers for the current project. See
 :class:`ape.managers.compilers.CompilerManager`."""
 
-networks = _NetworkManager(config, plugin_manager)  # type: ignore
+networks = _NetworkManager(config=config, plugin_manager=plugin_manager)
 """Manages the networks for the current project. See
 :class:`ape.managers.networks.NetworkManager`."""
 
-_converters = _ConversionManager(config, plugin_manager, networks)  # type: ignore
+_converters = _ConversionManager(config=config, plugin_manager=plugin_manager, networks=networks)
 
-chain = _ChainManager(networks)  # type: ignore
+chain = _ChainManager(networks=networks, converters=_converters)
 """
 The current connected blockchain; requires an active provider.
 Useful for development purposes, such as controlling the state of the blockchain.
 Also handy for querying data about the chain and managing local caches.
 """
 
-accounts = _AccountManager(config, _converters, plugin_manager, networks)  # type: ignore
+accounts = _AccountManager(
+    config=config, converters=_converters, plugin_manager=plugin_manager, network_manager=networks
+)
 """Manages accounts for the current project. See :class:`ape.managers.accounts.AccountManager`."""
 
 Project = _partial(
@@ -67,7 +69,7 @@ Project = _partial(
 """User-facing class for instantiating Projects (in addition to the currently
 active ``project``). See :class:`ape.managers.project.ProjectManager`."""
 
-project = Project(config.PROJECT_FOLDER)
+project = Project(path=config.PROJECT_FOLDER)
 """The currently active project. See :class:`ape.managers.project.ProjectManager`."""
 
 Contract = _partial(_Contract, networks=networks, converters=_converters)

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -1,10 +1,10 @@
-from typing import Dict, Iterator, List, Type
+from typing import ClassVar, Dict, Iterator, List, Type
 
 from pluggy import PluginManager  # type: ignore
 
 from ape.api.accounts import AccountAPI, AccountContainerAPI, TestAccountAPI
 from ape.types import AddressType
-from ape.utils import cached_property, singledispatchmethod
+from ape.utils import cached_property, injected_before_use, singledispatchmethod
 
 from .config import ConfigManager
 from .converters import ConversionManager
@@ -27,23 +27,10 @@ class AccountManager:
         my_accounts = accounts.load("dev")
     """
 
-    config: ConfigManager
-    converters: ConversionManager
-    plugin_manager: PluginManager
-    network_manager: NetworkManager
-
-    def __init__(
-        self,
-        *,
-        config: ConfigManager,
-        converters: ConversionManager,
-        plugin_manager: PluginManager,
-        network_manager: NetworkManager,
-    ) -> None:
-        self.config = config
-        self.converters = converters
-        self.plugin_manager = plugin_manager
-        self.network_manager = network_manager
+    config: ClassVar[ConfigManager] = injected_before_use()  # type: ignore
+    converters: ClassVar[ConversionManager] = injected_before_use()  # type: ignore
+    plugin_manager: ClassVar[PluginManager] = injected_before_use()  # type: ignore
+    network_manager: ClassVar[NetworkManager] = injected_before_use()  # type: ignore
 
     @cached_property
     def containers(self) -> Dict[str, AccountContainerAPI]:

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -1,6 +1,5 @@
 from typing import Dict, Iterator, List, Type
 
-from dataclassy import dataclass
 from pluggy import PluginManager  # type: ignore
 
 from ape.api.accounts import AccountAPI, AccountContainerAPI, TestAccountAPI
@@ -12,7 +11,6 @@ from .converters import ConversionManager
 from .networks import NetworkManager
 
 
-@dataclass
 class AccountManager:
     """
     The ``AccountManager`` is a container of containers for
@@ -33,6 +31,19 @@ class AccountManager:
     converters: ConversionManager
     plugin_manager: PluginManager
     network_manager: NetworkManager
+
+    def __init__(
+        self,
+        *,
+        config: ConfigManager,
+        converters: ConversionManager,
+        plugin_manager: PluginManager,
+        network_manager: NetworkManager,
+    ) -> None:
+        self.config = config
+        self.converters = converters
+        self.plugin_manager = plugin_manager
+        self.network_manager = network_manager
 
     @cached_property
     def containers(self) -> Dict[str, AccountContainerAPI]:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -293,14 +293,19 @@ class ChainManager(_ConnectedChain):
     _block_container_map: Dict[int, BlockContainer] = {}
     _account_history_map: Dict[int, AccountHistory] = {}
 
+    def __init__(self) -> None:
+        BlockContainer._networks = self._networks
+        BlockContainer._converters = self._converters
+
+        AccountHistory._networks = self._networks
+        AccountHistory._converters = self._converters
+
     @property
     def blocks(self) -> BlockContainer:
         """
         The list of blocks on the chain.
         """
         if self.chain_id not in self._block_container_map:
-            BlockContainer._networks = self._networks
-            BlockContainer._converters = self._converters
             blocks = BlockContainer()
             self._block_container_map[self.chain_id] = blocks
 
@@ -312,8 +317,6 @@ class ChainManager(_ConnectedChain):
         A mapping of transactions from the active session to the account responsible.
         """
         if self.chain_id not in self._account_history_map:
-            AccountHistory._networks = self._networks
-            AccountHistory._converters = self._converters
             history = AccountHistory()
             self._account_history_map[self.chain_id] = history
 

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-from dataclassy import dataclass
 from ethpm_types import ContractType
 
 from ape.api import CompilerAPI
@@ -13,7 +12,6 @@ from ape.utils import cached_property
 from .config import ConfigManager
 
 
-@dataclass
 class CompilerManager:
     """
     The singleton that manages :class:`~ape.api.compiler.CompilerAPI` instances.
@@ -29,6 +27,10 @@ class CompilerManager:
 
     config: ConfigManager
     plugin_manager: PluginManager
+
+    def __init__(self, *, config: ConfigManager, plugin_manager: PluginManager) -> None:
+        self.config = config
+        self.plugin_manager = plugin_manager
 
     def __repr__(self):
         return f"<CompilerManager len(registered_compilers)={len(self.registered_compilers)}>"

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import ClassVar, Dict, List, Optional, Set
 
 from ethpm_types import ContractType
 
@@ -7,7 +7,7 @@ from ape.api import CompilerAPI
 from ape.exceptions import CompilerError
 from ape.logging import logger
 from ape.plugins import PluginManager
-from ape.utils import cached_property
+from ape.utils import cached_property, injected_before_use
 
 from .config import ConfigManager
 
@@ -25,12 +25,8 @@ class CompilerManager:
         from ape import compilers  # "compilers" is the CompilerManager singleton
     """
 
-    config: ConfigManager
-    plugin_manager: PluginManager
-
-    def __init__(self, *, config: ConfigManager, plugin_manager: PluginManager) -> None:
-        self.config = config
-        self.plugin_manager = plugin_manager
+    config: ClassVar[ConfigManager] = injected_before_use()  # type: ignore
+    plugin_manager: ClassVar[PluginManager] = injected_before_use()  # type: ignore
 
     def __repr__(self):
         return f"<CompilerManager len(registered_compilers)={len(self.registered_compilers)}>"

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -2,8 +2,6 @@ import json
 from pathlib import Path
 from typing import Dict, List, Union
 
-from dataclassy import dataclass
-
 from ape.api import ConfigDict, ConfigItem
 from ape.convert import to_address
 from ape.exceptions import ConfigError
@@ -19,7 +17,6 @@ class DeploymentConfig(ConfigItem):
     contract_type: str
 
 
-@dataclass
 class ConfigManager:
     """
     The singleton responsible for managing the ``ape-config.yaml`` project file.
@@ -49,6 +46,19 @@ class ConfigManager:
     deployments: Dict[str, Dict[str, List[DeploymentConfig]]] = {}
     plugin_manager: PluginManager
     _plugin_configs_by_project: Dict[str, Dict[str, ConfigItem]] = {}
+
+    def __init__(
+        self,
+        *,
+        data_folder: Path,
+        request_header: Dict,
+        project_folder: Path,
+        plugin_manager: PluginManager,
+    ) -> None:
+        self.DATA_FOLDER = data_folder
+        self.REQUEST_HEADER = request_header
+        self.PROJECT_FOLDER = project_folder
+        self.plugin_manager = plugin_manager
 
     @property
     def packages_folder(self) -> Path:

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -1,13 +1,13 @@
 import json
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import ClassVar, Dict, List, Union
 
 from ape.api import ConfigDict, ConfigItem
 from ape.convert import to_address
 from ape.exceptions import ConfigError
 from ape.logging import logger
 from ape.plugins import PluginManager
-from ape.utils import load_config
+from ape.utils import injected_before_use, load_config
 
 CONFIG_FILE_NAME = "ape-config.yaml"
 
@@ -44,7 +44,7 @@ class ConfigManager:
     contracts_folder: Path = None  # type: ignore
     dependencies: Dict[str, str] = {}
     deployments: Dict[str, Dict[str, List[DeploymentConfig]]] = {}
-    plugin_manager: PluginManager
+    plugin_manager: ClassVar[PluginManager] = injected_before_use()  # type: ignore
     _plugin_configs_by_project: Dict[str, Dict[str, ConfigItem]] = {}
 
     def __init__(
@@ -53,12 +53,10 @@ class ConfigManager:
         data_folder: Path,
         request_header: Dict,
         project_folder: Path,
-        plugin_manager: PluginManager,
     ) -> None:
         self.DATA_FOLDER = data_folder
         self.REQUEST_HEADER = request_header
         self.PROJECT_FOLDER = project_folder
-        self.plugin_manager = plugin_manager
 
     @property
     def packages_folder(self) -> Path:

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -49,7 +49,6 @@ class ConfigManager:
 
     def __init__(
         self,
-        *,
         data_folder: Path,
         request_header: Dict,
         project_folder: Path,

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, Dict, List, Tuple, Type, Union
+from typing import Any, ClassVar, Dict, List, Tuple, Type, Union
 
 from eth_utils import is_checksum_address, is_hex, is_hex_address, to_checksum_address
 from hexbytes import HexBytes
@@ -9,7 +9,7 @@ from ape.api import AddressAPI, ConverterAPI
 from ape.exceptions import ConversionError
 from ape.plugins import PluginManager
 from ape.types import AddressType
-from ape.utils import cached_property
+from ape.utils import cached_property, injected_before_use
 
 from .config import ConfigManager
 from .networks import NetworkManager
@@ -180,16 +180,9 @@ class ConversionManager:
         amount = convert("1 gwei", int)
     """
 
-    config: ConfigManager
-    plugin_manager: PluginManager
-    networks: NetworkManager
-
-    def __init__(
-        self, *, config: ConfigManager, plugin_manager: PluginManager, networks: NetworkManager
-    ) -> None:
-        self.config = config
-        self.plugin_manager = plugin_manager
-        self.networks = networks
+    config: ClassVar[ConfigManager] = injected_before_use()  # type: ignore
+    plugin_manager: ClassVar[PluginManager] = injected_before_use()  # type: ignore
+    networks: ClassVar[NetworkManager] = injected_before_use()  # type: ignore
 
     def __repr__(self):
         return "<ConversionManager>"

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -2,7 +2,6 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Dict, List, Tuple, Type, Union
 
-from dataclassy import dataclass
 from eth_utils import is_checksum_address, is_hex, is_hex_address, to_checksum_address
 from hexbytes import HexBytes
 
@@ -166,7 +165,6 @@ class TimestampConverter(ConverterAPI):
 timestamp_converter = TimestampConverter(None, None, None)  # type: ignore
 
 
-@dataclass
 class ConversionManager:
     """
     A singleton that manages all the converters.
@@ -185,6 +183,13 @@ class ConversionManager:
     config: ConfigManager
     plugin_manager: PluginManager
     networks: NetworkManager
+
+    def __init__(
+        self, *, config: ConfigManager, plugin_manager: PluginManager, networks: NetworkManager
+    ) -> None:
+        self.config = config
+        self.plugin_manager = plugin_manager
+        self.networks = networks
 
     def __repr__(self):
         return "<ConversionManager>"

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -1,10 +1,11 @@
-from typing import Dict, Iterator, Optional
+from typing import ClassVar, Dict, Iterator, Optional
 
 import yaml
 from pluggy import PluginManager  # type: ignore
 
 from ape.api import EcosystemAPI, ProviderAPI, ProviderContextManager
 from ape.exceptions import ConfigError, NetworkError
+from ape.utils import injected_before_use
 
 from .config import ConfigManager
 
@@ -24,15 +25,11 @@ class NetworkManager:
            ...
     """
 
-    config: ConfigManager
-    plugin_manager: PluginManager
+    config: ClassVar[ConfigManager] = injected_before_use()  # type: ignore
+    plugin_manager: ClassVar[PluginManager] = injected_before_use()  # type: ignore
     _active_provider: Optional[ProviderAPI] = None
     _default: Optional[str] = None
     _ecosystems_by_project: Dict[str, Dict[str, EcosystemAPI]] = {}
-
-    def __init__(self, *, config: ConfigManager, plugin_manager: PluginManager) -> None:
-        self.config = config
-        self.plugin_manager = plugin_manager
 
     def __repr__(self):
         return f"<NetworkManager, active_provider={self.active_provider}>"

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -1,7 +1,6 @@
 from typing import Dict, Iterator, Optional
 
 import yaml
-from dataclassy import dataclass
 from pluggy import PluginManager  # type: ignore
 
 from ape.api import EcosystemAPI, ProviderAPI, ProviderContextManager
@@ -10,7 +9,6 @@ from ape.exceptions import ConfigError, NetworkError
 from .config import ConfigManager
 
 
-@dataclass
 class NetworkManager:
     """
     The set of all blockchain network ecosystems registered from the plugin system.
@@ -31,6 +29,10 @@ class NetworkManager:
     _active_provider: Optional[ProviderAPI] = None
     _default: Optional[str] = None
     _ecosystems_by_project: Dict[str, Dict[str, EcosystemAPI]] = {}
+
+    def __init__(self, *, config: ConfigManager, plugin_manager: PluginManager) -> None:
+        self.config = config
+        self.plugin_manager = plugin_manager
 
     def __repr__(self):
         return f"<NetworkManager, active_provider={self.active_provider}>"

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Collection, Dict, List, Optional, Union
 
 import requests
-from dataclassy import dataclass
 from ethpm_types import Checksum, Compiler, ContractType, PackageManifest, Source
 from ethpm_types.manifest import PackageName
 from ethpm_types.utils import compute_checksum
@@ -16,14 +15,13 @@ from ape.contracts import ContractContainer
 from ape.exceptions import ProjectError
 from ape.logging import logger
 from ape.managers.networks import NetworkManager
-from ape.utils import get_all_files_in_directory, get_relative_path, github_client
+from ape.utils import cached_property, get_all_files_in_directory, get_relative_path, github_client
 
 from .compilers import CompilerManager
 from .config import ConfigManager
 from .converters import ConversionManager
 
 
-@dataclass
 class ProjectManager:
     """
     A manager for accessing contract-types, dependencies, and other project resources.
@@ -75,17 +73,20 @@ class ProjectManager:
     :py:attr:`ape.managers.networks.NetworkManager.active_provider`.
     """
 
-    dependencies: Dict[str, PackageManifest] = dict()
-
-    def __post_init__(self):
-        if isinstance(self.path, str):
-            self.path = Path(self.path)
-
-        config = self.config.load()
-        self.dependencies = {
-            n: self._extract_dependency_manifest(n, dep_id)
-            for n, dep_id in config.dependencies.items()
-        }
+    def __init__(
+        self,
+        *,
+        path: Path,
+        config: ConfigManager,
+        converter: ConversionManager,
+        compilers: CompilerManager,
+        networks: NetworkManager,
+    ) -> None:
+        self.path = Path(path) if isinstance(path, str) else path
+        self.config = config
+        self.converter = converter
+        self.compilers = compilers
+        self.networks = networks
 
     def __repr__(self):
         return "<ProjectManager>"
@@ -166,6 +167,14 @@ class ProjectManager:
 
     def __str__(self) -> str:
         return f'Project("{self.path}")'
+
+    @cached_property
+    def dependencies(self) -> Dict[str, PackageManifest]:
+        config = self.config.load()
+        return {
+            n: self._extract_dependency_manifest(n, dep_id)
+            for n, dep_id in config.dependencies.items()
+        }
 
     @property
     def _cache_folder(self) -> Path:

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -81,7 +81,6 @@ class ProjectManager:
 
     def __init__(
         self,
-        *,
         path: Path,
     ) -> None:
         self.path = Path(path) if isinstance(path, str) else path

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -4,7 +4,7 @@ import sys
 import tempfile
 from importlib import import_module
 from pathlib import Path
-from typing import Collection, Dict, List, Optional, Union
+from typing import ClassVar, Collection, Dict, List, Optional, Union
 
 import requests
 from ethpm_types import Checksum, Compiler, ContractType, PackageManifest, Source
@@ -15,7 +15,13 @@ from ape.contracts import ContractContainer
 from ape.exceptions import ProjectError
 from ape.logging import logger
 from ape.managers.networks import NetworkManager
-from ape.utils import cached_property, get_all_files_in_directory, get_relative_path, github_client
+from ape.utils import (
+    cached_property,
+    get_all_files_in_directory,
+    get_relative_path,
+    github_client,
+    injected_before_use,
+)
 
 from .compilers import CompilerManager
 from .config import ConfigManager
@@ -46,19 +52,19 @@ class ProjectManager:
     path: Path
     """The project path."""
 
-    config: ConfigManager
+    config: ClassVar[ConfigManager] = injected_before_use()  # type: ignore
     """
     A reference to :class:`~ape.managers.config.ConfigManager`, which
     manages project and plugin configurations.
     """
 
-    converter: ConversionManager
+    converter: ClassVar[ConversionManager] = injected_before_use()  # type: ignore
     """
     A reference to the conversion utilities in
     :class:`~ape.managers.converters.ConversionManager`.
     """
 
-    compilers: CompilerManager
+    compilers: ClassVar[CompilerManager] = injected_before_use()  # type: ignore
     """
     The group of compiler plugins for compiling source files. See
     :class:`~ape.managers.compilers.CompilerManager` for more information.
@@ -66,7 +72,7 @@ class ProjectManager:
     to more easily compile sources.
     """
 
-    networks: NetworkManager
+    networks: ClassVar[NetworkManager] = injected_before_use()  # type: ignore
     """
     The manager of networks, :class:`~ape.managers.networks.NetworkManager`.
     To get the active provide, use
@@ -77,16 +83,8 @@ class ProjectManager:
         self,
         *,
         path: Path,
-        config: ConfigManager,
-        converter: ConversionManager,
-        compilers: CompilerManager,
-        networks: NetworkManager,
     ) -> None:
         self.path = Path(path) if isinstance(path, str) else path
-        self.config = config
-        self.converter = converter
-        self.compilers = compilers
-        self.networks = networks
 
     def __repr__(self):
         return "<ProjectManager>"

--- a/src/ape/plugins/__init__.py
+++ b/src/ape/plugins/__init__.py
@@ -114,7 +114,7 @@ def valid_impl(api_class: Any) -> bool:
 
 
 class PluginManager:
-    def __init__(self):
+    def __init__(self) -> None:
         # NOTE: This actually loads the plugins, and should only be done once
         for _, name, ispkg in pkgutil.iter_modules():
             if name.startswith("ape_") and ispkg:

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -463,7 +463,7 @@ errors will occur. This class cannot be instantiated on its own.
 
 class injected_before_use(property):
     """
-    Dependencies are injected class variables that must be set before use
+    Injected properties are injected class variables that must be set before use
     NOTE: do not appear in a Pydantic model's set of properties
     """
 
@@ -487,6 +487,7 @@ __all__ = [
     "GeneratedDevAccount",
     "generate_dev_accounts",
     "get_all_files_in_directory",
+    "injected_before_use",
     "load_config",
     "singledispatchmethod",
     "USER_AGENT",

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -460,6 +460,17 @@ also abstract (meaning it has methods that **must** be implemented or else
 errors will occur. This class cannot be instantiated on its own.
 """
 
+
+class injected_before_use(property):
+    """
+    Dependencies are injected class variables that must be set before use
+    NOTE: do not appear in a Pydantic model's set of properties
+    """
+
+    def __get__(self, *args):
+        raise ValueError("Value not set. Please inject this property before calling.")
+
+
 __all__ = [
     "abstractdataclass",
     "abstractmethod",

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -95,7 +95,7 @@ def project_folder(request, config):
 @pytest.fixture
 def project(project_folder):
     previous_project = ape.project
-    project = Project(project_folder)
+    project = Project(path=project_folder)
     ape.project = project
     yield project
     ape.project = previous_project


### PR DESCRIPTION
### What I did
 Removes `dataclassy` from all the managers and makes them regular python classes. Uses `injected_before_use` class to act as a property placeholder for the injected properties

### How I did it
Adds `injected_before_use` class 
 Adds `__init__()` methods to pass the required non-injected properties by keyword.

### How to verify it
All tests run

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
