### PR TITLE
fix: handle importing 'collections.abc.Mapping' in python 3.10

### DIFF
--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -1,4 +1,3 @@
-import collections
 import json
 import os
 import re
@@ -7,6 +6,7 @@ import sys
 import tempfile
 import zipfile
 from abc import ABCMeta, abstractmethod
+from collections import namedtuple
 from copy import deepcopy
 from functools import lru_cache, partial
 from io import BytesIO
@@ -41,6 +41,11 @@ try:
     from functools import singledispatchmethod  # type: ignore
 except ImportError:
     from singledispatchmethod import singledispatchmethod  # type: ignore
+try:
+    from collections.abc import Mapping as CollectionsMapping  # type: ignore
+except ImportError:
+    # Python <3.10
+    from collections import Mapping as CollectionsMapping  # type: ignore
 
 
 _python_version = (
@@ -161,7 +166,7 @@ def deep_merge(dict1, dict2) -> Dict:
     result = deepcopy(dict1)
 
     for key, value in dict2.items():
-        if isinstance(value, collections.Mapping):
+        if isinstance(value, CollectionsMapping):
             result[key] = deep_merge(result.get(key, {}), value)
         else:
             result[key] = deepcopy(dict2[key])
@@ -221,7 +226,7 @@ def load_config(path: Path, expand_envars=True, must_exist=False) -> Dict:
         return {}
 
 
-GeneratedDevAccount = collections.namedtuple("GeneratedDevAccount", ("address", "private_key"))
+GeneratedDevAccount = namedtuple("GeneratedDevAccount", ("address", "private_key"))
 """
 An account key-pair generated from the test mnemonic. Set the test mnemonic
 in your ``ape-config.yaml`` file under the ``test`` section. Access your test

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -7,7 +7,6 @@ import tempfile
 import zipfile
 from abc import ABCMeta, abstractmethod
 from collections import namedtuple
-from copy import deepcopy
 from functools import lru_cache, partial
 from io import BytesIO
 from pathlib import Path
@@ -41,12 +40,6 @@ try:
     from functools import singledispatchmethod  # type: ignore
 except ImportError:
     from singledispatchmethod import singledispatchmethod  # type: ignore
-try:
-    from collections.abc import Mapping as CollectionsMapping  # type: ignore
-except ImportError:
-    # Python <3.10
-    from collections import Mapping as CollectionsMapping  # type: ignore
-
 
 _python_version = (
     f"{sys.version_info.major}.{sys.version_info.minor}"
@@ -153,25 +146,6 @@ def get_package_version(obj: Any) -> str:
 
 __version__ = get_package_version(__name__)
 USER_AGENT = f"Ape/{__version__} (Python/{_python_version})"
-
-
-def deep_merge(dict1, dict2) -> Dict:
-    """
-    Merge two dictionaries recursively.
-
-    Returns:
-        dict: The result of the merge as a new dictionary.
-    """
-
-    result = deepcopy(dict1)
-
-    for key, value in dict2.items():
-        if isinstance(value, CollectionsMapping):
-            result[key] = deep_merge(result.get(key, {}), value)
-        else:
-            result[key] = deepcopy(dict2[key])
-
-    return result
 
 
 def expand_environment_variables(contents: str) -> str:
@@ -578,7 +552,6 @@ __all__ = [
     "AbstractDataClassMeta",
     "cached_property",
     "dataclass",
-    "deep_merge",
     "expand_environment_variables",
     "extract_nested_value",
     "get_relative_path",


### PR DESCRIPTION
### What I did

Delete method causing `ImportError` in python 3.10 from importing `collections.Mapping`.

### How I did it

Method is not used so deleting it.

### How to verify it

`mypy` should work again (causing errors in other PRs). **Thanks mypy for finding this bug btw.**

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
