### PR TITLE
fix: log level default value race condition

### DIFF
--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -12,7 +12,7 @@ from ape.cli.choices import (
 )
 from ape.cli.utils import Abort
 from ape.exceptions import ContractError
-from ape.logging import LogLevel, logger
+from ape.logging import DEFAULT_LOG_LEVEL, LogLevel, logger
 from ape.managers.project import ProjectManager
 
 
@@ -82,7 +82,7 @@ def verbosity_option(cli_logger):
             "--verbosity",
             "-v",
             callback=_set_level,
-            default=LogLevel.INFO.name,
+            default=DEFAULT_LOG_LEVEL,
             metavar="LVL",
             expose_value=False,
             help=f"One of {names_str}",

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -18,6 +18,7 @@ class LogLevel(Enum):
 
 logging.addLevelName(LogLevel.SUCCESS.value, LogLevel.SUCCESS.name)
 logging.SUCCESS = LogLevel.SUCCESS.value  # type: ignore
+DEFAULT_LOG_LEVEL = LogLevel.INFO.name
 
 
 def success(self, message, *args, **kws):
@@ -102,6 +103,7 @@ class CliLogger:
         self._logger = _logger
         self._web3_request_manager_logger = _get_logger("web3.RequestManager")
         self._web3_http_provider_logger = _get_logger("web3.providers.HTTPProvider")
+        self.set_level(DEFAULT_LOG_LEVEL)
 
     @property
     def level(self) -> int:
@@ -166,4 +168,4 @@ def _get_logger(name: str) -> logging.Logger:
 logger = CliLogger()
 
 
-__all__ = ["logger", "LogLevel"]
+__all__ = ["DEFAULT_LOG_LEVEL", "logger", "LogLevel"]


### PR DESCRIPTION
### What I did

Issues where there is a race condition with the default log level getting set.

If you add print statements around the line in the `logging.py` module like so:

```python
        print(self._logger.level)
        self.set_level(DEFAULT_LOG_LEVEL)
        print(self._logger.level)
```

It outputs `0` first and then `20` the second time.


### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
