### PR TITLE
docs: fix 'get_provider()' argument documentation

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -480,7 +480,7 @@ class NetworkAPI:
         Args:
             provider_name (str, optional): The name of the provider to get. Defaults to ``None``.
               When ``None``, returns the default provider.
-            provider_settings dict, optional): Settings to apply to the provider. Defaults to
+            provider_settings (dict, optional): Settings to apply to the provider. Defaults to
               ``None``.
 
         Returns:


### PR DESCRIPTION
### What I did

Issue where part of the docs was not loading correctly.

### How I did it

build docs

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
