### PR TITLE
refactor: make range work more like python builtin

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -8,6 +8,7 @@ from ethpm_types.utils import compute_checksum
 from packaging import version as version_util
 from pydantic import ValidationError
 
+from ape.exceptions import ProjectError
 from ape.logging import logger
 from ape.utils import (
     abstractdataclass,
@@ -226,6 +227,12 @@ class DependencyAPI:
             if s.name.lower() not in ("package.json", "package-lock.json")
         ]
         project_manifest = project.create_manifest(file_paths=sources)
+
+        if not project_manifest.contract_types:
+            raise ProjectError(
+                f"No contract types found in dependency '{self.name}'. "
+                "Do you have the correct compilers installed?"
+            )
 
         # Cache the manifest for future use outside of this tempdir.
         self._target_manifest_cache_file.parent.mkdir(exist_ok=True, parents=True)

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -631,6 +631,9 @@ class ProviderAPI:
             NotImplementedError: Unless overridden.
         """
 
+    def __repr__(self):
+        return f"<{self.__class__.__name__} {self.name}>"
+
     def _try_track_receipt(self, receipt: ReceiptAPI):
         if self._chain:
             self._chain.account_history.append(receipt)

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -90,24 +90,26 @@ class BlockContainer(_ConnectedChain):
             Iterator[:class:`~ape.api.providers.BlockAPI`]
         """
 
-        return self.range()
+        return self.range(len(self))
 
-    def range(self, start: int = 0, stop: Optional[int] = None) -> Iterator[BlockAPI]:
+    def range(self, start: int, stop: Optional[int] = None) -> Iterator[BlockAPI]:
         """
         Iterate over blocks. Works similarly to python ``range()``.
 
         Args:
-            start (int): The first block, by number, to include in the range.
-              Defaults to 0.
+            start (int): The start number in the range if given two
+              values otherwise the last number if just given a single value.
             stop (Optional[int]): The block number to stop before. Also the total
-             number of blocks to get.
+              number of blocks to get. If not setting a ``start`` value, only pass
+              in a single argument for ``start`` (just like python's built-in ``range``).
 
         Returns:
             Iterator[:class:`~ape.api.providers.BlockAPI`]
         """
 
         if stop is None:
