### PR TITLE
fix: support uninstalling editable plugins

### DIFF
--- a/src/ape_plugins/utils.py
+++ b/src/ape_plugins/utils.py
@@ -11,9 +11,23 @@ CORE_PLUGINS = {p for p in __modules__ if p != "ape"}
 
 def is_plugin_installed(plugin: str) -> bool:
     plugin = plugin.replace("_", "-")
-    reqs = subprocess.check_output([sys.executable, "-m", "pip", "freeze"])
-    installed_packages = [r.decode().split("==")[0] for r in reqs.split()]
-    return plugin in installed_packages
+    python_packages = [
+        r
+        for r in subprocess.check_output([sys.executable, "-m", "pip", "freeze"])
+        .decode()
+        .split("\n")
+        if r
+    ]
+
+    for package in python_packages:
+        if "==" in package:
+            if package.split("==")[0] == plugin:
+                return True
+        elif plugin.startswith("-e") and ".git" in plugin:
+            if package.split(".git")[0].split("/")[-1] == plugin:
+                return True
+
+    return False
 
 
 def extract_module_and_package_install_names(item: Dict) -> Tuple[str, str]:

--- a/src/ape_plugins/utils.py
+++ b/src/ape_plugins/utils.py
@@ -11,7 +11,7 @@ CORE_PLUGINS = {p for p in __modules__ if p != "ape"}
 
 def is_plugin_installed(plugin: str) -> bool:
     plugin = plugin.replace("_", "-")
-    python_packages = [
+    pip_freeze_output_lines = [
         r
         for r in subprocess.check_output([sys.executable, "-m", "pip", "freeze"])
         .decode()
@@ -19,13 +19,11 @@ def is_plugin_installed(plugin: str) -> bool:
         if r
     ]
 
-    for package in python_packages:
-        if "==" in package:
-            if package.split("==")[0] == plugin:
-                return True
-        elif plugin.startswith("-e") and ".git" in plugin:
-            if package.split(".git")[0].split("/")[-1] == plugin:
-                return True
+    for package in pip_freeze_output_lines:
+        if package.split("==")[0] == plugin:
+            return True
+        elif package.split(".git")[0].split("/")[-1] == plugin:
+            return True
 
     return False
 


### PR DESCRIPTION
### What I did

Currently, if you have installed plugins in editable mode, you are not able to remove them using `ape plugins remove`. This is because ape does not recognize them as installed.

This PR fixes that issue.

**This makes ape look less bad when demoing!**

### How I did it

Handle editable plugin entries in the `pip freeze` output.

### How to verify it

# Install a plugin in editable mode
`pip install -e ~/PythonProjects/ape-solidity`

# Remove plugin
`ape plugins remove solidity -y`

# Install plugin from pypi
`ape plugins add solidity`

# Remove plugin
`ape plugins remove solidity -y`

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
