### PR TITLE
chore: upgrade click

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
         name: black
@@ -21,7 +21,7 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.941
+    rev: v0.942
     hooks:
     -   id: mypy
         additional_dependencies: [types-PyYAML, types-requests]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require = {
         "hypothesis-jsonschema==0.19.0",  # JSON Schema fuzzer extension
     ],
     "lint": [
-        "black>=21.12b0,<22.0",  # auto-formatter and linter
+        "black>=22.3.0,<23.0",  # auto-formatter and linter
         "mypy>=0.941,<1.0",  # Static type analyzer
         "types-PyYAML",  # NOTE: Needed due to mypy typeshed
         "types-requests",  # NOTE: Needed due to mypy typeshed
@@ -74,7 +74,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "backports.cached_property ; python_version<'3.8'",
-        "click>=8.0.0",
+        "click>=8.1.0",
         "eth-account==0.5.7",
         # TODO: update when ethpm-types v0.1.1 is released, after ape v0.2.0 release
         "ethpm-types>=0.1.0b7,<0.1.1",

--- a/tests/functional/conversion/test_ether.py
+++ b/tests/functional/conversion/test_ether.py
@@ -11,8 +11,8 @@ from ape_ethereum._converters import ETHER_UNITS
 @pytest.mark.fuzzing
 @given(
     value=st.decimals(
-        min_value=-(2 ** 255),
-        max_value=2 ** 256 - 1,
+        min_value=-(2**255),
+        max_value=2**256 - 1,
         allow_infinity=False,
         allow_nan=False,
     ),


### PR DESCRIPTION
### What I did
`click` v8.1.0 was released a few hours ago, however this breaks `black` so update the pin for that as well

fixes: #504

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
