### PR TITLE
fix: added feature to handle slicing when getting accounts

### DIFF
--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -42,7 +42,7 @@ class TestAccountManager(list, ManagerAccessMixin):
         raise IndexError(f"No account at index '{account_id}'.")
 
     @__getitem__.register
-    def __getitem_slice(self, account_id: slice) -> List[AccountAPI]:
+    def __getitem_slice(self, account_id: slice):
         start_idx = account_id.start or 0
         if start_idx < 0:
             start_idx += len(self)
@@ -232,7 +232,7 @@ class AccountManager(BaseManager):
         raise IndexError(f"No account at index '{account_id}'.")
 
     @__getitem__.register
-    def __getitem_slice(self, account_id: slice) -> List[AccountAPI]:
+    def __getitem_slice(self, account_id: slice):
         """
         Get list of accounts by slice. For example, when you do the CLI command
         ``ape accounts list --all``, you will see a list of enumerated accounts

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -33,11 +33,24 @@ class TestAccountManager(list, ManagerAccessMixin):
 
     @__getitem__.register
     def __getitem_int(self, account_id: int):
+        if account_id < 0:
+            account_id = len(self) + account_id
         for idx, account in enumerate(self.accounts):
             if account_id == idx:
                 return account
 
         raise IndexError(f"No account at index '{account_id}'.")
+
+    @__getitem__.register
+    def __getitem_slice(self, account_id: slice) -> List[AccountAPI]:
+        start_idx = account_id.start or 0
+        if start_idx < 0:
+            start_idx += len(self)
+        stop_idx = account_id.stop or len(self)
+        if stop_idx < 0:
+            stop_idx += len(self)
+        step_size = account_id.step or 1
+        return [self[i] for i in range(start_idx, stop_idx, step_size)]
 
     @__getitem__.register
     def __getitem_str(self, account_str: str):

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -210,11 +210,36 @@ class AccountManager(BaseManager):
             :class:`~ape.api.accounts.AccountAPI`
         """
 
+        if account_id < 0:
+            account_id = len(self) + account_id
         for idx, account in enumerate(self):
             if account_id == idx:
                 return account
 
         raise IndexError(f"No account at index '{account_id}'.")
+
+    @__getitem__.register
+    def __getitem_slice(self, account_id: slice) -> List[AccountAPI]:
+        """
+        Get list of accounts by slice. For example, when you do the CLI command
+        ``ape accounts list --all``, you will see a list of enumerated accounts
+        by their indices. Use this method as a quicker, ad-hoc way to get an
+        accounts from a slice. **NOTE**: It is generally preferred to use
+        :meth:`~ape.managers.accounts.AccountManager.load` or
+        :meth:`~ape.managers.accounts.AccountManager.__getitem_str`.
+
+        Returns:
+            List[:class:`~ape.api.accounts.AccountAPI`]
+        """
+
+        start_idx = account_id.start or 0
+        if start_idx < 0:
+            start_idx += len(self)
+        stop_idx = account_id.stop or len(self)
+        if stop_idx < 0:
+            stop_idx += len(self)
+        step_size = account_id.step or 1
+        return [self[i] for i in range(start_idx, stop_idx, step_size)]
 
     @__getitem__.register
     def __getitem_str(self, account_str: str) -> AccountAPI:

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -73,3 +73,12 @@ def test_send_transaction_sets_defaults(sender, receiver):
     receipt = sender.transfer(receiver, "1 GWEI", gas_limit=None, required_confirmations=None)
     assert receipt.gas_limit > 0
     assert receipt.required_confirmations == 0
+
+
+def test_get_accounts(test_accounts):
+    a, b = test_accounts[:2]
+    assert a == test_accounts[0]
+    assert b == test_accounts[1]
+    c = test_accounts[-1]
+    assert c == test_accounts[len(test_accounts) - 1]
+    assert len(test_accounts[::2]) == len(test_accounts) / 2


### PR DESCRIPTION
### What I did
Added ability to handle slicing when getting accounts

fixes: #605

### How I did it
added another singledispatchmethod item called __getitem_slice

### How to verify it
```bash
ape console
```
```python
[1] accounts[-1]
[2] accounts[:2]
```

### Checklist

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
