### PR TITLE
test: (pydantic refactor continued) remove unneeded mock in tests

### DIFF
--- a/tests/functional/geth/test_providers.py
+++ b/tests/functional/geth/test_providers.py
@@ -39,7 +39,6 @@ class TestEthereumProvider:
         )
         provider._web3 = mock_web3
 
-        mock_network_api.ecosystem.receipt_class = _create_mock_receipt()
         web3_error_data = {
             "code": -32000,
             "message": "Test Error Message",
@@ -62,7 +61,6 @@ class TestEthereumProvider:
             request_header="",
         )
         provider._web3 = mock_web3
-        mock_network_api.ecosystem.receipt_class = _create_mock_receipt()
         test_err = Web3ContractLogicError(f"execution reverted: {_TEST_REVERT_REASON}")
         mock_web3.eth.send_raw_transaction.side_effect = test_err
 
@@ -83,7 +81,6 @@ class TestEthereumProvider:
             request_header="",
         )
         provider._web3 = mock_web3
-        mock_network_api.ecosystem.receipt_class = _create_mock_receipt()
         test_err = Web3ContractLogicError("execution reverted")
         mock_web3.eth.send_raw_transaction.side_effect = test_err
 

--- a/tests/functional/geth/test_providers.py
+++ b/tests/functional/geth/test_providers.py
@@ -3,26 +3,10 @@ from pathlib import Path
 import pytest
 from web3.exceptions import ContractLogicError as Web3ContractLogicError
 
-from ape.api import ReceiptAPI, TransactionStatusEnum
 from ape.exceptions import ContractLogicError, TransactionError
 from ape_geth import GethProvider
 
 _TEST_REVERT_REASON = "TEST REVERT REASON."
-
-
-def _create_mock_receipt(status=TransactionStatusEnum.NO_ERROR, gas_used=0):
-    class MockReceipt(ReceiptAPI):
-        @classmethod
-        def decode(cls, data: dict) -> "ReceiptAPI":
-            return MockReceipt(
-                txn_hash="test-hash",  # type: ignore
-                status=status,  # type: ignore
-                gas_used=gas_used,  # type: ignore
-                gas_price="60000000000",  # type: ignore
-                block_number=0,  # type: ignore
-            )
-
-    return MockReceipt
 
 
 class TestEthereumProvider:


### PR DESCRIPTION
### What I did

This mock is not needed. Left over from Pydantic refactor.

### How I did it

Piecing together Ecosystem stuff in my head.

### How to verify it
passing tests suffice

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
