### PR TITLE
fix: issue where if you set one geth network URI, all other default network URIs would vanish

### DIFF
--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -140,8 +140,8 @@ class GethProvider(Web3Provider, UpstreamProvider):
     @property
     def uri(self) -> str:
         ecosystem_config = getattr(self.config, self.network.ecosystem.name)
-        network_config = ecosystem_config.get(self.network.name, DEFAULT_SETTINGS)
-        return network_config.get("uri", DEFAULT_SETTINGS["uri"])
+        network_config = ecosystem_config.get(self.network.name) or DEFAULT_SETTINGS
+        return network_config.get("uri") or DEFAULT_SETTINGS["uri"]
 
     @property
     def connection_str(self) -> str:

--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -139,7 +139,9 @@ class GethProvider(Web3Provider, UpstreamProvider):
 
     @property
     def uri(self) -> str:
-        return getattr(self.config, self.network.ecosystem.name)[self.network.name]["uri"]
+        ecosystem_config = getattr(self.config, self.network.ecosystem.name)
+        network_config = ecosystem_config.get(self.network.name, DEFAULT_SETTINGS)
+        return network_config.get("uri", DEFAULT_SETTINGS["uri"])
 
     @property
     def connection_str(self) -> str:

--- a/tests/integration/cli/projects/geth/ape-config.yaml
+++ b/tests/integration/cli/projects/geth/ape-config.yaml
@@ -1,3 +1,11 @@
 ethereum:
   local:
     default_provider: geth
+
+# Change the default URI for one of the networks to
+# ensure that the default values of the other networks
+# remain unchanged.
+geth:
+  ethereum:
+    mainnet:
+      uri: localhost:5000

--- a/tests/integration/cli/test_networks.py
+++ b/tests/integration/cli/test_networks.py
@@ -1,3 +1,6 @@
+from ape.api.networks import LOCAL_NETWORK_NAME
+from ape_geth.providers import DEFAULT_SETTINGS
+
 from .utils import skip_projects, skip_projects_except
 
 _DEFAULT_NETWORKS_TREE = """
@@ -98,6 +101,11 @@ def test_list_yaml(ape_cli, runner):
 
 
 @skip_projects_except(["geth"])
-def test_change_default_from_config_file(ape_cli, runner):
+def test_geth(ape_cli, runner, networks):
     result = runner.invoke(ape_cli, ["networks", "list"])
     assert_rich_text(result.output, _GETH_NETWORKS_YAML)
+
+    # Assert that URI still exists for local network
+    # (was bug where one network's URI disappeared when setting different network's URI)
+    geth_provider = networks.get_provider_from_choice(f"ethereum:{LOCAL_NETWORK_NAME}:geth")
+    assert geth_provider.uri == DEFAULT_SETTINGS["uri"]


### PR DESCRIPTION
### What I did

Issue where if you set a network default URI for the geth plugin in your project, that the default network URIs for the other networks will now all missing from the config, so you get `KeyError` when trying to access them.

### How I did it

Use default URI when network config missing.

### How to verify it

Use `local` network in a project that specified the `mainnet` URI for the geth provide.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
