### PR TITLE
fix: use warnings instead of erroring in config network processing

### DIFF
--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -7,7 +7,7 @@ from hexbytes import HexBytes
 from pydantic import root_validator
 
 from ape.api import ConfigDict, DependencyAPI, PluginConfig
-from ape.exceptions import ConfigError
+from ape.exceptions import ConfigError, NetworkError
 from ape.logging import logger
 from ape.utils import BaseInterfaceModel, load_config, to_address
 
@@ -29,15 +29,15 @@ class DeploymentConfigCollection(dict):
     ):
         for ecosystem_name, networks in data.items():
             if ecosystem_name not in valid_ecosystem_names:
-                raise ConfigError(f"Invalid ecosystem '{ecosystem_name}' in deployments config.")
+                logger.warning(f"Invalid ecosystem '{ecosystem_name}' in deployments config.")
 
             for network_name, contract_deployments in networks.items():
                 if network_name not in valid_network_names:
-                    raise ConfigError(f"Invalid network '{network_name}' in deployments config.")
+                    logger.warning(f"Invalid network '{network_name}' in deployments config.")
 
                 for deployment in [d for d in contract_deployments]:
                     if "address" not in deployment:
-                        raise ConfigError(
+                        logger.warning(
                             f"Missing 'address' field in deployment "
                             f"(ecosystem={ecosystem_name}, network={network_name})"
                         )
@@ -49,7 +49,7 @@ class DeploymentConfigCollection(dict):
                     try:
                         deployment["address"] = to_address(address)
                     except ValueError as err:
-                        raise ConfigError(str(err)) from err
+                        logger.warning(str(err))
 
         super().__init__(data)
 
@@ -142,7 +142,11 @@ class ConfigManager(BaseInterfaceModel):
         self.default_ecosystem = configs["default_ecosystem"] = user_config.pop(
             "default_ecosystem", "ethereum"
         )
-        self.network_manager.set_default_ecosystem(self.default_ecosystem)
+
+        try:
+            self.network_manager.set_default_ecosystem(self.default_ecosystem)
+        except NetworkError as err:
+            logger.warning(str(err))
 
         dependencies = user_config.pop("dependencies", []) or []
         if not isinstance(dependencies, list):

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -43,6 +43,7 @@ class DeploymentConfigCollection(dict):
                             f"Missing 'address' field in deployment "
                             f"(ecosystem={ecosystem_name}, network={network_name})"
                         )
+                        continue
 
                     address = deployment["address"]
                     if isinstance(address, int):

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -30,10 +30,12 @@ class DeploymentConfigCollection(dict):
         for ecosystem_name, networks in data.items():
             if ecosystem_name not in valid_ecosystem_names:
                 logger.warning(f"Invalid ecosystem '{ecosystem_name}' in deployments config.")
+                continue
 
             for network_name, contract_deployments in networks.items():
                 if network_name not in valid_network_names:
                     logger.warning(f"Invalid network '{network_name}' in deployments config.")
+                    continue
 
                 for deployment in [d for d in contract_deployments]:
                     if "address" not in deployment:

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -1,6 +1,7 @@
+import logging
+
 import pytest
 
-from ape.exceptions import ConfigError
 from ape.managers.config import DeploymentConfigCollection
 
 DEPLOYMENTS = {
@@ -23,8 +24,7 @@ def test_integer_deployment_addresses():
     "ecosystems,networks,err_part",
     [(["fantom"], ["mainnet"], "ecosystem"), (["ethereum"], ["local"], "network")],
 )
-def test_bad_value_in_deployments(ecosystems, networks, err_part):
-    with pytest.raises(ConfigError) as err:
+def test_bad_value_in_deployments(ecosystems, networks, err_part, caplog):
+    with caplog.at_level(logging.WARNING):
         DeploymentConfigCollection(DEPLOYMENTS, ecosystems, networks)
-
-    assert f"Invalid {err_part}" in str(err.value)
+        assert "Invalid ecosystem 'ethereum' in deployments config." in caplog.records[0].message

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -27,4 +27,4 @@ def test_integer_deployment_addresses():
 def test_bad_value_in_deployments(ecosystems, networks, err_part, caplog):
     with caplog.at_level(logging.WARNING):
         DeploymentConfigCollection(DEPLOYMENTS, ecosystems, networks)
-        assert "Invalid ecosystem 'ethereum' in deployments config." in caplog.records[0].message
+        assert f"Invalid {err_part}" in caplog.records[0].message


### PR DESCRIPTION
### What I did

Made it so we use warnings instead of errors in config processing.
Reason: I was unable to install `ape-cairo` and `ape-starknet` in my demo starknet project because errors would happen.

### How I did it

Change `raise` statement to be `logger.warning` statements.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
