### PR TITLE
fix: exclude private repos from 'ape plugins list -a'

### DIFF
--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -373,7 +373,7 @@ class GithubClient:
         return {
             repo.name.replace("-", "_")
             for repo in self.ape_org.get_repos()
-            if repo.name.startswith("ape-")
+            if not repo.private and repo.name.startswith("ape-")
         }
 
     def get_release(self, repo_path: str, version: str) -> GitRelease:


### PR DESCRIPTION
### What I did

Exclude private repos from list.
This is to make the experience consistent for ape devs and **to make demos not accidentally reveal private information**.

### How I did it

check `.private` property of repo

### How to verify it

`ape plugins list -a`

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
