### PR TITLE
refactor: use repr method instead of str

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -217,7 +217,7 @@ class ReceiptAPI:
     receiver: str
     nonce: int
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {self.txn_hash}>"
 
     def raise_for_status(self):


### PR DESCRIPTION
Noticed that when you don't assign anything to the output of a transaction, it displays via `repr` by default in `ape console`. However, this was ugly.
