### PR TITLE
feat: add get_transaction_trace to provider

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         "click>=8.0.0",
         "eth-account==0.5.7",
         "ethpm-types>=0.1.0b7",
-        "evm-trace>=0.1.0.a1",
+        "evm-trace>=0.1.0.a2",
         "hexbytes>=0.2.2,<1.0.0",
         "packaging>=20.9,<21.0",
         "pandas>=1.3.0,<2.0",

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         "click>=8.0.0",
         "eth-account==0.5.7",
         "ethpm-types>=0.1.0b7",
+        "evm-trace>=0.1.0.a1",
         "hexbytes>=0.2.2,<1.0.0",
         "packaging>=20.9,<21.0",
         "pandas>=1.3.0,<2.0",

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -365,10 +365,13 @@ class ProviderAPI(BaseInterfaceModel):
     @raises_not_implemented
     def get_transaction_trace(self, txn_hash: str) -> Iterator[TraceFrame]:
         """
-        Provides a detailed description of CALL and RETURN opcodes.
+        Provide a detailed description of opcodes.
+
+        Args:
+            txn_hash (str): The hash of a transaction to trace.
 
         Returns:
-            Iterator(EvmTrace): EVM stack trace object.
+            Iterator(EvmTrace): Transaction execution trace object.
         """
 
     def prepare_transaction(self, txn: TransactionAPI) -> TransactionAPI:

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -33,17 +33,7 @@ from ape.exceptions import (
 )
 from ape.logging import logger
 from ape.types import AddressType, BlockID, ContractLog, SnapshotID
-from ape.utils import BaseInterfaceModel, abstractmethod, cached_property
-
-
-def raises_not_implemented(fn):
-    def inner(*args, **kwargs):
-        raise NotImplementedError(
-            f"Attempted to call method '{fn.__name__}' in 'ProviderAPI', "
-            f"which is only available in 'TestProviderAPI'."
-        )
-
-    return inner
+from ape.utils import BaseInterfaceModel, abstractmethod, cached_property, raises_not_implemented
 
 
 class BlockGasAPI(BaseInterfaceModel):
@@ -372,6 +362,7 @@ class ProviderAPI(BaseInterfaceModel):
             bool: ``True`` if successfully unlocked account and ``False`` otherwise.
         """
 
+    @raises_not_implemented
     def get_transaction_trace(self, txn_hash: str) -> Iterator[TraceFrame]:
         """
         Provides a detailed description of CALL and RETURN opcodes.
@@ -379,7 +370,6 @@ class ProviderAPI(BaseInterfaceModel):
         Returns:
             Iterator(EvmTrace): EVM stack trace object.
         """
-        raise NotImplementedError("Transaction tracing is not supported.")
 
     def prepare_transaction(self, txn: TransactionAPI) -> TransactionAPI:
         """

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -14,6 +14,7 @@ from eth_abi.abi import encode_single
 from eth_typing import HexStr
 from eth_utils import add_0x_prefix, keccak
 from ethpm_types.abi import EventABI
+from evm_trace import TraceFrame
 from hexbytes import HexBytes
 from pydantic import Field, validator
 from web3 import Web3
@@ -370,6 +371,15 @@ class ProviderAPI(BaseInterfaceModel):
         Returns:
             bool: ``True`` if successfully unlocked account and ``False`` otherwise.
         """
+
+    def get_transaction_trace(self, txn_hash: str) -> Iterator[TraceFrame]:
+        """
+        Provides a detailed description of CALL and RETURN opcodes.
+
+        Returns:
+            Iterator(EvmTrace): EVM stack trace object.
+        """
+        raise NotImplementedError("Transaction tracing is not supported.")
 
     def prepare_transaction(self, txn: TransactionAPI) -> TransactionAPI:
         """

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -727,6 +727,15 @@ class BaseInterfaceModel(BaseInterface, BaseModel):
         return super().json(*args, **kwargs)
 
 
+def raises_not_implemented(fn):
+    def inner(*args, **kwargs):
+        raise NotImplementedError(
+            f"Attempted to call method '{fn.__qualname__}', " "method not supported."
+        )
+
+    return inner
+
+
 __all__ = [
     "abstractmethod",
     "BaseInterfaceModel",
@@ -742,6 +751,7 @@ __all__ = [
     "get_all_files_in_directory",
     "injected_before_use",
     "load_config",
+    "raises_not_implemented",
     "singledispatchmethod",
     "stream_response",
     "to_address",

--- a/src/ape/utils.py
+++ b/src/ape/utils.py
@@ -728,9 +728,13 @@ class BaseInterfaceModel(BaseInterface, BaseModel):
 
 
 def raises_not_implemented(fn):
+    """
+    Decorator for raising helpful not implemented error.
+    """
+
     def inner(*args, **kwargs):
         raise NotImplementedError(
-            f"Attempted to call method '{fn.__qualname__}', " "method not supported."
+            f"Attempted to call method '{fn.__qualname__}', method not supported."
         )
 
     return inner


### PR DESCRIPTION
### What I did
Adds `get_transaction_trace()` to `ProviderAPI`.

 starts the work on #347 

### How I did it
Added method will throw `NotImplementedError` if the plugin does not support transaction tracing.

### How to verify it
Call the method on a provider, once the hardhat implementation is merged, an EVM `TraceFrame` will be returned.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
