### PR TITLE
feat: add ape init

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ setup(
             "ape_run=ape_run._cli:cli",
             "ape_networks=ape_networks._cli:cli",
             "ape_test=ape_test._cli:cli",
+            "ape_init=ape_init._cli:cli",
         ],
     },
     python_requires=">=3.7,<3.11",

--- a/src/ape_init/_cli.py
+++ b/src/ape_init/_cli.py
@@ -15,7 +15,6 @@ def cli(cli_ctx, github):
         try:
             github_client.clone_repo(github, Path.cwd())
         except Exception as err:
-
             raise Abort(f"({type(err).__name__}) {err.data}") from err
 
         shutil.rmtree(Path.cwd() / ".git")

--- a/src/ape_init/_cli.py
+++ b/src/ape_init/_cli.py
@@ -1,26 +1,39 @@
+import shutil
 from pathlib import Path
 
 import click
 
-from ape.cli import ape_cli_context
+from ape.cli import Abort, ape_cli_context
+from ape.utils import github_client
 
 
 @click.command(short_help="Initalize an ape project")
 @ape_cli_context()
-def cli(cli_ctx):
-    project_folder = Path.cwd()
+@click.option("--github")
+def cli(cli_ctx, github):
+    if github:
+        try:
+            github_client.clone_repo(github, Path.cwd())
+        except Exception as err:
 
-    for folder_name in ["contracts", "tests", "scripts"]:
-        # Create target Directory
-        folder = project_folder / folder_name
-        if folder.exists():
-            cli_ctx.logger.warning(f"'{folder}' exists")
-        else:
-            folder.mkdir(exist_ok=False)
+            raise Abort(f"({type(err).__name__}) {err.data}") from err
 
-    ape_config = project_folder / "ape-config.yaml"
-    if ape_config.exists():
-        cli_ctx.logger.warning(f"'{ape_config}' exists")
+        shutil.rmtree(Path.cwd() / ".git")
+
     else:
-        project_name = click.prompt("Please enter project name")
-        ape_config.write_text(f"name: {project_name}\n")
+        project_folder = Path.cwd()
+
+        for folder_name in ["contracts", "tests", "scripts"]:
+            # Create target Directory
+            folder = project_folder / folder_name
+            if folder.exists():
+                cli_ctx.logger.warning(f"'{folder}' exists")
+            else:
+                folder.mkdir(exist_ok=False)
+
+        ape_config = project_folder / "ape-config.yaml"
+        if ape_config.exists():
+            cli_ctx.logger.warning(f"'{ape_config}' exists")
+        else:
+            project_name = click.prompt("Please enter project name")
+            ape_config.write_text(f"name: {project_name}\n")

--- a/src/ape_init/_cli.py
+++ b/src/ape_init/_cli.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import click
+
+from ape.cli import ape_cli_context
+
+
+@click.command(short_help="Initalize an ape project")
+@ape_cli_context()
+def cli(cli_ctx):
+    project_folder = Path.cwd()
+
+    for folder_name in ["contracts", "tests", "scripts"]:
+        # Create target Directory
+        folder = project_folder / folder_name
+        if folder.exists():
+            cli_ctx.logger.warning(f"'{folder}' exists")
+        else:
+            folder.mkdir(exist_ok=False)
+
+    ape_config = project_folder / "ape-config.yaml"
+    if ape_config.exists():
+        cli_ctx.logger.warning(f"'{ape_config}' exists")
+    else:
+        project_name = click.prompt("Please enter project name")
+        ape_config.write_text(f"name: {project_name}\n")


### PR DESCRIPTION
### What I did

Created the ape init command to make ape project and its default folders

contracts/
tests/
scripts/
ape-config.yaml

optional command --githhub username/repo

### How I did it

created a first class plugin

### How to verify it

install ape
create an empty folder
and type:

`ape init`
`ape init --github username/repo`

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
