### PR TITLE
feat: added DatetimeConverter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
         "eth_abi==2.1.1",
         "eth-utils==1.10.0",
         "eth-rlp==0.2.1",
+        "python-dateutil>=2.8.2,<3.0",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -1,7 +1,8 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any, ClassVar, Dict, List, Tuple, Type, Union
 
+from dateutil.parser import parse  # type: ignore
 from eth_utils import is_checksum_address, is_hex, is_hex_address, to_checksum_address
 from hexbytes import HexBytes
 
@@ -141,25 +142,32 @@ list_tuple_converter = ListTupleConverter(None, None, None)  # type: ignore
 
 class TimestampConverter(ConverterAPI):
     """
-    Converts string of ``"%m-%d-%Y %H:%M:%S"`` format to a timestamp.
-    Must be UTC timezone
+    Converts either a string, datetime object, or a timedelta object to a timestamp.
+    No timezone required, but should be formatted to UTC.
     """
 
-    def is_convertible(self, value: str) -> bool:
-        if not isinstance(value, str):
+    def is_convertible(self, value: Union[str, datetime, timedelta]) -> bool:
+        if not isinstance(value, (str, datetime, timedelta)):
             return False
-        if " " not in value or len(value.split(" ")) > 2:
-            return False
-        try:
-            datetime.strptime(value, "%m-%d-%Y %H:%M:%S")
-        except ValueError:
-            return False
+        if isinstance(value, str):
+            if " " not in value and len(value.split(" ")) > 2:
+                return False
+            else:
+                try:
+                    parse(value)
+                except ValueError:
+                    return False
         return True
 
-    def convert(self, value: str) -> int:
-        return int(
-            datetime.strptime(value, "%m-%d-%Y %H:%M:%S").replace(tzinfo=timezone.utc).timestamp()
-        )
+    def convert(self, value: Union[str, datetime, timedelta]) -> int:
+        if isinstance(value, str):
+            return int(parse(value).replace(tzinfo=timezone.utc).timestamp())
+        elif isinstance(value, datetime):
+            return int(value.replace(tzinfo=timezone.utc).timestamp())
+        elif isinstance(value, timedelta):
+            return int((datetime.now(timezone.utc) + value).timestamp())
+        else:
+            raise ConversionError
 
 
 timestamp_converter = TimestampConverter(None, None, None)  # type: ignore

--- a/tests/functional/conversion/test_timestamp.py
+++ b/tests/functional/conversion/test_timestamp.py
@@ -1,6 +1,25 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
 from ape import convert
 
 
-def test_convert_string_timestamp():
-    time = "10-15-2021 12:15:12"
-    assert convert(time, int) == 1634300112
+@pytest.mark.parametrize(
+    "args",
+    (
+        [
+            "10-15-2021 12:15:12",
+            "2021-10-15 12:15:12",
+            "15-10-2021 12:15:12",
+            datetime.fromisoformat("2021-10-15 12:15:12"),
+        ]
+    ),
+)
+def test_convert_string_timestamp(args):
+    assert convert(args, int) == 1634300112
+
+
+def test_convert_timedelta_timestamp():
+    delta = timedelta(days=2, hours=2, minutes=12)
+    assert convert(delta, int) == int((datetime.now(timezone.utc) + delta).timestamp())


### PR DESCRIPTION
…ity issue with PyCharm/mypy

### What I did

Added DatetimeConverter
PyCharm and mypy failed to recognize the need for inputs in DatetimeConverter() on line 163 of src.ape.managers.converters.py
Solves issue #436

### How I did it

Very similar implementation to TimestampConverter. I wonder if we could have just added some functionality to TimestampConverter to read in either a datetime or string. Not necessarily needed, doesn't change anything else

### How to verify it

Test passed when there are `None` inputs in datetime_converter = DatetimeConverter() implementation

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
