### PR TITLE
fix: transfer send_everything does not work properly

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -145,9 +145,13 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
 
         if not value:
             if "send_everything" not in kwargs:
-                raise ValueError("Transfer without value argument requires kwarg send_everything=True")
-            if kwargs['send_everything'] != True:
-                raise ValueError("Transfer without value argument requires kwarg send_everything=True")
+                raise ValueError(
+                    "Transfer without value argument requires kwarg send_everything=True"
+                )
+            if not kwargs["send_everything"]:
+                raise ValueError(
+                    "Transfer without value argument requires kwarg send_everything=True"
+                )
             return self.call(txn, kwargs["send_everything"])
 
         return self.call(txn, send_everything=value is None)

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -100,8 +100,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
                 txn.value = self.balance - (txn.max_fee * txn.gas_limit)
                 error_message = error_message + f"{txn.max_fee * txn.gas_limit}"
             else:
-                txn.value = self.balance - txn.max_fee
-                error_message = error_message + f"{txn.max_fee}"
+                raise TransactionError(message="The txn.gas_limit is not set.")
             assert txn.value > 0, error_message
 
         txn.signature = self.sign_transaction(txn)

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -146,7 +146,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
                     "Kwarg send_everything=True requires transfer without value argument"
                 )
             txn.value = self._convert(value, int)
-            return self.call(txn, send_everything=value is None)
+            return self.call(txn)
 
         elif not kwargs.get("send_everything"):
             raise ValueError("Transfer without value argument requires kwarg send_everything=True")

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -102,7 +102,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
                 txn.value = self.balance - (txn.max_fee * txn.gas_limit)
             if txn.value <= 0:
                 error_message = error_message + f"{txn.max_fee * txn.gas_limit}"
-                raise ValueError(message=error_message)
+                raise ValueError(error_message)
 
         txn.signature = self.sign_transaction(txn)
         if not txn.signature:

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -93,18 +93,15 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         txn = self.prepare_transaction(txn)
 
         if send_everything:
+            error_message = "Sender does not have enough to cover transaction value and gas: "
             if txn.max_fee is None:
                 raise TransactionError(message="Max fee must not be None.")
             if txn.gas_limit:
                 txn.value = self.balance - (txn.max_fee * txn.gas_limit)
-                error_message = f"Sender does not have enough {self.balance}\
-                    to cover transaction value {txn.value} and \
-                    gas {txn.max_fee * txn.gas_limit}"
+                error_message = error_message + f"{txn.max_fee * txn.gas_limit}"
             else:
                 txn.value = self.balance - txn.max_fee
-                error_message = f"Sender does not have enough {self.balance}\
-                    to cover transaction value {txn.value} and \
-                    gas {txn.max_fee}"
+                error_message = error_message + f"{txn.max_fee}"
             assert txn.value > 0, error_message
 
         txn.signature = self.sign_transaction(txn)

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -144,12 +144,10 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
             txn.value = self._convert(value, int)
 
         if not value:
-            assert (
-                "send_everything" in kwargs
-            ), "Transfer without value argument requires kwarg send_everything=True"
-            assert kwargs[
-                "send_everything"
-            ], "Transfer without value argument requires kwarg send_everything=True"
+            if "send_everything" not in kwargs:
+                raise ValueError("Transfer without value argument requires kwarg send_everything=True")
+            if kwargs['send_everything'] != True:
+                raise ValueError("Transfer without value argument requires kwarg send_everything=True")
             return self.call(txn, kwargs["send_everything"])
 
         return self.call(txn, send_everything=value is None)

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -97,13 +97,12 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
                 raise TransactionError(message="Max fee must not be None.")
             if not txn.gas_limit or txn.gas_limit is None:
                 raise TransactionError(message="The txn.gas_limit is not set.")
-            elif txn.value <= 0:
+            txn.value = self.balance - (txn.max_fee * txn.gas_limit)
+            if txn.value <= 0:
                 raise ValueError(
                     f"Sender does not have enough to cover transaction value and gas: \
                     {txn.max_fee * txn.gas_limit}"
                 )
