### PR TITLE
fix: error message when provider not found

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -660,7 +660,7 @@ class NetworkAPI(BaseInterfaceModel):
         if provider_name in self.providers:
             self._default_provider = provider_name
         else:
-            raise NetworkError(f"No providers found for network '{self.name}'")
+            raise NetworkError(f"Provider '{provider_name}' not found.")
 
     def use_default_provider(
         self, provider_settings: Optional[Dict] = None

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -64,8 +64,6 @@ def test_default_provider_not_found(config, networks):
     eth_config = {"ethereum": {"mainnet": {"default_provider": "DOES_NOT_EXIST"}}}
 
     with temp_config(eth_config, config):
-        with pytest.raises(NetworkError) as err:
+        with pytest.raises(NetworkError, match="Provider 'DOES_NOT_EXIST' not found."):
             # Trigger re-loading the Ethereum config.
             _ = networks.ecosystems
-
-        assert str(err.value) == "Provider 'DOES_NOT_EXIST' not found."

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -15,13 +15,14 @@ from ape.managers.config import CONFIG_FILE_NAME, DeploymentConfigCollection
 def temp_config(data: Dict, config):
     with tempfile.TemporaryDirectory() as temp_dir_str:
         temp_dir = Path(temp_dir_str)
-        config.PROJECT_FOLDER = temp_dir
-        config_file = temp_dir / CONFIG_FILE_NAME
-        config_file.touch()
-        config_file.write_text(yaml.dump(data))
-        yield
-        config_file.unlink()
-        config.load(force_reload=True)
+        with config.using_project(temp_dir):
+            config._cached_configs = {}
+            config_file = temp_dir / CONFIG_FILE_NAME
+            config_file.touch()
+            config_file.write_text(yaml.dump(data))
+            yield
+            config_file.unlink()
+            config._cached_configs = {}
 
 
 def test_integer_deployment_addresses(networks):

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -20,6 +20,8 @@ def temp_config(data: Dict, config):
         config_file.touch()
         config_file.write_text(yaml.dump(data))
         yield
+        config_file.unlink()
+        config.load(force_reload=True)
 
 
 def test_integer_deployment_addresses(networks):


### PR DESCRIPTION
### What I did

I had a project saying to use `infura` as my default provider.
However - I didn't have the plugin installed. The error message I received was confusing, it said something like
`"No providers to handle network 'mainnet'"`, which simply was not true.

I realized the real error eventually and adjusted the error message and then added a test.

### How I did it

Change error message to say `Provider 'provider' not installed'

### How to verify it

Add this to your `ape-config.yaml` file

```yaml
ethereum:
  mainnet:
    default_provider: DOES_NOT_EXIST
```

See the error message it yields!

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
