### PR TITLE
docs: fix issue with address type

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -339,8 +339,7 @@ class AccountContainerAPI:
             NotImplementError: When not overridden within a plugin.
 
         Args:
-            address (address :class:`~ape.types.AddressType`):
-                        The address of the account to delete.
+            address (``AddressType``): The address of the account to delete.
 
         """
         raise NotImplementedError("Must define this method to use `container.remove(acct)`.")
@@ -353,7 +352,7 @@ class AccountContainerAPI:
             IndexError: When the given account address is not in this container.
 
         Args:
-            address (:class:`~ape.types.AddressType`): An account address.
+            address (``AddressType``): An account address.
 
         Returns:
             bool: ``True`` if ``ape`` manages the account with the given address.

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -280,6 +280,10 @@ class AccountContainerAPI:
         """
         Get an account by address.
 
+        Args:
+            address (``AddressType``): The address to get. The type is an alias to
+              `ChecksumAddress <https://eth-typing.readthedocs.io/en/latest/types.html#checksumaddress>`__.  # noqa: E501
+
         Raises:
             IndexError: When there is no local account with the given address.
 

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -152,7 +152,8 @@ class Address(AddressAPI):
         The raw address type.
 
         Returns:
-            ``AddressType``
+            ``AddressType``: An alias to
+            `ChecksumAddress <https://eth-typing.readthedocs.io/en/latest/types.html#checksumaddress>`__.  # noqa: E501
         """
 
         return self._address

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -55,8 +55,7 @@ class AddressAPI:
 
     def __eq__(self, other: object) -> bool:
         """
-        Compares :class:`~ape.api.AddressAPI`/``str`` objects by converting to
-        :class:`~ape.types.AddressType`.
+        Compares :class:`~ape.api.AddressAPI`/``str`` objects by converting to ``AddressType``.
 
         Returns:
             bool: comparison result
@@ -153,7 +152,7 @@ class Address(AddressAPI):
         The raw address type.
 
         Returns:
-            :class:`~ape.types.AddressType`
+            ``AddressType``
         """
 
         return self._address

--- a/src/ape/api/explorers.py
+++ b/src/ape/api/explorers.py
@@ -26,8 +26,7 @@ class ExplorerAPI:
         Get an address URL, such as for a transaction.
 
         Args:
-            address (:class:`~ape.types.AddressType`): The address to
-              get the URL for.
+            address (``AddressType``): The address to get the URL for.
 
         Returns:
             str
@@ -51,7 +50,7 @@ class ExplorerAPI:
         Get the contract type for a given address if it has been published in an explorer.
 
         Args:
-            address (:class:`~ape.types.AddressType`): The contract address.
+            address (``AddressType``): The contract address.
 
         Returns:
             Optional[``ContractType``]: If not published, returns ``None``.
@@ -63,7 +62,7 @@ class ExplorerAPI:
         Get a list of list of transactions performed by an address.
 
         Args:
-            address (:class:`~ape.types.AddressType`): The account address.
+            address (``AddressType``): The account address.
 
         Returns:
             Iterator[:class:`~ape.api.providers.ReceiptAPI`]

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -254,7 +254,7 @@ class ContractInstance(AddressAPI):
         The address of the contract.
 
         Returns:
-            :class:`~ape.types.AddressType`
+            ``AddressType``
         """
         return self._address
 

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -217,7 +217,7 @@ class AccountManager:
         Determine if the given address matches an account in ``ape``.
 
         Args:
-            address (:class:`~ape.types.AddressType`): The address to check.
+            address (``AddressType``): The address to check.
 
         Returns:
             bool: ``True`` when the given address is found.

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -207,7 +207,7 @@ class AccountHistory(_ConnectedChain):
         Get the list of transactions from the active session for the given address.
 
         Args:
-            address (:class:`~ape.types.AddressType`): The sender of the desired transactions.
+            address (``AddressType``): The sender of the desired transactions.
 
         Returns:
             List[:class:`~ape.api.providers.TransactionAPI`]: The list of transactions. If there