-            else:
-                txn.value = self.balance - (txn.max_fee * txn.gas_limit)
 
         txn.signature = self.sign_transaction(txn)
         if not txn.signature:
@@ -150,12 +149,9 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
             return self.call(txn, send_everything=value is None)
 
         elif not kwargs.get("send_everything"):
-            raise ValueError(
-                "Transfer without value argument requires kwarg send_everything=True"
-            )
+            raise ValueError("Transfer without value argument requires kwarg send_everything=True")
         else:
             return self.call(txn, send_everything=True)
-
 
     def deploy(self, contract: "ContractContainer", *args, **kwargs) -> "ContractInstance":
         """

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -149,7 +149,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
             txn.value = self._convert(value, int)
 
         if not value:
-            if "send_everything" not in kwargs or not kwargs["send_everything"]:
+            if not kwargs.get("send_everything"):
                 raise ValueError(
                     "Transfer without value argument requires kwarg send_everything=True"
                 )

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -97,13 +97,13 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
                 raise TransactionError(message="Max fee must not be None.")
             if not txn.gas_limit or txn.gas_limit is None:
                 raise TransactionError(message="The txn.gas_limit is not set.")
-            else:
-                txn.value = self.balance - (txn.max_fee * txn.gas_limit)
-            if txn.value <= 0:
+            elif txn.value <= 0:
                 raise ValueError(
                     f"Sender does not have enough to cover transaction value and gas: \
                     {txn.max_fee * txn.gas_limit}"
                 )
+            else:
+                txn.value = self.balance - (txn.max_fee * txn.gas_limit)
 
         txn.signature = self.sign_transaction(txn)
         if not txn.signature:

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -147,15 +147,15 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
                     "Kwarg send_everything=True requires transfer without value argument"
                 )
             txn.value = self._convert(value, int)
+            return self.call(txn, send_everything=value is None)
 
-        if not value:
-            if not kwargs.get("send_everything"):
-                raise ValueError(
-                    "Transfer without value argument requires kwarg send_everything=True"
-                )
-            return self.call(txn, kwargs["send_everything"])
+        elif not kwargs.get("send_everything"):
+            raise ValueError(
+                "Transfer without value argument requires kwarg send_everything=True"
+            )
+        else:
+            return self.call(txn, send_everything=True)
 
-        return self.call(txn, send_everything=value is None)
 
     def deploy(self, contract: "ContractContainer", *args, **kwargs) -> "ContractInstance":
         """

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -96,12 +96,13 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
             error_message = "Sender does not have enough to cover transaction value and gas: "
             if txn.max_fee is None:
                 raise TransactionError(message="Max fee must not be None.")
-            if txn.gas_limit:
-                txn.value = self.balance - (txn.max_fee * txn.gas_limit)
-                error_message = error_message + f"{txn.max_fee * txn.gas_limit}"
-            else:
+            if not txn.gas_limit or txn.gas_limit is None:
                 raise TransactionError(message="The txn.gas_limit is not set.")
-            assert txn.value > 0, error_message
+            else:
+                txn.value = self.balance - (txn.max_fee * txn.gas_limit)
+            if txn.value <= 0:
+                error_message = error_message + f"{txn.max_fee * txn.gas_limit}"
+                raise ValueError(message=error_message)
 
         txn.signature = self.sign_transaction(txn)
         if not txn.signature:

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -144,11 +144,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
             txn.value = self._convert(value, int)
 
         if not value:
-            if "send_everything" not in kwargs:
-                raise ValueError(
-                    "Transfer without value argument requires kwarg send_everything=True"
-                )
-            if not kwargs["send_everything"]:
+            if "send_everything" not in kwargs or not kwargs["send_everything"]:
                 raise ValueError(
                     "Transfer without value argument requires kwarg send_everything=True"
                 )

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -79,6 +79,12 @@ def test_transfer_without_value_send_everything_true(sender, receiver):
     assert sender.balance < convert("1 finney", int), "Sender balance is not nominal"
 
 
