### PR TITLE
fix: issue where we were using a default mutable argument

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -228,12 +228,12 @@ class ContractEvent(ManagerAccessMixin):
         self,
         contract: "ContractInstance",
         abis: List[EventABI],
-        cached_logs: List[ContractLog] = [],
+        cached_logs: List[ContractLog] = None,
     ) -> None:
         super().__init__()
         self.contract = contract
         self.abis = abis
-        self.cached_logs = cached_logs
+        self.cached_logs = cached_logs or []
 
 
 class ContractInstance(BaseAddress):


### PR DESCRIPTION
### What I did

We were using a default mutable argument, which is python anti-pattern than can lead to some highly unusual situations:
https://duckduckgo.com/?q=default+mutable+arugments+python&t=brave&ia=web

### How I did it

Default to None and coerce to empty list in first line of init

### How to verify it

with your eyeballs is fine

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
