### PR TITLE
fix: regression where could not specify contract type

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -446,8 +446,10 @@ class ContractCache(BaseManager):
 
         return contract_type or default
 
-    def instance_at(self, address: "AddressType") -> BaseAddress:
-        contract_type = self.get(address)
+    def instance_at(
+        self, address: "AddressType", contract_type: Optional[ContractType] = None
+    ) -> BaseAddress:
+        contract_type = contract_type or self.get(address)
         if contract_type:
             return self.create_contract(address, contract_type)
 

--- a/tests/functional/test_contracts.py
+++ b/tests/functional/test_contracts.py
@@ -35,6 +35,17 @@ def test_init_at_unknown_address():
     assert contract.address == SOLIDITY_CONTRACT_ADDRESS
 
 
+def test_init_specify_contract_type(
+    solidity_contract_instance, vyper_contract_type, owner, networks_connected_to_tester
+):
+    # Vyper contract type is very close to solidity's.
+    # This test purposely uses the other just to show we are able to specify it externally.
+    contract = Contract(solidity_contract_instance.address, contract_type=vyper_contract_type)
+    assert contract.address == solidity_contract_instance.address
+    assert contract.setNumber(2, sender=owner)
+    assert contract.myNumber() == 2
+
+
 def test_deploy(
     sender, contract_container, networks_connected_to_tester, project, chain, clean_contracts_cache
 ):

--- a/tests/functional/test_contracts.py
+++ b/tests/functional/test_contracts.py
@@ -42,6 +42,7 @@ def test_init_specify_contract_type(
     # This test purposely uses the other just to show we are able to specify it externally.
     contract = Contract(solidity_contract_instance.address, contract_type=vyper_contract_type)
     assert contract.address == solidity_contract_instance.address
+    assert contract.contract_type == vyper_contract_type
     assert contract.setNumber(2, sender=owner)
     assert contract.myNumber() == 2
 


### PR DESCRIPTION
### What I did

Accidental regression where could no longer specify `contract_type` in `ape.Contract` which broke `ape-tokens`.

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
