### PR TITLE
fix: use a default message in Abort when user does not provide message argument

### DIFF
--- a/src/ape/cli/utils.py
+++ b/src/ape/cli/utils.py
@@ -15,13 +15,12 @@ class Abort(click.ClickException):
     """
 
     def __init__(self, message: Optional[str] = None):
-        caller = getframeinfo(stack()[1][0])
-        file_path = Path(caller.filename)
-        location = file_path.name if file_path.exists() else caller.filename
-        message = (
-            message
-            or f"Operation aborted in {location}::{caller.function} on line {caller.lineno}."
-        )
+        if not message:
+            caller = getframeinfo(stack()[1][0])
+            file_path = Path(caller.filename)
+            location = file_path.name if file_path.exists() else caller.filename
+            message = f"Operation aborted in {location}::{caller.function} on line {caller.lineno}."
+
         super().__init__(message)
 
     def show(self, file=None):

--- a/src/ape/cli/utils.py
+++ b/src/ape/cli/utils.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import click
 
 from ape.logging import logger
@@ -10,10 +12,8 @@ class Abort(click.ClickException):
     useful for all user-facing errors.
     """
 
-    def __init__(self, message):
-        if not message.endswith("."):
-            message = f"{message}."
-
+    def __init__(self, message: Optional[str] = None):
+        message = message or "Operation aborted."
         super().__init__(message)
 
     def show(self, file=None):

--- a/src/ape/cli/utils.py
+++ b/src/ape/cli/utils.py
@@ -1,3 +1,4 @@
+from inspect import getframeinfo, stack
 from typing import Optional
 
 import click
@@ -13,7 +14,11 @@ class Abort(click.ClickException):
     """
 
     def __init__(self, message: Optional[str] = None):
-        message = message or "Operation aborted."
+        caller = getframeinfo(stack()[1][0])
+        message = (
+            message
+            or f"Operation aborted in {caller.filename}::{caller.function} on line {caller.lineno}."
+        )
         super().__init__(message)
 
     def show(self, file=None):

--- a/src/ape/cli/utils.py
+++ b/src/ape/cli/utils.py
@@ -1,4 +1,5 @@
 from inspect import getframeinfo, stack
+from pathlib import Path
 from typing import Optional
 
 import click
@@ -15,9 +16,11 @@ class Abort(click.ClickException):
 
     def __init__(self, message: Optional[str] = None):
         caller = getframeinfo(stack()[1][0])
+        file_path = Path(caller.filename)
+        location = file_path.name if file_path.exists() else caller.filename
         message = (
             message
-            or f"Operation aborted in {caller.filename}::{caller.function} on line {caller.lineno}."
+            or f"Operation aborted in {location}::{caller.function} on line {caller.lineno}."
         )
         super().__init__(message)
 

--- a/tests/functional/test_exceptions.py
+++ b/tests/functional/test_exceptions.py
@@ -1,0 +1,5 @@
+from ape.cli import Abort
+
+
+def test_abort():
+    assert str(Abort()) == "Operation aborted in test_exceptions.py::test_abort on line 5."


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #465 

### How I did it

Remove period thing
Make argument optional.
Always coerce to `"Operation aborted."`

### How to verify it

```python
raise Abort()
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
