### PR TITLE
fix: use module name when registering providers

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -6,6 +6,7 @@ from ethpm_types.abi import ConstructorABI, EventABI, MethodABI
 from pluggy import PluginManager  # type: ignore
 
 from ape.exceptions import NetworkError, NetworkNotFoundError
+from ape.plugins import clean_plugin_name
 from ape.types import AddressType
 from ape.utils import abstractdataclass, abstractmethod, cached_property, dataclass
 
@@ -454,7 +455,7 @@ class NetworkAPI:
 
         for plugin_name, plugin_tuple in self.plugin_manager.providers:
             ecosystem_name, network_name, provider_class = plugin_tuple
-            provider_name = provider_class.__module__.split(".")[0].split("_")[-1]
+            provider_name = clean_plugin_name(provider_class.__module__.split(".")[0])
 
             if self.ecosystem.name == ecosystem_name and self.name == network_name:
                 # NOTE: Lazily load provider config

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -450,9 +450,9 @@ class NetworkAPI:
             Dict[str, partial[:class:`~ape.api.providers.ProviderAPI`]]
         """
 
-        providers = {}
-
         from ape.plugins import clean_plugin_name
+
+        providers = {}
 
         for plugin_name, plugin_tuple in self.plugin_manager.providers:
             ecosystem_name, network_name, provider_class = plugin_tuple

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -455,7 +455,6 @@ class NetworkAPI:
         for plugin_name, plugin_tuple in self.plugin_manager.providers:
             ecosystem_name, network_name, provider_class = plugin_tuple
             provider_name = provider_class.__module__.split(".")[0].split("_")[-1]
-            print(f"{ecosystem_name}:{network_name}:{provider_name}")
 
             if self.ecosystem.name == ecosystem_name and self.name == network_name:
                 # NOTE: Lazily load provider config

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -452,7 +452,7 @@ class NetworkAPI:
 
         providers = {}
 
-from ape.plugins import clean_plugin_name
+        from ape.plugins import clean_plugin_name
 
         for plugin_name, plugin_tuple in self.plugin_manager.providers:
             ecosystem_name, network_name, provider_class = plugin_tuple

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -6,7 +6,6 @@ from ethpm_types.abi import ConstructorABI, EventABI, MethodABI
 from pluggy import PluginManager  # type: ignore
 
 from ape.exceptions import NetworkError, NetworkNotFoundError
-from ape.plugins import clean_plugin_name
 from ape.types import AddressType
 from ape.utils import abstractdataclass, abstractmethod, cached_property, dataclass
 
@@ -452,6 +451,8 @@ class NetworkAPI:
         """
 
         providers = {}
+
+from ape.plugins import clean_plugin_name
 
         for plugin_name, plugin_tuple in self.plugin_manager.providers:
             ecosystem_name, network_name, provider_class = plugin_tuple

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -454,12 +454,14 @@ class NetworkAPI:
 
         for plugin_name, plugin_tuple in self.plugin_manager.providers:
             ecosystem_name, network_name, provider_class = plugin_tuple
+            provider_name = provider_class.__module__.split(".")[0].split("_")[-1]
+            print(f"{ecosystem_name}:{network_name}:{provider_name}")
 
             if self.ecosystem.name == ecosystem_name and self.name == network_name:
-                # NOTE: Lazily load and provider config on load
-                providers[plugin_name] = partial(
+                # NOTE: Lazily load provider config
+                providers[provider_name] = partial(
                     provider_class,
-                    name=plugin_name,
+                    name=provider_name,
                     config=self.config_manager.get_config(plugin_name),
                     network=self,
                     # NOTE: No need to have separate folder, caching should be interoperable

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -85,7 +85,9 @@ class NetworkManager:
                     if default_provider in network.providers:
                         network.set_default_provider(default_provider)
                     else:
-                        raise ConfigError(f"No provider named '{default_provider}'.")
+                        raise ConfigError(
+                            f"No provider '{default_provider}' in '{network_name}' network."
+                        )
 
             ecosystem_dict[plugin_name] = ecosystem
 


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #500 

### How I did it

* The module approach
Reason: It worked when I tried it and is easy to do. Non-breaking changes. Low risk. I don't see downsides?

### How to verify it

https://github.com/ApeWorX/ape-fantom

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
