### PR TITLE
refactor: leverage query manager to complete historical block range queries

### DIFF
--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -25,7 +25,7 @@ class _BaseQuery(BaseModel):
 
         Returns:
             List[str]: list of columns to be returned in pandas
-                dataframes during block query.
+            dataframes during block query.
         """
         ...
 

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -27,7 +27,6 @@ class _BaseQuery(BaseModel):
             List[str]: list of columns to be returned in pandas
             dataframes during block query.
         """
-        ...
 
     @validator("columns")
     def check_columns(cls, data: List[str]) -> List[str]:
@@ -69,7 +68,7 @@ class BlockQuery(_BaseBlockQuery):
         return list(BlockAPI.__fields__)
 
 
-class _BaseAccountQuery(BaseModel):
+class _BaseAccountQuery(_BaseQuery):
     start_nonce: NonNegativeInt = 0
     stop_nonce: NonNegativeInt
 

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -74,7 +74,7 @@ class _BaseAccountQuery(BaseModel):
     stop_nonce: NonNegativeInt
 
     @root_validator(pre=True)
-    def check_start_nonce_before_stop_nonce(cls, values: Dict):
+    def check_start_nonce_before_stop_nonce(cls, values: Dict) -> Dict:
         if values["stop_nonce"] < values["start_nonce"]:
             raise ValueError(
                 f"stop_nonce: '{values['stop_nonce']}' cannot be less than "

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -2,18 +2,36 @@ from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 from ethpm_types.abi import EventABI, MethodABI
-from pydantic import BaseModel, NonNegativeInt, root_validator
+from pydantic import BaseModel, NonNegativeInt, root_validator, validator
 
-from ape._compat import Literal
 from ape.types import AddressType
 from ape.utils import BaseInterfaceModel, abstractmethod
+
+from .providers import BlockAPI
+from .transactions import TransactionAPI
 
 QueryType = Union["BlockQuery", "AccountQuery", "ContractEventQuery", "ContractMethodQuery"]
 
 
 class _BaseQuery(BaseModel):
-    type: str  # Used as discriminator
+
     columns: List[str]
+
+    @classmethod
+    @abstractmethod
+    def all_fields(cls) -> List[str]:
+        ...
+
+    @validator("columns")
+    def check_columns(cls, data):
+        all_fields = cls.all_fields()
+        if len(data) == 1 and data[0] == "*":
+            return all_fields
+        else:
+            assert len(set(data)) == len(data), f"Duplicate fields in {data}"
+            for d in data:
+                assert d in all_fields, f"Unrecognized field '{d}', must be one of {all_fields}"
+        return data
 
 
 class _BaseBlockQuery(_BaseQuery):
@@ -37,7 +55,9 @@ class BlockQuery(_BaseBlockQuery):
     blocks between ``start_block`` and ``stop_block``.
     """
 
-    type: Literal["blocks"] = "blocks"
+    @classmethod
+    def all_fields(cls) -> List[str]:
+        return list(BlockAPI.__fields__)
 
 
 class _BaseAccountQuery(BaseModel):
@@ -61,8 +81,11 @@ class AccountQuery(_BaseAccountQuery):
     of transactions made by ``account`` between ``start_nonce`` and ``stop_nonce``.
     """
 
-    type: Literal["accounts"] = "accounts"
     account: AddressType
+
+    @classmethod
+    def all_fields(cls) -> List[str]:
+        return list(TransactionAPI.__fields__)
 
 
 class ContractEventQuery(_BaseBlockQuery):
@@ -71,9 +94,16 @@ class ContractEventQuery(_BaseBlockQuery):
     logs emitted by ``contract`` between ``start_block`` and ``stop_block``.
     """
 
-    type: Literal["contract_events"] = "contract_events"
     contract: AddressType
     event: EventABI
+
+    @classmethod
+    def all_fields(cls) -> List[str]:
+        # TODO: Figure out how to get the event ABI as a class property
+        #   for the validator
+        return [
+            i.name for i in cls.event.inputs if i.name is not None
+        ]  # if i.name is not None just for mypy
 
 
 class ContractMethodQuery(_BaseBlockQuery):
@@ -82,10 +112,15 @@ class ContractMethodQuery(_BaseBlockQuery):
     over a range of blocks between ``start_block`` and ``stop_block``.
     """
 
-    type: Literal["contract_calls"] = "contract_calls"
     contract: AddressType
     method: MethodABI
     method_args: Dict[str, Any]
+
+    @classmethod
+    def all_fields(cls) -> List[str]:
+        # TODO: Figure out how to get the event ABI as a class property
+        #   for the validator
+        return [o.name for o in cls.method.outputs if o.name is not None]  # just for mypy
 
 
 class QueryAPI(BaseInterfaceModel):

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -30,7 +30,7 @@ class _BaseQuery(BaseModel):
         ...
 
     @validator("columns")
-    def check_columns(cls, data: str) -> Union[List[str], str]:
+    def check_columns(cls, data: List[str]) -> List[str]:
         all_fields = cls.all_fields()
         if len(data) == 1 and data[0] == "*":
             return all_fields

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -182,8 +182,11 @@ class BlockContainer(BaseManager):
         elif start_or_stop < 0:
             raise ValueError(f"stop '{stop}' cannot be negative.")
 
-        for i in range(start, stop, step):
-            yield self._get_block(i)
+        # Note: the range stop block is a non-inclusive stop.
+        #       Where as the query method is an inclusive stop.
+        results = self.query("*", start_block=start, stop_block=stop - 1)  # type: ignore
+        for _, row in results.iterrows():
+            yield BlockAPI.parse_obj(row.to_dict())
 
     def poll_blocks(
         self,

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -186,7 +186,7 @@ class BlockContainer(BaseManager):
         #       `.query` method uses an inclusive stop, so we must adjust downwards.
         results = self.query("*", start_block=start, stop_block=stop - 1)  # type: ignore
         for _, row in results.iterrows():
-            yield BlockAPI.parse_obj(row.to_dict())
+            yield self.provider.network.ecosystem.decode_block(dict(row.to_dict()))
 
     def poll_blocks(
         self,

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -182,8 +182,8 @@ class BlockContainer(BaseManager):
         elif start_or_stop < 0:
             raise ValueError(f"stop '{stop}' cannot be negative.")
 
-        # Note: the range stop block is a non-inclusive stop.
-        #       Where as the query method is an inclusive stop.
+        # Note: the range `stop_block` is a non-inclusive stop, while the
+        #       `.query` method uses an inclusive stop, so we must adjust downwards.
         results = self.query("*", start_block=start, stop_block=stop - 1)  # type: ignore
         for _, row in results.iterrows():
             yield BlockAPI.parse_obj(row.to_dict())

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -38,10 +38,8 @@ class DefaultQueryProvider(QueryAPI):
 
     @perform_query.register
     def perform_block_query(self, query: BlockQuery) -> pd.DataFrame:
-        if not self.network_manager.active_provider:
-            raise QueryEngineError("Not connected to an active network")
         blocks_iter = map(
-            self.network_manager.active_provider.get_block,
+            self.provider.get_block,
             # NOTE: the range stop block is a non-inclusive stop.
             #       Where as the query method is an inclusive stop.
             range(query.start_block, query.stop_block + 1),

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -136,7 +136,7 @@ class Receipt(ReceiptAPI):
 class BlockGasFee(BlockGasAPI):
     @classmethod
     def decode(cls, data: Dict) -> BlockGasAPI:
-        return BlockGasFee(**data)  # type: ignore
+        return BlockGasFee.parse_obj(data)
 
 
 class BlockConsensus(BlockConsensusAPI):
@@ -189,7 +189,11 @@ class Ethereum(EcosystemAPI):
         )
 
     def decode_block(self, data: Dict) -> BlockAPI:
-
+        # TODO: when we flatten the Block structure, remove these hacks
+        if "gas_data" in data:
+            data.update(data.pop("gas_data"))
+        if "consensus_data" in data:
+            data.update(data.pop("consensus_data"))
         return Block(  # type: ignore
             gas_data=BlockGasFee.decode(data),
             consensus_data=BlockConsensus.decode(data),
@@ -197,7 +201,8 @@ class Ethereum(EcosystemAPI):
             size=data.get("size"),
             timestamp=data.get("timestamp"),
             hash=data.get("hash"),
-            parent_hash=data.get("parentHash"),
+            # TODO: when we flatten the Block structure, remove this hack.
+            parent_hash=data.get("parentHash") or data.get("parent_hash"),
         )
 
     def encode_calldata(self, abi: Union[ConstructorABI, MethodABI], *args) -> bytes:

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -3,7 +3,7 @@ from ape import chain
 
 def test_basic_query(eth_tester_provider):
     chain.mine(3)
-    assert chain.blocks.query("number").to_dict() == {"number": {0: 0, 1: 1, 2: 2}}
+    assert chain.blocks.query("number").to_dict() == {"number": {0: 0, 1: 1, 2: 2, 3: 3}}
     df = chain.blocks.query("number", "timestamp")
-    assert len(df) == 3
-    assert df["timestamp"][2] >= df["timestamp"][1] >= df["timestamp"][0]
+    assert len(df) == 4
+    assert df["timestamp"][3] > df["timestamp"][2] >= df["timestamp"][1] >= df["timestamp"][0]

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -36,9 +36,10 @@ def test_block_query(eth_tester_provider):
 
 def test_account_query(eth_tester_provider):
     chain.mine(3)
+    query_kwargs = dict(account="0x0000000000000000000000000000000000000000", start_nonce=0, stop_nonce=2)
     with pytest.raises(ValidationError) as err:
-        AccountQuery(columns=["none"], start_nonce=0, stop_nonce=2)
-    assert "validation error for AccountQuery" in str(err.value)
+        AccountQuery(columns=["none"], **query_kwargs)
+    assert "Unrecognized field 'none'" in str(err.value)
     with pytest.raises(ValidationError) as err:
-        AccountQuery(columns=["number", "timestamp", "number"], start_nonce=0, stop_nonce=2)
-    assert "validation error for AccountQuery" in str(err.value)
+        AccountQuery(columns=["nonce", "chain_id", "nonce"], **query_kwargs)
+    assert "Duplicate fields in ['nonce', 'chain_id', 'nonce']" in str(err.value)

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -29,10 +29,16 @@ def test_block_query(eth_tester_provider):
     with pytest.raises(ValidationError) as err:
         BlockQuery(columns=["numbr"], start_block=0, stop_block=2)
     assert "Unrecognized field 'numbr'" in str(err.value)
+    with pytest.raises(ValidationError) as err:
+        BlockQuery(columns=["number", "timestamp", "number"], start_block=0, stop_block=2)
+    assert "Duplicate fields in ['number', 'timestamp', 'number']" in str(err.value)
 
 
 def test_account_query(eth_tester_provider):
     chain.mine(3)
     with pytest.raises(ValidationError) as err:
         AccountQuery(columns=["none"], start_nonce=0, stop_nonce=2)
+    assert "validation error for AccountQuery" in str(err.value)
+    with pytest.raises(ValidationError) as err:
+        AccountQuery(columns=["number", "timestamp", "number"], start_nonce=0, stop_nonce=2)
     assert "validation error for AccountQuery" in str(err.value)

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -1,4 +1,8 @@
+import pytest
+from pydantic import ValidationError
+
 from ape import chain
+from ape.api.query import AccountQuery, BlockQuery, ContractEventQuery, ContractMethodQuery
 
 
 def test_basic_query(eth_tester_provider):
@@ -7,3 +11,28 @@ def test_basic_query(eth_tester_provider):
     df = chain.blocks.query("number", "timestamp")
     assert len(df) == 4
     assert df["timestamp"][3] > df["timestamp"][2] >= df["timestamp"][1] >= df["timestamp"][0]
+    df_all = chain.blocks.query("*")
+    columns = list(df_all.columns)
+    assert [
+        "gas_data",
+        "consensus_data",
+        "hash",
+        "number",
+        "parent_hash",
+        "size",
+        "timestamp",
+    ] == columns
+
+
+def test_block_query(eth_tester_provider):
+    chain.mine(3)
+    with pytest.raises(ValidationError) as err:
+        BlockQuery(columns=["columns"], start_block=0, stop_block=2)
+    assert "Unrecognized field 'columns" in str(err.value)
+
+
+def test_account_query(eth_tester_provider):
+    chain.mine(3)
+    with pytest.raises(ValidationError) as err:
+        AccountQuery(columns=["colu"], start_nonce=0, stop_nonce=2)
+    assert "validation error for AccountQuery" in str(err.value)

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -36,7 +36,9 @@ def test_block_query(eth_tester_provider):
 
 def test_account_query(eth_tester_provider):
     chain.mine(3)
-    query_kwargs = dict(account="0x0000000000000000000000000000000000000000", start_nonce=0, stop_nonce=2)
+    query_kwargs = dict(
+        account="0x0000000000000000000000000000000000000000", start_nonce=0, stop_nonce=2
+    )
     with pytest.raises(ValidationError) as err:
         AccountQuery(columns=["none"], **query_kwargs)
     assert "Unrecognized field 'none'" in str(err.value)

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -27,12 +27,12 @@ def test_basic_query(eth_tester_provider):
 def test_block_query(eth_tester_provider):
     chain.mine(3)
     with pytest.raises(ValidationError) as err:
-        BlockQuery(columns=["columns"], start_block=0, stop_block=2)
-    assert "Unrecognized field 'columns" in str(err.value)
+        BlockQuery(columns=["numbr"], start_block=0, stop_block=2)
+    assert "Unrecognized field 'numbr'" in str(err.value)
 
 
 def test_account_query(eth_tester_provider):
     chain.mine(3)
     with pytest.raises(ValidationError) as err:
-        AccountQuery(columns=["colu"], start_nonce=0, stop_nonce=2)
+        AccountQuery(columns=["none"], start_nonce=0, stop_nonce=2)
     assert "validation error for AccountQuery" in str(err.value)

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -2,7 +2,7 @@ import pytest
 from pydantic import ValidationError
 
 from ape import chain
-from ape.api.query import AccountQuery, BlockQuery, ContractEventQuery, ContractMethodQuery
+from ape.api.query import AccountQuery, BlockQuery
 
 
 def test_basic_query(eth_tester_provider):

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -13,7 +13,7 @@ def test_basic_query(eth_tester_provider):
     assert df["timestamp"][3] > df["timestamp"][2] >= df["timestamp"][1] >= df["timestamp"][0]
     df_all = chain.blocks.query("*")
     columns = list(df_all.columns)
-    assert [
+    assert columns == [
         "gas_data",
         "consensus_data",
         "hash",
@@ -21,7 +21,7 @@ def test_basic_query(eth_tester_provider):
         "parent_hash",
         "size",
         "timestamp",
-    ] == columns
+    ]
 
 
 def test_block_query(eth_tester_provider):

--- a/tests/functional/conversion/test_ether.py
+++ b/tests/functional/conversion/test_ether.py
@@ -11,8 +11,8 @@ from ape_ethereum._converters import ETHER_UNITS
 @pytest.mark.fuzzing
 @given(
     value=st.decimals(
-        min_value=-(2 ** 255),
-        max_value=2 ** 256 - 1,
+        min_value=-(2**255),
+        max_value=2**256 - 1,
         allow_infinity=False,
         allow_nan=False,
     ),

--- a/tests/functional/conversion/test_ether.py
+++ b/tests/functional/conversion/test_ether.py
@@ -11,8 +11,8 @@ from ape_ethereum._converters import ETHER_UNITS
 @pytest.mark.fuzzing
 @given(
     value=st.decimals(
-        min_value=-(2**255),
-        max_value=2**256 - 1,
+        min_value=-(2 ** 255),
+        max_value=2 ** 256 - 1,
         allow_infinity=False,
         allow_nan=False,
     ),


### PR DESCRIPTION
### What I did
Pulled functionality of the chain.blocks.range to DefaultQueryProvider

fixes: #595

### How I did it
Refactor of the range function and DefaultQueryProvider as well as some changes to api.query

### How to verify it
Built in tests for chain and query

### Checklist

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
