### PR TITLE
fix: handle when network values don't exist in choice-parser

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -133,7 +133,7 @@ class EcosystemAPI(BaseInterfaceModel):
         Returns:
             :class:`~ape.api.networks.NetworkAPI`
         """
-        return self._try_get_network(network_name)
+        return self.get_network(network_name)
 
     def __getattr__(self, network_name: str) -> "NetworkAPI":
         """
@@ -155,7 +155,7 @@ class EcosystemAPI(BaseInterfaceModel):
             :class:`~ape.api.networks.NetworkAPI`
         """
         network_name = network_name.replace("_", "-")
-        return self._try_get_network(network_name)
+        return self.get_network(network_name)
 
     def add_network(self, network_name: str, network: "NetworkAPI"):
         """
@@ -221,7 +221,20 @@ class EcosystemAPI(BaseInterfaceModel):
     def create_transaction(self, **kwargs) -> "TransactionAPI":
         ...
 
-    def _try_get_network(self, network_name):
+    def get_network(self, network_name: str) -> "NetworkAPI":
+        """
+        Get the network for the given name.
+
+        Args:
+              network_name (str): The name of the network to get.
+
+        Raises:
+              :class:`~ape.exceptions.NetworkNotFoundError`: When the network is not present.
+
+        Returns:
+              :class:`~ape.api.networks.NetworkAPI`
+        """
+
         if network_name in self.networks:
             return self.networks[network_name]
         else:
@@ -499,7 +512,7 @@ class NetworkAPI(BaseInterfaceModel):
 
         else:
             message = (
-                f"'{provider_name}' is not a valid network for ecosystem '{self.ecosystem.name}'"
+                f"'{provider_name}' is not a valid provider for ecosystem '{self.ecosystem.name}'"
             )
             raise NetworkError(message)
 

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -136,10 +136,10 @@ class ConfigManager(BaseInterfaceModel):
         user_config = load_config(config_file) if config_file.exists() else {}
         self.name = configs["name"] = user_config.pop("name", "")
         self.version = configs["version"] = user_config.pop("version", "")
-
         self.default_ecosystem = configs["default_ecosystem"] = user_config.pop(
             "default_ecosystem", "ethereum"
         )
+        self.network_manager.set_default_ecosystem(self.default_ecosystem)
 
         dependencies = user_config.pop("dependencies", []) or []
         if not isinstance(dependencies, list):

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -320,14 +320,14 @@ class NetworkManager(BaseManager):
             # Only ecosystem and network were specified, not provider
             ecosystem_name, network_name = selections
             ecosystem = self.get_ecosystem(ecosystem_name or self.default_ecosystem.name)
-            network = ecosystem.get_network(network_name)
+            network = ecosystem.get_network(network_name or ecosystem.default_network)
             return network.get_provider(provider_settings=provider_settings)
 
         elif len(selections) == 3:
             # Everything is specified, use specified provider for ecosystem and network
             ecosystem_name, network_name, provider_name = selections
             ecosystem = self.get_ecosystem(ecosystem_name or self.default_ecosystem.name)
-            network = ecosystem.get_network(network_name)
+            network = ecosystem.get_network(network_name or ecosystem.default_network)
             return network.get_provider(
                 provider_name=provider_name, provider_settings=provider_settings
             )

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -250,6 +250,12 @@ class NetworkManager(BaseManager):
             if ecosystem_has_providers:
                 yield ecosystem_name
 
+    def get_ecosystem(self, ecosystem_name: str) -> EcosystemAPI:
+        if ecosystem_name not in self.ecosystem_names:
+            raise NetworkError(f"Ecosystem '{ecosystem_name}' not found.")
+
+        return self.ecosystems[ecosystem_name]
+
     def get_provider_from_choice(
         self,
         network_choice: Optional[str] = None,
@@ -291,7 +297,7 @@ class NetworkManager(BaseManager):
         if selections == network_choice or len(selections) == 1:
             # Either split didn't work (in which case it matches the start)
             # or there was nothing after the ``:`` (e.g. "ethereum:")
-            ecosystem = self.ecosystems[selections[0] or self.default_ecosystem.name]
+            ecosystem = self.get_ecosystem(selections[0] or self.default_ecosystem.name)
             # By default, the "local" network should be specified for
             # any ecosystem (this should not correspond to a production chain)
             default_network = ecosystem.default_network
@@ -300,16 +306,15 @@ class NetworkManager(BaseManager):
         elif len(selections) == 2:
             # Only ecosystem and network were specified, not provider
             ecosystem_name, network_name = selections
-            ecosystem = self.ecosystems[ecosystem_name or self.default_ecosystem.name]
-            network = ecosystem[network_name or ecosystem.default_network]
+            ecosystem = self.get_ecosystem(ecosystem_name or self.default_ecosystem.name)
+            network = ecosystem.get_network(network_name)
             return network.get_provider(provider_settings=provider_settings)
 
         elif len(selections) == 3:
-            # Everything is specified, use specified provider for ecosystem
-            # and network
+            # Everything is specified, use specified provider for ecosystem and network
             ecosystem_name, network_name, provider_name = selections
-            ecosystem = self.ecosystems[ecosystem_name or self.default_ecosystem.name]
-            network = ecosystem[network_name or ecosystem.default_network]
+            ecosystem = self.get_ecosystem(ecosystem_name or self.default_ecosystem.name)
+            network = ecosystem.get_network(network_name)
             return network.get_provider(
                 provider_name=provider_name, provider_settings=provider_settings
             )

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -251,6 +251,19 @@ class NetworkManager(BaseManager):
                 yield ecosystem_name
 
     def get_ecosystem(self, ecosystem_name: str) -> EcosystemAPI:
+        """
+        Get the ecosystem for the given name.
+
+        Args:
+            ecosystem_name (str): The name of the ecosystem to get.
+
+        Raises:
+            :class:`~ape.exceptions.NetworkError`: When the ecosystem is not found.
+
+        Returns:
+            :class:`~ape.api.networks.EcosystemAPI`
+        """
+
         if ecosystem_name not in self.ecosystem_names:
             raise NetworkError(f"Ecosystem '{ecosystem_name}' not found.")
 


### PR DESCRIPTION
### What I did

* Make it raise better errors when ecosystems or networks don't exist in the network choice.
* Call `set_default_ecosystem()` in a place (was missing before somehow...)

### How I did it

* Delegate to getter methods that already raise instead of using dict access.

### How to verify it

* Use bad networks / ecosystems in `--network` CLI option
* Make sure changing the default ecosystem works

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
