### PR TITLE
feat: allow plugins to register str converters

### DIFF
--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -186,6 +186,7 @@ class ConversionManager(BaseManager):
             Decimal: [],
             list: [ListTupleConverter()],
             tuple: [ListTupleConverter()],
+            str: [],
         }
 
         for plugin_name, (conversion_type, converter_class) in self.plugin_manager.converters:


### PR DESCRIPTION
### What I did

Made it so that plugins can register converters that converts to str types.
Before, you would get a `ConversionError` saying you couldn't register this type.

**NOTE**: I am now realizing I don't actually need this feature (was a misunderstanding). However, it seems like something that should still exist?

### How I did it

Added `str` with an empty list to the pre-defined list.

### How to verify it

You can now register a converter that converts `str` in a plugin to 

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
