### PR TITLE
fix: make debug work for failed-to-load plugins

### DIFF
--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -162,6 +162,9 @@ class CliLogger:
 def _get_logger(name: str) -> logging.Logger:
     """Get a logger with the given ``name`` and configure it for usage with Click."""
     cli_logger = logging.getLogger(name)
+    handler = ClickHandler(echo_kwargs=CLICK_ECHO_KWARGS)
+    handler.setFormatter(ApeColorFormatter())
+    cli_logger.handlers = [handler]
 
     # NOTE: We need to set the verbosity from the CLI option earlier than click lets us.
     for arg_i in range(len(sys.argv) - 1):
@@ -173,13 +176,11 @@ def _get_logger(name: str) -> logging.Logger:
                 cli_logger.setLevel(level)
             else:
                 names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"
-                raise click.BadParameter(f"Must be one of '{names_str}', not '{level}'.")
+                cli_logger.error(f"Must be one of '{names_str}', not '{level}'.")
+                sys.exit(2)
         else:
             cli_logger.setLevel(DEFAULT_LOG_LEVEL)
 
-    handler = ClickHandler(echo_kwargs=CLICK_ECHO_KWARGS)
-    handler.setFormatter(ApeColorFormatter())
-    cli_logger.handlers = [handler]
     return cli_logger
 
 

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -2,13 +2,13 @@
 import logging
 import sys
 import traceback
-from enum import Enum
+from enum import IntEnum
 from typing import IO
 
 import click
 
 
-class LogLevel(Enum):
+class LogLevel(IntEnum):
     ERROR = logging.ERROR
     WARNING = logging.WARNING
     SUCCESS = logging.INFO + 1

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -163,7 +163,7 @@ def _get_logger(name: str) -> logging.Logger:
     """Get a logger with the given ``name`` and configure it for usage with Click."""
     cli_logger = logging.getLogger(name)
 
-    # NOTE: We need set the verbosity from the CLI option earlier than click lets us.
+    # NOTE: We need to set the verbosity from the CLI option earlier than click lets us.
     for arg_i in range(len(sys.argv) - 1):
         if sys.argv[arg_i] == "-v" or sys.argv[arg_i] == "--verbosity":
             level = sys.argv[arg_i + 1].upper()
@@ -174,7 +174,6 @@ def _get_logger(name: str) -> logging.Logger:
             else:
                 names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"
                 raise click.BadParameter(f"Must be one of '{names_str}', not '{level}'.")
-            # else: let ``click`` handle the error later on.
         else:
             cli_logger.setLevel(DEFAULT_LOG_LEVEL)
 

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -104,13 +104,15 @@ class CliLogger:
         self._logger = _logger
         self._web3_request_manager_logger = _get_logger("web3.RequestManager")
         self._web3_http_provider_logger = _get_logger("web3.providers.HTTPProvider")
-        self.set_level(DEFAULT_LOG_LEVEL)
 
     @property
     def level(self) -> int:
         return self._logger.level
 
     def set_level(self, level_name: str):
+        if level_name == self._logger.level:
+            return
+
         self._logger.setLevel(level_name)
         self._web3_request_manager_logger.setLevel(level_name)
         self._web3_http_provider_logger.setLevel(level_name)
@@ -160,6 +162,22 @@ class CliLogger:
 def _get_logger(name: str) -> logging.Logger:
     """Get a logger with the given ``name`` and configure it for usage with Click."""
     cli_logger = logging.getLogger(name)
+
+    # NOTE: We need set the verbosity from the CLI option earlier than click lets us.
+    for arg_i in range(len(sys.argv) - 1):
+        if sys.argv[arg_i] == "-v" or sys.argv[arg_i] == "--verbosity":
+            level = sys.argv[arg_i + 1].upper()
+            level_names = [lvl.name for lvl in LogLevel]
+
+            if level in level_names:
+                cli_logger.setLevel(level)
+            else:
+                names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"
+                raise click.BadParameter(f"Must be one of '{names_str}', not '{level}'.")
+            # else: let ``click`` handle the error later on.
+        else:
+            cli_logger.setLevel(DEFAULT_LOG_LEVEL)
+
     handler = ClickHandler(echo_kwargs=CLICK_ECHO_KWARGS)
     handler.setFormatter(ApeColorFormatter())
     cli_logger.handlers = [handler]

--- a/src/ape/plugins/__init__.py
+++ b/src/ape/plugins/__init__.py
@@ -1,10 +1,9 @@
 import functools
 import importlib
 import pkgutil
-import sys
 from typing import Any, Callable, Generator, Iterator, List, Optional, Tuple, Type, cast
 
-from ape.logging import LogLevel, logger
+from ape.logging import logger
 
 from .account import AccountPlugin
 from .compiler import CompilerPlugin
@@ -123,15 +122,6 @@ class PluginManager:
     _unimplemented_plugins: List[str] = []
 
     def __init__(self) -> None:
-        # NOTE: This is a hack to make 'ape -v debug' correctly debug failing plugins.
-        for arg_i in range(len(sys.argv) - 1):
-            if sys.argv[arg_i] == "-v" or sys.argv[arg_i] == "--verbosity":
-                level = sys.argv[arg_i + 1].upper()
-
-                if level in [lvl.name for lvl in LogLevel]:
-                    logger.set_level(level)
-                # else: let ``click`` handle the error later on.
-
         # NOTE: This actually loads the plugins, and should only be done once
         for _, name, ispkg in pkgutil.iter_modules():
             if name.startswith("ape_") and ispkg:

--- a/src/ape/plugins/__init__.py
+++ b/src/ape/plugins/__init__.py
@@ -1,9 +1,10 @@
 import functools
 import importlib
 import pkgutil
+import sys
 from typing import Any, Callable, Generator, Iterator, List, Optional, Tuple, Type, cast
 
-from ape.logging import logger
+from ape.logging import LogLevel, logger
 
 from .account import AccountPlugin
 from .compiler import CompilerPlugin
@@ -122,6 +123,15 @@ class PluginManager:
     _unimplemented_plugins: List[str] = []
 
     def __init__(self) -> None:
+        # NOTE: This is a hack to make 'ape -v debug' correctly debug failing plugins.
+        for arg_i in range(len(sys.argv) - 1):
+            if sys.argv[arg_i] == "-v" or sys.argv[arg_i] == "--verbosity":
+                level = sys.argv[arg_i + 1].upper()
+
+                if level in [lvl.name for lvl in LogLevel]:
+                    logger.set_level(level)
+                # else: let ``click`` handle the error later on.
+
         # NOTE: This actually loads the plugins, and should only be done once
         for _, name, ispkg in pkgutil.iter_modules():
             if name.startswith("ape_") and ispkg:


### PR DESCRIPTION
### What I did

Currently, if a plugin fails to load, it says you can debug the reason why... but the `-v` argument does not load in time, so you really cannot. Debugging other stuff works but not the failed to load plugins; that stuff happens really early in the lifecycle now.

This PR addresses this bug and forces a more eager setting LogLevel of the logger.

### How I did it

At plugin load time, check `sys.argv` and set the logger then.

### How to verify it

Step 1: Break a plugin so it does not load
Step 2: Run `ape` notice it failed to load
Step 3: Run `ape -v debug` and notice you get a stacktrace
Step 4: Run `ape networks list -v debug` and notice the command still works AND you get a stacktrace at top for the failed to load plugin
Step 5: Notice `ape -v` fails the normal way and not in some weird way (careful arg indexing)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
