### PR TITLE
feat: ability to compile external projects

### DIFF
--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import ClassVar, Dict, List, Set
+from typing import ClassVar, Dict, List, Optional, Set
 
 from ethpm_types import ContractType
 
@@ -96,6 +96,33 @@ class CompilerManager:
                 contract_types_dict[contract_type.name] = contract_type
 
         return contract_types_dict  # type: ignore
+
+    def compile_external_project(
+        self,
+        contract_filepaths: List[Path],
+        project_path: Path,
+        contracts_path: Optional[Path] = None,
+    ) -> Dict[str, ContractType]:
+        """
+        Compile an external project.
+
+        Raises:
+            :class:`~ape.exceptions.CompilerError`: When there is no compiler found for the given
+              extension as well as when there is a contract-type collision across compilers.
+
+        Args:
+            contract_filepaths (List[pathlib.Path]): The list of files to compile,
+              as ``pathlib.Path`` objects.
+            project_path (pathlib.Path): The path to the project to compile.
+            contracts_path (pathlib.Path): The path to the project's contracts.
+              Defaults to the ``project-path/contracts``.
+
+        Returns:
+            Dict[str, ``ContractType``]: A mapping of contract names to their type.
+        """
+
+        with self.config.using_project(project_path, contracts_folder=contracts_path):
+            return self.compile(contract_filepaths)
 
     def _get_contract_extensions(self, contract_filepaths: List[Path]) -> Set[str]:
         extensions = set(path.suffix for path in contract_filepaths)

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -115,7 +115,7 @@ class CompilerManager:
               as ``pathlib.Path`` objects.
             project_path (pathlib.Path): The path to the project to compile.
             contracts_path (pathlib.Path): The path to the project's contracts.
-              Defaults to the ``project-path/contracts``.
+              Defaults to the ``<project_path>/contracts``.
 
         Returns:
             Dict[str, ``ContractType``]: A mapping of contract names to their type.

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -215,7 +215,8 @@ class ConfigManager:
 
         Args:
             project_folder (pathlib.Path): The path of the context's project.
-            contracts_folder (pathlib.Path): The path to the context's source files.
+            contracts_folder (Optional[pathlib.Path]): The path to the context's source files.
+              Defaults to ``<project_path>/contracts``.
 
         Returns:
             Generator

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -1,6 +1,7 @@
 import json
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, Generator, List, Union
 
 from dataclassy import dataclass
 
@@ -182,6 +183,28 @@ class ConfigManager:
             project_config[name] = config.serialize() if isinstance(config, ConfigItem) else config
 
         return project_config
+
+    @contextmanager
+    def using_project(self, project_folder: Path, contracts_folder: Path) -> Generator:
+        """
+        Temporarily change the project context.
+        Args:
+            project_folder (pathlib.Path): The path of the context's project.
+            contracts_folder (pathlib.Path): The path to the context's source files.
+        Returns:
+            ContextManager
+        """
+
+        initial_project_path = self.PROJECT_FOLDER
+        initial_contracts_path = self.contracts_folder
+
+        self.PROJECT_FOLDER = project_folder
+        self.contracts_folder = contracts_folder
+
+        yield
+
+        self.PROJECT_FOLDER = initial_project_path
+        self.contracts_folder = initial_contracts_path
 
     def __str__(self) -> str:
         """

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -188,11 +188,24 @@ class ConfigManager:
     def using_project(self, project_folder: Path, contracts_folder: Path) -> Generator:
         """
         Temporarily change the project context.
+
+        Usage example::
+
+            from pathlib import Path
+            from ape import config, Project
+
+            project_path = Path("path/to/project")
+            contracts_path = project_path / "contracts"
+
+            with config.using_project(project_path, contracts_path):
+                my_project = Project(project_path)
+
         Args:
             project_folder (pathlib.Path): The path of the context's project.
             contracts_folder (pathlib.Path): The path to the context's source files.
+
         Returns:
-            ContextManager
+            Generator
         """
 
         initial_project_path = self.PROJECT_FOLDER

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -1,7 +1,7 @@
 import json
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar, Dict, Generator, List, Union
+from typing import TYPE_CHECKING, ClassVar, Dict, Generator, List, Optional, Union
 
 from ape.api import ConfigDict, ConfigItem
 from ape.convert import to_address
@@ -197,7 +197,7 @@ class ConfigManager:
 
     @contextmanager
     def using_project(
-        self, project_folder: Path, contracts_folder: Path
+        self, project_folder: Path, contracts_folder: Optional[Path] = None
     ) -> Generator["ProjectManager", None, None]:
         """
         Temporarily change the project context.
