### PR TITLE
fix: handle non-length 42 addresses in to_address utility method

### DIFF
--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -201,13 +201,15 @@ def expand_environment_variables(contents: str) -> str:
 
 def to_address(value: Union[int, str, bytes]) -> AddressType:
     """
-    Makes a checksum address given a supported format.
+    Make a checksum address given a supported format.
+    Borrowed from ``eth_utils.to_checksum_address()`` but supports
+    non-length 42 addresses.
 
     Args:
         value (Union[int, str, bytes]): The value to convert.
 
     Returns:
-
+        ``AddressType``: The converted address.
     """
     try:
         hex_address = hexstr_if_str(to_hex, value).lower()

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -214,8 +214,10 @@ def to_address(value: Union[int, str, bytes]) -> AddressType:
     try:
         hex_address = hexstr_if_str(to_hex, value).lower()
     except AttributeError:
-        raise AddressError("Value must be any string, instead got type {}".format(type(value)))
-    address_hash = encode_hex(keccak(text=remove_0x_prefix(HexStr(hex_address))))
+        raise AddressError(f"Value must be any string, instead got type {type(value)}")
+
+    cleaned_address = remove_0x_prefix(HexStr(hex_address))
+    address_hash = encode_hex(keccak(text=cleaned_address))
 
     checksum_address = add_0x_prefix(
         HexStr(
@@ -225,7 +227,9 @@ def to_address(value: Union[int, str, bytes]) -> AddressType:
             )
         )
     )
-    return AddressType(HexAddress(checksum_address))
+
+    hex_address = HexAddress(checksum_address)
+    return AddressType(hex_address)
 
 
 def load_config(path: Path, expand_envars=True, must_exist=False) -> Dict:

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -2,10 +2,13 @@ from pathlib import Path
 
 import pytest
 
-from ape.utils import extract_nested_value, get_relative_path
+from ape.types import AddressType
+from ape.utils import extract_nested_value, get_relative_path, to_address
 
 _TEST_DIRECTORY_PATH = Path("/This/is/a/test/")
 _TEST_FILE_PATH = _TEST_DIRECTORY_PATH / "scripts" / "script.py"
+_TEST_ADDRESS_LENGTH_42 = "0x1e59ce931B4CFea3fe4B875411e280e173cB7A9C"
+_TEST_ADDRESS_LENGTH_65 = "0x3371cA9a145A2168095bA668F9032E32A36257bEbb8f19B324953BdfAbF986D"
 
 
 def test_get_relative_path_from_project():
@@ -48,3 +51,18 @@ def test_extract_nested_value():
 def test_extract_nested_value_non_dict_in_middle_returns_none():
     structure = {"foo": {"non_dict": 3, "bar": {"test": "expected_value"}}}
     assert not extract_nested_value(structure, "foo", "non_dict", "test")
+
+
+@pytest.mark.parametrize(
+    "address,expected",
+    [
+        (_TEST_ADDRESS_LENGTH_42, _TEST_ADDRESS_LENGTH_42),
+        (_TEST_ADDRESS_LENGTH_42.lower(), _TEST_ADDRESS_LENGTH_42),
+        (int(_TEST_ADDRESS_LENGTH_42, 16), _TEST_ADDRESS_LENGTH_42),
+        (_TEST_ADDRESS_LENGTH_65, _TEST_ADDRESS_LENGTH_65),
+        (_TEST_ADDRESS_LENGTH_65.lower(), _TEST_ADDRESS_LENGTH_65),
+        (int(_TEST_ADDRESS_LENGTH_65, 16), _TEST_ADDRESS_LENGTH_65),
+    ],
+)
+def test_to_address_length_42(address, expected):
+    assert to_address(address) == AddressType(expected)  # type: ignore

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from eth_typing import HexAddress, HexStr
 
 from ape.types import AddressType
 from ape.utils import extract_nested_value, get_relative_path, to_address
@@ -9,6 +10,9 @@ _TEST_DIRECTORY_PATH = Path("/This/is/a/test/")
 _TEST_FILE_PATH = _TEST_DIRECTORY_PATH / "scripts" / "script.py"
 _TEST_ADDRESS_LENGTH_42 = "0x1e59ce931B4CFea3fe4B875411e280e173cB7A9C"
 _TEST_ADDRESS_LENGTH_65 = "0x3371cA9a145A2168095bA668F9032E32A36257bEbb8f19B324953BdfAbF986D"
+_TEST_ADDRESS_LENGTH_65_BASE_10_INT = (
+    1454312956425231564955025285697091227660359923931196392608153442662173612141
+)
 
 
 def test_get_relative_path_from_project():
@@ -62,7 +66,8 @@ def test_extract_nested_value_non_dict_in_middle_returns_none():
         (_TEST_ADDRESS_LENGTH_65, _TEST_ADDRESS_LENGTH_65),
         (_TEST_ADDRESS_LENGTH_65.lower(), _TEST_ADDRESS_LENGTH_65),
         (int(_TEST_ADDRESS_LENGTH_65, 16), _TEST_ADDRESS_LENGTH_65),
+        (_TEST_ADDRESS_LENGTH_65_BASE_10_INT, _TEST_ADDRESS_LENGTH_65),
     ],
 )
 def test_to_address_length_42(address, expected):
-    assert to_address(address) == AddressType(expected)  # type: ignore
+    assert to_address(address) == AddressType(HexAddress(HexStr(expected)))


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #579 

### How I did it
<!-- Discuss the thought process behind the change -->

* Copy code from `eth_utils.to_checksum_address()` method
* Replace part that assumes the length is 42 with the length of `hex_address` that gets created.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

See tests!

Or, install an ecosystem plugin that does not have addresses with this length and make sure you can do stuff like `ape accounts list --all` and they show up.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
