### PR TITLE
fix: contract ABI repr errors

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -112,7 +112,7 @@ class ContractCallHandler(ManagerAccessMixin):
         self.abis = abis
 
     def __repr__(self) -> str:
-        abis = sorted(self.abis, key=lambda abi: len(abi.values or []))  # type: ignore
+        abis = sorted(self.abis, key=lambda abi: len(abi.inputs or []))
         return abis[-1].signature
 
     def _convert_tuple(self, v: tuple) -> tuple:
@@ -190,7 +190,7 @@ class ContractTransactionHandler(ManagerAccessMixin):
         self.abis = abis
 
     def __repr__(self) -> str:
-        abis = sorted(self.abis, key=lambda abi: len(abi.values or []))  # type: ignore
+        abis = sorted(self.abis, key=lambda abi: len(abi.inputs or []))
         return abis[-1].signature
 
     def _convert_tuple(self, v: tuple) -> tuple:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -232,6 +232,9 @@ class ContractEvent(ManagerAccessMixin):
         self.abi = abi
         self.cached_logs = cached_logs or []
 
+    def __repr__(self):
+        return self.abi.signature
+
     @property
     def name(self) -> str:
         """

--- a/tests/functional/test_contracts.py
+++ b/tests/functional/test_contracts.py
@@ -21,6 +21,16 @@ def test_deploy(sender, contract_container):
     assert contract.address == CONTRACT_ADDRESS
 
 
+def test_repr(contract_instance):
+    assert repr(contract_instance) == f"<TestContract {contract_instance.address}>"
+    assert repr(contract_instance.set_number) == "set_number(uint256 num)"
+    assert repr(contract_instance.my_number) == "my_number() -> uint256"
+    assert (
+        repr(contract_instance.NumberChange)
+        == "NumberChange(uint256 prev_num, uint256 indexed new_num)"
+    )
+
+
 def test_contract_logs_from_receipts(owner, contract_instance):
     event_type = contract_instance.NumberChange
 


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #621 

Also adjust repr for events

### How I did it

Return the ABI with the most inputs? I am not sure what the original intent is. Also, what causes functions to have multiple ABIs? I haven't seen this. I can adjust the test case to account for this once I fully know.

### How to verify it

the tests show that this is at least working now, even though more clarification is needed regarding methods with multuple 

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
