### PR TITLE
fix: ape compile dependent imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         "packaging>=20.9,<21.0",
         "pandas>=1.3.0,<2.0",
         "pluggy>=0.13.1,<1.0",
-        "pydantic>=1.9.0,<2.0",
+        "pydantic==1.9.0",
         "PyGithub>=1.54,<2.0",
         "pygit2>=1.7.2,<2.0",
         "pyyaml>=0.2.5",

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         "packaging>=20.9,<21.0",
         "pandas>=1.3.0,<2.0",
         "pluggy>=0.13.1,<1.0",
-        "pydantic==1.9.0",
+        "pydantic>=1.9.0,<2.0",
         "PyGithub>=1.54,<2.0",
         "pygit2>=1.7.2,<2.0",
         "pyyaml>=0.2.5",

--- a/src/ape/api/compiler.py
+++ b/src/ape/api/compiler.py
@@ -1,9 +1,9 @@
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import Dict, List, Optional, Set
 
 from ethpm_types import ContractType
 
-from ape.utils import BaseInterfaceModel, abstractmethod
+from ape.utils import BaseInterfaceModel, abstractmethod, get_relative_path, raises_not_implemented
 
 
 class CompilerAPI(BaseInterfaceModel):
@@ -50,6 +50,45 @@ class CompilerAPI(BaseInterfaceModel):
         Returns:
             List[:class:`~ape.type.contract.ContractType`]
         """
+
+    @raises_not_implemented
+    def fetch_imports(
+        self, contract_filepaths: List[Path], base_path: Optional[Path]
+    ) -> Dict[str, List[str]]:
+        """
+        Returns a list of imports for each contract in a given compiler.
+
+        Args:
+            contract_filepaths (List[pathlib.Path]): A list of source file paths to compile.
+            base_path (Optional[pathlib.Path]): Optionally provide the base path, such as the
+              project ``contracts/`` directory. Defaults to ``None``. When using in a project
+              via ``ape compile``, gets set to the project's ``contracts/`` directory.
+
+        Returns:
+            Dict[str, List[str]]
+        """
+
+    def _get_filename_dict_from_paths(
+        self, paths: List[Path], base_path: Optional[Path]
+    ) -> Dict[str, List[str]]:
+        """
+        Structure for getting a list of paths related to a filename.
+        Used to create a broad/generous assumption of related paths for a filename.
+        """
+        filename_dict: Dict[str, List[str]] = {}
+
+        for p in paths:
+            filename = str(p).split("/")[-1]
+
+            if not filename_dict.get(filename):
+                filename_dict[filename] = []
+
+            if base_path:
+                p = get_relative_path(p, base_path)
+
+            filename_dict[filename].append(str(p))
+
+        return filename_dict
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {self.name}>"

--- a/src/ape/api/compiler.py
+++ b/src/ape/api/compiler.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Set
 
 from ethpm_types import ContractType
 
-from ape.utils import BaseInterfaceModel, abstractmethod, get_relative_path, raises_not_implemented
+from ape.utils import BaseInterfaceModel, abstractmethod, raises_not_implemented
 
 
 class CompilerAPI(BaseInterfaceModel):
@@ -56,7 +56,7 @@ class CompilerAPI(BaseInterfaceModel):
         self, contract_filepaths: List[Path], base_path: Optional[Path]
     ) -> Dict[str, List[str]]:
         """
-        Returns a list of imports for each contract in a given compiler.
+        Returns a list of imports as source_ids for each contract's source_id in a given compiler.
 
         Args:
             contract_filepaths (List[pathlib.Path]): A list of source file paths to compile.
@@ -65,30 +65,8 @@ class CompilerAPI(BaseInterfaceModel):
               via ``ape compile``, gets set to the project's ``contracts/`` directory.
 
         Returns:
-            Dict[str, List[str]]
+            Dict[str, List[str]] {source_id: [import_source_id, ...], ...}
         """
-
-    def _get_filename_dict_from_paths(
-        self, paths: List[Path], base_path: Optional[Path]
-    ) -> Dict[str, List[str]]:
-        """
-        Structure for getting a list of paths related to a filename.
-        Used to create a broad/generous assumption of related paths for a filename.
-        """
-        filename_dict: Dict[str, List[str]] = {}
-
-        for p in paths:
-            filename = str(p).split("/")[-1]
-
-            if not filename_dict.get(filename):
-                filename_dict[filename] = []
-
-            if base_path:
-                p = get_relative_path(p, base_path)
-
-            filename_dict[filename].append(str(p))
-
-        return filename_dict
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {self.name}>"

--- a/src/ape/api/compiler.py
+++ b/src/ape/api/compiler.py
@@ -65,7 +65,7 @@ class CompilerAPI(BaseInterfaceModel):
               via ``ape compile``, gets set to the project's ``contracts/`` directory.
 
         Returns:
-            Dict[str, List[str]] {source_id: [import_source_id, ...], ...}
+            Dict[str, List[str]] A dictionary like ``{source_id: [import_source_id, ...], ...}``
         """
 
     def __repr__(self) -> str:

