### PR TITLE
fix: bug preventing compiling dependencies in a project with no source files

### DIFF
--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -309,6 +309,9 @@ class ProjectManager(BaseManager):
         extensions_found = []
 
         def _append_extensions_in_dir(directory: Path):
+            if not directory.is_dir():
+                return
+
             for file in directory.iterdir():
                 if file.is_dir():
                     _append_extensions_in_dir(file)

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -383,6 +383,8 @@ class ProjectManager(BaseManager):
             types for each compiled contract.
         """
 
+        self._load_dependencies()
+
         if not self.contracts_folder.exists():
             return {}
 
@@ -390,9 +392,7 @@ class ProjectManager(BaseManager):
         if not use_cache and in_source_cache.exists():
             shutil.rmtree(str(in_source_cache))
 
-        self._load_dependencies()
         file_paths = [file_paths] if isinstance(file_paths, Path) else file_paths
-
         manifest = self._project.create_manifest(file_paths, use_cache=use_cache)
         return manifest.contract_types or {}
 

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -40,16 +40,15 @@ def cli(cli_ctx, file_paths, use_cache, display_size):
         cli_ctx.logger.warning("Nothing to compile.")
         return
 
-    if file_paths:
-        ext_given = [p.suffix for p in file_paths if p]
-        ext_with_missing_compilers = cli_ctx.project_manager.extensions_with_missing_compilers(
-            ext_given
-        )
+    ext_given = [p.suffix for p in file_paths if p]
+    ext_with_missing_compilers = cli_ctx.project_manager.extensions_with_missing_compilers(
+        ext_given
+    )
 
-        if ext_with_missing_compilers:
-            extensions_str = ", ".join(ext_with_missing_compilers)
-            message = f"No compilers detected for the following extensions: {extensions_str}"
-            cli_ctx.logger.warning(message)
+    if ext_with_missing_compilers:
+        extensions_str = ", ".join(ext_with_missing_compilers)
+        message = f"No compilers detected for the following extensions: {extensions_str}"
+        cli_ctx.logger.warning(message)
 
     contract_types = cli_ctx.project_manager.load_contracts(
         file_paths=file_paths, use_cache=use_cache

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -35,20 +35,21 @@ def cli(cli_ctx, file_paths, use_cache, display_size):
     a project is loaded. You do not have to manually trigger a recompile.
     """
 
-    if not file_paths and cli_ctx.project_manager.sources_missing:
-        contracts_dir = cli_ctx.config_manager.contracts_folder
-        cli_ctx.logger.warning(f"No source files found in '{contracts_dir}'.")
+    sources_missing = cli_ctx.project_manager.sources_missing
+    if not file_paths and sources_missing and len(cli_ctx.project_manager.dependencies) == 0:
+        cli_ctx.logger.warning("Nothing to compile.")
         return
 
-    ext_given = [p.suffix for p in file_paths if p]
-    ext_with_missing_compilers = cli_ctx.project_manager.extensions_with_missing_compilers(
-        ext_given
-    )
+    if file_paths:
+        ext_given = [p.suffix for p in file_paths if p]
+        ext_with_missing_compilers = cli_ctx.project_manager.extensions_with_missing_compilers(
+            ext_given
+        )
 
