### PR TITLE
feat: default query provider

### DIFF
--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -13,7 +13,7 @@ QueryType = Union["BlockQuery", "AccountQuery", "ContractEventQuery", "ContractM
 
 class _BaseQuery(BaseModel):
     type: str  # Used as discriminator
-    columns: Union[str, List[str]]
+    columns: List[str]
 
 
 class _BaseBlockQuery(_BaseQuery):

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from ape.api import BlockAPI, ReceiptAPI
 from ape.api.address import BaseAddress
-from ape.api.query import BlockQuery, QueryAPI
+from ape.api.query import BlockQuery
 from ape.exceptions import ChainError, UnknownSnapshotError
 from ape.logging import logger
 from ape.types import AddressType, BlockID, SnapshotID

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -88,7 +88,7 @@ class BlockContainer(BaseManager):
 
     def query(
         self,
-        columns: Union[str, List[str]],
+        *columns: List[str],
         start_block: int = 0,
         stop_block: Optional[int] = None,
         engine_to_use: Optional[QueryAPI] = None,

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -91,7 +91,7 @@ class BlockContainer(BaseManager):
         *columns: List[str],
         start_block: int = 0,
         stop_block: Optional[int] = None,
-        engine_to_use: Optional[QueryAPI] = None,
+        engine_to_use: Optional[str] = None,
     ) -> pd.DataFrame:
         """
         A method for querying blocks and returning a pandas DataFrame. If you
@@ -104,12 +104,12 @@ class BlockContainer(BaseManager):
               than the chain length.
 
         Args:
-            columns (Union[str, List[str]]): columns in the DataFrame to return
+            columns (List[str]): columns in the DataFrame to return
             start_block (int): The first block, by number, to include in the
               query. Defaults to 0.
             stop_block (Optional[int]): The last block, by number, to include
               in the query. Defaults to the latest block.
-            engine_to_use (Optional[QueryAPI]): query engine to use, bypasses query
+            engine_to_use (Optional[str]): query engine to use, bypasses query
               engine selection algorithm.
 
         Returns:

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -17,9 +17,9 @@ def get_columns_from_item(query: _BaseQuery, item: BaseModel) -> Dict[str, Any]:
 
 class DefaultQueryProvider(QueryAPI):
     """
-     Default implementation of the ape.api.query.QueryAPI
-     Allows for the query of blockchain data using connected provider
-     """
+    Default implementation of the ape.api.query.QueryAPI
+    Allows for the query of blockchain data using connected provider
+    """
 
     def estimate_query(self, query: QueryType) -> Optional[int]:
         """

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -26,6 +26,7 @@ class DefaultQueryProvider(QueryAPI):
     returns:
         pd.DataFrame: response of query in a pandas dataframe
     """
+
     def estimate_query(self, query: QueryType) -> Optional[int]:
         """
         Estimates the time that the query will take as a timestamp

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -17,15 +17,9 @@ def get_columns_from_item(query: _BaseQuery, item: BaseModel) -> Dict[str, Any]:
 
 class DefaultQueryProvider(QueryAPI):
     """
-    Default implementation of the ape.api.query.QueryAPI
-    Allows for the query of blockchain data
-
-    Args:
-        query: (``QueryType``): query to execute
-
-    returns:
-        pd.DataFrame: response of query in a pandas dataframe
-    """
+     Default implementation of the ape.api.query.QueryAPI
+     Allows for the query of blockchain data using connected provider
+     """
 
     def estimate_query(self, query: QueryType) -> Optional[int]:
         """

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -2,11 +2,10 @@ from functools import partial
 from typing import Any, Dict, Optional
 
 import pandas as pd
-from eth_utils import keccak, to_bytes, to_hex
 from pydantic import BaseModel
 
 from ape.api import QueryAPI, QueryType
-from ape.api.query import BlockQuery, ContractEventQuery, _BaseQuery
+from ape.api.query import BlockQuery, _BaseQuery
 from ape.exceptions import QueryEngineError
 from ape.plugins import clean_plugin_name
 from ape.utils import ManagerAccessMixin, cached_property

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -1,12 +1,12 @@
-from eth_utils import keccak, to_hex, to_bytes
 from functools import partial
 from typing import Any, Dict, Optional
 
 import pandas as pd
+from eth_utils import keccak, to_bytes, to_hex
 from pydantic import BaseModel
 
 from ape.api import QueryAPI, QueryType
-from ape.api.query import ContractEventQuery, BlockQuery, _BaseQuery
+from ape.api.query import BlockQuery, ContractEventQuery, _BaseQuery
 from ape.exceptions import QueryEngineError
 from ape.plugins import clean_plugin_name
 from ape.utils import ManagerAccessMixin, cached_property
@@ -31,7 +31,7 @@ class DefaultQueryProvider(QueryAPI):
 
         if isinstance(query, BlockQuery):
             blocks_iter = self.chain_manager.blocks.range(query.start_block, query.stop_block)
-            blocks_iter = map(partial(get_columns_from_item, query), blocks_iter)
+            blocks_iter = map(partial(get_columns_from_item, query), blocks_iter)  # type: ignore
             return pd.DataFrame(columns=query.columns, data=blocks_iter)
 
         raise QueryEngineError(f"Cannot handle '{type(query)}'.")
@@ -65,7 +65,7 @@ class QueryManager(ManagerAccessMixin):
             engine_name = clean_plugin_name(plugin_name)
             engines[engine_name] = engine_class()
 
-        return engines
+        return engines  # type: ignore
 
     def query(self, query: QueryType, engine_to_use: Optional[str] = None) -> pd.DataFrame:
         """

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -1,11 +1,8 @@
-from ape import accounts, chain
+from ape import chain
 
 
 def test_basic_query(test_provider):
-    a = accounts.test_accounts[0]
-    a.transfer(a, 100)
-    a.transfer(a, 100)
-    a.transfer(a, 100)
+    chain.mine(3)
     assert chain.blocks.query("number").to_dict() == {"number": {0: 0, 1: 1, 2: 2}}
     df = chain.blocks.query("number", "timestamp")
     assert len(df) == 3

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -1,7 +1,7 @@
 from ape import chain
 
 
-def test_basic_query(test_provider):
+def test_basic_query(eth_tester_provider):
     chain.mine(3)
     assert chain.blocks.query("number").to_dict() == {"number": {0: 0, 1: 1, 2: 2}}
     df = chain.blocks.query("number", "timestamp")

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -1,0 +1,14 @@
+from ape import accounts, chain
+
+
+def test_basic_query(test_provider):
+    a = accounts.test_accounts[0]
+    a.transfer(a, 100)
+    a.transfer(a, 100)
+    a.transfer(a, 100)
+    df = chain.blocks.query("number")
+    assert len(df) == 3
+    assert df["number"][0] == 0
+    df = chain.blocks.query("number", "timestamp")
+    assert len(df) == 3
+    assert df["timestamp"][2] > df["timestamp"][1] > df["timestamp"][0]

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -6,9 +6,7 @@ def test_basic_query(test_provider):
     a.transfer(a, 100)
     a.transfer(a, 100)
     a.transfer(a, 100)
-    df = chain.blocks.query("number")
-    assert len(df) == 3
-    assert df["number"][0] == 0
+    assert chain.blocks.query("number").to_dict() == {"number": {0: 0, 1: 1, 2: 2}}
     df = chain.blocks.query("number", "timestamp")
     assert len(df) == 3
-    assert df["timestamp"][2] > df["timestamp"][1] > df["timestamp"][0]
+    assert df["timestamp"][2] >= df["timestamp"][1] >= df["timestamp"][0]

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -2,9 +2,7 @@ import pytest
 from eth.exceptions import HeaderNotFound
 
 import ape
-
 from ape import networks
-
 from ape.api import (
     AccountContainerAPI,
     EcosystemAPI,

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -119,9 +119,3 @@ def sender(test_accounts):
 @pytest.fixture
 def receiver(test_accounts):
     return test_accounts[1]
-
-
-@pytest.fixture
-def test_provider():
-    with networks.ethereum.local.use_provider("test") as provider:
-        yield provider

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -2,6 +2,9 @@ import pytest
 from eth.exceptions import HeaderNotFound
 
 import ape
+
+from ape import networks
+
 from ape.api import (
     AccountContainerAPI,
     EcosystemAPI,
@@ -118,3 +121,9 @@ def sender(test_accounts):
 @pytest.fixture
 def receiver(test_accounts):
     return test_accounts[1]
+
+
+@pytest.fixture
+def test_provider():
+    with networks.ethereum.local.use_provider("test") as provider:
+        yield provider

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -2,7 +2,6 @@ import pytest
 from eth.exceptions import HeaderNotFound
 
 import ape
-from ape import networks
 from ape.api import (
     AccountContainerAPI,
     EcosystemAPI,


### PR DESCRIPTION
### What I did

Added a default block query under src/ape/api/managers

fixes: #526 

### How I did it

Perform query required a map function in order to deal with potential memory issues when performing large queries

### How to verify it

Must add tests, but this was how I tested it from the ape console:

```python
In [1]: a = accounts.test_accounts[0]
In [2]: a.transfer(a, 100)
In [3]: a.transfer(a, 100)
In [4]: a.transfer(a, 100)
In [5]: chain.blocks.query("number")
In [6]: chain.blocks.query("number", "timestamp")
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
