### PR TITLE
feat: detect minimal proxies

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -370,7 +370,8 @@ class EcosystemAPI(BaseInterfaceModel):
             address (str): The address of the contract.
 
         Returns:
-            ProxyInfoAPI or None if the contract does not use any known proxy pattern.
+            Optional[:class:`~ape.api.networks.ProxyInfoAPI`]: Returns ``None`` if the contract 
+            does not use any known proxy pattern.
         """
         return None
 

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -357,7 +357,7 @@ class EcosystemAPI(BaseInterfaceModel):
 
         return data
 
-    def proxy_info(self, address: AddressType) -> Any:
+    def get_proxy_info(self, address: AddressType) -> Any:
         return None
 
 

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -357,6 +357,9 @@ class EcosystemAPI(BaseInterfaceModel):
 
         return data
 
+    def proxy_info(self, address: AddressType) -> Any:
+        return None
+
 
 class ProviderContextManager:
     """

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -23,7 +23,12 @@ LOCAL_NETWORK_NAME = "local"
 
 
 class ProxyInfoAPI(BaseModel):
+    """
+    Information about a proxy contract.
+    """
+
     target: AddressType
+    """The address of the implementation contract."""
 
 
 class EcosystemAPI(BaseInterfaceModel):

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Type
 
 from ethpm_types.abi import ConstructorABI, EventABI, MethodABI
 from hexbytes import HexBytes
+from pydantic import BaseModel
 
 from ape.exceptions import NetworkError, NetworkNotFoundError
 from ape.types import AddressType, ContractLog, RawAddress
@@ -19,6 +20,10 @@ if TYPE_CHECKING:
 
 
 LOCAL_NETWORK_NAME = "local"
+
+
+class ProxyInfoAPI(BaseModel):
+    target: AddressType
 
 
 class EcosystemAPI(BaseInterfaceModel):
@@ -357,7 +362,7 @@ class EcosystemAPI(BaseInterfaceModel):
 
         return data
 
-    def get_proxy_info(self, address: AddressType) -> Any:
+    def get_proxy_info(self, address: AddressType) -> Optional[ProxyInfoAPI]:
         """
         Information about a proxy contract such as proxy type and implementation address.
 
@@ -365,7 +370,7 @@ class EcosystemAPI(BaseInterfaceModel):
             address (str): The address of the contract.
 
         Returns:
-            Any: ProxyInfo or None if the contract does not use any known proxy pattern.
+            ProxyInfoAPI or None if the contract does not use any known proxy pattern.
         """
         return None
 

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -358,6 +358,15 @@ class EcosystemAPI(BaseInterfaceModel):
         return data
 
     def get_proxy_info(self, address: AddressType) -> Any:
+        """
+        Information about a proxy contract such as proxy type and implementation address.
+
+        Args:
+            address (str): The address of the contract.
+
+        Returns:
+            Any: ProxyInfo or None if the contract does not use any known proxy pattern.
+        """
         return None
 
 

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -375,7 +375,7 @@ class EcosystemAPI(BaseInterfaceModel):
             address (str): The address of the contract.
 
         Returns:
-            Optional[:class:`~ape.api.networks.ProxyInfoAPI`]: Returns ``None`` if the contract 
+            Optional[:class:`~ape.api.networks.ProxyInfoAPI`]: Returns ``None`` if the contract
             does not use any known proxy pattern.
         """
         return None

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -168,6 +168,7 @@ class ProviderAPI(BaseInterfaceModel):
 
         Args:
             address (str): The address of the contract.
+            slot (int): Storage slot to read the value of.
 
         Returns:
             bytes: The value of the storage slot.

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -172,7 +172,6 @@ class ProviderAPI(BaseInterfaceModel):
         Returns:
             bytes: The value of the storage slot.
         """
-        raise NotImplementedError("get_storage_at is not implemented by this provider")
 
     @abstractmethod
     def get_nonce(self, address: str) -> int:
@@ -604,6 +603,9 @@ class Web3Provider(ProviderAPI, ABC):
 
     def get_code(self, address: str) -> bytes:
         return self.web3.eth.get_code(address)  # type: ignore
