### PR TITLE
feat: support calling transactions

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -186,6 +186,13 @@ class ContractTransactionHandler(ManagerAccessMixin):
 
     @property
     def call(self) -> ContractCallHandler:
+        """
+        Get the :class:`~ape.contracts.base.ContractCallHandler` equivalent
+        of this transaction handler. The call-handler uses the ``eth_call``
+        RPC under-the-hood and thus it gets reverted before submitted.
+        This a useful way to simulate a transaction without invoking it.
+        """
+
         return ContractCallHandler(self.contract, self.abis)
 
     def _convert_tuple(self, v: tuple) -> tuple:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -184,6 +184,10 @@ class ContractTransactionHandler(ManagerAccessMixin):
         abis = sorted(self.abis, key=lambda abi: len(abi.inputs or []))
         return abis[-1].signature
 
+    @property
+    def call(self) -> ContractCallHandler:
+        return ContractCallHandler(self.contract, self.abis)
+
     def _convert_tuple(self, v: tuple) -> tuple:
         return self.conversion_manager.convert(v, tuple)
 

--- a/tests/functional/test_contracts.py
+++ b/tests/functional/test_contracts.py
@@ -346,3 +346,12 @@ def test_solidity_named_tuple(solidity_contract_instance):
 def test_vyper_named_tuple(vyper_contract_instance):
     actual = vyper_contract_instance.getMultipleValues()
     assert actual == (123, 321)
+
+
+def test_call_transaction(contract_instance, owner, chain):
+    # Transaction never submitted because using `call`.
+    init_block = chain.blocks[-1]
+    contract_instance.setNumber.call(1, sender=owner)
+
+    # No mining happens because its a call
+    assert init_block == chain.blocks[-1]


### PR DESCRIPTION
### What I did

Supports `project.MyContract.my_method.call` to use `eth_call` instead of actually transacting.

### How I did it

Add

```python
@property
def call() -> ContractCallHandler
```

to `ContractTransactionHandler`

### How to verify it

You can now do `project.MyContract.my_mutable_method.call(args)`

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
