### PR TITLE
fix: avoid issues with pip by making it a core dependency

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,9 +15,7 @@ jobs:
               python-version: 3.8
 
         - name: Install Dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install .[lint]
+          run: pip install .[lint]
 
         - name: Run Black
           run: black --check .
@@ -40,9 +38,7 @@ jobs:
               python-version: 3.8
 
         - name: Install Dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install .[lint,test]
+          run: pip install .[lint,test]
 
         - name: Run MyPy
           run: mypy .
@@ -64,9 +60,7 @@ jobs:
               python-version: ${{ matrix.python-version }}
 
         - name: Install Dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install .[test]
+          run: pip install .[test]
 
         - name: Run Tests
           run: pytest -m "not fuzzing" -s --cov
@@ -86,9 +80,7 @@ jobs:
               python-version: 3.8
 
         - name: Install Dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install .[test]
+          run: pip install .[test]
 
         - name: Run Tests
           run: pytest -m "fuzzing" --no-cov -s

--- a/docs/userguides/quickstart.md
+++ b/docs/userguides/quickstart.md
@@ -56,7 +56,6 @@ You can install the latest release via
 [pip](https://pypi.org/project/pip/):
 
 ```bash
-pip install -U pip
 pip install eth-ape
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
         "hexbytes>=0.2.2,<1.0.0",
         "packaging>=20.9,<21.0",
         "pandas>=1.3.0,<2.0",
+        "pip>=22.0.4",  # NOTE: `pip` creates problems if it is not up to date
         "pluggy>=0.13.1,<1.0",
         "pydantic>=1.9.0,<2.0",
         "PyGithub>=1.54,<2.0",


### PR DESCRIPTION
### What I did
Should hopefully take care of a few issues that arise from not having the latest version of `pip` when installing

### How I did it
Added `pip` to core dependencies

### How to verify it
Validate plugin installs

### Checklist

- [x] All changes are completed
- [x] ~~New test cases have been added~~
- [x] Documentation has been updated
