### PR TITLE
docs: add missing raises statement to 'parse_network_choice()' method

### DIFF
--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -259,6 +259,10 @@ class NetworkManager:
         :py:attr:`~ape.managers.networks.NetworkManager.network_choices` for all
         available choices (or use CLI command ``ape networks list``).
 
+        Raises:
+            :class:`~ape.exceptions.NetworkError`: When the given network choice does not
+              match any known network.
+
         Args:
             network_choice (str, optional): The network choice
               (see :py:attr:`~ape.managers.networks.NetworkManager.network_choices`).


### PR DESCRIPTION
### What I did

Adds missing `Raises:` doc. I was trying to find what this method raises but had to dig. This should help with that.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
