### PR TITLE
fix: dont except errors from first class plugins

### DIFF
--- a/src/ape/plugins/__init__.py
+++ b/src/ape/plugins/__init__.py
@@ -3,6 +3,7 @@ import importlib
 import pkgutil
 from typing import Any, Callable, Generator, Iterator, List, Optional, Tuple, Type, cast
 
+from ape.__modules__ import __modules__
 from ape.logging import logger
 
 from .account import AccountPlugin
@@ -128,6 +129,10 @@ class PluginManager:
                 try:
                     plugin_manager.register(importlib.import_module(name))
                 except Exception as err:
+                    if name in __modules__:
+                        # Don't except errors from first class plugins.
+                        raise
+
                     logger.warn_from_exception(err, f"Error loading plugin package '{name}'.")
 
     def __repr__(self):


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #155 

### How I did it

Don't exept errors from first class plugins

### How to verify it

1. On `main` branch, go to a first class plugin e.g. `ape_ethereum` and mess it up (add random characters to any file so it doesn't load right in Python)

2. Type `ape`
You will get WARNINGs like this:

```
WARNING: Error loading plugin package 'ape_ethereum'.
NameError: name 'asdf' is not defined
```

but ape will still work. **This is how we want second and third class plugins to work but if this happens to a first class plugins, that means the developer is currently messing up and this is not released.**

3. Checkout this branch and repeat step 2, now you should get a full stack trace

e.g.
```
  File "src/ape/plugins/__init__.py", line 130, in __init__
    plugin_manager.register(importlib.import_module(name))
  File ".pyenv/versions/3.10.1/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "ape/src/ape_ethereum/__init__.py", line 8, in <module>
    asdf
NameError: name 'asdf' is not defined

```

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
