### PR TITLE
fix: simplify ReceiptAPI console representation

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -220,6 +220,9 @@ class ReceiptAPI:
     def __str__(self) -> str:
         return f"<{self.__class__.__name__} {self.txn_hash}>"
 
+    def __repr__(self):
+        return str(self)
+
     def raise_for_status(self):
         """
         Handle provider-specific errors regarding a non-successful


### PR DESCRIPTION
### What I did

Receipt repr now looks like this:

```
In [4]: c.fund(sender=a, value=100)
Out[4]: <Receipt 0x317afbbd6841dc5efeaace1847af9adaf4695c93f27d2f73bded4961fa794e31>
```

### How I did it

Seemed like the `str` implementation was already a bit repr-y, copied that.

### How to verify it

`ape console`
make a transaction.
see receipt.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