@@ -210,7 +210,7 @@ class ConfigManager:
             project_path = Path("path/to/project")
             contracts_path = project_path / "contracts"
 
-            with config.using_project(project_path, contracts_path):
+            with config.using_project(project_path):
                 my_project = Project(project_path)
 
         Args:
@@ -220,6 +220,9 @@ class ConfigManager:
         Returns:
             Generator
         """
+
+        contracts_folder = contracts_folder or project_folder / "contracts"
+
         import ape
 
         initial_project_path = self.PROJECT_FOLDER

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -153,9 +153,7 @@ class ProjectManager:
 
                 manifest.name = PackageName(name.lower().replace("_", "-"))
                 manifest.sources = self._create_source_dict(sources, base_path=temp_contracts_path)
-                manifest.contract_types = self.compilers.compile(
-                    sources, base_path=temp_contracts_path
-                )
+                manifest.contract_types = self.compilers.compile(sources)
                 manifest_dict = manifest.dict()
 
                 # Validates manifest dict
@@ -385,9 +383,7 @@ class ProjectManager:
         # NOTE: filter by checksum, etc., and compile what's needed
         #       to bring our cached manifest up-to-date
         needs_compiling = list(filter(file_needs_compiling, sources))
-        compiled_contract_types = self.compilers.compile(
-            needs_compiling, base_path=self.contracts_folder
-        )
+        compiled_contract_types = self.compilers.compile(needs_compiling)
         contract_types.update(compiled_contract_types)
 
         # Re-calculate sources in case there are generated files (such as from 'ape-solidity').

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -77,15 +77,6 @@ def pytest_collection_modifyitems(session, config, items):
 
 
 @pytest.fixture(params=project_names)
-def project_folder(request, config):
-    project_source_dir = projects_directory / request.param
-    project_dest_dir = config.PROJECT_FOLDER / project_source_dir.name
-    copy_tree(project_source_dir.as_posix(), project_dest_dir.as_posix())
-    with config.using_project(project_dest_dir, project_dest_dir / "contracts"):
-        yield project_dest_dir
-
-
-@pytest.fixture(params=project_names)
 def project(request, config):
     project_source_dir = projects_directory / request.param
     project_dest_dir = config.PROJECT_FOLDER / project_source_dir.name

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -82,7 +82,7 @@ def project(request, config):
     project_dest_dir = config.PROJECT_FOLDER / project_source_dir.name
     copy_tree(project_source_dir.as_posix(), project_dest_dir.as_posix())
 
-    with config.using_project(project_dest_dir, project_dest_dir / "contracts") as project:
+    with config.using_project(project_dest_dir) as project:
         yield project
 
 

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -84,12 +84,8 @@ def project_folder(request, config):
     project_source_dir = projects_directory / request.param
     project_dest_dir = config.PROJECT_FOLDER / project_source_dir.name
     copy_tree(project_source_dir.as_posix(), project_dest_dir.as_posix())
-    previous_project_folder = config.PROJECT_FOLDER
-    config.PROJECT_FOLDER = project_dest_dir
-    config.contracts_folder = project_dest_dir / "contracts"
-    yield project_dest_dir
-    config.PROJECT_FOLDER = previous_project_folder
-    config.contracts_folder = previous_project_folder / "contracts"
+    with config.using_project(project_dest_dir, project_dest_dir / "contracts"):
+        yield project_dest_dir
 
 
 @pytest.fixture


### PR DESCRIPTION
### What I did

*NOTE*: This PR is also a design proposal. I am trying to make comping dependency projects into manifest works better. I have everything working well in this PR: https://github.com/ApeWorX/ape/pull/431.  However, that PR is getting very large so this is part of my effort to try and break it down.

#### Added

* New method `compile_project()` in the `CompilerManager` that takes the project path and the contracts path as well as the sources. The intent is to compile cleanly without the active project's interference. Otherwise, we get weird issues with dependency recursion.
* New method content manager method `using_project` in the `ConfigManager` that temporarily changes the `PROJECT_FOLDER` and the `contract_folder` properties. This is useful for compiling dependencies as well in our tests (`conftest.py` changes).

### How I did it

Freshly re-registering compiling before compiling outsider projects. This way, the configs are all set to their defaults... This does feel hacky, I admit.

### How to verify it

Go outside your project directory and run the following in `ape console`:

```python
source_file = Path("user/ApeProjects/MyProject/contracts/MyContract.sol")
source_file.exists()  # <-- Ensure exists
compilers.compile_project([source_file], source_file.parent.parent, source_file.parent)
INFO: Compiling 'MyContract.sol'.
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
