### PR TITLE
fix: bug where plugin name showed up in available plugins when it was installed

### DIFF
--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -119,21 +119,23 @@ def _list(cli_ctx, display_all):
         sections["Installed Core Plugins"] = [installed_core_plugins]
 
     # Get all plugins that are available and not already installed.
-    available_plugins = list(github_client.available_plugins - installed_org_plugins.keys())
+    available_plugins = list(
+        github_client.available_plugins - {p.strip() for p in installed_org_plugins.keys()}
+    )
 
     formatted_org_plugins = [f"{k}{v}" for k, v in installed_org_plugins.items()]
-    formateted_installed_third_party_plugins = [
+    formatted_installed_third_party_plugins = [
         f"{k}{v}" for k, v in installed_third_party_plugins.items()
     ]
     # Get the list of plugin lists that are populated.
     installed_plugin_lists = [
-        ls for ls in [formatted_org_plugins, formateted_installed_third_party_plugins] if ls
+        ls for ls in [formatted_org_plugins, formatted_installed_third_party_plugins] if ls
     ]
     if installed_plugin_lists:
         sections["Installed Plugins"] = installed_plugin_lists
     elif not display_all and available_plugins:
         # User has no plugins installed | can't verify installed plugins
-        click.echo("No secondary plugins installed. Use '--all' to see available plugins.")
+        click.echo("No plugins installed. Use '--all' to see available plugins.")
 
     if display_all:
         available_second_output = _format_output(available_plugins)

--- a/tests/integration/cli/test_misc.py
+++ b/tests/integration/cli/test_misc.py
@@ -1,7 +1,4 @@
 import pytest
-from github import RateLimitExceededException
-
-from .utils import skip_projects_except
 
 
 # NOTE: test all the things without a direct test elsewhere
@@ -21,26 +18,3 @@ from .utils import skip_projects_except
 def test_invocation(ape_cli, runner, args):
     result = runner.invoke(ape_cli, args)
     assert result.exit_code == 0, result.output
-
-
-# Only run these tests once (limited to single arbitrary project).
-# This is to prevent Github from rate limiting us and causing test failures.
-@skip_projects_except(["empty-config"])
-@pytest.mark.parametrize(
-    "args",
-    (
-        ["plugins", "list"],
-        ["plugins", "list", "--all"],
-    ),
-)
-def test_invocation_run_once(ape_cli, runner, args):
-    result = runner.invoke(ape_cli, args)
-
-    if result.exit_code != 0:
-        # Check if failed because we were rate-limited.
-        # If that is the case, consider the test as passing.
-        err = result.exception
-        if not isinstance(err, RateLimitExceededException):
-            assert False, result.output
-
-    # Test Passed

--- a/tests/integration/cli/test_plugins.py
+++ b/tests/integration/cli/test_plugins.py
@@ -14,7 +14,9 @@ def plugins_xfail():
     """
 
     def wrapper(f):
-        f = pytest.mark.xfail(strict=False, reason="Github rate limiting issues")(f)
+        f = pytest.mark.xfail(
+            strict=False, reason="Github rate limiting issues or plugin install issues"
+        )(f)
         f = skip_projects_except(["test"])(f)
         return f
 

--- a/tests/integration/cli/test_plugins.py
+++ b/tests/integration/cli/test_plugins.py
@@ -2,9 +2,26 @@ import pytest
 
 from tests.integration.cli.utils import skip_projects_except
 
+TEST_PLUGIN_NAME = "tokens"
 
-@pytest.mark.xfail(strict=False, reason="Github rate limiting issues")
-@skip_projects_except(["test"])  # Only run on single project to prevent rate-limiting in CI/CD
+
+def plugins_xfail():
+    """
+    Currently, there are two reasons we know these tests will fail.
+
+    1. GitHub rate limiting issues
+    2. Unable to figure out how to properly install a python package while python is running.
+    """
+
+    def wrapper(f):
+        f = pytest.mark.xfail(strict=False, reason="Github rate limiting issues")(f)
+        f = skip_projects_except(["test"])(f)
+        return f
+
+    return wrapper
+
+
+@plugins_xfail()
 def test_list_excludes_core_plugins(ape_cli, runner):
     result = runner.invoke(ape_cli, ["plugins", "list"])
     assert result.exit_code == 0, result.output
@@ -13,9 +30,19 @@ def test_list_excludes_core_plugins(ape_cli, runner):
     assert "geth" not in result.output, "networks is not supposed to be in Installed Plugins"
 
 
-@pytest.mark.xfail(strict=False, reason="Requires plugins installed")
-@skip_projects_except(["test"])  # Only run on single project to prevent rate-limiting in CI/CD
+@plugins_xfail()
 def test_list_include_version(ape_cli, runner):
+    # TODO: Figure out how to install plugin prior to test.
     result = runner.invoke(ape_cli, ["plugins", "list"])
     assert result.exit_code == 0, result.output
     assert "0.1" in result.output, "version is not in output"
+
+
+@plugins_xfail()
+def test_list_does_not_repeat(ape_cli, runner):
+    # TODO: Figure out how to install plugin prior to test.
+    result = runner.invoke(ape_cli, ["plugins", "list", "--all"])
+    sections = result.output.split("\n\n")
+    assert "tokens" in sections[1]
+    assert "tokens" not in sections[0]
+    assert "tokens" not in sections[2]


### PR DESCRIPTION
### What I did

Fix bug where plugin name showed up in available plugins when it was installed

### How I did it

Strip the items in a set.

### How to verify it

Run the test.
Note: plugins tests currently are manual because of issues like this: https://github.com/ApeWorX/ape/issues/285

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
