### PR TITLE
fix: default contracts folder path

### DIFF
--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -206,6 +206,7 @@ class ProjectManager(BaseManager):
         Returns:
             :class:`~ape.api.projects.ProjectAPI`
         """
+        contracts_folder = contracts_folder or path / "contracts"
 
         def _try_create_project(proj_cls: Type[ProjectAPI]) -> Optional[ProjectAPI]:
             with self.config_manager.using_project(path, contracts_folder=contracts_folder):

--- a/tests/integration/cli/test_project.py
+++ b/tests/integration/cli/test_project.py
@@ -1,0 +1,16 @@
+from .utils import skip_projects_except
+
+
+@skip_projects_except(["with-dependency"])
+def test_get_project_without_contracts_path(project):
+    proj_path = project.path / "dependency_c"
+    proj = project.get_project(proj_path)
+    assert proj.contracts_folder == proj_path / "contracts"
+
+
+@skip_projects_except(["with-dependency"])
+def test_get_project_with_contracts_path(project):
+    proj_path = project.path / "dependency_a"
+    proj = project.get_project(proj_path, proj_path / "sources")
+    assert proj.contracts_folder != proj_path / "contracts"
+    assert proj.contracts_folder == proj_path / "sources"


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->
While working on the source imports, I set up a test that used `project_manager.get_project()` and didn't pass the contracts folder and received a validation error. 

I corrected the contracts folder default behavior and added tests.
<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
