### PR TITLE
fix: handle exiting pytest when provider never connects

### DIFF
--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -19,6 +19,7 @@ class PytestApeRunner(ManagerAccessMixin):
     ):
         self.pytest_config = pytest_config
         self._warned_for_missing_features = False
+        self._provider_is_connected = False
         ape.reverts = RevertsContextManager  # type: ignore
 
     @property
@@ -137,11 +138,18 @@ class PytestApeRunner(ManagerAccessMixin):
                 self._network_choice
             )
             self.network_manager.active_provider.connect()
+            self._provider_is_connected = True
+        else:
+            raise pytest.UsageError(f"No tests found in '{Path.cwd()}'.")
 
     def pytest_sessionfinish(self):
         """
         Called after whole test run finished, right before returning the exit
         status to the system.
+
+        **NOTE**: This hook fires even when exceptions occur, so we cannot
+        assume the provider successfully connected.
         """
-        if self.chain_manager:
+        if self._provider_is_connected:
             self.chain_manager.provider.disconnect()
+            self._provider_is_connected = False

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -139,8 +139,6 @@ class PytestApeRunner(ManagerAccessMixin):
             )
             self.network_manager.active_provider.connect()
             self._provider_is_connected = True
-        else:
-            raise pytest.UsageError(f"No tests found in '{Path.cwd()}'.")
 
     def pytest_sessionfinish(self):
         """

--- a/src/ape_test/_cli.py
+++ b/src/ape_test/_cli.py
@@ -17,5 +17,4 @@ def cli(cli_ctx, pytest_args):
     return_code = pytest.main([*pytest_args], ["ape_test"])
     if return_code:
         # only exit with non-zero status to make testing easier
-        cli_ctx.logger.error("Failed to run pytest")
         sys.exit(return_code)


### PR DESCRIPTION
### What I did

fixes: #525

Before output:

```bash
collected 0 items / 1 error                                                                                                                                                                    
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
ERROR: (ProviderNotConnectedError) Not connected to a network provider
```

New output:

```bash
==================================================================================== no tests ran in 0.01s =====================================================================================
```

### How I did it

* Don't try to disconnect if connect never happens
* Remove logger error stmt from `ape_test._cli.py` as it just noise and does add anything (pytest output is what matters)

This works exactly the same using `pytest` without ape installed.

### How to verify it

go to a directory without tests and run `ape test`

See output expected outputs above for both `main` and this branch!

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
