### PR TITLE
fix: bug preventing "no" from working in signing prompt

### DIFF
--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -108,7 +108,7 @@ class KeyfileAccount(AccountAPI):
 
     def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
         user_approves = self.__autosign or click.confirm(f"{msg}\n\nSign: ")
-        if self.locked and not user_approves:
+        if not user_approves:
             return None
 
         signed_msg = EthAccount.sign_message(msg, self.__key)
@@ -120,7 +120,7 @@ class KeyfileAccount(AccountAPI):
 
     def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:
         user_approves = self.__autosign or click.confirm(f"{txn}\n\nSign: ")
-        if self.locked and not user_approves:
+        if not user_approves:
             return None
 
         signed_txn = EthAccount.sign_transaction(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from tempfile import mkdtemp
 
 import pytest
+from click.testing import CliRunner
 
 import ape
 
@@ -89,3 +90,8 @@ def temp_accounts_path(config):
 
     if path.exists():
         shutil.rmtree(path)
+
+
+@pytest.fixture
+def runner(project):
+    yield CliRunner()

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -3,7 +3,6 @@ from importlib import import_module
 from pathlib import Path
 
 import pytest
-from click.testing import CliRunner
 
 from .utils import NodeId, project_names, project_skipper, projects_directory
 
@@ -83,11 +82,6 @@ def project(request, config):
 
     with config.using_project(project_dest_dir) as project:
         yield project
-
-
-@pytest.fixture
-def runner(project):
-    yield CliRunner()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #671 

### How I did it

Removed unneeded check and added lots of tests to make sure is working.
Please let me know if there are missing test cases.

### How to verify it

1. Transact using keyfile account and leave account unlocked
2. Transact again in same session only when it asks you to sign, say "no". It should not sign! Before, it was.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