+def test_transfer_with_value_send_everything_true(sender, receiver):
+    with pytest.raises(ValueError) as err:
+        sender.transfer(receiver, 1, send_everything=True)
+    assert str(err.value) == "Kwarg send_everything=True requires transfer without value argument"
+
+
 def test_transfer_with_prompts(runner, receiver, temp_ape_account):
     # "y\na\ny": yes sign, password, yes keep unlocked
     with runner.isolation("y\na\ny"):

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -77,6 +77,9 @@ def test_transfer_without_value_send_everything_true(sender, receiver):
     sender.transfer(receiver, send_everything=True)
     assert receiver.balance > initial_balance, "Receiver has same balance after transfer"
     assert sender.balance < convert("1 finney", int), "Sender balance is not nominal"
+    with pytest.raises(ValueError) as err:
+        sender.transfer(receiver, send_everything=True)
+    assert "Sender does not have enough to cover transaction value and gas:" in str(err.value)
 
 
 def test_transfer_with_value_send_everything_true(sender, receiver):

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -61,13 +61,13 @@ def test_transfer(sender, receiver):
 
 
 def test_transfer_without_value(sender, receiver):
-    with pytest.raises(AssertionError) as err:
+    with pytest.raises(ValueError) as err:
         sender.transfer(receiver)
     assert str(err.value) == "Transfer without value argument requires kwarg send_everything=True"
 
 
 def test_transfer_without_value_send_everything_false(sender, receiver):
-    with pytest.raises(AssertionError) as err:
+    with pytest.raises(ValueError) as err:
         sender.transfer(receiver, send_everything=False)
     assert str(err.value) == "Transfer without value argument requires kwarg send_everything=True"
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -75,7 +75,7 @@ def test_transfer_without_value_send_everything_false(sender, receiver):
 def test_transfer_without_value_send_everything_true(sender, receiver):
     initial_balance = receiver.balance
     sender.transfer(receiver, send_everything=True)
-    assert receiver.balance > initial_balance
+    assert receiver.balance > initial_balance, "Receiver has same balance after transfer"
 
 
 def test_transfer_with_prompts(runner, receiver, temp_ape_account):

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -60,6 +60,24 @@ def test_transfer(sender, receiver):
     assert receiver.balance == expected
 
 
+def test_transfer_without_value(sender, receiver):
+    with pytest.raises(AssertionError) as err:
+        sender.transfer(receiver)
+    assert str(err.value) == "Transfer without value argument requires kwarg send_everything=True"
+
+
+def test_transfer_without_value_send_everything_false(sender, receiver):
+    with pytest.raises(AssertionError) as err:
+        sender.transfer(receiver, send_everything=False)
+    assert str(err.value) == "Transfer without value argument requires kwarg send_everything=True"
+
+
+def test_transfer_without_value_send_everything_true(sender, receiver):
+    initial_balance = receiver.balance
+    sender.transfer(receiver, send_everything=True)
+    assert receiver.balance > initial_balance
+
+
 def test_transfer_with_prompts(runner, receiver, temp_ape_account):
     # "y\na\ny": yes sign, password, yes keep unlocked
     with runner.isolation("y\na\ny"):

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -76,6 +76,7 @@ def test_transfer_without_value_send_everything_true(sender, receiver):
     initial_balance = receiver.balance
     sender.transfer(receiver, send_everything=True)
     assert receiver.balance > initial_balance, "Receiver has same balance after transfer"
+    assert sender.balance < convert("1 finney", int), "Sender balance is not nominal"
 
 
 def test_transfer_with_prompts(runner, receiver, temp_ape_account):


### PR DESCRIPTION
### What I did
`transfer(receiver)` now throws error message
`transfer(receiver, send_everything=False)` now throws error message
`transfer(receiver, send_everything=True)` now works

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: https://github.com/ApeWorX/ape/issues/728

### How I did it
discussed at length https://github.com/ApeWorX/ape/issues/728

### How to verify it
test cases have been added 

### Checklist

- [x] All changes are completed
- [x] New test cases have been added
- [ ] Documentation has been updated
