### PR TITLE
feat: allow network choice filtering

### DIFF
--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -168,8 +168,21 @@ class NetworkChoice(click.Choice):
     A ``click.Choice`` to provide network choice defaults for the active project.
     """
 
-    def __init__(self, case_sensitive=True):
-        super().__init__(list(networks.network_choices), case_sensitive)
+    def __init__(
+        self,
+        case_sensitive=True,
+        ecosystem: Optional[str] = None,
+        network: Optional[str] = None,
+        provider: Optional[str] = None,
+    ):
+        super().__init__(
+            list(
+                networks.get_network_choices(
+                    ecosystem_filter=ecosystem, network_filter=network, provider_filter=provider
+                )
+            ),
+            case_sensitive,
+        )
 
     def get_metavar(self, param):
         return "[ecosystem-name][:[network-name][:[provider-name]]]"

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -90,20 +90,30 @@ def ape_cli_context():
     return decorator
 
 
-def network_option(default: str = None):
+def network_option(
+    default: Optional[str] = None,
+    ecosystem: Optional[str] = None,
+    network: Optional[str] = None,
+    provider: Optional[str] = None,
+):
     """
     A ``click.option`` for specifying a network.
 
     Args:
-        default (str): Optionally, change which network to
+        default (Optional[str]): Optionally, change which network to
           use as the default. Defaults to how ``ape`` normally
           selects a default network.
+        ecosystem (Optional[str]): Filter the options by ecosystem. Defaults to ``None``.
+        network: Optional[str]): Filter the options by network. Defaults to ``None``.
+        provider (Optional[str]): Filter the options by provider. Defaults to ``None``.
     """
 
     default = default or networks.default_ecosystem.name
     return click.option(
         "--network",
-        type=NetworkChoice(case_sensitive=False),
+        type=NetworkChoice(
+            case_sensitive=False, ecosystem=ecosystem, network=network, provider=provider
+        ),
         default=default,
         help="Override the default network and provider. (see ``ape networks list`` for options)",
         show_default=True,


### PR DESCRIPTION
### What I did

Allows user to filter the network choices available. Helpful for limiting available networks per plugin CLI commands or user scripts who only care about a select few of options.

### How I did it
Made `network_choices` a method that accepts the filter strs

### How to verify it
`network_option()` still works and you can additionally filter out stuff via `ecosystem="fantom"` to only get `fantom` network options

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
