### PR TITLE
fix: issue where could not use dependencies with non v-prefixed Github release tags

### DIFF
--- a/src/ape/utils/github.py
+++ b/src/ape/utils/github.py
@@ -79,6 +79,7 @@ class GithubClient:
 
         release = _try_get_release(version)
         if not release:
+            original_version = str(version)
             # Try an alternative tag style
             if version.startswith("v"):
                 version = version.lstrip("v")
@@ -87,9 +88,7 @@ class GithubClient:
 
             release = _try_get_release(version)
             if not release:
-                raise ProjectError(
-                    f"Unknown version '{version.lstrip('v')}' for repo '{repo.name}'."
-                )
+                raise ProjectError(f"Unknown version '{original_version}' for repo '{repo.name}'.")
 
         return release
 

--- a/src/ape/utils/github.py
+++ b/src/ape/utils/github.py
@@ -71,13 +71,27 @@ class GithubClient:
         if version == "latest":
             return repo.get_latest_release()
 
-        if not version.startswith("v"):
-            version = f"v{version}"
+        def _try_get_release(vers):
+            try:
+                return repo.get_release(vers)
+            except UnknownObjectException:
+                return None
 
-        try:
-            return repo.get_release(version)
-        except UnknownObjectException:
-            raise ProjectError(f"Unknown version '{version.lstrip('v')}' for repo '{repo.name}'.")
+        release = _try_get_release(version)
+        if not release:
+            # Try an alternative tag style
+            if version.startswith("v"):
+                version = version.lstrip("v")
+            else:
+                version = f"v{version}"
+
+            release = _try_get_release(version)
+            if not release:
+                raise ProjectError(
+                    f"Unknown version '{version.lstrip('v')}' for repo '{repo.name}'."
+                )
+
+        return release
 
     def get_repo(self, repo_path: str) -> GithubRepository:
         """

--- a/tests/functional/utils/test_github.py
+++ b/tests/functional/utils/test_github.py
@@ -1,0 +1,11 @@
+import tempfile
+
+from ape.utils.github import GithubClient
+
+
+class TestGithubClient:
+    def test_clone_repo(self):
+        # NOTE: this test actually clones the repo.
+        client = GithubClient()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            client.clone_repo("dapphub/ds-test", temp_dir, branch="master")

--- a/tests/functional/utils/test_github.py
+++ b/tests/functional/utils/test_github.py
@@ -1,6 +1,32 @@
 import tempfile
 
+import pytest
+from github import UnknownObjectException
+
 from ape.utils.github import GithubClient
+
+
+@pytest.fixture
+def mock_client(mocker):
+    return mocker.MagicMock()
+
+
+@pytest.fixture
+def mock_repo(mocker):
+    return mocker.MagicMock()
+
+
+@pytest.fixture
+def mock_release(mocker):
+    return mocker.MagicMock()
+
+
+@pytest.fixture
+def github_client_with_mocks(mock_client, mock_repo):
+    client = GithubClient()
+    mock_client.get_repo.return_value = mock_repo
+    client._client = mock_client
+    return client
 
 
 class TestGithubClient:
@@ -9,3 +35,39 @@ class TestGithubClient:
         client = GithubClient()
         with tempfile.TemporaryDirectory() as temp_dir:
             client.clone_repo("dapphub/ds-test", temp_dir, branch="master")
+
+    def test_get_release(self, github_client_with_mocks, mock_repo):
+        github_client_with_mocks.get_release("test/path", "0.1.0")
+
+        # Test that we used the given tag.
+        mock_repo.get_release.assert_called_once_with("0.1.0")
+
+    def test_get_release_when_tag_fails_tries_with_v(
+        self, mock_release, github_client_with_mocks, mock_repo
+    ):
+        # This test makes sure that if we try to get a release and the `v` is not needed,
+        # it will try again without the `v`.
+        def side_effect(version):
+            if version.startswith("v"):
+                raise UnknownObjectException("", {}, {})
+
+            return mock_release
+
+        mock_repo.get_release.side_effect = side_effect
+        actual = github_client_with_mocks.get_release("test/path", "v0.1.0")
+        assert actual == mock_release
+
+    def test_get_release_when_tag_fails_tries_without_v(
+        self, mock_release, github_client_with_mocks, mock_repo
+    ):
+        # This test makes sure that if we try to get a release and the `v` is needed,
+        # it will try again with the `v`.
+        def side_effect(version):
+            if not version.startswith("v"):
+                raise UnknownObjectException("", {}, {})
+
+            return mock_release
+
+        mock_repo.get_release.side_effect = side_effect
+        actual = github_client_with_mocks.get_release("test/path", "0.1.0")
+        assert actual == mock_release

--- a/tests/functional/utils/test_misc.py
+++ b/tests/functional/utils/test_misc.py
@@ -1,0 +1,18 @@
+from ape.utils.misc import add_padding_to_strings, extract_nested_value
+
+
+def test_extract_nested_value():
+    structure = {"foo": {"bar": {"test": "expected_value"}}}
+    assert extract_nested_value(structure, "foo", "bar", "test") == "expected_value"
+
+
+def test_extract_nested_value_non_dict_in_middle_returns_none():
+    structure = {"foo": {"non_dict": 3, "bar": {"test": "expected_value"}}}
+    assert not extract_nested_value(structure, "foo", "non_dict", "test")
+
+
+def test_add_spacing_to_strings():
+    string_list = ["foo", "address", "ethereum"]
+    expected = ["foo         ", "address     ", "ethereum    "]
+    actual = add_padding_to_strings(string_list, extra_spaces=4)
+    assert actual == expected

--- a/tests/functional/utils/test_os.py
+++ b/tests/functional/utils/test_os.py
@@ -3,13 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from ape.utils import (
-    GithubClient,
-    add_padding_to_strings,
-    extract_nested_value,
-    get_all_files_in_directory,
-    get_relative_path,
-)
+from ape.utils.os import get_all_files_in_directory, get_relative_path
 
 _TEST_DIRECTORY_PATH = Path("/This/is/a/test/")
 _TEST_FILE_PATH = _TEST_DIRECTORY_PATH / "scripts" / "script.py"
@@ -45,29 +39,6 @@ def test_get_relative_path_roots():
     root = Path("/")
     actual = get_relative_path(root, root)
     assert actual == Path()
-
-
-def test_extract_nested_value():
-    structure = {"foo": {"bar": {"test": "expected_value"}}}
-    assert extract_nested_value(structure, "foo", "bar", "test") == "expected_value"
-
-
-def test_extract_nested_value_non_dict_in_middle_returns_none():
-    structure = {"foo": {"non_dict": 3, "bar": {"test": "expected_value"}}}
-    assert not extract_nested_value(structure, "foo", "non_dict", "test")
-
-
-def test_add_spacing_to_strings():
-    string_list = ["foo", "address", "ethereum"]
-    expected = ["foo         ", "address     ", "ethereum    "]
-    actual = add_padding_to_strings(string_list, extra_spaces=4)
-    assert actual == expected
-
-
-def test_clone_repo():
-    client = GithubClient()
-    with tempfile.TemporaryDirectory() as temp_dir:
-        client.clone_repo("dapphub/ds-test", temp_dir, branch="master")
 
 
 def test_get_all_files_in_directory():


### PR DESCRIPTION
### What I did

Fix little issue where we couldn't download repos using the `version:` github method when the github tag was**not** prefixed with a `v`.

### How I did it

Try the way it is first normally.
Then, try either stripping the `v` or adding `v` as a final attempt.

### How to verify it

You can now use https://github.com/smartcontractkit/chainlink-brownie-contracts as a dependency with config:

```yaml
dependencies:
  - name: chainlink
    github: smartcontractkit/chainlink-brownie-contracts
    contracts_folder: contracts/src/v0.4
    version: 0.4.1
```

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
