### PR TITLE
fix: adjust to honest python versions and upgrade web3.py dependency

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
               python-version: 3.8
 
         - name: Install Dependencies
-          run: pip install .[lint]
+          run: pip install --upgrade pip && pip install .[lint]
 
         - name: Run Black
           run: black --check .

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ setup(
             "ape_init=ape_init._cli:cli",
         ],
     },
-    python_requires=">=3.7,<3.11",
+    python_requires=">=3.7.2,<3.11",
     extras_require=extras_require,
     py_modules=packages_data["__modules__"],
     license="Apache-2.0",

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
         "rich>=10.14,<11",
         "tqdm>=4.62.3,<5.0",
         "typing-extensions ; python_version<'3.8'",
-        "web3[tester]==5.27.0",
+        "web3[tester]==5.28.0",
         "eth_abi==2.1.1",
         "eth-utils==1.10.0",
         "eth-rlp==0.2.1",

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
         "rich>=10.14,<11",
         "tqdm>=4.62.3,<5.0",
         "typing-extensions ; python_version<'3.8'",
-        "web3[tester]==5.28.0",
+        "web3[tester]>=5.28.0,<6.0",
         "eth_abi==2.1.1",
         "eth-utils==1.10.0",
         "eth-rlp==0.2.1",


### PR DESCRIPTION
### What I did

We cannot support python versions 3.7 and 3.7.1; they are not part of the list of python versions the `ipfshttpclient` package supports: https://github.com/ipfs-shipyard/py-ipfs-http-client/blob/master/pyproject.toml#L15-L23

And `ipfshttpclient` is a dependency of `web.py`. I raised an issue here https://github.com/ethereum/web3.py/issues/2378 to see if we can get it also upgraded there.

### How I did it

bump!

### How to verify it

install ape on your python 3.7 version (which is probably python 3.7.12 or something)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
