### PR TITLE
fix: mainnet fork naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Ape provides an IPython interactive console with useful pre-defined locals to in
 To interact with a deployed contract in a local environment, start by opening the console:
 
 ```bash
-ape console --network :mainnet-fork:hardhat
+ape console --network :mainnet_fork:hardhat
 ```
 
 Visit [Ape Console](https://docs.apeworx.io/ape/stable/commands/console.html) to learn how to use Ape Console.

--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -127,7 +127,7 @@ Set default network and network providers:
 
 ```yaml
 ethereum:
-  default_network: mainnet-fork
+  default_network: mainnet_fork
   mainnet_fork:
     default_provider: hardhat
 ```

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -22,7 +22,7 @@ def test_get_network_choices_filter_ecosystem(networks):
 
 
 def test_get_network_choices_filter_network(networks):
-    actual = {c for c in networks.get_network_choices(network_filter="mainnet-fork")}
+    actual = {c for c in networks.get_network_choices(network_filter="mainnet_fork")}
     assert actual == set()
 
 

--- a/tests/integration/cli/test_networks.py
+++ b/tests/integration/cli/test_networks.py
@@ -28,7 +28,7 @@ ecosystems:
     providers:
     - name: geth
       isDefault: true
-  - name: mainnet-fork
+  - name: mainnet_fork
     providers: []
   - name: ropsten
     providers:


### PR DESCRIPTION
### What I did
I can see that mainnet fork has two different names.
I have made changes so that it's using `mainnet_fork`
