### PR TITLE
fix: use step parameter to block_container.range() method

### DIFF
--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -45,6 +45,7 @@ class _BaseQuery(BaseModel):
 class _BaseBlockQuery(_BaseQuery):
     start_block: NonNegativeInt = 0
     stop_block: NonNegativeInt
+    step: NonNegativeInt = 1
 
     @root_validator(pre=True)
     def check_start_block_before_stop_block(cls, values):

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 from ethpm_types.abi import EventABI, MethodABI
-from pydantic import BaseModel, NonNegativeInt, root_validator, validator
+from pydantic import BaseModel, NonNegativeInt, PositiveInt, root_validator, validator
 
 from ape.types import AddressType
 from ape.utils import BaseInterfaceModel, abstractmethod
@@ -45,7 +45,7 @@ class _BaseQuery(BaseModel):
 class _BaseBlockQuery(_BaseQuery):
     start_block: NonNegativeInt = 0
     stop_block: NonNegativeInt
-    step: NonNegativeInt = 1
+    step: PositiveInt = 1
 
     @root_validator(pre=True)
     def check_start_block_before_stop_block(cls, values):

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -185,8 +185,13 @@ class BlockContainer(BaseManager):
         # Note: the range `stop_block` is a non-inclusive stop, while the
         #       `.query` method uses an inclusive stop, so we must adjust downwards.
         results = self.query("*", start_block=start, stop_block=stop - 1)  # type: ignore
+
+        step_tracker = step - 1  # Set right before step we log the first block
         for _, row in results.iterrows():
-            yield self.provider.network.ecosystem.decode_block(dict(row.to_dict()))
+            step_tracker += 1
+            if step_tracker == step:
+                yield self.provider.network.ecosystem.decode_block(dict(row.to_dict()))
+                step_tracker = 0
 
     def poll_blocks(
         self,

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -91,6 +91,7 @@ class BlockContainer(BaseManager):
         *columns: List[str],
         start_block: int = 0,
         stop_block: Optional[int] = None,
+        step: int = 1,
         engine_to_use: Optional[str] = None,
     ) -> pd.DataFrame:
         """
@@ -109,6 +110,8 @@ class BlockContainer(BaseManager):
               query. Defaults to 0.
             stop_block (Optional[int]): The last block, by number, to include
               in the query. Defaults to the latest block.
+            step (int): The number of blocks to iterate between block numbers.
+              Defaults to ``1``.
             engine_to_use (Optional[str]): query engine to use, bypasses query
               engine selection algorithm.
 
@@ -129,6 +132,7 @@ class BlockContainer(BaseManager):
             columns=columns,
             start_block=start_block,
             stop_block=stop_block,
+            step=step,
             engine_to_use=engine_to_use,
         )
 
@@ -184,14 +188,10 @@ class BlockContainer(BaseManager):
 
         # Note: the range `stop_block` is a non-inclusive stop, while the
         #       `.query` method uses an inclusive stop, so we must adjust downwards.
-        results = self.query("*", start_block=start, stop_block=stop - 1)  # type: ignore
+        results = self.query("*", start_block=start, stop_block=stop - 1, step=step)  # type: ignore
 
-        step_tracker = step - 1  # Set right before step we log the first block
         for _, row in results.iterrows():
-            step_tracker += 1
-            if step_tracker == step:
-                yield self.provider.network.ecosystem.decode_block(dict(row.to_dict()))
-                step_tracker = 0
+            yield self.provider.network.ecosystem.decode_block(dict(row.to_dict()))
 
     def poll_blocks(
         self,

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -33,7 +33,6 @@ class DefaultQueryProvider(QueryAPI):
 
     @singledispatchmethod
     def perform_query(self, query: QueryType) -> pd.DataFrame:
-
         raise QueryEngineError(f"Cannot handle '{type(query)}'.")
 
     @perform_query.register
@@ -42,7 +41,7 @@ class DefaultQueryProvider(QueryAPI):
             self.provider.get_block,
             # NOTE: the range stop block is a non-inclusive stop.
             #       Where as the query method is an inclusive stop.
-            range(query.start_block, query.stop_block + 1),
+            range(query.start_block, query.stop_block + 1, query.step),
         )
         block_dicts_iter = map(partial(get_columns_from_item, query), blocks_iter)
         return pd.DataFrame(columns=query.columns, data=block_dicts_iter)

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -111,6 +111,13 @@ def test_blocks_range_too_high_stop(chain_at_block_5):
     )
 
 
+def test_block_range_with_step(chain_at_block_5):
+    blocks = [b for b in chain_at_block_5.blocks.range(3, step=2)]
+    assert len(blocks) == 2
+    assert blocks[0].number == 0
+    assert blocks[1].number == 2
+
+
 def test_set_pending_timestamp(chain):
     start_timestamp = chain.pending_timestamp
     chain.pending_timestamp += 3600


### PR DESCRIPTION
### What I did

Noticed we were no longing using the `step` parameter on `chain.blocks.range()` method.
Fixed it!

### How I did it

Honor `step`.

### How to verify it

See test :)

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
