### PR TITLE
fix: network manager console representation bug fix

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -430,6 +430,9 @@ class NetworkAPI(BaseInterfaceModel):
 
     _default_provider: str = ""
 
+    def __repr__(self) -> str:
+        return f"<{self.name} chain_id={self.chain_id}>"
+
     @cached_property
     def config(self) -> PluginConfig:
         """

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -29,7 +29,7 @@ class NetworkManager(BaseManager):
     _ecosystems_by_project: Dict[str, Dict[str, EcosystemAPI]] = {}
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} active_provider={self.active_provider}>"
+        return f"<{self.__class__.__name__} active_provider={repr(self.active_provider)}>"
 
     @property
     def active_provider(self) -> Optional[ProviderAPI]:

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -49,3 +49,12 @@ def test_get_provider_when_not_found(networks):
         network.get_provider("test")
 
     assert "'test' is not a valid provider for network 'rinkeby-fork'" in str(err.value)
+
+
+def test_repr(networks_connected_to_tester):
+    assert (
+        repr(networks_connected_to_tester) == "<NetworkManager active_provider=<test chain_id=61>>"
+    )
+
+    # Check individual network
+    assert repr(networks_connected_to_tester.provider.network) == "<local chain_id=61>"


### PR DESCRIPTION
### What I did

Bug where the `NetworkManager` repr was incredibly verbose, causing the terminal to sometimes fail to see everything.

### How I did it

Call `repr` on provider within network manager repr

### How to verify it

1. Open console `ape console`
2. Type `networks`
3. Verify it fits nicely on a single line
See tests!

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
