### PR TITLE
feat: configure transaction acceptance timeout

### DIFF
--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -94,3 +94,13 @@ event_type = contract.MyEvent
 for log in receipt.decode_logs(event_type.abi):
     print(log.amount)  # Assuming 'amount' is a property on the event.
 ```
+
+## Transaction Acceptance Timeout
+
+**NOTE** For longer running scripts, you may need to increase the transaction acceptance timeout.
+The default value is 2 minutes.
+In your `ape-config.yaml` file, add the following:
+
+```yaml
+transaction_acceptance_timeout: 600  # 5 minutes
+```

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -556,7 +556,10 @@ class Web3Provider(ProviderAPI, ABC):
         if required_confirmations < 0:
             raise TransactionError(message="Required confirmations cannot be negative.")
 
-        receipt_data = self.web3.eth.wait_for_transaction_receipt(HexBytes(txn_hash))
+        timeout = self.config_manager.transaction_acceptance_timeout
+        receipt_data = self.web3.eth.wait_for_transaction_receipt(
+            HexBytes(txn_hash), timeout=timeout
+        )
         txn = self.web3.eth.get_transaction(txn_hash)  # type: ignore
         receipt = self.network.ecosystem.decode_receipt(
             {

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 
 CONFIG_FILE_NAME = "ape-config.yaml"
+DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT = 120
 
 
 class DeploymentConfig(PluginConfig):
@@ -100,6 +101,12 @@ class ConfigManager(BaseInterfaceModel):
     default_ecosystem: str = "ethereum"
     """The default ecosystem to use. Defaults to ``"ethereum"``."""
 
+    transaction_acceptance_timeout: int = DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT
+    """
+    The amount of time to wait for a transaction to be accepted on the network.
+    Does not include waiting for block-confirmations.
+    """
+
     _cached_configs: Dict[str, Dict[str, Any]] = {}
 
     @root_validator(pre=True)
@@ -127,6 +134,9 @@ class ConfigManager(BaseInterfaceModel):
             self.dependencies = cache.get("dependencies", [])
             self.deployments = cache.get("deployments", {})
             self.contracts_folder = cache.get("contracts_folder", self.PROJECT_FOLDER / "contracts")
+            self.transaction_acceptance_timeout = cache.get(
+                "transaction_acceptance_timeout", DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT
+            )
             return cache
 
         # First, load top-level configs. Then, load all the plugin configs.
@@ -139,6 +149,9 @@ class ConfigManager(BaseInterfaceModel):
         self.version = configs["version"] = user_config.pop("version", "")
         self.default_ecosystem = configs["default_ecosystem"] = user_config.pop(
             "default_ecosystem", "ethereum"
+        )
+        self.transaction_acceptance_timeout = user_config.pop(
+            "transaction_acceptance_timeout", DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT
         )
 
         try:

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -4,7 +4,7 @@ from typing import Dict
 import pytest
 
 from ape.exceptions import NetworkError
-from ape.managers.config import DeploymentConfigCollection
+from ape.managers.config import DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT, DeploymentConfigCollection
 
 
 def test_integer_deployment_addresses(networks):
@@ -53,3 +53,11 @@ def test_default_provider_not_found(temp_config, config, networks):
         ):
             # Trigger re-loading the Ethereum config.
             _ = networks.ecosystems
+
+
+def test_transaction_acceptance_timeout(temp_config, config, networks):
+    assert config.transaction_acceptance_timeout == DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT
+    new_value = DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT + 10
+    timeout_config = {"transaction_acceptance_timeout": new_value}
+    with temp_config(timeout_config, config):
+        assert config.transaction_acceptance_timeout == new_value


### PR DESCRIPTION
### What I did

Allow configuring `timeout` parameter on `web.py` `wait_for_transaction()` method.

### How I did it

Allow `ape-config.yaml` to configure the value and pass that value into the web.py method. Leave the default behavior otherwise.

### How to verify it

Create a config like:

```yaml
transaction_acceptance_timeout: X
```

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
