### PR TITLE
fix: dependent sources compiling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Committing will now automatically run the local hooks and ensure that your commi
 
 ## Github Access Token
 
-If you are a member of ApeWorX and would like to install private plugins, 
+If you are a member of ApeWorX and would like to install private plugins,
 [create a Github access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 
 Once you have your token, export it to your terminal session:
@@ -80,4 +80,4 @@ A pull request represents the start of a discussion, and doesn't necessarily nee
 If you are opening a work-in-progress pull request to verify that it passes CI tests, please consider
 [marking it as a draft](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
 
-Join the Ethereum Python [Discord](https://discord.gg/PcEJ54yX) if you have any questions.
+Join the ApeWorX [Discord](https://discord.gg/7gshPtGd) if you have any questions.

--- a/setup.py
+++ b/setup.py
@@ -76,8 +76,7 @@ setup(
         "backports.cached_property ; python_version<'3.8'",
         "click>=8.1.0",
         "eth-account==0.5.7",
-        # TODO: update when ethpm-types v0.1.1 is released, after ape v0.2.0 release
-        "ethpm-types>=0.1.0b7,<0.1.1",
+        "ethpm-types>=0.1.0,<0.2.0",
         "evm-trace>=0.1.0.a2",
         "hexbytes>=0.2.2,<1.0.0",
         "packaging>=20.9,<21.0",


### PR DESCRIPTION
### What I did
Updated the discord link to point to the ApeWorX channel
Updated `ethpm-types` version and pinning
Renamed `sources` to be more specific about being paths and not actual `Source` objects.
Added logic for setting source references i.e. dependent sources
Added logic to add source references to `needs_compiling`

- [ ] add `TODO` comments referencing what will change when breaking update is applied to `CompilerAPI`
- [ ] research what vyper will require
- [ ] open another issue for adding `type` setting/logic to `Source` objects


<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #623 

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->
Run through the example in the issue/ticket
<img width="868" alt="Screen Shot 2022-04-02 at 9 43 28 PM" src="https://user-images.githubusercontent.com/32708219/161408914-84b2c10a-612a-44e6-a1a9-e4af6da9a79c.png">


### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
