### PR TITLE
feat: cache chain ID to make less RPC calls

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -26,6 +26,7 @@ from ape.contracts._utils import LogInputABICollection
 from ape.exceptions import (
     DecodingError,
     ProviderError,
+    ProviderNotConnectedError,
     RPCTimeoutError,
     SubprocessError,
     SubprocessTimeoutError,
@@ -99,6 +100,9 @@ class ProviderAPI(BaseInterfaceModel):
 
     request_header: dict
     """A header to set on HTTP/RPC requests."""
+
+    cached_chain_id: Optional[int] = None
+    """Implementation providers may use this to cache and re-use chain ID."""
 
     @abstractmethod
     def connect(self):
@@ -478,7 +482,14 @@ class Web3Provider(ProviderAPI, ABC):
     [web3.py](https://web3py.readthedocs.io/en/stable/) python package.
     """
 
-    _web3: Web3 = None  # type: ignore
+    _web3: Optional[Web3] = None
+
+    @property
+    def web3(self) -> Web3:
+        if not self._web3:
+            raise ProviderNotConnectedError()
+
+        return self._web3
 
     def update_settings(self, new_settings: dict):
         self.disconnect()
@@ -489,10 +500,10 @@ class Web3Provider(ProviderAPI, ABC):
         txn_dict = txn.dict()
         return self._web3.eth.estimate_gas(txn_dict)  # type: ignore
 
-    @cached_property
+    @property
     def chain_id(self) -> int:
-        if hasattr(self._web3, "eth"):
-            return self._web3.eth.chain_id
+        if hasattr(self.web3, "eth"):
+            return self.web3.eth.chain_id
         else:
             return self.network.chain_id
 
@@ -502,7 +513,7 @@ class Web3Provider(ProviderAPI, ABC):
 
     @property
     def priority_fee(self) -> int:
-        return self._web3.eth.max_priority_fee
+        return self.web3.eth.max_priority_fee
 
     @property
     def base_fee(self) -> int:
@@ -521,27 +532,27 @@ class Web3Provider(ProviderAPI, ABC):
             if block_id.isnumeric():
                 block_id = add_0x_prefix(block_id)
 
-        block_data = self._web3.eth.get_block(block_id)
+        block_data = self.web3.eth.get_block(block_id)
         return self.network.ecosystem.decode_block(block_data)  # type: ignore
 
     def get_nonce(self, address: str) -> int:
-        return self._web3.eth.get_transaction_count(address)  # type: ignore
+        return self.web3.eth.get_transaction_count(address)  # type: ignore
 
     def get_balance(self, address: str) -> int:
-        return self._web3.eth.get_balance(address)  # type: ignore
+        return self.web3.eth.get_balance(address)  # type: ignore
 
     def get_code(self, address: str) -> bytes:
-        return self._web3.eth.get_code(address)  # type: ignore
+        return self.web3.eth.get_code(address)  # type: ignore
 
     def send_call(self, txn: TransactionAPI) -> bytes:
-        return self._web3.eth.call(txn.dict())
+        return self.web3.eth.call(txn.dict())
 
     def get_transaction(self, txn_hash: str, required_confirmations: int = 0) -> ReceiptAPI:
         if required_confirmations < 0:
             raise TransactionError(message="Required confirmations cannot be negative.")
 
-        receipt_data = self._web3.eth.wait_for_transaction_receipt(HexBytes(txn_hash))
-        txn = self._web3.eth.get_transaction(txn_hash)  # type: ignore
+        receipt_data = self.web3.eth.wait_for_transaction_receipt(HexBytes(txn_hash))
+        txn = self.web3.eth.get_transaction(txn_hash)  # type: ignore
         receipt = self.network.ecosystem.decode_receipt(
             {
                 "provider": self,
@@ -676,11 +687,11 @@ class Web3Provider(ProviderAPI, ABC):
             else:
                 log_filter["topics"] = event_parameters.pop("topics")
 
-            log_result = [dict(log) for log in self._web3.eth.get_logs(log_filter)]  # type: ignore
+            log_result = [dict(log) for log in self.web3.eth.get_logs(log_filter)]  # type: ignore
             yield from self.network.ecosystem.decode_logs(abi, log_result)
 
     def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
-        txn_hash = self._web3.eth.send_raw_transaction(txn.serialize_transaction())
+        txn_hash = self.web3.eth.send_raw_transaction(txn.serialize_transaction())
         req_confs = (
             txn.required_confirmations
             if txn.required_confirmations is not None
@@ -764,6 +775,7 @@ class SubprocessProvider(ProviderAPI):
         Subclasses override this method to do provider-specific disconnection tasks.
         """
 
+        self.cached_chain_id = None
         if self.process:
             self.stop()
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -489,7 +489,7 @@ class Web3Provider(ProviderAPI, ABC):
         txn_dict = txn.dict()
         return self._web3.eth.estimate_gas(txn_dict)  # type: ignore
 
-    @property
+    @cached_property
     def chain_id(self) -> int:
         if hasattr(self._web3, "eth"):
             return self._web3.eth.chain_id

--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -243,7 +243,7 @@ class GethProvider(Web3Provider, UpstreamProvider):
     @property
     def _node_info(self) -> Optional[NodeInfo]:
         try:
-            return self._web3.geth.admin.node_info()
+            return self.web3.geth.admin.node_info()
         except ValueError:
             # Unsupported API in user's geth.
             return None

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -15,7 +15,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
 
     _tester: PyEVMBackend
 
-    def __init__(self, **data):
+    def __init__(self, **data) -> None:
         super().__init__(**data)
         self._tester = PyEVMBackend.from_mnemonic(
             mnemonic=self.config["mnemonic"],

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -8,49 +8,53 @@ from web3.providers.eth_tester.defaults import API_ENDPOINTS
 from ape.api import ReceiptAPI, TestProviderAPI, TransactionAPI, Web3Provider
 from ape.exceptions import ContractLogicError, OutOfGasError, TransactionError, VirtualMachineError
 from ape.types import SnapshotID
-from ape.utils import cached_property, gas_estimation_error_message
+from ape.utils import gas_estimation_error_message
 
 
 class LocalProvider(TestProviderAPI, Web3Provider):
 
     _tester: PyEVMBackend
-    _web3: Web3
 
-    def __init__(self, **data) -> None:
+    def __init__(self, **data):
         super().__init__(**data)
-
         self._tester = PyEVMBackend.from_mnemonic(
             mnemonic=self.config["mnemonic"],
             num_accounts=self.config["number_of_accounts"],
         )
+
+    def connect(self):
         self._web3 = Web3(EthereumTesterProvider(ethereum_tester=self._tester))
         self._web3.middleware_onion.add(simple_cache_middleware)
 
-    def connect(self):
-        pass
-
     def disconnect(self):
-        pass
+        self.cached_chain_id = None
+        self._web3 = None
 
     def update_settings(self, new_settings: dict):
         pass
 
     def estimate_gas_cost(self, txn: TransactionAPI) -> int:
         try:
-            return self._web3.eth.estimate_gas(txn.dict())  # type: ignore
+            result = self.web3.eth.estimate_gas(txn.dict())  # type: ignore
+            return result
         except ValidationError as err:
             message = gas_estimation_error_message(err)
             raise TransactionError(base_err=err, message=message) from err
         except TransactionFailed as err:
             raise _get_vm_err(err) from err
 
-    @cached_property
+    @property
     def chain_id(self) -> int:
-        if hasattr(self._web3, "eth"):
-            return self._web3.eth.chain_id
+        if self.cached_chain_id is not None:
+            return self.cached_chain_id
+        elif hasattr(self.web3, "eth"):
+            chain_id = self.web3.eth.chain_id
+        else:
+            default_value = API_ENDPOINTS["eth"]["chainId"]()
+            chain_id = int(default_value, 16)
 
-        default_value = API_ENDPOINTS["eth"]["chainId"]()
-        return int(default_value, 16)
+        self.cached_chain_id = chain_id
+        return chain_id
 
     @property
     def gas_price(self) -> int:
@@ -67,7 +71,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
             data["gas"] = int(1e12)
 
         try:
-            return self._web3.eth.call(data)
+            return self.web3.eth.call(data)
         except ValidationError as err:
             raise VirtualMachineError(base_err=err) from err
         except TransactionFailed as err:
@@ -75,7 +79,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
 
     def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
         try:
-            txn_hash = self._web3.eth.send_raw_transaction(txn.serialize_transaction())
+            txn_hash = self.web3.eth.send_raw_transaction(txn.serialize_transaction())
         except ValidationError as err:
             raise VirtualMachineError(base_err=err) from err
         except TransactionFailed as err:

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -13,7 +13,7 @@ from ape.api import (
     TransactionAPI,
 )
 from ape.contracts import ContractContainer, ContractInstance
-from ape.exceptions import ChainError, ContractLogicError
+from ape.exceptions import ChainError, ContractLogicError, ProviderNotConnectedError
 from ape_ethereum.transactions import TransactionStatusEnum
 
 TEST_ADDRESS = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
@@ -137,24 +137,24 @@ def pytest_runtest_protocol(item, nextitem):
 
         try:
             ape.chain.restore(snapshot_id)
-        except (HeaderNotFound, ChainError):
+        except (HeaderNotFound, ChainError, ProviderNotConnectedError):
             pass
     else:
         yield
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def networks_connected_to_tester():
     with ape.networks.parse_network_choice("::test"):
         yield ape.networks
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def ethereum(networks_connected_to_tester):
     return networks_connected_to_tester.ethereum
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def eth_tester_provider(networks_connected_to_tester):
     yield networks_connected_to_tester.active_provider
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -155,8 +155,8 @@ def ethereum(networks_connected_to_tester):
 
 
 @pytest.fixture
-def eth_tester_provider(networks):
-    yield networks.active_provider
+def eth_tester_provider(networks_connected_to_tester):
+    yield networks_connected_to_tester.active_provider
 
 
 @pytest.fixture

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -10,6 +10,11 @@ from ape.exceptions import AccountsError, ContractLogicError, TransactionError
 ALIAS = "__FUNCTIONAL_TESTS_ALIAS__"
 
 
+@pytest.fixture(autouse=True, scope="module")
+def connected(eth_tester_provider):
+    yield
+
+
 @pytest.fixture
 def temp_ape_account(keyparams, temp_accounts_path):
     test_keyfile_path = temp_accounts_path / f"{ALIAS}.json"

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -24,9 +24,7 @@ def test_chain_id_is_cached(eth_tester_provider):
 def test_chain_id_when_none_raises(eth_tester_provider):
     eth_tester_provider.disconnect()
 
-    with pytest.raises(ProviderNotConnectedError) as err:
+    with pytest.raises(ProviderNotConnectedError, match="Not connected to a network provider."):
         _ = eth_tester_provider.chain_id
-
-    assert str(err.value) == "Not connected to a network provider."
 
     eth_tester_provider.connect()  # Undo

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -1,10 +1,32 @@
-def test_chain_id(eth_tester_provider):
-    expected_chain_id = 61
+import pytest
 
+from ape.exceptions import ProviderNotConnectedError
+
+EXPECTED_CHAIN_ID = 61
+
+
+def test_chain_id(eth_tester_provider):
     chain_id = eth_tester_provider.chain_id
-    assert chain_id == expected_chain_id
+    assert chain_id == EXPECTED_CHAIN_ID
+
+
+def test_chain_id_is_cached(eth_tester_provider):
+    _ = eth_tester_provider.chain_id
 
     # Unset `_web3` to show that it is not used in a second call to `chain_id`.
+    web3 = eth_tester_provider._web3
     eth_tester_provider._web3 = None
     chain_id = eth_tester_provider.chain_id
-    assert chain_id == expected_chain_id
+    assert chain_id == EXPECTED_CHAIN_ID
+    eth_tester_provider._web3 = web3  # Undo
+
+
+def test_chain_id_when_none_raises(eth_tester_provider):
+    eth_tester_provider.disconnect()
+
+    with pytest.raises(ProviderNotConnectedError) as err:
+        _ = eth_tester_provider.chain_id
+
+    assert str(err.value) == "Not connected to a network provider."
+
+    eth_tester_provider.connect()  # Undo

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -1,0 +1,10 @@
+def test_chain_id(eth_tester_provider):
+    expected_chain_id = 61
+
+    chain_id = eth_tester_provider.chain_id
+    assert chain_id == expected_chain_id
+
+    # Unset `_web3` to show that it is not used in a second call to `chain_id`.
+    eth_tester_provider._web3 = None
+    chain_id = eth_tester_provider.chain_id
+    assert chain_id == expected_chain_id


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
partially fixes: #483 

### How I did it

* Track a cached chain ID.
* Unset when `disconnect()`
* Fix bug where you could not disconnect the `EthTester` provider.

### How to verify it

Before this PR, there were 3 requests made to `chain_id()` RPC when deploying a contract.
Now, there are only 2.
There only needs to be 1 but this bug is preventing that: 
https://github.com/ethereum/web3.py/pull/2450

^ The other part to fixing the issue is completing the `web3.py` PR and bump our version of it here

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
