### PR TITLE
fix: use contract name in error message when no attribute found

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -307,7 +307,8 @@ class ContractInstance(AddressAPI):
         if num_matching_conditions == 0:
             # Didn't find anything that matches
             # NOTE: `__getattr__` *must* raise `AttributeError`
-            raise AttributeError(f"{self.__class__.__name__} has no attribute '{attr_name}'.")
+            name = self._contract_type.name or self.__class__.__name__
+            raise AttributeError(f"'{name}' has no attribute '{attr_name}'.")
 
         elif num_matching_conditions > 1:
             # ABI should not contain a mix of events, mutable and view methods that match


### PR DESCRIPTION
### What I did

Currently, if you try to access a non-existent function or event on a `ContractInstance`, you get the error:

```
ContractInstance has no attribute 'mint'.
```

Now, you get the error:

```
'BananaJamToken' has no attribute 'mint'.
```

### How I did it

Use `self._contract_type.name` if it is not `None`.

### How to verify it

Deploy a contract.
Try calling a method on it but spell it wrong or something.
Check error message.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
