### PR TITLE
fix: bump ethpm types to prevent bugs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         "click>=8.0.0",
         "dataclassy==0.10.4",  # NOTE: Pinned due to issue with `Type[<nothing>]`
         "eth-account==0.5.7",
-        "ethpm-types>=0.1.0b5",
+        "ethpm-types>=0.1.0b7",
         "hexbytes>=0.2.2,<1.0.0",
         "packaging>=20.9,<21.0",
         "pandas>=1.3.0,<2.0",


### PR DESCRIPTION
### What I did

Bumps ethpm-types so we are not using versions with known bugs. Seems like pip likes to install the earliest version that it can sometimes.

### How I did it

bump

### How to verify it

are able to compile open zeppelin after a fresh install of ape

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
