### PR TITLE
fix: issue preventing --all flag from working on accounts list command

### DIFF
--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -6,7 +6,6 @@ from eth_utils import to_bytes
 
 from ape import accounts
 from ape.cli import ape_cli_context, existing_alias_argument, non_existing_alias_argument
-from ape.plugins import clean_plugin_name
 from ape_accounts import KeyfileAccount
 
 
@@ -31,12 +30,8 @@ def _list(cli_ctx, show_all_plugins):
     if "accounts" not in accounts.containers:
         cli_ctx.abort("Accounts plugin unexpectedly failed to load.")
 
-    containers = (
-        accounts.containers.values() if show_all_plugins else [accounts.containers["accounts"]]
-    )
-    account_map = {
-        clean_plugin_name(c.__module__.split(".")[0]): [a for a in c.accounts] for c in containers
-    }
+    containers = accounts.containers if show_all_plugins else {"accounts": _get_container()}
+    account_map = {n: [a for a in c.accounts] for n, c in containers.items()}
     account_map = [pair for pair in {n: ls for n, ls in account_map.items() if len(ls) > 0}.items()]
 
     if sum([len(c) for c in account_map]) == 0:

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -47,14 +47,14 @@ def _list(cli_ctx, show_all_plugins):
     for index in range(num_containers):
         plugin_name, container = account_map[index]
         num_accounts = len(container)
-        msg = f"Found {num_accounts} account"
+        header = f"Found {num_accounts} account"
         if num_accounts > 1:
-            msg = f"{msg}s"  # 'account' -> 'accounts'
+            header = f"{header}s"  # 'account' -> 'accounts'
 
         if show_all_plugins:
-            msg = f"{msg} in the '{plugin_name}' plugin"
+            header = f"{header} in the '{plugin_name}' plugin"
 
-        click.echo(f"{msg}:")
+        click.echo(f"{header}:")
 
         for account in container:
             alias_display = f" (alias: '{account.alias}')" if account.alias else ""

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -27,7 +27,7 @@ def cli():
 @click.option("--all", help="Output accounts from all plugins", is_flag=True)
 @ape_cli_context()
 def _list(cli_ctx, all):
-    account_list = accounts if all else accounts.containers.get("accounts", [])
+    account_list = list(accounts if all else accounts.containers.get("accounts", []).accounts)
     if len(account_list) == 0:
         cli_ctx.logger.warning("No accounts found.")
         return
@@ -38,7 +38,7 @@ def _list(cli_ctx, all):
     else:
         click.echo("Found 1 account:")
 
-    for account in account_list.accounts:
+    for account in account_list:
         alias_display = f" (alias: '{account.alias}')" if account.alias else ""
         click.echo(f"  {account.address}{alias_display}")
 

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -27,18 +27,18 @@ def cli():
 @click.option("--all", help="Output accounts from all plugins", is_flag=True)
 @ape_cli_context()
 def _list(cli_ctx, all):
-    accounts_to_output = accounts if all else accounts.containers.get("accounts", [])
-    if len(accounts_to_output) == 0:
+    account_list = accounts if all else accounts.containers.get("accounts", [])
+    if len(account_list) == 0:
         cli_ctx.logger.warning("No accounts found.")
         return
 
-    elif len(accounts_to_output) > 1:
+    elif len(account_list) > 1:
         click.echo(f"Found {len(accounts)} accounts:")
 
     else:
         click.echo("Found 1 account:")
 
-    for account in accounts_to_output.accounts:
+    for account in account_list.accounts:
         alias_display = f" (alias: '{account.alias}')" if account.alias else ""
         click.echo(f"  {account.address}{alias_display}")
 

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -24,10 +24,12 @@ def cli():
 
 # Different name because `list` is a keyword
 @cli.command(name="list", short_help="List available local accounts")
-@click.option("--all", help="Output accounts from all plugins", is_flag=True)
+@click.option("--all", "show_all_plugins", help="Output accounts from all plugins", is_flag=True)
 @ape_cli_context()
-def _list(cli_ctx, all):
-    account_list = list(accounts if all else accounts.containers.get("accounts", []).accounts)
+def _list(cli_ctx, show_all_plugins):
+    account_list = list(
+        accounts if show_all_plugins else accounts.containers.get("accounts", []).accounts
+    )
     if len(account_list) == 0:
         cli_ctx.logger.warning("No accounts found.")
         return

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -47,9 +47,6 @@ def _list(cli_ctx, show_all_plugins):
     for index in range(num_containers):
         plugin_name, container = account_map[index]
         num_accounts = len(container)
-        if num_accounts == 0:
-            continue
-
         msg = f"Found {num_accounts} account"
         if num_accounts > 1:
             msg = f"{msg}s"  # 'account' -> 'accounts'

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -150,6 +150,13 @@ def test_list(ape_cli, runner, test_keyfile):
     assert ALIAS in result.output
 
 
+def test_list_all(ape_cli, runner, test_keyfile):
+    # Check availability
+    assert test_keyfile.exists()
+    result = runner.invoke(ape_cli, ["accounts", "list", "--all"])
+    assert ALIAS in result.output
+
+
 @pytest.mark.skip(reason="Changes to underlying structure make mocks incorrect")
 def test_list_excludes_external_accounts(ape_cli, runner, mock_account_manager):
     result = runner.invoke(ape_cli, ["accounts", "list"])

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -44,7 +44,9 @@ def keyparams():
 
 @pytest.fixture(autouse=True)
 def temp_keyfile_path(config):
-    test_keyfile_path = Path(config.DATA_FOLDER / "accounts" / f"{ALIAS}.json")
+    temp_accounts_dir = Path(config.DATA_FOLDER) / "accounts"
+    temp_accounts_dir.mkdir(exist_ok=True, parents=True)
+    test_keyfile_path = temp_accounts_dir / f"{ALIAS}.json"
 
     if test_keyfile_path.exists():
         # Corrupted from a previous test


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->
* Fixed bug preventing `ape accounts list --all` from working correctly (it would error).
* Short plugin names in output when user does --all (to see what accounts come from which plugin)
* Added a test to make sure bug does not come back
* Cleaned up other tests

### How I did it
Just needed to handle the types correctly in that scenario.

### How to verify it

Run the following with some account plugins installed:

```bash
ape accounts list
ape accounts list --all
```

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
