### PR TITLE
fix: always return chain id from network when using live network

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -20,7 +20,7 @@ from pydantic import Field, validator
 from web3 import Web3
 
 from ape.api.config import PluginConfig
-from ape.api.networks import NetworkAPI
+from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI
 from ape.api.transactions import ReceiptAPI, TransactionAPI
 from ape.contracts._utils import LogInputABICollection
 from ape.exceptions import (
@@ -502,10 +502,15 @@ class Web3Provider(ProviderAPI, ABC):
 
     @property
     def chain_id(self) -> int:
-        if hasattr(self.web3, "eth"):
-            return self.web3.eth.chain_id
-        else:
+        if self.network.name != LOCAL_NETWORK_NAME and not self.network.name.endswith("-fork"):
+            # If using a live network, the chain ID is hardcoded.
             return self.network.chain_id
+
+        elif hasattr(self.web3, "eth"):
+            return self.web3.eth.chain_id
+
+        else:
+            raise ProviderNotConnectedError()
 
     @property
     def gas_price(self) -> int:


### PR DESCRIPTION
### What I did

Fixes an issue when using `mainnet-fork:hardhat` and you do `vars(provider)`, it would fail with `ProviderNotConnectedError` because it as trying to get the chain ID from the mainnet upstream provider (which is not connected really).

### How I did it

The fix is to do exactly the same thing that we are doing except **in a better, more optimized order**.
The solution: Detect if using a live network and return the hardcoded chain ID without first checking if `web3` is a thing.

### How to verify it

Connect to mainnet fork:

```bash
ape console --network :mainnet-fork:hardhat
```

Run this:

```python
vars(networks.provider)
```

It should not fail anymore. Before, it did.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
