### PR TITLE
refactor: use single dispatch for DefaultQueryProvider

### DIFF
--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -8,7 +8,7 @@ from ape.api import QueryAPI, QueryType
 from ape.api.query import BlockQuery, _BaseQuery
 from ape.exceptions import QueryEngineError
 from ape.plugins import clean_plugin_name
-from ape.utils import ManagerAccessMixin, cached_property
+from ape.utils import ManagerAccessMixin, cached_property, singledispatchmethod
 
 
 def get_columns_from_item(query: _BaseQuery, item: BaseModel) -> Dict[str, Any]:
@@ -21,38 +21,24 @@ class DefaultQueryProvider(QueryAPI):
     Allows for the query of blockchain data using connected provider
     """
 
+    @singledispatchmethod
     def estimate_query(self, query: QueryType) -> Optional[int]:
-        """
-        Estimates the time that the query will take as a timestamp
-
-        Args:
-            query (``QueryType``): The transaction data you want to query
-
-        Returns:
-             Optional[int]: Depends on whether the query can be completed
-        """
-        if isinstance(query, BlockQuery):
-            # NOTE: Very loose estimate of 100ms per block
-            return (query.stop_block - query.start_block) * 100
-
         return None  # can't handle this query
 
+    @estimate_query.register
+    def estimate_block_query(self, query: BlockQuery) -> Optional[int]:
+        # NOTE: Very loose estimate of 100ms per block
+        return (query.stop_block - query.start_block) * 100
+
+    @singledispatchmethod
     def perform_query(self, query: QueryType) -> pd.DataFrame:
-        """
-        Performs a query
-
-        Args:
-            query (``QueryType``): The specific transaction data you want to query
-
-        Returns:
-            pd.DataFrame: A pandas dataframe
-        """
-        if isinstance(query, BlockQuery):
-            blocks_iter = self.chain_manager.blocks.range(query.start_block, query.stop_block)
-            block_dicts_iter = map(partial(get_columns_from_item, query), blocks_iter)
-            return pd.DataFrame(columns=query.columns, data=block_dicts_iter)
-
         raise QueryEngineError(f"Cannot handle '{type(query)}'.")
+
+    @perform_query.register
+    def perform_block_query(self, query: BlockQuery) -> pd.DataFrame:
+        blocks_iter = self.chain_manager.blocks.range(query.start_block, query.stop_block)
+        block_dicts_iter = map(partial(get_columns_from_item, query), blocks_iter)
+        return pd.DataFrame(columns=query.columns, data=block_dicts_iter)
 
 
 class QueryManager(ManagerAccessMixin):

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -23,13 +23,6 @@ class DefaultQueryProvider(QueryAPI):
 
     @singledispatchmethod
     def estimate_query(self, query: QueryType) -> Optional[int]:
-        """
-        Estimates the time that the query will take as a timestamp
-        Args:
-            query (``QueryType``): The transaction data you want to query
-        Returns:
-             Optional[int]: Depends on whether the query can be completed
-        """
 
         return None  # can't handle this query
 
@@ -40,13 +33,6 @@ class DefaultQueryProvider(QueryAPI):
 
     @singledispatchmethod
     def perform_query(self, query: QueryType) -> pd.DataFrame:
-        """
-        Performs a query
-        Args:
-            query (``QueryType``): The specific transaction data you want to query
-        Returns:
-            pd.DataFrame: A pandas dataframe
-        """
 
         raise QueryEngineError(f"Cannot handle '{type(query)}'.")
 

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -23,6 +23,14 @@ class DefaultQueryProvider(QueryAPI):
 
     @singledispatchmethod
     def estimate_query(self, query: QueryType) -> Optional[int]:
+        """
+        Estimates the time that the query will take as a timestamp
+        Args:
+            query (``QueryType``): The transaction data you want to query
+        Returns:
+             Optional[int]: Depends on whether the query can be completed
+        """
+
         return None  # can't handle this query
 
     @estimate_query.register
@@ -32,6 +40,14 @@ class DefaultQueryProvider(QueryAPI):
 
     @singledispatchmethod
     def perform_query(self, query: QueryType) -> pd.DataFrame:
+        """
+        Performs a query
+        Args:
+            query (``QueryType``): The specific transaction data you want to query
+        Returns:
+            pd.DataFrame: A pandas dataframe
+        """
+
         raise QueryEngineError(f"Cannot handle '{type(query)}'.")
 
     @perform_query.register

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -689,7 +689,7 @@ class BaseInterfaceModel(BaseInterface, BaseModel):
 
         #    TypeError: cannot pickle '_thread.RLock' object
 
-        keep_untouched = (cached_property,)
+        keep_untouched = (cached_property, singledispatchmethod)
         arbitrary_types_allowed = True
         underscore_attrs_are_private = True
         anystr_strip_whitespace = True


### PR DESCRIPTION
### What I did
Added singledispatch to DefaultQueryProvider

### How I did it
Under the config for the BaseInterfaceModel I added singledispatchmethod to keep_untouched
Then added @singledispatchmethod

### How to verify it
Passes original test

### Checklist

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
