### PR TITLE
feat: support configuring default ecosystem

### DIFF
--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -19,6 +19,16 @@ This is useful for projects that compile contracts outside their directory.
 contracts_folder: "~/GlobalContracts"
 ```
 
+## Default Ecosystem
+
+You can change the default ecosystem by including the following:
+
+```yaml
+default_ecosystem: fantom
+```
+
+The default ecosystem is `ethereum`.
+
 ## Dependencies
 
 Configure dependencies for your ape project.

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from ape.managers.query import QueryManager
     from ape.plugins import PluginManager
 
+
 DEFAULT_NUMBER_OF_TEST_ACCOUNTS = 10
 DEFAULT_TEST_MNEMONIC = "test test test test test test test test test test test junk"
 


### PR DESCRIPTION
### What I did

Allows user to config a default ecosystem.

### How I did it

* Add new item to config
* Set it as the default
* Also called `load()` before trying to get a config because of a "race" condition.

### How to verify it

* Create a project using an ecosystem that is not Ethereum
* Add this to config: `default_ecosystem: the-ecosystem` replacing `the-ecosystem` with whatever ecosystem you are using.
* Run `ape console` and make sure it uses your default ecosystem

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] New test cases have been added
- [x] Documentation has been updated
