### PR TITLE
refactor: pulled logic from ChainManager.blocks.range to DefaultQueryProvider

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -134,6 +134,57 @@ class BlockContainer(BaseManager):
 
         return self.query_manager.query(query)
 
+    def range(
+        self, start_or_stop: int, stop: Optional[int] = None, step: int = 1
+    ) -> Iterator[BlockAPI]:
+        """
+        Iterate over blocks. Works similarly to python ``range()``.
+
+        Raises:
+            :class:`~ape.exceptions.ChainError`: When ``stop`` is greater
+                than the chain length.
+            :class:`~ape.exceptions.ChainError`: When ``stop`` is less
+                than ``start_block``.
+            :class:`~ape.exceptions.ChainError`: When ``stop`` is less
+                than 0.
+            :class:`~ape.exceptions.ChainError`: When ``start`` is less
+                than 0.
+
+        Args:
+            start_or_stop (int): When given just a single value, it is the stop.
+              Otherwise, it is the start. This mimics the behavior of ``range``
+              built-in Python function.
+            stop (Optional[int]): The block number to stop before. Also the total
+              number of blocks to get. If not setting a start value, is set by
+              the first argument.
+            step (Optional[int]): The value to increment by. Defaults to ``1``.
+             number of blocks to get. Defaults to the latest block.
+
+        Returns:
+            Iterator[:class:`~ape.api.providers.BlockAPI`]
+        """
+
+        if stop is None:
+            stop = start_or_stop
+            start = 0
+        else:
+            start = start_or_stop
+
+        if stop > len(self):
+            raise ChainError(
+                f"'stop={stop}' cannot be greater than the chain length ({len(self)}). "
+                f"Use '{self.poll_blocks.__name__}()' to wait for future blocks."
+            )
+        elif stop < start:
+            raise ValueError(f"stop '{stop}' cannot be less than start '{start}'.")
+        elif stop < 0:
+            raise ValueError(f"start '{start}' cannot be negative.")
+        elif start_or_stop < 0:
+            raise ValueError(f"stop '{stop}' cannot be negative.")
+
+        for i in range(start, stop, step):
+            yield self._get_block(i)
+
     def poll_blocks(
         self,
         start: Optional[int] = None,

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -134,9 +134,7 @@ class BlockContainer(BaseManager):
 
         return self.query_manager.query(query)
 
-    def range(
-        self, start_or_stop: int, step: int = 1
-    ) -> Iterator[BlockAPI]:
+    def range(self, start_or_stop: int, step: int = 1) -> Iterator[BlockAPI]:
         return self.query_manager.get_blocks(start_or_stop, stop=None, step=step)
 
     def poll_blocks(

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -137,53 +137,7 @@ class BlockContainer(BaseManager):
     def range(
         self, start_or_stop: int, stop: Optional[int] = None, step: int = 1
     ) -> Iterator[BlockAPI]:
-        """
-        Iterate over blocks. Works similarly to python ``range()``.
-
-        Raises:
-            :class:`~ape.exceptions.ChainError`: When ``stop`` is greater
-                than the chain length.
-            :class:`~ape.exceptions.ChainError`: When ``stop`` is less
-                than ``start_block``.
-            :class:`~ape.exceptions.ChainError`: When ``stop`` is less
-                than 0.
-            :class:`~ape.exceptions.ChainError`: When ``start`` is less
-                than 0.
-
-        Args:
-            start_or_stop (int): When given just a single value, it is the stop.
-              Otherwise, it is the start. This mimics the behavior of ``range``
-              built-in Python function.
-            stop (Optional[int]): The block number to stop before. Also the total
-              number of blocks to get. If not setting a start value, is set by
-              the first argument.
-            step (Optional[int]): The value to increment by. Defaults to ``1``.
-             number of blocks to get. Defaults to the latest block.
-
-        Returns:
-            Iterator[:class:`~ape.api.providers.BlockAPI`]
-        """
-
-        if stop is None:
-            stop = start_or_stop
-            start = 0
-        else:
-            start = start_or_stop
-
-        if stop > len(self):
-            raise ChainError(
-                f"'stop={stop}' cannot be greater than the chain length ({len(self)}). "
-                f"Use '{self.poll_blocks.__name__}()' to wait for future blocks."
-            )
-        elif stop < start:
-            raise ValueError(f"stop '{stop}' cannot be less than start '{start}'.")
-        elif stop < 0:
-            raise ValueError(f"start '{start}' cannot be negative.")
-        elif start_or_stop < 0:
-            raise ValueError(f"stop '{stop}' cannot be negative.")
-
-        for i in range(start, stop, step):
-            yield self._get_block(i)
+        return self.query_manager.query.get_blocks(start_or_stop, stop, step)
 
     def poll_blocks(
         self,

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -137,7 +137,7 @@ class BlockContainer(BaseManager):
     def range(
         self, start_or_stop: int, stop: Optional[int] = None, step: int = 1
     ) -> Iterator[BlockAPI]:
-        return self.query_manager.query.get_blocks(start_or_stop, stop, step)
+        return self.query_manager.get_blocks(start_or_stop, stop, step)
 
     def poll_blocks(
         self,

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -135,9 +135,9 @@ class BlockContainer(BaseManager):
         return self.query_manager.query(query)
 
     def range(
-        self, start_or_stop: int, stop: Optional[int] = None, step: int = 1
+        self, start_or_stop: int, step: int = 1
     ) -> Iterator[BlockAPI]:
-        return self.query_manager.get_blocks(start_or_stop, stop, step)
+        return self.query_manager.get_blocks(start_or_stop, stop=None, step=step)
 
     def poll_blocks(
         self,

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -134,8 +134,10 @@ class BlockContainer(BaseManager):
 
         return self.query_manager.query(query)
 
-    def range(self, start_or_stop: int, step: int = 1) -> Iterator[BlockAPI]:
-        return self.query_manager.get_blocks(start_or_stop, stop=None, step=step)
+    def range(
+        self, start_or_stop: int, stop: Optional[int] = None, step: int = 1
+    ) -> Iterator[BlockAPI]:
+        return self.query_manager.get_blocks(start_or_stop, stop, step)
 
     def poll_blocks(
         self,

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -134,57 +134,6 @@ class BlockContainer(BaseManager):
 
         return self.query_manager.query(query)
 
-    def range(
-        self, start_or_stop: int, stop: Optional[int] = None, step: int = 1
-    ) -> Iterator[BlockAPI]:
-        """
-        Iterate over blocks. Works similarly to python ``range()``.
-
-        Raises:
-            :class:`~ape.exceptions.ChainError`: When ``stop`` is greater
-                than the chain length.
-            :class:`~ape.exceptions.ChainError`: When ``stop`` is less
-                than ``start_block``.
-            :class:`~ape.exceptions.ChainError`: When ``stop`` is less
-                than 0.
-            :class:`~ape.exceptions.ChainError`: When ``start`` is less
-                than 0.
-
-        Args:
-            start_or_stop (int): When given just a single value, it is the stop.
-              Otherwise, it is the start. This mimics the behavior of ``range``
-              built-in Python function.
-            stop (Optional[int]): The block number to stop before. Also the total
-              number of blocks to get. If not setting a start value, is set by
-              the first argument.
-            step (Optional[int]): The value to increment by. Defaults to ``1``.
-             number of blocks to get. Defaults to the latest block.
-
-        Returns:
-            Iterator[:class:`~ape.api.providers.BlockAPI`]
-        """
-
-        if stop is None:
-            stop = start_or_stop
-            start = 0
-        else:
-            start = start_or_stop
-
-        if stop > len(self):
-            raise ChainError(
-                f"'stop={stop}' cannot be greater than the chain length ({len(self)}). "
-                f"Use '{self.poll_blocks.__name__}()' to wait for future blocks."
-            )
-        elif stop < start:
-            raise ValueError(f"stop '{stop}' cannot be less than start '{start}'.")
-        elif stop < 0:
-            raise ValueError(f"start '{start}' cannot be negative.")
-        elif start_or_stop < 0:
-            raise ValueError(f"stop '{stop}' cannot be negative.")
-
-        for i in range(start, stop, step):
-            yield self._get_block(i)
-
     def poll_blocks(
         self,
         start: Optional[int] = None,

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -1,12 +1,12 @@
 from functools import partial
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Iterator
 
 import pandas as pd
 from pydantic import BaseModel
 
-from ape.api import QueryAPI, QueryType
+from ape.api import QueryAPI, QueryType, BlockAPI
 from ape.api.query import BlockQuery, _BaseQuery
-from ape.exceptions import QueryEngineError
+from ape.exceptions import QueryEngineError, ChainError
 from ape.plugins import clean_plugin_name
 from ape.utils import ManagerAccessMixin, cached_property, singledispatchmethod
 
@@ -38,9 +38,60 @@ class DefaultQueryProvider(QueryAPI):
 
     @perform_query.register
     def perform_block_query(self, query: BlockQuery) -> pd.DataFrame:
-        blocks_iter = self.chain_manager.blocks.range(query.start_block, query.stop_block)
+        blocks_iter = self.range(query.start_block, query.stop_block)
         block_dicts_iter = map(partial(get_columns_from_item, query), blocks_iter)
         return pd.DataFrame(columns=query.columns, data=block_dicts_iter)
+
+    def range(
+        self, start_or_stop: int, stop: Optional[int] = None, step: int = 1
+    ) -> Iterator[BlockAPI]:
+        """
+        Iterate over blocks. Works similarly to python ``range()``.
+
+        Raises:
+            :class:`~ape.exceptions.ChainError`: When ``stop`` is greater
+                than the chain length.
+            :class:`~ape.exceptions.ChainError`: When ``stop`` is less
+                than ``start_block``.
+            :class:`~ape.exceptions.ChainError`: When ``stop`` is less
+                than 0.
+            :class:`~ape.exceptions.ChainError`: When ``start`` is less
+                than 0.
+
+        Args:
+            start_or_stop (int): When given just a single value, it is the stop.
+              Otherwise, it is the start. This mimics the behavior of ``range``
+              built-in Python function.
+            stop (Optional[int]): The block number to stop before. Also the total
+              number of blocks to get. If not setting a start value, is set by
+              the first argument.
+            step (Optional[int]): The value to increment by. Defaults to ``1``.
+             number of blocks to get. Defaults to the latest block.
+
+        Returns:
+            Iterator[:class:`~ape.api.providers.BlockAPI`]
+        """
+
+        if stop is None:
+            stop = start_or_stop
+            start = 0
+        else:
+            start = start_or_stop
+
+        if stop > len(self.chain_manager.blocks):
+            raise ChainError(
+                f"'stop={stop}' cannot be greater than the chain length ({len(self.chain_manager.blocks)}). "
+                f"Use '{self.chain_manager.blocks.poll_blocks.__name__}()' to wait for future blocks."
+            )
+        elif stop < start:
+            raise ValueError(f"stop '{stop}' cannot be less than start '{start}'.")
+        elif stop < 0:
+            raise ValueError(f"start '{start}' cannot be negative.")
+        elif start_or_stop < 0:
+            raise ValueError(f"stop '{stop}' cannot be negative.")
+
+        for i in range(start, stop, step):
+            yield self.chain_manager.blocks._get_block(i)
 
 
 class QueryManager(ManagerAccessMixin):

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -1,12 +1,12 @@
 from functools import partial
-from typing import Any, Dict, Optional, Iterator
+from typing import Any, Dict, Iterator, Optional
 
 import pandas as pd
 from pydantic import BaseModel
 
-from ape.api import QueryAPI, QueryType, BlockAPI
+from ape.api import BlockAPI, QueryAPI, QueryType
 from ape.api.query import BlockQuery, _BaseQuery
-from ape.exceptions import QueryEngineError, ChainError
+from ape.exceptions import QueryEngineError
 from ape.plugins import clean_plugin_name
 from ape.utils import ManagerAccessMixin, cached_property, singledispatchmethod
 
@@ -38,60 +38,12 @@ class DefaultQueryProvider(QueryAPI):
 
     @perform_query.register
     def perform_block_query(self, query: BlockQuery) -> pd.DataFrame:
-        blocks_iter = self.range(query.start_block, query.stop_block)
+        blocks_iter = self.get_blocks(query.start_block, query.stop_block)
         block_dicts_iter = map(partial(get_columns_from_item, query), blocks_iter)
         return pd.DataFrame(columns=query.columns, data=block_dicts_iter)
 
-    def range(
-        self, start_or_stop: int, stop: Optional[int] = None, step: int = 1
-    ) -> Iterator[BlockAPI]:
-        """
-        Iterate over blocks. Works similarly to python ``range()``.
-
-        Raises:
-            :class:`~ape.exceptions.ChainError`: When ``stop`` is greater
-                than the chain length.
-            :class:`~ape.exceptions.ChainError`: When ``stop`` is less
-                than ``start_block``.
-            :class:`~ape.exceptions.ChainError`: When ``stop`` is less
-                than 0.
-            :class:`~ape.exceptions.ChainError`: When ``start`` is less
-                than 0.
-
-        Args:
-            start_or_stop (int): When given just a single value, it is the stop.
-              Otherwise, it is the start. This mimics the behavior of ``range``
-              built-in Python function.
-            stop (Optional[int]): The block number to stop before. Also the total
-              number of blocks to get. If not setting a start value, is set by
-              the first argument.
-            step (Optional[int]): The value to increment by. Defaults to ``1``.
-             number of blocks to get. Defaults to the latest block.
-
-        Returns:
-            Iterator[:class:`~ape.api.providers.BlockAPI`]
-        """
-
-        if stop is None:
-            stop = start_or_stop
-            start = 0
-        else:
-            start = start_or_stop
-
-        if stop > len(self.chain_manager.blocks):
-            raise ChainError(
-                f"'stop={stop}' cannot be greater than the chain length ({len(self.chain_manager.blocks)}). "
-                f"Use '{self.chain_manager.blocks.poll_blocks.__name__}()' to wait for future blocks."
-            )
-        elif stop < start:
-            raise ValueError(f"stop '{stop}' cannot be less than start '{start}'.")
-        elif stop < 0:
-            raise ValueError(f"start '{start}' cannot be negative.")
-        elif start_or_stop < 0:
-            raise ValueError(f"stop '{stop}' cannot be negative.")
-
-        for i in range(start, stop, step):
-            yield self.chain_manager.blocks._get_block(i)
+    def get_blocks(self, start_or_stop: int, stop: Optional[int] = None) -> Iterator[BlockAPI]:
+        return self.chain_manager.blocks.range(start_or_stop, stop)
 
 
 class QueryManager(ManagerAccessMixin):

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -155,7 +155,8 @@ class QueryManager(ManagerAccessMixin):
             raise ChainError(
                 f"'stop={stop}' cannot be greater than the "
                 f"chain length ({len(self.chain_manager.blocks)}). "
-                f"Use '{self.chain_manager.blocks.poll_blocks.__name__}()' to wait for future blocks."
+                f"Use '{self.chain_manager.blocks.poll_blocks.__name__}()' "
+                f"to wait for future blocks."
             )
         elif stop < start:
             raise ValueError(f"stop '{stop}' cannot be less than start '{start}'.")

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from ape.api import BlockAPI, QueryAPI, QueryType
 from ape.api.query import BlockQuery, _BaseQuery
-from ape.exceptions import QueryEngineError
+from ape.exceptions import ChainError, QueryEngineError
 from ape.plugins import clean_plugin_name
 from ape.utils import ManagerAccessMixin, cached_property, singledispatchmethod
 
@@ -42,8 +42,55 @@ class DefaultQueryProvider(QueryAPI):
         block_dicts_iter = map(partial(get_columns_from_item, query), blocks_iter)
         return pd.DataFrame(columns=query.columns, data=block_dicts_iter)
 
-    def get_blocks(self, start_or_stop: int, stop: Optional[int] = None) -> Iterator[BlockAPI]:
-        return self.chain_manager.blocks.range(start_or_stop, stop)
+    def get_blocks(
+        self, start_or_stop: int, stop: Optional[int] = None, step: int = 1
+    ) -> Iterator[BlockAPI]:
+        """
+        Iterate over blocks. Works similarly to python ``range()``.
+
+        Raises:
+            :class:`~ape.exceptions.ChainError`: When ``stop`` is greater
+                than the chain length.
+            :class:`~ape.exceptions.ChainError`: When ``stop`` is less
+                than ``start_block``.
+            :class:`~ape.exceptions.ChainError`: When ``stop`` is less
+                than 0.
+            :class:`~ape.exceptions.ChainError`: When ``start`` is less
+                than 0.
+
+        Args:
+            start_or_stop (int): When given just a single value, it is the stop.
+              Otherwise, it is the start. This mimics the behavior of ``range``
+              built-in Python function.
+            stop (Optional[int]): The block number to stop before. Also the total
+              number of blocks to get. If not setting a start value, is set by
+              the first argument.
+            step (Optional[int]): The value to increment by. Defaults to ``1``.
+             number of blocks to get. Defaults to the latest block.
+
+        Returns:
+            Iterator[:class:`~ape.api.providers.BlockAPI`]
+        """
+
+        if stop is None:
+            stop = start_or_stop
+            start = 0
+        else:
+            start = start_or_stop
+
+        if stop > len(self.chain_manager.blocks):
+            raise ChainError(
+                f"'stop={stop}' cannot be greater than the chain length ({len(self.chain_manager)}). "
+                f"Use '{self.chain_manager.poll_blocks.__name__}()' to wait for future blocks."
+            )
+        elif stop < start:
+            raise ValueError(f"stop '{stop}' cannot be less than start '{start}'.")
+        elif stop < 0:
+            raise ValueError(f"start '{start}' cannot be negative.")
+        elif start_or_stop < 0:
+            raise ValueError(f"stop '{stop}' cannot be negative.")
+
+        return [self.chain_manager.blocks._get_block(i) for i in range(start, stop, step)]
 
 
 class QueryManager(ManagerAccessMixin):

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -80,7 +80,8 @@ class DefaultQueryProvider(QueryAPI):
 
         if stop > len(self.chain_manager.blocks):
             raise ChainError(
-                f"'stop={stop}' cannot be greater than the chain length ({len(self.chain_manager)}). "
+                f"'stop={stop}' cannot be greater than the "
+                f"chain length ({len(self.chain_manager.blocks)}). "
                 f"Use '{self.chain_manager.poll_blocks.__name__}()' to wait for future blocks."
             )
         elif stop < start:


### PR DESCRIPTION
### What I did

Pull the range longic from ChainManager.blocks.range and place that functionality in DefaultQueryProvider

fixes: #595

### How I did it
Grabbed the functionality from ChainManager.blocks.range (which was in BlockContainer) and pulled it to DefaultQueryProvider

### How to verify it
Currently, the only tests that I have ran are:
```bash
ape console
```

```python
a = accounts.test_accounts[0]
a.transfer(a, 100)
a.transfer(a, 100)
a.transfer(a, 100)
chain.blocks.query("number", "timestamp")
```

```
   number   timestamp  size
0       0  1647968057   517
1       1  1647986057   627
2       2  1647986154   627
```

I also ran pytest test_basic_query(), which passed

### Checklist

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
