### PR TITLE
refactor: share default test mnemonic

### DIFF
--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     from ape.plugins import PluginManager
 
 DEFAULT_NUMBER_OF_TEST_ACCOUNTS = 10
+DEFAULT_TEST_MNEMONIC = "test test test test test test test test test test test junk"
 
 _python_version = (
     f"{sys.version_info.major}.{sys.version_info.minor}"
@@ -230,7 +231,7 @@ Config example::
 
 
 def generate_dev_accounts(
-    mnemonic: str,
+    mnemonic: str = DEFAULT_TEST_MNEMONIC,
     number_of_accounts: int = DEFAULT_NUMBER_OF_TEST_ACCOUNTS,
     hd_path_format="m/44'/60'/0'/{}",
 ) -> List[GeneratedDevAccount]:

--- a/src/ape_test/__init__.py
+++ b/src/ape_test/__init__.py
@@ -1,14 +1,15 @@
 from ape import plugins
 from ape.api import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME
+from ape.utils import DEFAULT_NUMBER_OF_TEST_ACCOUNTS, DEFAULT_TEST_MNEMONIC
 
 from .accounts import TestAccount, TestAccountContainer
 from .providers import LocalProvider
 
 
 class Config(PluginConfig):
-    mnemonic: str = "test test test test test test test test test test test junk"
-    number_of_accounts: int = 10
+    mnemonic: str = DEFAULT_TEST_MNEMONIC
+    number_of_accounts: int = DEFAULT_NUMBER_OF_TEST_ACCOUNTS
 
 
 @plugins.register(plugins.Config)


### PR DESCRIPTION
### What I did

For use in plugins like hardhat and fantom

### How I did it

put in `ape.utils` and use in `ape_test`

### How to verify it

import in hardhat or fantom

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
