### PR TITLE
fix: handle non alpha chars in contract names

### DIFF
--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -43,7 +43,9 @@ class BaseProject(ProjectAPI):
 
         for extension in self.compiler_manager.registered_compilers:
             r_ext = extension.replace(".", "\\.")
-            files.extend(get_all_files_in_directory(self.contracts_folder, pattern=rf"\w+{r_ext}"))
+            files.extend(
+                get_all_files_in_directory(self.contracts_folder, pattern=rf"[\w|-]+{r_ext}")
+            )
 
         return files
 

--- a/tests/integration/cli/projects/one-interface/contracts/Interface-with-hyphens.json
+++ b/tests/integration/cli/projects/one-interface/contracts/Interface-with-hyphens.json
@@ -1,0 +1,3 @@
+[
+    {"name":"foo","type":"fallback", "stateMutability":"nonpayable"}
+]

--- a/tests/integration/cli/projects/one-interface/contracts/InterfaceWithNumber123.json
+++ b/tests/integration/cli/projects/one-interface/contracts/InterfaceWithNumber123.json
@@ -1,0 +1,3 @@
+[
+    {"name":"foo","type":"fallback", "stateMutability":"nonpayable"}
+]

--- a/tests/integration/cli/projects/one-interface/contracts/Interface_with_underscores.json
+++ b/tests/integration/cli/projects/one-interface/contracts/Interface_with_underscores.json
@@ -1,0 +1,3 @@
+[
+    {"name":"foo","type":"fallback", "stateMutability":"nonpayable"}
+]


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #662 

### How I did it

Adjusted the regex pattern that handles extension chains.

### How to verify it

Compile OZ contracts

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
