### PR TITLE
fix: regression where ape.Contract() would not fetch the contract type from the explorer

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -440,6 +440,10 @@ class ContractCache(BaseManager):
 
         contract_type = self._get_contract_type_from_disk(address)
 
+        if not contract_type:
+            # Also gets cached to disc for faster lookup next time.
+            contract_type = self._get_contract_type_from_explorer(address)
+
         # Cache locally for faster in-session look-up.
         if contract_type:
             self._local_contracts[address] = contract_type


### PR DESCRIPTION
### What I did

This was a regression...
Before, we were fetching the contract from Etherscan and that part got somehow dropped out of the PR!

here puts it back! But the problem: **There is no good way to test this feature**
Had a discussion with @fubuloubu about registering the contract cache work as an `ExplorerAPI`, which would solve that concern. I would really like tests for this.

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
