### PR TITLE
fix: version issue to display in installed sections

### DIFF
--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -100,7 +100,7 @@ def _list(cli_ctx, display_all):
     spaced_names = add_padding_to_strings([p[0] for p in plugin_list], extra_spaces=4)
 
     for name in spaced_names:
-        plugin = ApePlugin(name)
+        plugin = ApePlugin(name.strip())
         if plugin.is_part_of_core:
             if not display_all:
                 continue
@@ -121,9 +121,13 @@ def _list(cli_ctx, display_all):
     # Get all plugins that are available and not already installed.
     available_plugins = list(github_client.available_plugins - installed_org_plugins.keys())
 
+    formatted_org_plugins = [f"{k}{v}" for k, v in installed_org_plugins.items()]
+    formateted_installed_third_party_plugins = [
+        f"{k}{v}" for k, v in installed_third_party_plugins.items()
+    ]
     # Get the list of plugin lists that are populated.
     installed_plugin_lists = [
-        ls for ls in [installed_org_plugins, installed_third_party_plugins] if ls
+        ls for ls in [formatted_org_plugins, formateted_installed_third_party_plugins] if ls
     ]
     if installed_plugin_lists:
         sections["Installed Plugins"] = installed_plugin_lists

--- a/tests/integration/cli/test_plugins.py
+++ b/tests/integration/cli/test_plugins.py
@@ -11,3 +11,11 @@ def test_list_excludes_core_plugins(ape_cli, runner):
     assert "console" not in result.output, "console is not supposed to be in Installed Plugins"
     assert "networks" not in result.output, "networks is not supposed to be in Installed Plugins"
     assert "geth" not in result.output, "networks is not supposed to be in Installed Plugins"
+
+
+@pytest.mark.xfail(strict=False, reason="Requires plugins installed")
+@skip_projects_except(["test"])  # Only run on single project to prevent rate-limiting in CI/CD
+def test_list_include_version(ape_cli, runner):
+    result = runner.invoke(ape_cli, ["plugins", "list"])
+    assert result.exit_code == 0, result.output
+    assert "0.1" in result.output, "version is not in output"


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

Fixed the output for `ape plugins list` to have the installed section display the versions


<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #

### How I did it
<!-- Discuss the thought process behind the change -->

formatted the display to include it. It had it earlier but it broke. 

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

install plugins and check with `ape plugins list` and/or `ape plugins list --all`

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