--- a/src/ape/api/compiler.py
+++ b/src/ape/api/compiler.py
@@ -65,7 +65,7 @@ class CompilerAPI(BaseInterfaceModel):
               via ``ape compile``, gets set to the project's ``contracts/`` directory.
 
         Returns:
-            Dict[str, List[str]] A dictionary like ``{source_id: [import_source_id, ...], ...}``
+            Dict[str, List[str]]: A dictionary like ``{source_id: [import_source_id, ...], ...}``
         """
 
     def __repr__(self) -> str:

--- a/src/ape/api/compiler.py
+++ b/src/ape/api/compiler.py
@@ -52,7 +52,7 @@ class CompilerAPI(BaseInterfaceModel):
         """
 
     @raises_not_implemented
-    def fetch_imports(
+    def get_imports(
         self, contract_filepaths: List[Path], base_path: Optional[Path]
     ) -> Dict[str, List[str]]:
         """

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Collection, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from ethpm_types import Checksum, ContractType, PackageManifest, Source
 from ethpm_types.manifest import PackageName
@@ -99,7 +99,7 @@ class ProjectAPI(BaseInterfaceModel):
     @classmethod
     def _create_manifest(
         cls,
-        sources: Collection[Path],
+        source_paths: List[Path],
         contracts_path: Path,
         contract_types: Dict[str, ContractType],
         name: Optional[str] = None,
@@ -114,25 +114,36 @@ class ProjectAPI(BaseInterfaceModel):
         if version:
             manifest.version = version
 
-        manifest.sources = cls._create_source_dict(sources, contracts_path)
+        manifest.sources = cls._create_source_dict(source_paths, contracts_path)
         manifest.contract_types = contract_types
         return PackageManifest(**manifest.dict())
 
     @classmethod
     def _create_source_dict(
-        cls, contract_paths: Collection[Path], base_path: Path
+        cls, contract_filepaths: List[Path], base_path: Path
     ) -> Dict[str, Source]:
-        return {
-            str(get_relative_path(source, base_path)): Source(  # type: ignore
+        imports_dict: Dict[str, List[str]] = cls.compiler_manager.fetch_imports(
+            contract_filepaths, base_path
+        )
+        references_dict: Dict[str, List[str]] = cls.compiler_manager.get_references(
+            imports_dict=imports_dict
+        )
+
+        source_dict: Dict[str, Source] = {}
+        for source_path in contract_filepaths:
+            key = str(get_relative_path(source_path, base_path))
+            source_dict[key] = Source(  # type: ignore
                 checksum=Checksum(  # type: ignore
                     algorithm="md5",
-                    hash=compute_checksum(source.read_bytes()),
+                    hash=compute_checksum(source_path.read_bytes()),
                 ),
                 urls=[],
-                content=source.read_text(),
+                content=source_path.read_text(),
+                imports=imports_dict.get(key, []),
+                references=references_dict.get(key, []),
             )
-            for source in contract_paths
-        }
+
+        return source_dict
 
 
 class DependencyAPI(BaseInterfaceModel):

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -116,18 +116,18 @@ class ProjectAPI(BaseInterfaceModel):
 
         manifest.sources = cls._create_source_dict(source_paths, contracts_path)
         manifest.contract_types = contract_types
-        return PackageManifest(**manifest.dict())
+        return manifest
 
     @classmethod
     def _create_source_dict(
         cls, contract_filepaths: List[Path], base_path: Path
     ) -> Dict[str, Source]:
-        imports_dict: Dict[str, List[str]] = cls.compiler_manager.get_imports(
+        source_imports: Dict[str, List[str]] = cls.compiler_manager.get_imports(
             contract_filepaths, base_path
-        )
-        references_dict: Dict[str, List[str]] = cls.compiler_manager.get_references(
-            imports_dict=imports_dict
-        )
+        )  # {source_id: [import_source_ids, ...], ...}
+        source_references: Dict[str, List[str]] = cls.compiler_manager.get_references(
+            imports_dict=source_imports
+        )  # {source_id: [referring_source_ids, ...], ...}
 
         source_dict: Dict[str, Source] = {}
         for source_path in contract_filepaths:
@@ -139,11 +139,11 @@ class ProjectAPI(BaseInterfaceModel):
                 ),
                 urls=[],
                 content=source_path.read_text(),
-                imports=imports_dict.get(key, []),
-                references=references_dict.get(key, []),
+                imports=source_imports.get(key, []),
+                references=source_references.get(key, []),
             )
 
-        return source_dict
+        return source_dict  # {source_id: Source}
 
 
 class DependencyAPI(BaseInterfaceModel):

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -122,7 +122,7 @@ class ProjectAPI(BaseInterfaceModel):
     def _create_source_dict(
         cls, contract_filepaths: List[Path], base_path: Path
     ) -> Dict[str, Source]:
-        imports_dict: Dict[str, List[str]] = cls.compiler_manager.fetch_imports(
+        imports_dict: Dict[str, List[str]] = cls.compiler_manager.get_imports(
             contract_filepaths, base_path
         )
         references_dict: Dict[str, List[str]] = cls.compiler_manager.get_references(

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -130,7 +130,7 @@ class CompilerManager(BaseManager):
               via ``ape compile``, gets set to the project's ``contracts/`` directory.
 
         Returns:
-            Dict[str, List[str]] A dictionary like ``{source_id: [import_source_id, ...], ...}``
+            Dict[str, List[str]]: A dictionary like ``{source_id: [import_source_id, ...], ...}``
         """
         imports_dict: Dict[str, List[str]] = {}
 
@@ -160,7 +160,7 @@ class CompilerManager(BaseManager):
               via ``ape compile``, gets set to the project's ``contracts/`` directory.
 
         Returns:
-            Dict[str, List[str]] A dictionary like ``{source_id: [referring_source_id, ...], ...}``
+            Dict[str, List[str]]: A dictionary like ``{source_id: [referring_source_id, ...], ...}``
         """
         references_dict: Dict[str, List[str]] = {}
         if not imports_dict:

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -120,7 +120,7 @@ class CompilerManager(BaseManager):
         self, contract_filepaths: List[Path], base_path: Optional[Path]
     ) -> Dict[str, List[str]]:
         """
-        Combines import dicts from all compilers, where the key is a contract's source_id
+        Combine import dicts from all compilers, where the key is a contract's source_id
         and the value is a list of import source_ids.
 
         Args:
@@ -149,7 +149,7 @@ class CompilerManager(BaseManager):
 
     def get_references(self, imports_dict: Dict[str, List[str]]) -> Dict[str, List[str]]:
         """
-        Provides a mapping containing all referenced source_ids for a given project.
+        Provide a mapping containing all referenced source_ids for a given project.
         Each entry contains a source_id as a key and list of source_ids that reference a
         given contract.
 

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -120,8 +120,8 @@ class CompilerManager(BaseManager):
         self, contract_filepaths: List[Path], base_path: Optional[Path]
     ) -> Dict[str, List[str]]:
         """
-        Combines import dicts from all compilers, where the key is a contract path
-        and the value is a list of import paths.
+        Combines import dicts from all compilers, where the key is a contract's source_id
+        and the value is a list of import source_ids.
 
         Args:
             contract_filepaths (List[pathlib.Path]): A list of source file paths to compile.
@@ -130,7 +130,7 @@ class CompilerManager(BaseManager):
               via ``ape compile``, gets set to the project's ``contracts/`` directory.
 
         Returns:
-            Dict[str, List[str]]
+            Dict[str, List[str]] {source_id: [import_source_id, ...], ...}
         """
         imports_dict: Dict[str, List[str]] = {}
 
@@ -148,6 +148,19 @@ class CompilerManager(BaseManager):
         return imports_dict
 
     def get_references(self, imports_dict: Dict[str, List[str]]) -> Dict[str, List[str]]:
+        """
+        Reversed dictionary from contract imports dictionary. Each entry is a list of
+        source_ids that reference the source_id key of a given contract.
+
+        Args:
+            contract_filepaths (List[pathlib.Path]): A list of source file paths to compile.
+            base_path (Optional[pathlib.Path]): Optionally provide the base path, such as the
+              project ``contracts/`` directory. Defaults to ``None``. When using in a project
+              via ``ape compile``, gets set to the project's ``contracts/`` directory.
+
+        Returns:
+            Dict[str, List[str]] {source_id: [referring_source_id, ...], ...}
+        """
         references_dict: Dict[str, List[str]] = {}
         if imports_dict:
             for key, imports_list in imports_dict.items():

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -116,7 +116,7 @@ class CompilerManager(BaseManager):
 
         return contract_types_dict  # type: ignore
 
-    def fetch_imports(
+    def get_imports(
         self, contract_filepaths: List[Path], base_path: Optional[Path]
     ) -> Dict[str, List[str]]:
         """
@@ -134,9 +134,9 @@ class CompilerManager(BaseManager):
         """
         imports_dict: Dict[str, List[str]] = {}
 
-        for _, compiler in self.compiler_manager.registered_compilers.items():
+        for _, compiler in self.registered_compilers.items():
             try:
-                imports = compiler.fetch_imports(
+                imports = compiler.get_imports(
                     contract_filepaths=contract_filepaths, base_path=base_path
                 )
             except NotImplementedError:

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -130,7 +130,7 @@ class CompilerManager(BaseManager):
               via ``ape compile``, gets set to the project's ``contracts/`` directory.
 
         Returns:
-            Dict[str, List[str]] {source_id: [import_source_id, ...], ...}
+            Dict[str, List[str]] A dictionary like ``{source_id: [import_source_id, ...], ...}``
         """
         imports_dict: Dict[str, List[str]] = {}
 
@@ -149,8 +149,9 @@ class CompilerManager(BaseManager):
 
     def get_references(self, imports_dict: Dict[str, List[str]]) -> Dict[str, List[str]]:
         """
-        Reversed dictionary from contract imports dictionary. Each entry is a list of
-        source_ids that reference the source_id key of a given contract.
+        Provides a mapping containing all referenced source_ids for a given project.
+        Each entry contains a source_id as a key and list of source_ids that reference a
+        given contract.
 
         Args:
             contract_filepaths (List[pathlib.Path]): A list of source file paths to compile.
@@ -159,15 +160,17 @@ class CompilerManager(BaseManager):
               via ``ape compile``, gets set to the project's ``contracts/`` directory.
 
         Returns:
-            Dict[str, List[str]] {source_id: [referring_source_id, ...], ...}
+            Dict[str, List[str]] A dictionary like ``{source_id: [referring_source_id, ...], ...}``
         """
         references_dict: Dict[str, List[str]] = {}
-        if imports_dict:
-            for key, imports_list in imports_dict.items():
-                for filepath in imports_list:
-                    if filepath not in references_dict:
-                        references_dict[filepath] = []
-                    references_dict[filepath].append(key)
+        if not imports_dict:
+            return {}
+
+        for key, imports_list in imports_dict.items():
+            for filepath in imports_list:
+                if filepath not in references_dict:
+                    references_dict[filepath] = []
+                references_dict[filepath].append(key)
 
         return references_dict
 

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -111,7 +111,7 @@ class BaseProject(ProjectAPI):
                 if contract_type.source_id not in deleted_source_ids
             }
 