-    if ext_with_missing_compilers:
-        extensions_str = ", ".join(ext_with_missing_compilers)
-        message = f"No compilers detected for the following extensions: {extensions_str}"
-        cli_ctx.logger.warning(message)
+        if ext_with_missing_compilers:
+            extensions_str = ", ".join(ext_with_missing_compilers)
+            message = f"No compilers detected for the following extensions: {extensions_str}"
+            cli_ctx.logger.warning(message)
 
     contract_types = cli_ctx.project_manager.load_contracts(
         file_paths=file_paths, use_cache=use_cache

--- a/tests/integration/cli/projects/only-dependency/ape-config.yaml
+++ b/tests/integration/cli/projects/only-dependency/ape-config.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: __test_dependency_a__
+    local: ./dependency_a
+    contracts_folder: sources

--- a/tests/integration/cli/projects/only-dependency/dependency_a/ape-config.yaml
+++ b/tests/integration/cli/projects/only-dependency/dependency_a/ape-config.yaml
@@ -1,0 +1,2 @@
+contracts_folder: sources
+name: __test_dependency_a__

--- a/tests/integration/cli/projects/only-dependency/dependency_a/sources/DependencyA.json
+++ b/tests/integration/cli/projects/only-dependency/dependency_a/sources/DependencyA.json
@@ -1,0 +1,3 @@
+[
+    {"name":"foo","type":"fallback", "stateMutability":"nonpayable"}
+]

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -7,17 +7,19 @@ from ape.contracts import ContractContainer
 from .utils import skip_projects, skip_projects_except
 
 
-@skip_projects(["unregistered-contracts", "one-interface", "geth", "with-dependency"])
+@skip_projects(
+    ["unregistered-contracts", "one-interface", "geth", "only-dependency", "with-dependency"]
+)
 def test_compile_missing_contracts_dir(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["compile"])
     assert result.exit_code == 0, result.output
     assert "WARNING" in result.output, result.output
-    assert "No source files found in" in result.output
+    assert "Nothing to compile" in result.output
 
 
 @skip_projects_except(["unregistered-contracts"])
 def test_missing_extensions(ape_cli, runner, project):
-    result = runner.invoke(ape_cli, ["compile"])
+    result = runner.invoke(ape_cli, ["compile", "--force"])
     assert result.exit_code == 0, result.output
     assert "WARNING: No compilers detected for the following extensions:" in result.output
     assert ".test" in result.output
@@ -31,7 +33,17 @@ def test_no_compiler_for_extension(ape_cli, runner, project):
     assert "WARNING: No compilers detected for the following extensions: .test" in result.output
 
 
-@skip_projects(["empty-config", "no-config", "script", "unregistered-contracts", "test", "geth"])
+@skip_projects(
+    [
+        "empty-config",
+        "no-config",
+        "script",
+        "only-dependency",
+        "unregistered-contracts",
+        "test",
+        "geth",
+    ]
+)
 def test_compile(ape_cli, runner, project, clean_cache):
     result = runner.invoke(ape_cli, ["compile"], catch_exceptions=False)
     assert result.exit_code == 0, result.output
@@ -125,7 +137,7 @@ def test_compile_non_ape_project_deletes_ape_config_file(ape_cli, runner, projec
 
 
 @skip_projects_except(["only-dependency"])
-def test_compile_only_dependency(ape_cli, runner, project):
+def test_compile_only_dependency(ape_cli, runner, project, clean_cache):
     dependency_cache = project.path / "dependency_a" / ".build"
     if dependency_cache.is_dir():
         shutil.rmtree(str(dependency_cache))

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -1,3 +1,5 @@
+import shutil
+
 import pytest
 
 from ape.contracts import ContractContainer
@@ -113,3 +115,14 @@ def test_compile_individual_contract_excludes_other_contract(ape_cli, runner, pr
     result = runner.invoke(ape_cli, ["compile", "Project", "--force"], catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert "Other" not in result.output
+
+
+@skip_projects_except(["only-dependency"])
+def test_compile_only_dependency(ape_cli, runner, project):
+    dependency_cache = project.path / "dependency_a" / ".build"
+    if dependency_cache.is_dir():
+        shutil.rmtree(str(dependency_cache))
+
+    result = runner.invoke(ape_cli, ["compile", "--force"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    assert "Compiling 'DependencyA.json'" in result.output


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #659 

### How I did it

* Before warning and exiting early, check if the project has dependencies, which triggers them to get downloaded
* Additionally, allow `load_projects()` to still load dependencies before early returning (This is extra and may help from a programmatic perspective and help reduce potential for regression)

### How to verify it

* Create a project that does not have a `contracts/` directory but does use dependencies.
* Run `ape compile`
* It should download and compile the dependencies

See tests as well!

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
