### PR TITLE
fix: bug preventing the use of pytest built-in fixtures in ape tests

### DIFF
--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -15,14 +15,27 @@ class PytestApeFixtures(ManagerAccessMixin):
 
     @pytest.fixture(scope="session")
     def accounts(self) -> List[TestAccountAPI]:
+        """
+        The ape account test manager containing pre-funded test accounts.
+        """
+
         return self.account_manager.test_accounts
 
     @pytest.fixture(scope="session")
     def chain(self) -> ChainManager:
+        """
+        The chain manager for manipulating the blockchain in your test
+        setups and tear-downs.
+        """
+
         return self.chain_manager
 
     @pytest.fixture(scope="session")
     def project(self) -> ProjectManager:
+        """
+        The project manager for accessing contract types and dependencies.
+        """
+
         return self.project_manager
 
     def _isolation(self) -> Iterator[None]:

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -10,6 +10,10 @@ from ape.utils import ManagerAccessMixin
 
 
 class PytestApeFixtures(ManagerAccessMixin):
+    # NOTE: Avoid including links, markdown, or rst in method-docs
+    # for fixtures, as they are used in output from the command
+    # `ape test -q --fixture` (`pytest -q --fixture`).
+
     def __init__(self):
         self._warned_for_unimplemented_snapshot = False
 

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -95,8 +95,13 @@ class PytestApeRunner(ManagerAccessMixin):
             # isolation is disabled via cmdline option
             return
 
-        # list of scopes for each fixture of the test (including `autouse` fixtures)
-        scopes = [item._fixtureinfo.name2fixturedefs[f][0].scope for f in item.fixturenames]
+        fixture_map = item.session._fixturemanager._arg2fixturedefs
+        scopes = []
+        for name, fixture in fixture_map.items():
+            if name in item.fixturenames:
+                definitions = fixture_map[name]
+                for definition in definitions:
+                    scopes.append(definition.scope)
 
         for scope in ["session", "package", "module", "class"]:
             # iterate through scope levels and insert the isolation fixture

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -96,12 +96,12 @@ class PytestApeRunner(ManagerAccessMixin):
             return
 
         fixture_map = item.session._fixturemanager._arg2fixturedefs
-        scopes = []
-        for name, fixture in fixture_map.items():
-            if name in item.fixturenames:
-                definitions = fixture_map[name]
-                for definition in definitions:
-                    scopes.append(definition.scope)
+        scopes = [
+            definition.scope
+            for name, definitions in fixture_map.items()
+            if name in item.fixturenames
+            for definition in definitions
+        ]
 
         for scope in ["session", "package", "module", "class"]:
             # iterate through scope levels and insert the isolation fixture

--- a/tests/integration/cli/projects/test/tests/test_fixture_isolation.py
+++ b/tests/integration/cli/projects/test/tests/test_fixture_isolation.py
@@ -27,7 +27,3 @@ def test_isolation_first(alice, bob, chain):
 def test_isolation_second(bob, chain):
     assert chain.provider.get_block("latest").number == 1
     assert bob.balance == 1_000_001 * 10**18
-
-
-def test_can_use_built_in_fixtures(chain, capsys):
-    assert True

--- a/tests/integration/cli/projects/test/tests/test_fixture_isolation.py
+++ b/tests/integration/cli/projects/test/tests/test_fixture_isolation.py
@@ -27,3 +27,7 @@ def test_isolation_first(alice, bob, chain):
 def test_isolation_second(bob, chain):
     assert chain.provider.get_block("latest").number == 1
     assert bob.balance == 1_000_001 * 10**18
+
+
+def test_can_use_built_in_fixtures(chain, capsys):
+    assert True

--- a/tests/integration/cli/projects/test/tests/test_misc.py
+++ b/tests/integration/cli/projects/test/tests/test_misc.py
@@ -1,0 +1,2 @@
+def test_can_use_built_in_fixtures(chain, capsys):
+    assert True

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -1,16 +1,26 @@
 from .utils import skip_projects_except
 
+projects_with_tests = skip_projects_except(["test"])
 
-@skip_projects_except(["test"])
+
+@projects_with_tests
 def test_test(ape_cli, runner):
     # test cases implicitly test built-in isolation
     result = runner.invoke(ape_cli, ["test"])
     assert result.exit_code == 0, result.output
 
 
-@skip_projects_except(["test"])
+@projects_with_tests
 def test_test_isolation_disabled(ape_cli, runner):
     # check the disable isolation option actually disables built-in isolation
     result = runner.invoke(ape_cli, ["test", "--disable-isolation", "--setup-show"])
     assert result.exit_code == 1
     assert "F _function_isolation" not in result.output
+
+
+@projects_with_tests
+def test_fixture_docs(ape_cli, runner):
+    result = runner.invoke(ape_cli, ["test", "-q", "--fixtures"])
+    assert "ape account test manager" in result.output
+    assert "The chain manager for manipulating the blockchain" in result.output
+    assert "The project manager for accessing contract types and dependencies" in result.output


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #713 
Also adds docs to fixtures

### How I did it

Use session fixturemanager as point-of-reference for getting fixture info 

### How to verify it

You can no run the tests in https://github.com/fubuloubu/ERC4626

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