-            def need_compiling(source_path: Path) -> bool:
+            def does_need_compiling(source_path: Path) -> bool:
                 source_id = str(get_relative_path(source_path, self.contracts_folder))
 
                 if source_id not in cached_sources:
@@ -129,7 +129,7 @@ class BaseProject(ProjectAPI):
                 return checksum != cached_checksum.hash  # Contents changed
 
             # NOTE: Filter by checksum to only update what's needed
-            needs_compiling = set(filter(need_compiling, source_paths))
+            needs_compiling = set(filter(does_need_compiling, source_paths))
 
             # NOTE: Add referring path imports for each source path
             referenced_paths: List[Path] = []

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -108,7 +108,7 @@ class BaseProject(ProjectAPI):
                 if contract_type.source_id not in deleted_source_ids
             }
 
-            def source_ids_need_compiling(source_path: Path) -> bool:
+            def need_compiling(source_path: Path) -> bool:
                 source_id = str(get_relative_path(source_path, self.contracts_folder))
 
                 if source_id not in cached_sources:
@@ -126,7 +126,7 @@ class BaseProject(ProjectAPI):
                 return checksum != cached_checksum.hash  # Contents changed
 
             # NOTE: Filter by checksum to only update what's needed
-            needs_compiling = set(filter(source_ids_need_compiling, source_paths))
+            needs_compiling = set(filter(need_compiling, source_paths))
 
             # NOTE: Add referring source_id imports for each source path
             referenced_source_ids: List[str] = []


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->
Adds `imports` list and `references` list to `PackageManifest`'s `source` object.
Adds check for `references` list when compiling from cache to see if dependent references need additional compiling.

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
partial fix for #623 
unblocks @sabotagebeats on #81 

### How I did it
<!-- Discuss the thought process behind the change -->
Logic for fetching imports is in the compiler plugins, i.e. `ape-solidity`
https://github.com/ApeWorX/ape-solidity/pull/36


### How to verify it
<!-- Discuss any methods that should be used to verify the change -->
Follow the steps in #623   NOTE: One failing test based on a change of account repr, has nothing to do with this PR

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
