### PR TITLE
fix: bug preventing 'ape compile' from finding contract paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         "click>=8.0.0",
         "dataclassy==0.10.4",  # NOTE: Pinned due to issue with `Type[<nothing>]`
         "eth-account==0.5.6",
-        "ethpm-types>=0.1.0b3",
+        "ethpm-types==0.1.0b3",
         "hexbytes>=0.2.2,<1.0.0",
         "packaging>=20.9,<21.0",
         "pluggy>=0.13.1,<1.0",

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -568,7 +568,9 @@ class ProjectManager:
         def find_in_dir(dir_path: Path) -> Optional[Path]:
             for file_path in dir_path.iterdir():
                 if file_path.is_dir():
-                    return find_in_dir(file_path)
+                    result = find_in_dir(file_path)
+                    if result:
+                        return result
 
                 # If the user provided an extension, it has to match.
                 ext_okay = ext == file_path.suffix if ext is not None else True
@@ -677,7 +679,7 @@ class ProjectManager:
 
             return console()
 
-    def _load_dependencies(self):
+    def _load_dependencies(self) -> Dict[str, PackageManifest]:
         return {d.name: d.extract_manifest() for d in self.config.dependencies}
 
     # @property

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -7,7 +7,7 @@ from .utils import skip_projects, skip_projects_except
 def test_compile_missing_contracts_dir(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["compile"])
     assert result.exit_code == 0, result.output
-    assert "WARNING" in result.output
+    assert "WARNING" in result.output, result.output
     assert "No source files found in" in result.output
 
 


### PR DESCRIPTION
### What I did

Fix the bug causing failures in all our CI/CD tests.
Turns out it is real bug, kind of a big one.
Basically, we were short-circuiting `None` without fully searching for the contract in the path.
This prevents contracts from compiling.

Probably fixes: #469 
Explains why I couldn't repro it, it only happens some of the time, depending the order of searching in a path

### How I did it

only return in recurse if not None

### How to verify it

passing tests will tell ya

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
