### PR TITLE
fix: issue preventing filtering plugin accounts in the CLI util option

### DIFF
--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -100,7 +100,7 @@ def get_user_selected_account(
         :class:`~ape.api.accounts.AccountAPI`
     """
 
-    if account_type and (type(account_type) != type or not issubclass(account_type, AccountAPI)):
+    if account_type and not issubclass(account_type, AccountAPI):
         raise AccountsError(f"Cannot return accounts with type '{account_type}'.")
 
     prompt = AccountAliasPromptChoice(account_type=account_type, prompt_message=prompt_message)

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -98,7 +98,7 @@ class BaseTransaction(TransactionAPI):
         signed_txn = encode_transaction(unsigned_txn, signature)
 
         if self.sender and EthAccount.recover_transaction(signed_txn) != self.sender:
-            raise SignatureError("Recovered Signer doesn't match sender!")
+            raise SignatureError("Recovered signer doesn't match sender!")
 
         return signed_txn
 


### PR DESCRIPTION
### What I did

This part of this check causes issues when trying to get only Ledger accounts using the CLI option.
I don't think it is needed either.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
