### PR TITLE
fix: raise attribute error in EcosystemAPI getattr

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -179,8 +179,10 @@ class EcosystemAPI(BaseInterfaceModel):
         Returns:
             :class:`~ape.api.networks.NetworkAPI`
         """
-        network_name = network_name.replace("_", "-")
-        return self.get_network(network_name)
+        try:
+            return self.get_network(network_name.replace("_", "-"))
+        except NetworkNotFoundError:
+            return self.__getattribute__(network_name)
 
     def add_network(self, network_name: str, network: "NetworkAPI"):
         """

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -128,6 +128,7 @@ class BaseInterfaceModel(BaseInterface, BaseModel):
         arbitrary_types_allowed = True
         underscore_attrs_are_private = True
         anystr_strip_whitespace = True
+        copy_on_model_validation = False
 
     def __dir__(self) -> List[str]:
         """


### PR DESCRIPTION
### What I did

Trying to resolve a Pydantic anomaly but also something we should probably do anyway 

### How I did it

Delegate back to `__getattribute__` when network not found.

### How to verify it

If CI/CD passes, that is a good thing!
Also the error is better now when accessing unknown networks on an ecosystem using dot access.

```python
networks.ethereum.remove_network()  # Method not a thing
```

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