@@ -240,7 +240,7 @@ class AccountHistory(_ConnectedChain):
         Iterate through the list of address-types to list of transaction receipts.
 
         Returns:
-            Iterator[Tuple[:class:`~ape.types.AddressType`, :class:`~ape.api.providers.ReceiptAPI`]]
+            Iterator[Tuple[``AddressType``, :class:`~ape.api.providers.ReceiptAPI`]]
         """
         yield from self._map.items()
 

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -43,8 +43,7 @@ hex_converter = HexConverter(None, None, None)  # type: ignore
 
 class AddressAPIConverter(ConverterAPI):
     """
-    A converter that converts an :class:`~ape.api.address.AddressAPI` to a
-    :class:`~ape.types.AddressType`.
+    A converter that converts an :class:`~ape.api.address.AddressAPI` to a ``AddressType``.
     """
 
     def is_convertible(self, value: Any) -> bool:
@@ -52,13 +51,13 @@ class AddressAPIConverter(ConverterAPI):
 
     def convert(self, value: AddressAPI) -> AddressType:
         """
-        Convert the given value to :class:`~ape.types.AddressType`.
+        Convert the given value to ``AddressType``.
 
         Args:
             value (str): The value to convert.
 
         Returns:
-            :class:`~ape.types.AddressType`
+            ``AddressType``
         """
 
         return value.address
@@ -69,8 +68,7 @@ address_api_converter = AddressAPIConverter(None, None, None)  # type: ignore
 
 class HexAddressConverter(ConverterAPI):
     """
-    A converter that converts a checksummed address ``str`` to a
-    :class:`~ape.types.AddressType`.
+    A converter that converts a checksummed address ``str`` to a ``AddressType``.
     """
 
     def is_convertible(self, value: Any) -> bool:
@@ -78,13 +76,13 @@ class HexAddressConverter(ConverterAPI):
 
     def convert(self, value: str) -> AddressType:
         """
-        Convert the given value to a :class:`~ape.types.AddressType`.
+        Convert the given value to a ``AddressType``.
 
         Args:
             value (str): The address ``str`` to convert.
 
         Returns:
-            :class:`~ape.types.AddressType`
+            ``AddressType``
         """
 
         return to_checksum_address(value)
@@ -216,7 +214,7 @@ class ConversionManager:
     def is_type(self, value: Any, type: Type) -> bool:
         """
         Check if the value is the given type.
-        If given an :class:`~ape.types.AddressType`, will also check
+        If given an ``AddressType``, will also check
         that it is checksummed.
 
         Args:

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -57,7 +57,8 @@ class AddressAPIConverter(ConverterAPI):
             value (str): The value to convert.
 
         Returns:
-            ``AddressType``
+            ``AddressType``: An alias to
+            `ChecksumAddress <https://eth-typing.readthedocs.io/en/latest/types.html#checksumaddress>`__.  # noqa: E501
         """
 
         return value.address

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Union
 
-from eth_typing import ChecksumAddress
+from eth_typing import ChecksumAddress as AddressType
 from ethpm_types import (
     ABI,
     Bytecode,
@@ -38,9 +38,6 @@ Providers will expect and handle snapshot IDs differently. There shouldn't be a 
 providers when using this feature, so there should not be confusion over this type in practical use
 cases.
 """
-
-AddressType = ChecksumAddress  # type: ignore
-"""A type representing a checksummed address."""
 
 __all__ = [
     "ABI",


### PR DESCRIPTION
### What I did

There is a lot of buggy-ness with trying to link to the docs for `AddressType`, sometimes intermittently and when you least expect.

### How I did it

Instead, just have a few spots where were link to [ChecksumAddress](https://eth-typing.readthedocs.io/en/latest/types.html#checksumaddress)

Otherwise, put things kind of back to the way they were.

Most of this PR is removing dead links.

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
