### PR TITLE
fix: parent_hash field is set incorrectly

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -212,7 +212,7 @@ class Ethereum(EcosystemAPI):
             size=data.get("size"),
             timestamp=data.get("timestamp"),
             hash=data.get("hash"),
-            parent_hash=data.get("hash"),
+            parent_hash=data.get("parentHash"),
         )
 
     def encode_calldata(self, abi: Union[ConstructorABI, MethodABI], *args) -> bytes:

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -1,6 +1,7 @@
 import datetime
 
 import pytest
+from hexbytes import HexBytes
 
 from ape.exceptions import ChainError
 
@@ -90,9 +91,12 @@ def test_blocks_range(chain_at_block_5):
     assert len(blocks) == expected_number_of_blocks
 
     expected_number = 0
+    prev_block_hash = HexBytes("0x0000000000000000000000000000000000000000000000000000000000000000")
     for block in blocks:
         assert block.number == expected_number
         expected_number += 1
+        assert block.parent_hash == prev_block_hash
+        prev_block_hash = block.hash
 
 
 def test_blocks_range_too_high_stop(chain_at_block_5):


### PR DESCRIPTION
### What I did
Noticed that Ethereum blocks had the same value set for both `hash` and `parent_hash`, so I fixed it

fixes: #592
