### PR TITLE
feat: add utils method for adding spacing to strings

### DIFF
--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -326,29 +326,29 @@ def extract_nested_value(root: Mapping, *args: str) -> Optional[Dict]:
     return current_value
 
 
-def pad_strings(
-    str_list: List[str], extra_spaces: int = 0, filler: Optional[str] = None
+def add_padding_to_strings(
+    str_list: List[str], extra_spaces: int = 0, space_character: Optional[str] = None
 ) -> List[str]:
     """
-    Append spacing to the end of a list of strings
-    such that they are all the same length.
+    Append spacing to each string in a list of strings such that
+    they all have the same length.
 
     Args:
         str_list (List[str]): The list of strings to add padding to.
         extra_spaces (Optional[int]): Optionally append extra spacing.
-        filler (Optional[str]): The character to use in the padding.
+        space_character (Optional[str]): The character to use in the padding.
           Defaults to the empty string.
 
     Returns:
         List[str]: A list of equal-length strings with padded spaces.
     """
 
-    filler = filler or ""
+    space_character = space_character or ""
     longest_item = len(max(str_list, key=len))
     spaced_items = []
 
     for value in str_list:
-        spacing = (longest_item - len(value) + extra_spaces) * filler
+        spacing = (longest_item - len(value) + extra_spaces) * space_character
         spaced_items.append(f"{value}{spacing}")
 
     return spaced_items

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -336,7 +336,7 @@ def add_padding_to_strings(
     they all have the same length.
 
     Args:
-        str_list (List[str]): The list of strings to add padding to.
+        str_list (List[str]): The list of strings that need padding.
         extra_spaces (int): Optionally append extra spacing. Defaults to ``0``.
         space_character (str): The character to use in the padding. Defaults to ``" "``.
 

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -337,9 +337,8 @@ def add_padding_to_strings(
 
     Args:
         str_list (List[str]): The list of strings to add padding to.
-        extra_spaces (Optional[int]): Optionally append extra spacing.
-        space_character (str): The character to use in the padding.
-          Defaults to ``" "``.
+        extra_spaces (int): Optionally append extra spacing. Defaults to ``0``.
+        space_character (str): The character to use in the padding. Defaults to ``" "``.
 
     Returns:
         List[str]: A list of equal-length strings with padded spaces.

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -327,7 +327,9 @@ def extract_nested_value(root: Mapping, *args: str) -> Optional[Dict]:
 
 
 def add_padding_to_strings(
-    str_list: List[str], extra_spaces: int = 0, space_character: Optional[str] = None
+    str_list: List[str],
+    extra_spaces: int = 0,
+    space_character: str = " ",
 ) -> List[str]:
     """
     Append spacing to each string in a list of strings such that
@@ -336,14 +338,13 @@ def add_padding_to_strings(
     Args:
         str_list (List[str]): The list of strings to add padding to.
         extra_spaces (Optional[int]): Optionally append extra spacing.
-        space_character (Optional[str]): The character to use in the padding.
-          Defaults to the empty string.
+        space_character (str): The character to use in the padding.
+          Defaults to ``" "``.
 
     Returns:
         List[str]: A list of equal-length strings with padded spaces.
     """
 
-    space_character = space_character or ""
     longest_item = len(max(str_list, key=len))
     spaced_items = []
 

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -326,6 +326,34 @@ def extract_nested_value(root: Mapping, *args: str) -> Optional[Dict]:
     return current_value
 
 
+def pad_strings(
+    str_list: List[str], extra_spaces: int = 0, filler: Optional[str] = None
+) -> List[str]:
+    """
+    Append spacing to the end of a list of strings
+    such that they are all the same length.
+
+    Args:
+        str_list (List[str]): The list of strings to add padding to.
+        extra_spaces (Optional[int]): Optionally append extra spacing.
+        filler (Optional[str]): The character to use in the padding.
+          Defaults to the empty string.
+
+    Returns:
+        List[str]: A list of equal-length strings with padded spaces.
+    """
+
+    filler = filler or ""
+    longest_item = len(max(str_list, key=len))
+    spaced_items = []
+
+    for value in str_list:
+        spacing = (longest_item - len(value) + extra_spaces) * filler
+        spaced_items.append(f"{value}{spacing}")
+
+    return spaced_items
+
+
 def stream_response(download_url: str, progress_bar_description: str = "Downloading") -> bytes:
     """
     Download HTTP content by streaming and returning the bytes.

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -138,7 +138,7 @@ def _list(cli_ctx, display_all):
         if available_second_output:
             sections["Available Plugins"] = [available_second_output]
         elif github_client.available_plugins:
-            click.echo("You have installed all the available plugins\n")
+            click.echo("You have installed all the available plugins.\n")
 
     for i in range(0, len(sections)):
         header = list(sections.keys())[i]

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -8,7 +8,7 @@ import click
 from ape.cli import ape_cli_context, skip_confirmation_option
 from ape.managers.config import CONFIG_FILE_NAME
 from ape.plugins import plugin_manager
-from ape.utils import github_client, load_config, pad_strings
+from ape.utils import add_padding_to_strings, github_client, load_config
 from ape_plugins.utils import ApePlugin, ModifyPluginResultHandler
 
 
@@ -97,7 +97,7 @@ def _list(cli_ctx, display_all):
     installed_org_plugins = {}
     installed_third_party_plugins = {}
     plugin_list = plugin_manager.list_name_plugin()
-    spaced_names = pad_strings([p[0] for p in plugin_list], extra_spaces=4)
+    spaced_names = add_padding_to_strings([p[0] for p in plugin_list], extra_spaces=4)
 
     for name in spaced_names:
         plugin = ApePlugin(name)

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -8,7 +8,7 @@ import click
 from ape.cli import ape_cli_context, skip_confirmation_option
 from ape.managers.config import CONFIG_FILE_NAME
 from ape.plugins import plugin_manager
-from ape.utils import github_client, load_config
+from ape.utils import github_client, load_config, pad_strings
 from ape_plugins.utils import ApePlugin, ModifyPluginResultHandler
 
 
@@ -82,7 +82,7 @@ def upgrade_option(help: str = "", **kwargs):
     return click.option("-U", "--upgrade", default=False, is_flag=True, help=help, **kwargs)
 
 
-@cli.command(name="list")
+@cli.command(name="list", short_help="Display plugins")
 @click.option(
     "-a",
     "--all",
@@ -93,76 +93,59 @@ def upgrade_option(help: str = "", **kwargs):
 )
 @ape_cli_context()
 def _list(cli_ctx, display_all):
-    """Display plugins"""
-
-    installed_first_class_plugins = set()
-    installed_second_class_plugins = set()
-    installed_second_class_plugins_no_version = set()
-    installed_third_class_plugins = set()
-
+    installed_core_plugins = set()
+    installed_org_plugins = {}
+    installed_third_party_plugins = {}
     plugin_list = plugin_manager.list_name_plugin()
-    plugin_names = [p[0] for p in plugin_list]
-    longest_plugin_name = len(max(plugin_names, key=len))
-    space_buffer = 4
+    spaced_names = pad_strings([p[0] for p in plugin_list], extra_spaces=4)
 
-    for name, _ in plugin_list:
+    for name in spaced_names:
         plugin = ApePlugin(name)
-        spacing = (longest_plugin_name - len(plugin.name) + space_buffer) * " "
+
         if plugin.is_part_of_core:
             if not display_all:
-                continue  # NOTE: Skip 1st class plugins unless specified
+                continue
 
-            installed_first_class_plugins.add(name)
+            installed_core_plugins.add(name)
 
         elif plugin.is_available:
-            installed_second_class_plugins.add(f"{name}{spacing}{plugin.current_version}")
-            installed_second_class_plugins_no_version.add(name)
-
+            installed_org_plugins[name] = plugin.current_version
         elif not plugin.is_part_of_core or not plugin.is_available:
-            installed_third_class_plugins.add(f"{name}{spacing}{plugin.current_version}")
+            installed_third_party_plugins[name] = plugin.current_version
         else:
             cli_ctx.logger.error(f"'{plugin.name}' is not a plugin.")
 
     sections = {}
-
-    # First Class Plugins
     if display_all:
-        sections["Installed Core Plugins"] = [installed_first_class_plugins]
+        sections["Installed Core Plugins"] = [installed_core_plugins]
 
-    # Second and Third Class Plugins
-    available_second = list(
-        github_client.available_plugins - installed_second_class_plugins_no_version
-    )
+    # Get all plugins that are available and not already installed.
+    available_plugins = list(github_client.available_plugins - installed_org_plugins.keys())
 
-    installed_plugins = []
-    if installed_second_class_plugins:
-        installed_plugins.append(installed_second_class_plugins)
+    # Get the list of plugin lists that are populated.
+    installed_plugin_lists = [
+        ls for ls in [installed_org_plugins, installed_third_party_plugins] if ls
+    ]
 
-    if installed_third_class_plugins:
-        installed_plugins.append(installed_third_class_plugins)
-
-    if installed_plugins:
-        sections["Installed Plugins"] = installed_plugins
-    elif not display_all:
-        # user has no plugins installed | cant verify installed plugins
-        if available_second:
-            click.echo("No secondary plugins installed. Use '--all' to see available plugins.")
+    if installed_plugin_lists:
+        sections["Installed Plugins"] = installed_plugin_lists
+    elif not display_all and available_plugins:
+        # User has no plugins installed | can't verify installed plugins
+        click.echo("No secondary plugins installed. Use '--all' to see available plugins.")
 
     if display_all:
-        available_second_output = _format_output(available_second)
+        available_second_output = _format_output(available_plugins)
         if available_second_output:
             sections["Available Plugins"] = [available_second_output]
-
-        else:
-            if github_client.available_plugins:
-                click.echo("You have installed all the available Plugins\n")
+        elif github_client.available_plugins:
+            click.echo("You have installed all the available plugins\n")
 
     for i in range(0, len(sections)):
         header = list(sections.keys())[i]
         output = sections[header]
         _display_section(f"{header}:", output)
 
-        if i < (len(sections) - 1):
+        if i < len(sections) - 1:
             click.echo()
 
 

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from ape.utils import extract_nested_value, get_relative_path
+from ape.utils import add_padding_to_strings, extract_nested_value, get_relative_path
 
 _TEST_DIRECTORY_PATH = Path("/This/is/a/test/")
 _TEST_FILE_PATH = _TEST_DIRECTORY_PATH / "scripts" / "script.py"
@@ -48,3 +48,10 @@ def test_extract_nested_value():
 def test_extract_nested_value_non_dict_in_middle_returns_none():
     structure = {"foo": {"non_dict": 3, "bar": {"test": "expected_value"}}}
     assert not extract_nested_value(structure, "foo", "non_dict", "test")
+
+
+def test_add_spacing_to_strings():
+    string_list = ["foo", "address", "ethereum"]
+    expected = ["foo         ", "address     ", "ethereum    "]
+    actual = add_padding_to_strings(string_list, extra_spaces=4)
+    assert actual == expected


### PR DESCRIPTION
### What I did and How I did it

I wanted to do something similar to what we were doing in `ape plugins list` where we added spacing. I looked for a way to share this logic so we can do this again. While swapping it out in the `list` command implementation, I cleaned up the command's code.

### How to verify it

The `ape plugins list` command uses the new method `add_spacing_to_strings()`.
Run these commands like this:

`ape plugins list`
`ape plugins list --all`

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
