### PR TITLE
fix: change warning label to bright yellow

### DIFF
--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -34,7 +34,7 @@ logging.Logger.success = success  # type: ignore
 
 CLICK_STYLE_KWARGS = {
     LogLevel.ERROR: dict(fg="bright_red"),
-    LogLevel.WARNING: dict(fg="bright_red"),
+    LogLevel.WARNING: dict(fg="bright_yellow"),
     LogLevel.SUCCESS: dict(fg="bright_green"),
     LogLevel.INFO: dict(fg="blue"),
     LogLevel.DEBUG: dict(fg="blue"),


### PR DESCRIPTION
### What I did

Change warnings label color from Red to Yellow. Maybe I am too sensitive right now, but it feels like they are yelling at me a lot when they don't need to be.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
