### PR TITLE
fix: issue when console would not launch when exception raised

### DIFF
--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -1,3 +1,4 @@
+import traceback
 from pathlib import Path
 from runpy import run_module
 from typing import Any, Dict, Union
@@ -22,9 +23,13 @@ class ScriptCommand(click.MultiCommand):
             return super().invoke(ctx)
         except Exception:
             if ctx.params["interactive"]:
+                # Print the exception trace and then launch the console
+                err_info = traceback.format_exc()
+                click.echo(err_info)
                 self._launch_console()
-
-            raise
+            else:
+                # Don't handle error - raise exception as normal.
+                raise
 
     def _get_command(self, filepath: Path) -> Union[click.Command, click.Group, None]:
         relative_filepath = get_relative_path(filepath, self._project.path)

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 from runpy import run_module
-from typing import Dict, Union
+from typing import Any, Dict, Union
 
 import click
+from click import Context
 
 from ape.cli import NetworkBoundCommand, network_option
 from ape.logging import logger
@@ -15,6 +16,15 @@ class ScriptCommand(click.MultiCommand):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs, result_callback=self.result_callback)
         self._namespace = {}
+
+    def invoke(self, ctx: Context) -> Any:
+        try:
+            return super().invoke(ctx)
+        except Exception:
+            if ctx.params["interactive"]:
+                self._launch_console()
+
+            raise
 
     def _get_command(self, filepath: Path) -> Union[click.Command, click.Group, None]:
         relative_filepath = get_relative_path(filepath, self._project.path)
@@ -122,13 +132,14 @@ class ScriptCommand(click.MultiCommand):
 
     def result_callback(self, result, interactive):
         if interactive:
-            # TODO: Figure out how to pull out namespace for `extra_locals`
-            return console(
-                project=self._project,
-                extra_locals=self._namespace[self._command_called],
-            )
+            return self._launch_console()
 
         return result
+
+    def _launch_console(self):
+        # TODO: Figure out how to pull out namespace for `extra_locals`
+        extra_locals = {**self._namespace.get(self._command_called, {})}
+        return console(project=self._project, extra_locals=extra_locals)
 
 
 @click.command(

--- a/tests/integration/cli/projects/script/scripts/error.py
+++ b/tests/integration/cli/projects/script/scripts/error.py
@@ -1,0 +1,2 @@
+def main():
+    raise Exception("Expected exception")

--- a/tests/integration/cli/projects/script/scripts/error_cli.py
+++ b/tests/integration/cli/projects/script/scripts/error_cli.py
@@ -1,0 +1,6 @@
+import click
+
+
+@click.command(short_help="Use a subcommand")
+def cli():
+    raise Exception("Expected exception")  # noqa: T001


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #581

### How I did it

Catch the exception on invoke, check for `interactive`, launch console.
As far issue #581  goes, it seems like that is already fixed??? I am 

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
