### PR TITLE
fix: make ProviderAPI repr more digestable.

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -631,6 +631,9 @@ class ProviderAPI:
             NotImplementedError: Unless overridden.
         """
 
+    def __repr__(self):
+        return f"<{self.__class__.__name__} {self.name}>"
+
     def _try_track_receipt(self, receipt: ReceiptAPI):
         if self._chain:
             self._chain.account_history.append(receipt)


### PR DESCRIPTION
### What I did

make repr for providers easier to read and not super big/

### How I did it

### How to verify it

`ape console`

type `networks`

You should now see something like this:

```
<NetworkManager active_provider=<LocalProvider test>>
```

Before, it was a huge paragraph for provider.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
