### PR TITLE
chore: resolve conflict with rich

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras_require = {
     "release": [  # `release` GitHub Action job uses this
         "setuptools",  # Installation tool
         "wheel",  # Packaging tool
-        "twine",  # Package upload tool
+        "twine==3.8.0",  # Package upload tool
     ],
     "dev": [
         "commitizen>=2.19,<2.20",  # Manage commits and publishing releases


### PR DESCRIPTION
### What I did

Twine 4.0 has a dependency conflict with `rich`. We are currently unable to upgrade rich.

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
