### PR TITLE
fix: improve error message when using non-local geth network

### DIFF
--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -159,7 +159,11 @@ class GethProvider(Web3Provider, UpstreamProvider):
 
         if not self._web3.isConnected():
             if self.network.name != LOCAL_NETWORK_NAME:
-                raise ProviderError(f"Geth plugin expected process to be running on '{self.uri}'.")
+                raise ProviderError(
+                    f"When running on network '{self.network.name}', "
+                    f"the Geth plugin expects the Geth process to already "
+                    f"be running on '{self.uri}'."
+                )
 
             # Start an ephemeral geth process.
             parsed_uri = urlparse(self.uri)


### PR DESCRIPTION
### What I did
I was confused by own my error message so I sought to fix it.

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #

### How I did it
Mention the currently connected network.

### How to verify it
Use `ape-geth` and mainnet without geth actually being running

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
