### PR TITLE
refactor: store results of query for plugins that cache

### DIFF
--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -130,4 +130,3 @@ class QueryAPI:
             query (``QueryType``): query that was executed
             result (``pandas.DataFrame``): the result of the query
         """
-        pass

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -120,3 +120,14 @@ class QueryAPI:
         Returns:
             pandas.DataFrame
         """
+
+    def update_cache(self, query: QueryType, result: pd.DataFrame):
+        """
+        Allows a query plugin the chance to update any cache using the results obtained
+        from other query plugins. Defaults to doing nothing, override to store cache data.
+
+        Args:
+            query (``QueryType``): query that was executed
+            result (``pandas.DataFrame``): the result of the query
+        """
+        pass

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -87,5 +87,4 @@ class QueryManager:
         for engine in self.engines.values():
             engine.update_cache(query, result)
 
-        # Finally, return the result
         return result

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -64,20 +64,28 @@ class QueryManager:
             if engine_to_use not in self.engines:
                 raise QueryEngineError(f"Query engine `{engine_to_use}` not found.")
 
-            return self.engines[engine_to_use].perform_query(query)
+            engine = self.engines[engine_to_use]
 
-        # Get heuristics from all the query engines to perform this query
-        estimates = map(lambda qe: (qe, qe.estimate_query(query)), self.engines.values())
+        else:
+            # Get heuristics from all the query engines to perform this query
+            estimates = map(lambda qe: (qe, qe.estimate_query(query)), self.engines.values())
 
-        # Ignore query engines that can't perform this query
-        valid_estimates = filter(lambda qe: qe[1] is not None, estimates)
+            # Ignore query engines that can't perform this query
+            valid_estimates = filter(lambda qe: qe[1] is not None, estimates)
 
-        try:
-            # Find the "best" engine to perform the query
-            # NOTE: Sorted by fastest time heuristic
-            engine, _ = min(valid_estimates, key=lambda qe: qe[1])  # type: ignore
-        except ValueError as e:
-            raise QueryEngineError("No query engines are available.") from e
+            try:
+                # Find the "best" engine to perform the query
+                # NOTE: Sorted by fastest time heuristic
+                engine, _ = min(valid_estimates, key=lambda qe: qe[1])  # type: ignore
+            except ValueError as e:
+                raise QueryEngineError("No query engines are available.") from e
 
         # Go fetch the result from the engine
-        return engine.perform_query(query)
+        result = engine.perform_query(query)
+
+        # Update any caches
+        for engine in self.engines.values():
+            engine.update_cache(query, result)
+
+        # Finally, return the result
+        return result


### PR DESCRIPTION
### What I did
Thought about how if a plugin is slow on first try, but quick after that (e.g. Caching design), there is no mechanism available for the database to update its cache if it is not called. This adds an option method that will be called on all plugins that did _not_ execute the query so that they can do this. 

### How I did it
Add an interface 

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
