### PR TITLE
fix: typo in mainnet-fork

### DIFF
--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -128,7 +128,7 @@ Set default network and network providers:
 ```yaml
 ethereum:
   default_network: mainnet-fork
-  mainnet-fork:
+  mainnet_fork:
     default_provider: hardhat
 ```
 


### PR DESCRIPTION
fix typo in an example

source for correction: https://github.com/ApeWorX/ape/blob/2392d53afa6ba2181f62da7aeb14a85b52ae0be6/src/ape_ethereum/ecosystem.py#L61
