### PR TITLE
fix: raise when nothing compiled in dependency

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -8,6 +8,7 @@ from ethpm_types.utils import compute_checksum
 from packaging import version as version_util
 from pydantic import ValidationError
 
+from ape.exceptions import ProjectError
 from ape.logging import logger
 from ape.utils import (
     abstractdataclass,
@@ -226,6 +227,12 @@ class DependencyAPI:
             if s.name.lower() not in ("package.json", "package-lock.json")
         ]
         project_manifest = project.create_manifest(file_paths=sources)
+
+        if not project_manifest.contract_types:
+            raise ProjectError(
+                f"No contract types found in dependency '{self.name}'. "
+                "Do you have the correct compilers installed?"
+            )
 
         # Cache the manifest for future use outside of this tempdir.
         self._target_manifest_cache_file.parent.mkdir(exist_ok=True, parents=True)


### PR DESCRIPTION
### What I did

Before, if you compiled a dependency but didn't have any compilers installed, the dependency would get cached as a rather empty manifest file.

Now, if that happens, it will raise.

Still need a way (in the future) to have a way for the users to re-trigger downloading if they need.

### How I did it

Have no compilers.
Specify a dependency.
It show now fail instead of caching a lackluster manifest file.

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
