### PR TITLE
fix: load config at earlier point to prevent segfault when trying to access it

### DIFF
--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -41,6 +41,7 @@ class ApeCliContextObject:
             from ape import project
 
             self._project = project
+            self._project.config.load()
 
         return self._project
 

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -340,6 +340,8 @@ class ProjectManager:
             types for each compiled contract.
         """
 
+        _ = self.dependencies  # Force the loading of dependencies
+
         if isinstance(file_paths, Path):
             file_paths = [file_paths]
 

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -167,10 +167,9 @@ class ProjectManager:
 
     @cached_property
     def dependencies(self) -> Dict[str, PackageManifest]:
-        config = self.config.load()
         return {
             n: self._extract_dependency_manifest(n, dep_id)
-            for n, dep_id in config.dependencies.items()
+            for n, dep_id in self.config.dependencies.items()
         }
 
     @property
@@ -340,6 +339,7 @@ class ProjectManager:
             Dict[str, ``ContractType``]: A dictionary of contract names to their
             types for each compiled contract.
         """
+
         if isinstance(file_paths, Path):
             file_paths = [file_paths]
 


### PR DESCRIPTION
### What I did

fixes: #446

Tried to do `ape compile` bit was segfault-ing because config was not loaded yet and weirdness ensued.
So I made it load earlier

### How I did it

Load config in cli ctx object.

### How to verify it

able to compile again and stuff

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
