### PR TITLE
fix: issue causing the log level to get set multiple times

### DIFF
--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -105,6 +105,25 @@ class CliLogger:
         self._web3_request_manager_logger = _get_logger("web3.RequestManager")
         self._web3_http_provider_logger = _get_logger("web3.providers.HTTPProvider")
 
+        # NOTE: We need to set the verbosity from the CLI option earlier than click lets us.
+        log_level = DEFAULT_LOG_LEVEL
+        for arg_i in range(len(sys.argv) - 1):
+            if sys.argv[arg_i] == "-v" or sys.argv[arg_i] == "--verbosity":
+                level = sys.argv[arg_i + 1].upper()
+                level_names = [lvl.name for lvl in LogLevel]
+
+                if level in level_names:
+                    log_level = level
+                    break
+                else:
+                    names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"
+                    self._logger.error(f"Must be one of '{names_str}', not '{level}'.")
+                    sys.exit(2)
+
+        self._logger.setLevel(log_level)
+        self._web3_request_manager_logger.setLevel(log_level)
+        self._web3_http_provider_logger(log_level)
+
     @property
     def level(self) -> int:
         return self._logger.level
@@ -172,22 +191,6 @@ def _get_logger(name: str) -> logging.Logger:
     handler = ClickHandler(echo_kwargs=CLICK_ECHO_KWARGS)
     handler.setFormatter(ApeColorFormatter())
     cli_logger.handlers = [handler]
-
-    # NOTE: We need to set the verbosity from the CLI option earlier than click lets us.
-    for arg_i in range(len(sys.argv) - 1):
-        if sys.argv[arg_i] == "-v" or sys.argv[arg_i] == "--verbosity":
-            level = sys.argv[arg_i + 1].upper()
-            level_names = [lvl.name for lvl in LogLevel]
-
-            if level in level_names:
-                cli_logger.setLevel(level)
-            else:
-                names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"
-                cli_logger.error(f"Must be one of '{names_str}', not '{level}'.")
-                sys.exit(2)
-        else:
-            cli_logger.setLevel(DEFAULT_LOG_LEVEL)
-
     return cli_logger
 
 

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -122,7 +122,7 @@ class CliLogger:
 
         self._logger.setLevel(log_level)
         self._web3_request_manager_logger.setLevel(log_level)
-        self._web3_http_provider_logger(log_level)
+        self._web3_http_provider_logger.setLevel(log_level)
 
     @property
     def level(self) -> int:

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -107,10 +107,10 @@ class CliLogger:
 
         # NOTE: We need to set the verbosity from the CLI option earlier than click lets us.
         log_level = DEFAULT_LOG_LEVEL
+        level_names = [lvl.name for lvl in LogLevel]
         for arg_i in range(len(sys.argv) - 1):
             if sys.argv[arg_i] == "-v" or sys.argv[arg_i] == "--verbosity":
                 level = sys.argv[arg_i + 1].upper()
-                level_names = [lvl.name for lvl in LogLevel]
 
                 if level in level_names:
                     log_level = level


### PR DESCRIPTION
### What I did

Noticed we were setting the log level many times unnecessarily.
Made it only set once.

### How I did it

* Break the loop once it finds a user given log level argument
* Only call setLevel on each logger after finding the log level

### How to verify it

You can still set the log level in CLI commands.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
