### PR TITLE
fix: issue with -v debug when CLI plugins failed to load

### DIFF
--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -54,17 +54,10 @@ def verbosity_option(cli_logger):
     names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"
 
     def decorator(f):
-        def _set_level(ctx, param, value):
-            log_level = getattr(LogLevel, value.upper(), None)
-            if log_level is None:
-                raise click.BadParameter(f"Must be one of {names_str}, not {value}.")
-
-            cli_logger.set_level(log_level.name)
-
         return click.option(
             "--verbosity",
             "-v",
-            callback=_set_level,
+            callback=lambda ctx, param, value: cli_logger._load_from_sys_argv(),
             default=DEFAULT_LOG_LEVEL,
             metavar="LVL",
             expose_value=False,

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -54,7 +54,7 @@ def verbosity_option(cli_logger):
     names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"
 
     def set_level(ctx, param, value):
-        cli_logger._load_from_sys_argv(default=value)
+        cli_logger._load_from_sys_argv(default=value.upper())
 
     def decorator(f):
         return click.option(

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -53,11 +53,14 @@ def verbosity_option(cli_logger):
     level_names = [lvl.name for lvl in LogLevel]
     names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"
 
+    def set_level(ctx, param, value):
+        cli_logger._load_from_sys_argv(default=value)
+
     def decorator(f):
         return click.option(
             "--verbosity",
             "-v",
-            callback=lambda ctx, param, value: cli_logger._load_from_sys_argv(default=value),
+            callback=set_level,
             default=DEFAULT_LOG_LEVEL,
             metavar="LVL",
             expose_value=False,

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -57,7 +57,7 @@ def verbosity_option(cli_logger):
         return click.option(
             "--verbosity",
             "-v",
-            callback=lambda ctx, param, value: cli_logger._load_from_sys_argv(),
+            callback=lambda ctx, param, value: cli_logger._load_from_sys_argv(default=value),
             default=DEFAULT_LOG_LEVEL,
             metavar="LVL",
             expose_value=False,

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -104,8 +104,12 @@ class CliLogger:
         self._logger = _logger
         self._web3_request_manager_logger = _get_logger("web3.RequestManager")
         self._web3_http_provider_logger = _get_logger("web3.providers.HTTPProvider")
+        self._load_from_sys_argv()
 
-        # NOTE: We need to set the verbosity from the CLI option earlier than click lets us.
+    def _load_from_sys_argv(self):
+        """
+        Load from sys.argv to beat race condition with `click`.
+        """
         log_level = DEFAULT_LOG_LEVEL
         level_names = [lvl.name for lvl in LogLevel]
         for arg_i in range(len(sys.argv) - 1):

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -3,7 +3,7 @@ import logging
 import sys
 import traceback
 from enum import IntEnum
-from typing import IO, Union
+from typing import IO, Optional, Union
 
 import click
 
@@ -106,11 +106,11 @@ class CliLogger:
         self._web3_http_provider_logger = _get_logger("web3.providers.HTTPProvider")
         self._load_from_sys_argv()
 
-    def _load_from_sys_argv(self):
+    def _load_from_sys_argv(self, default: Optional[str] = None):
         """
         Load from sys.argv to beat race condition with `click`.
         """
-        log_level = DEFAULT_LOG_LEVEL
+        log_level = default or DEFAULT_LOG_LEVEL
         level_names = [lvl.name for lvl in LogLevel]
         for arg_i in range(len(sys.argv) - 1):
             if sys.argv[arg_i] == "-v" or sys.argv[arg_i] == "--verbosity":


### PR DESCRIPTION
### What I did

When using CLI plugins that fails, the `-v debug` flag would not register and I would not get a stack trace whereas it does for the non-CLI plugins. So, I figured out that it was more race conditions from click. Click actually calls the callback methods more than once. It does first to set the default value and again after it processes user args. So, it would get set to INFO, then the CLI plugin would fail to load, and then the DEBUG message would never get seen.
I fixed this.

### How I did it

Make the callback for the `verbosity_option` set from sys argv.
This makes it so plugins can still use this option (as currently it is not automatically given - will need to maybe look into `click-extensions` or whatever its called.

### How to verify it

Mess up a plugin, such as a config related error.
Like what I did is add key `hardhat:` in `ape-config.yaml` and don't put anything underneath it. It should error the plugin out.
Now, with this PR, you can use `-v debug` and can see the full stack trace, the same as it works elsewhere and should work.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