+
+    def get_storage_at(self, address: str, slot: int) -> bytes:
+        return self.web3.eth.get_storage_at(address, slot)  # type: ignore
 
     def send_call(self, txn: TransactionAPI) -> bytes:
         return self.web3.eth.call(txn.dict())

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -161,7 +161,17 @@ class ProviderAPI(BaseInterfaceModel):
             bytes: The contract byte-code.
         """
 
+    @raises_not_implemented
     def get_storage_at(self, address: str, slot: int) -> bytes:
+        """
+        Gets the raw value of a storage slot of a contract.
+
+        Args:
+            address (str): The address of the contract.
+
+        Returns:
+            bytes: The value of the storage slot.
+        """
         raise NotImplementedError("get_storage_at is not implemented by this provider")
 
     @abstractmethod

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -161,6 +161,9 @@ class ProviderAPI(BaseInterfaceModel):
             bytes: The contract byte-code.
         """
 
+    def get_storage_at(self, address: str, slot: int) -> bytes:
+        raise NotImplementedError("get_storage_at is not implemented by this provider")
+
     @abstractmethod
     def get_nonce(self, address: str) -> int:
         """

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -458,18 +458,25 @@ class ContractCache(BaseManager):
     def resolve_proxy(self, address: AddressType) -> Optional[AddressType]:
         code = self.provider.get_code(address).hex()[2:]
         patterns = [
-            r"363d3d373d3d3d363d73(.{40})5af43d82803e903d91602b57fd5bf3",  # eip-1167 minimal proxy contract
-            r"366000600037611000600036600073(.{40})5af4602c57600080fd5b6110006000f3",  # vyper <0.2.9 create_forwarder_to
-            r"36603057343d52307f830d2d700a97af574b186c80d40429385d24241565b08a7c559ba283a964d9b160203da23d3df35b3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e605b57fd5bf3",  # 0xsplits clones
+            # eip-1167 minimal proxy contract
+            r"363d3d373d3d3d363d73(.{40})5af43d82803e903d91602b57fd5bf3",
+            # vyper <0.2.9 create_forwarder_to
+            r"366000600037611000600036600073(.{40})5af4602c57600080fd5b6110006000f3",
+            # 0xsplits clones
+            r"36603057343d52307f830d2d700a97af574b186c80d40429385d24241565b08a7c559ba283a964d9"
+            + r"b160203da23d3df35b3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e605b57fd5bf3",
         ]
         for pattern in patterns:
             if match := re.match(pattern, code):
                 return self.conversion_manager.convert(match.group(1), AddressType)
 
         slots = [
-            int(self.provider.web3.keccak(text="eip1967.proxy.implementation").hex(), 16) - 1,  # eip-1967 standard proxy storage slots
-            self.provider.web3.keccak(text='org.zeppelinos.proxy.implementation'),  # openzeppelin upgradeability proxy
-            self.provider.web3.keccak(text="PROXIABLE"),  # eip-1822 universal upgradeable proxy standard (uups)
+            # eip-1967 standard proxy storage slots
+            int(self.provider.web3.keccak(text="eip1967.proxy.implementation").hex(), 16) - 1,
+            # openzeppelin upgradeability proxy
+            self.provider.web3.keccak(text="org.zeppelinos.proxy.implementation"),
+            # eip-1822 universal upgradeable proxy standard (uups)
+            self.provider.web3.keccak(text="PROXIABLE"),
         ]
         for slot in slots:
             storage = self.provider.web3.eth.get_storage_at(address, slot)

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -508,11 +508,11 @@ class ContractCache(BaseManager):
             outputs=[ABIType(type="address")],
         )
         try:
-            master_call = ContractCall(abi, address)()
+            master_copy = ContractCall(abi, address)()
             storage = self.provider.web3.eth.get_storage_at(address, 0)
-            master_slot = self.conversion_manager.convert(storage[-20:].hex(), AddressType)
-            if master_call == master_slot:
-                return master_call
+            slot_0 = self.conversion_manager.convert(storage[-20:].hex(), AddressType)
+            if master_copy == slot_0:
+                return master_copy
         except (DecodingError, ContractLogicError):
             pass
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -442,7 +442,7 @@ class ContractCache(BaseManager):
 
         if not contract_type:
             # Contract could be a minimal proxy
-            proxy = self.provider.network.ecosystem.proxy_info(address)
+            proxy = self.provider.network.ecosystem.get_proxy_info(address)
             if proxy:
                 return self.get(proxy.target)
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -445,7 +445,8 @@ class ContractCache(BaseManager):
 
         if not contract_type:
             # Contract could be a minimal proxy
-            if target := self.resolve_proxy(address):
+            target = self.resolve_proxy(address)
+            if target:
                 return self.get(target)
 
             # Also gets cached to disc for faster lookup next time.
@@ -469,7 +470,8 @@ class ContractCache(BaseManager):
             + r"b160203da23d3df35b3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e605b57fd5bf3",
         ]
         for pattern in patterns:
-            if match := re.match(pattern, code):
+            match = re.match(pattern, code)
+            if match:
                 return self.conversion_manager.convert(match.group(1), AddressType)
 
         slots = [

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -442,10 +442,9 @@ class ContractCache(BaseManager):
 
         if not contract_type:
             # Contract could be a minimal proxy
-            if hasattr(self.provider.network.ecosystem, "proxy_info"):
-                proxy = self.provider.network.ecosystem.proxy_info(address)
-                if proxy:
-                    return self.get(proxy.target)
+            proxy = self.provider.network.ecosystem.proxy_info(address)
+            if proxy:
+                return self.get(proxy.target)
 
             # Also gets cached to disc for faster lookup next time.
             contract_type = self._get_contract_type_from_explorer(address)

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -184,7 +184,6 @@ class Ethereum(EcosystemAPI):
                 target = self.conversion_manager.convert(match.group(1), AddressType)
                 return ProxyInfo(type=type, target=target)
 
-        keccak = self.provider.web3.keccak
         slots = {
             ProxyType.Standard: int(keccak(text="eip1967.proxy.implementation").hex(), 16) - 1,
             ProxyType.Beacon: int(keccak(text="eip1967.proxy.beacon").hex(), 16) - 1,

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -168,9 +168,9 @@ class Ethereum(EcosystemAPI):
         return str(address)
 
     def is_proxy(self, address: AddressType) -> bool:
-        return self.proxy_info(address) is not None
+        return self.get_proxy_info(address) is not None
 
-    def proxy_info(self, address: AddressType) -> ProxyInfo:
+    def get_proxy_info(self, address: AddressType) -> ProxyInfo:
         code = self.provider.get_code(address).hex()[2:]
         patterns = {
             ProxyType.Minimal: r"363d3d373d3d3d363d73(.{40})5af43d82803e903d91602b57fd5bf3",

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -171,7 +171,7 @@ class Ethereum(EcosystemAPI):
     def is_proxy(self, address: AddressType) -> bool:
         return self.get_proxy_info(address) is not None
 
-    def get_proxy_info(self, address: AddressType) -> ProxyInfo:
+    def get_proxy_info(self, address: AddressType) -> Optional[ProxyInfo]:
         code = self.provider.get_code(address).hex()[2:]
         patterns = {
             ProxyType.Minimal: r"363d3d373d3d3d363d73(.{40})5af43d82803e903d91602b57fd5bf3",

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -11,7 +11,6 @@ from eth_typing import HexStr
 from eth_utils import add_0x_prefix, hexstr_if_str, keccak, to_bytes, to_checksum_address
 from ethpm_types.abi import ABIType, ConstructorABI, EventABI, EventABIType, MethodABI
 from hexbytes import HexBytes
-from pydantic import BaseModel
 
 from ape.api import (
     BlockAPI,
@@ -22,7 +21,7 @@ from ape.api import (
     ReceiptAPI,
     TransactionAPI,
 )
-from ape.api.networks import LOCAL_NETWORK_NAME
+from ape.api.networks import LOCAL_NETWORK_NAME, ProxyInfoAPI
 from ape.contracts.base import ContractCall
 from ape.exceptions import ContractLogicError, DecodingError
 from ape.types import AddressType, ContractLog, RawAddress
@@ -58,9 +57,8 @@ class ProxyType(IntEnum):
     Delegate = 8  # eip-897 delegate proxy
 
 
-class ProxyInfo(BaseModel):
+class ProxyInfo(ProxyInfoAPI):
     type: ProxyType
-    target: AddressType
 
 
 class NetworkConfig(PluginConfig):

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -166,9 +166,6 @@ class Ethereum(EcosystemAPI):
     def encode_address(cls, address: AddressType) -> RawAddress:
         return str(address)
 
-    def is_proxy(self, address: AddressType) -> bool:
-        return self.get_proxy_info(address) is not None
-
     def get_proxy_info(self, address: AddressType) -> Optional[ProxyInfo]:
         code = self.provider.get_code(address).hex()[2:]
         patterns = {

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -184,7 +184,7 @@ class Ethereum(EcosystemAPI):
                 target = self.conversion_manager.convert(match.group(1), AddressType)
                 return ProxyInfo(type=type, target=target)
 
-        str_to_slot = lambda text: int(keccak(text=text).hex(), 16)
+        str_to_slot = lambda text: int(keccak(text=text).hex(), 16)  # noqa: E731
         slots = {
             ProxyType.Standard: str_to_slot("eip1967.proxy.implementation") - 1,
             ProxyType.Beacon: str_to_slot("eip1967.proxy.beacon") - 1,

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -1,4 +1,5 @@
 import itertools
+from enum import IntEnum
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from eth_abi import decode_abi as abi_decode
@@ -9,6 +10,7 @@ from eth_typing import HexStr
 from eth_utils import add_0x_prefix, hexstr_if_str, keccak, to_bytes, to_checksum_address
 from ethpm_types.abi import ConstructorABI, EventABI, EventABIType, MethodABI
 from hexbytes import HexBytes
+from pydantic.dataclasses import dataclass
 
 from ape.api import (
     BlockAPI,
@@ -40,6 +42,23 @@ NETWORKS = {
     "rinkeby": (4, 4),
     "goerli": (5, 5),
 }
+
+
+class ProxyType(IntEnum):
+    Minimal = 0
+    Standard = 1
+    Beacon = 2
+    UUPS = 3
+    Vyper = 4
+    Clones = 5
+    GnosisSafe = 6
+    OpenZeppelin = 7
+
+
+@dataclass
+class ProxyInfo:
+    type: ProxyType
+    target: AddressType
 
 
 class NetworkConfig(PluginConfig):

--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -239,9 +239,6 @@ class GethProvider(Web3Provider, UpstreamProvider):
             message = gas_estimation_error_message(tx_error)
             raise TransactionError(base_err=tx_error, message=message) from err
 
-    def get_storage_at(self, address: str, slot: int) -> bytes:
-        return self._web3.eth.get_storage_at(address, slot)  # type: ignore
-
     @property
     def _node_info(self) -> Optional[NodeInfo]:
         try:

--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -239,6 +239,9 @@ class GethProvider(Web3Provider, UpstreamProvider):
             message = gas_estimation_error_message(tx_error)
             raise TransactionError(base_err=tx_error, message=message) from err
 
+    def get_storage_at(self, address: str, slot: int) -> bytes:
+        return self._web3.eth.get_storage_at(address, slot)  # type: ignore
+
     @property
     def _node_info(self) -> Optional[NodeInfo]:
         try:


### PR DESCRIPTION
### What I did
Automatically infer ContractType for minimal proxies

fixes: #734

### How I did it
Match known bytecodes, storage slots and views, then request the target's ContractType.

API changes:
- EcosystemAPI: add `get_proxy_info`
- ProviderAPI: add `get_storage_at`

### How to verify it
- [EIP-1167](https://eips.ethereum.org/EIPS/eip-1167)
- [Vyper](https://github.com/vyperlang/vyper/blob/0b3f3b329e59cf90bbff8a883b49f1166eb716a2/vyper/functions/functions.py#L1420)
- [0xSplits Clones](https://github.com/0xSplits/splits-contracts/blob/main/contracts/libraries/Clones.sol#L32)
- [EIP-1967](https://eips.ethereum.org/EIPS/eip-1967)
- [EIP-1822](https://eips.ethereum.org/EIPS/eip-1822)
- [OpenZeppelin UpgradeableProxy](https://github.com/OpenZeppelin/openzeppelin-labs/blob/master/initializer_contracts/contracts/UpgradeabilityProxy.sol)
- [Gnosis Safe](https://github.com/safe-global/safe-contracts/blob/c36bcab46578a442862d043e12a83fec41143dec/contracts/proxies/GnosisSafeProxy.sol#L29-L34)
- [EIP-1967 Beacon Proxy](https://ethtx.info/0xbcf2cd0fac6278f89dcbcfc61c0b85e1f25cce1f40c5fbf48abbe2b93732281e/)
- [EIP-987 Delegate Proxy](https://eips.ethereum.org/EIPS/eip-897)

### Checklist

- [x] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
