### PR TITLE
docs: put sentence in correct spot in dependencies config guide

### DIFF
--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -43,6 +43,8 @@ dependencies:
     version: 4.4.2
 ```
 
+will download the [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts) package with version `4.4.2`.
+
 To ignore files from a dependency project, use the `exclude` setting to specify glob patterns:
 
 ```yaml
@@ -53,8 +55,6 @@ dependencies:
       - package.json    # Ignore package.json files.
       - mocks/**/*      # Ignore all files in the 'mocks' directory
 ```
-
-will download the [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts) package with version `4.4.2`.
 
 To use dependencies in the `ape-solidity` plugin, configure `import_remappings`:
 


### PR DESCRIPTION
### What I did

Noticed a sentence is in the wrong spot. Fixed it.

### How I did it

Moved sentence back to expected spot.

### How to verify it

Doc makes sense.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