-            stop = len(self)
+            stop = start
+            start = 0
 
         if stop > len(self):
             raise ChainError(

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -163,7 +163,8 @@ class BlockContainer(_ConnectedChain):
 
         Args:
             start_or_stop (int): When given just a single value, it is the stop.
-              Otherwise, it is the start. This mimics the behavior of ``range`` built-in Python function.
+              Otherwise, it is the start. This mimics the behavior of ``range``
+              built-in Python function.
             stop (Optional[int]): The block number to stop before. Also the total
               number of blocks to get. If not setting a start value, is set by
               the first argument.

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -124,12 +124,8 @@ class BlockContainer(_ConnectedChain):
         elif start < 0:
             raise ValueError(f"stop '{stop}' cannot be negative.")
 
-        step_counter = 0
-        for i in range(start, stop):
-            step_counter += 1
-            if step_counter == step:
-                yield self._get_block(i)
-                step_counter = 0
+        for i in range(start, stop, step):
+            yield self._get_block(i)
 
     def poll_blocks(
         self,

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -92,16 +92,18 @@ class BlockContainer(_ConnectedChain):
 
         return self.range(len(self))
 
-    def range(self, start: int, stop: Optional[int] = None, step: int = 1) -> Iterator[BlockAPI]:
+    def range(
+        self, start_or_stop: int, stop: Optional[int] = None, step: int = 1
+    ) -> Iterator[BlockAPI]:
         """
         Iterate over blocks. Works similarly to python ``range()``.
 
         Args:
-            start (int): The start number in the range if given two
-              values otherwise the last number if just given a single value.
+            start_or_stop (int): When given just a single value, it is the stop.
+              Otherwise, it is the start.
             stop (Optional[int]): The block number to stop before. Also the total
-              number of blocks to get. If not setting a ``start`` value, only pass
-              in a single argument for ``start`` (just like python's built-in ``range``).
+              number of blocks to get. If not setting a start value, is set by
+              the first argument.
             step (Optional[int]): The value to increment by. Defaults to ``1``.
 
         Returns:
@@ -109,8 +111,10 @@ class BlockContainer(_ConnectedChain):
         """
 
         if stop is None:
-            stop = start
+            stop = start_or_stop
             start = 0
+        else:
+            start = start_or_stop
 
         if stop > len(self):
             raise ChainError(
@@ -121,7 +125,7 @@ class BlockContainer(_ConnectedChain):
             raise ValueError(f"stop '{stop}' cannot be less than start '{start}'.")
         elif stop < 0:
             raise ValueError(f"start '{start}' cannot be negative.")
-        elif start < 0:
+        elif start_or_stop < 0:
             raise ValueError(f"stop '{stop}' cannot be negative.")
 
         for i in range(start, stop, step):

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -152,13 +152,13 @@ class BlockContainer(_ConnectedChain):
         Iterate over blocks. Works similarly to python ``range()``.
 
         Raises:
-            :class:`~ape.exceptions.ChainError`: When ``stop_block`` is greater
+            :class:`~ape.exceptions.ChainError`: When ``stop`` is greater
                 than the chain length.
-            :class:`~ape.exceptions.ChainError`: When ``stop_block`` is greater
+            :class:`~ape.exceptions.ChainError`: When ``stop`` is less
                 than ``start_block``.
-            :class:`~ape.exceptions.ChainError`: When ``stop_block`` is less
+            :class:`~ape.exceptions.ChainError`: When ``stop`` is less
                 than 0.
-            :class:`~ape.exceptions.ChainError`: When ``start_block`` is less
+            :class:`~ape.exceptions.ChainError`: When ``start`` is less
                 than 0.
 
         Args:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -163,7 +163,7 @@ class BlockContainer(_ConnectedChain):
 
         Args:
             start_or_stop (int): When given just a single value, it is the stop.
-              Otherwise, it is the start.
+              Otherwise, it is the start. This mimics the behavior of ``range`` built-in Python function.
             stop (Optional[int]): The block number to stop before. Also the total
               number of blocks to get. If not setting a start value, is set by
               the first argument.

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -92,7 +92,7 @@ class BlockContainer(_ConnectedChain):
 
         return self.range(len(self))
 
-    def range(self, start: int, stop: Optional[int] = None) -> Iterator[BlockAPI]:
+    def range(self, start: int, stop: Optional[int] = None, step: int = 1) -> Iterator[BlockAPI]:
         """
         Iterate over blocks. Works similarly to python ``range()``.
 
@@ -102,6 +102,7 @@ class BlockContainer(_ConnectedChain):
             stop (Optional[int]): The block number to stop before. Also the total
               number of blocks to get. If not setting a ``start`` value, only pass
               in a single argument for ``start`` (just like python's built-in ``range``).
+            step (Optional[int]): The value to increment by. Defaults to ``1``.
 
         Returns:
             Iterator[:class:`~ape.api.providers.BlockAPI`]
@@ -123,8 +124,12 @@ class BlockContainer(_ConnectedChain):
         elif start < 0:
             raise ValueError(f"stop '{stop}' cannot be negative.")
 
+        step_counter = 0
         for i in range(start, stop):
-            yield self._get_block(i)
+            step_counter += 1
+            if step_counter == step:
+                yield self._get_block(i)
+                step_counter = 0
 
     def poll_blocks(
         self,

--- a/tests/integration/test_chain.py
+++ b/tests/integration/test_chain.py
@@ -97,7 +97,7 @@ def test_blocks_range_too_high_stop(chain_at_block_5):
     len_plus_1 = len(chain_at_block_5.blocks) + 1
     with pytest.raises(ChainError) as err:
         # Have to run through generator to trigger code in definition.
-        _ = [_ for _ in chain_at_block_5.blocks.range(stop=len_plus_1)]
+        _ = [_ for _ in chain_at_block_5.blocks.range(len_plus_1)]
 
     assert str(err.value) == (
         f"'stop={len_plus_1}' cannot be greater than the chain length (6). "

--- a/tests/integration/test_chain.py
+++ b/tests/integration/test_chain.py
@@ -84,7 +84,7 @@ def test_iterate_blocks(chain_at_block_5):
 
 def test_blocks_range(chain_at_block_5):
     expected_number_of_blocks = 3  # Expecting blocks [0, 1, 2]
-    blocks = [b for b in chain_at_block_5.blocks.range(stop=3)]
+    blocks = [b for b in chain_at_block_5.blocks.range(3)]
     assert len(blocks) == expected_number_of_blocks
 
     expected_number = 0


### PR DESCRIPTION
### What I did

Made `chain.blocks.range` work even more like python built in range method by making it so if you provide a single value, that value is considered the end of the range instead of the beginning.

### How I did it

check if second arg is None, if so, set second arg to first arg and first arg to 0

### How to verify it

```python
for i in chain.blocks.range(5):
  print(chain.blocks[i])
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
