### PR TITLE
fix: (pydantic refactor continued) handle no contract type address init

### DIFF
--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -106,7 +106,8 @@ class Address(BaseAddress):
     or to refer to an EOA the user doesn't personally control.
     """
 
-    _address: AddressType
+    def __init__(self, address: AddressType):
+        self._address = address
 
     @property
     def address(self) -> AddressType:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -488,7 +488,7 @@ def _Contract(
     else:
         # We don't have a contract type from any source, provide raw address instead
         logger.warning(f"No contract type found for {address}")
-        return Address(address=converted_address)
+        return Address(converted_address)
 
 
 def _get_non_contract_error(address: str, network_name: str) -> ContractError:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -488,10 +488,7 @@ def _Contract(
     else:
         # We don't have a contract type from any source, provide raw address instead
         logger.warning(f"No contract type found for {address}")
-        return Address(  # type: ignore
-            _address=converted_address,
-            _provider=provider,
-        )
+        return Address(address=converted_address)
 
 
 def _get_non_contract_error(address: str, network_name: str) -> ContractError:

--- a/tests/integration/test_contracts.py
+++ b/tests/integration/test_contracts.py
@@ -1,0 +1,8 @@
+from ape import Contract
+from ape.api import Address
+
+
+def test_init_at_unknown_address():
+    address = "0x274b028b03A250cA03644E6c578D81f019eE1323"
+    contract = Contract(address)
+    assert type(contract) == Address

--- a/tests/integration/test_contracts.py
+++ b/tests/integration/test_contracts.py
@@ -6,3 +6,4 @@ def test_init_at_unknown_address():
     address = "0x274b028b03A250cA03644E6c578D81f019eE1323"
     contract = Contract(address)
     assert type(contract) == Address
+    assert contract.address == address


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #541 

### How I did it

* Use init method since not a pydantic model
* Remove unneeded param

### How to verify it

Deploy a contract, remember the address
Initialize contract with address. It fails to find the contract type because we are not yet caching those

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
