### PR TITLE
fix: bug preventing compiling individual contracts that use dependencies

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -120,7 +120,7 @@ class ProjectAPI(BaseInterfaceModel):
 
     @classmethod
     def _create_source_dict(
-        cls, contracts_paths: Collection[Path], base_path: Path
+        cls, contract_paths: Collection[Path], base_path: Path
     ) -> Dict[str, Source]:
         return {
             str(get_relative_path(source, base_path)): Source(  # type: ignore
@@ -131,7 +131,7 @@ class ProjectAPI(BaseInterfaceModel):
                 urls=[],
                 content=source.read_text(),
             )
-            for source in contracts_paths
+            for source in contract_paths
         }
 
 

--- a/src/ape/cli/paramtype.py
+++ b/src/ape/cli/paramtype.py
@@ -28,5 +28,5 @@ class AllFilePaths(Path):
     ) -> List[PathLibPath]:
         path = super().convert(value, param, ctx)
 
-        # NOTE: Return the path if it does not exist so it can it can be resolved downstream.
+        # NOTE: Return the path if it does not exist so it can be resolved downstream.
         return get_all_files_in_directory(path) if path.exists() else [path]

--- a/src/ape/cli/paramtype.py
+++ b/src/ape/cli/paramtype.py
@@ -27,4 +27,6 @@ class AllFilePaths(Path):
         self, value: Any, param: Optional["Parameter"], ctx: Optional["Context"]
     ) -> List[PathLibPath]:
         path = super().convert(value, param, ctx)
-        return get_all_files_in_directory(path)
+
+        # NOTE: Return the path if it does not exist so it can it can be resolved downstream.
+        return get_all_files_in_directory(path) if path.exists() else [path]

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -115,9 +115,9 @@ class CompilerManager(BaseManager):
 
     def _get_contract_extensions(self, contract_filepaths: List[Path]) -> Set[str]:
         extensions = set(path.suffix for path in contract_filepaths)
-        unhandled_extensions = extensions - set(self.registered_compilers)
+        unhandled_extensions = {s for s in extensions - set(self.registered_compilers) if s}
         if len(unhandled_extensions) > 0:
             unhandled_extensions_str = ", ".join(unhandled_extensions)
             raise CompilerError(f"No compiler found for extensions [{unhandled_extensions_str}].")
 
-        return extensions
+        return {e for e in extensions if e}

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -581,8 +581,11 @@ def get_all_files_in_directory(path: Path) -> List[Path]:
     Returns:
         List[pathlib.Path]: A list of files in the given directory.
     """
+    if not path.exists():
+        return []
+
     if path.is_dir():
-        return list(path.rglob("*.*"))
+        return [p for p in list(path.rglob("*.*")) if not p.is_dir() and p.exists()]
 
     return [path]
 

--- a/tests/integration/cli/projects/with-dependency/contracts/Other.json
+++ b/tests/integration/cli/projects/with-dependency/contracts/Other.json
@@ -1,0 +1,3 @@
+[
+    {"name":"foo","type":"fallback", "stateMutability":"nonpayable"}
+]


### PR DESCRIPTION
### What I did

fix bug that @Ninjagod1251 found where you give you an argument to `ape compile` and that contract has uncompiled dependencies, it would fail.

### How I did it

Ensure the dependencies are included in sources.
They are missing when the user passes in arguments but not otherwise.

### How to verify it

Go to a project with deps and run 
```bash
ape compile MyContractWithDeps
```

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
