### PR TITLE
fix: bug preventing longer contracts_folder paths in dependencies

### DIFF
--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -6,8 +6,8 @@ from ethpm_types import ContractType
 from ape.api import CompilerAPI
 from ape.exceptions import CompilerError
 from ape.logging import logger
+from ape.utils import get_relative_path
 
-from ..utils import get_relative_path
 from .base import BaseManager
 
 

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -7,14 +7,8 @@ from ape.api import CompilerAPI
 from ape.exceptions import CompilerError
 from ape.logging import logger
 
+from ..utils import get_relative_path
 from .base import BaseManager
-
-
-def _get_contract_path(path: Path, base_path: Path):
-    if base_path not in path.parents:
-        return path
-
-    return path.relative_to(base_path)
 
 
 class CompilerManager(BaseManager):
@@ -98,8 +92,8 @@ class CompilerManager(BaseManager):
             ]
 
             for path in paths_to_compile:
-                contract_path = _get_contract_path(path, self.config_manager.contracts_folder)
-                logger.info(f"Compiling '{contract_path}'.")
+                source_id = get_relative_path(path, self.config_manager.contracts_folder)
+                logger.info(f"Compiling '{source_id}'.")
 
             compiled_contracts = self.registered_compilers[extension].compile(
                 paths_to_compile, base_path=self.config_manager.contracts_folder

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -263,7 +263,7 @@ class ConfigManager(BaseInterfaceModel):
         Returns:
             Generator
         """
-
+        print(project_folder)
         contracts_folder = contracts_folder or project_folder / "contracts"
 
         initial_project_folder = self.PROJECT_FOLDER
@@ -281,5 +281,4 @@ class ConfigManager(BaseInterfaceModel):
         self.contracts_folder = initial_contracts_folder
         self.project_manager.path = initial_project_folder
 
-        if Path(initial_project_folder).is_dir():
-            os.chdir(initial_project_folder)
+        os.chdir(initial_project_folder)

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -264,7 +264,6 @@ class ConfigManager(BaseInterfaceModel):
             Generator
         """
         contracts_folder = contracts_folder or project_folder / "contracts"
-
         initial_project_folder = self.PROJECT_FOLDER
         initial_contracts_folder = self.contracts_folder
 
@@ -279,5 +278,4 @@ class ConfigManager(BaseInterfaceModel):
         self.PROJECT_FOLDER = initial_project_folder
         self.contracts_folder = initial_contracts_folder
         self.project_manager.path = initial_project_folder
-
         os.chdir(initial_project_folder)

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -263,7 +263,6 @@ class ConfigManager(BaseInterfaceModel):
         Returns:
             Generator
         """
-        print(project_folder)
         contracts_folder = contracts_folder or project_folder / "contracts"
 
         initial_project_folder = self.PROJECT_FOLDER

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -280,4 +280,6 @@ class ConfigManager(BaseInterfaceModel):
         self.PROJECT_FOLDER = initial_project_folder
         self.contracts_folder = initial_contracts_folder
         self.project_manager.path = initial_project_folder
-        os.chdir(initial_project_folder)
+
+        if Path(initial_project_folder).is_dir():
+            os.chdir(initial_project_folder)

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -64,7 +64,10 @@ class BaseProject(ProjectAPI):
         if self.version:
             config_data["version"] = self.version
 
-        config_data["contracts_folder"] = self.contracts_folder.name
+        contracts_folder_config_item = (
+            str(self.contracts_folder).replace(str(self.path), "").strip("/")
+        )
+        config_data["contracts_folder"] = contracts_folder_config_item
         with open(self.config_file, "w") as f:
             yaml.safe_dump(config_data, f)
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -34,6 +34,9 @@ def _get_raw_contract(compiler: str) -> Dict:
 RAW_SOLIDITY_CONTRACT_TYPE = _get_raw_contract("solidity")
 RAW_VYPER_CONTRACT_TYPE = _get_raw_contract("vyper")
 TEST_ADDRESS = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+DEPENDENCY_PROJECT_PATH = (
+    Path(__file__).parent / "data" / "projects" / "long_contracts_folder"
+).absolute()
 
 
 @pytest.fixture
@@ -191,20 +194,22 @@ def contract_instance(request, solidity_contract_instance, vyper_contract_instan
 
 
 @pytest.fixture
-def temp_config():
+def temp_config(config):
     @contextmanager
-    def func(data: Dict, config):
+    def func(data: Dict):
         with tempfile.TemporaryDirectory() as temp_dir_str:
             temp_dir = Path(temp_dir_str)
+            config._cached_configs = {}
+            config_file = temp_dir / CONFIG_FILE_NAME
+            config_file.touch()
+            config_file.write_text(yaml.dump(data))
+
+            config.load(force_reload=True)
             with config.using_project(temp_dir):
-                config._cached_configs = {}
-                config_file = temp_dir / CONFIG_FILE_NAME
-                config_file.touch()
-                config_file.write_text(yaml.dump(data))
-                config.load(force_reload=True)
                 yield
-                config_file.unlink()
-                config._cached_configs = {}
+
+            config_file.unlink()
+            config._cached_configs = {}
 
     return func
 
@@ -215,3 +220,18 @@ def clean_contracts_cache(chain):
     chain.contracts._local_contracts = {}
     yield
     chain.contracts._local_contracts = original_cached_contracts
+
+
+@pytest.fixture
+def dependency_config(temp_config):
+    dependencies_config = {
+        "dependencies": [
+            {
+                "local": str(DEPENDENCY_PROJECT_PATH),
+                "name": "testdependency",
+                "contracts_folder": "source/v0.1",
+            }
+        ]
+    }
+    with temp_config(dependencies_config):
+        yield

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -193,7 +193,7 @@ def contract_instance(request, solidity_contract_instance, vyper_contract_instan
     return solidity_contract_instance if request.param == "solidity" else vyper_contract_instance
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def temp_config(config):
     @contextmanager
     def func(data: Dict):
@@ -203,8 +203,8 @@ def temp_config(config):
             config_file = temp_dir / CONFIG_FILE_NAME
             config_file.touch()
             config_file.write_text(yaml.dump(data))
-
             config.load(force_reload=True)
+
             with config.using_project(temp_dir):
                 yield
 

--- a/tests/functional/data/projects/long_contracts_folder/source/v0.1/long_contracts_folder.json
+++ b/tests/functional/data/projects/long_contracts_folder/source/v0.1/long_contracts_folder.json
@@ -1,0 +1,3 @@
+[
+    {"name":"foo","type":"fallback", "stateMutability":"nonpayable"}
+]

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -3,7 +3,7 @@ from typing import Dict
 
 import pytest
 
-from ape.exceptions import ConfigError, NetworkError
+from ape.exceptions import NetworkError
 from ape.managers.config import DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT, DeploymentConfigCollection
 from tests.functional.conftest import DEPENDENCY_PROJECT_PATH
 
@@ -62,13 +62,6 @@ def test_transaction_acceptance_timeout(temp_config, config, networks):
     timeout_config = {"transaction_acceptance_timeout": new_value}
     with temp_config(timeout_config):
         assert config.transaction_acceptance_timeout == new_value
-
-
-def test_dependencies_bad_type(temp_config):
-    dependencies_config = {"dependencies": {"name": "baddep"}}
-    with pytest.raises(ConfigError):
-        with temp_config(dependencies_config):
-            assert True  # Shouldn't get here
 
 
 def test_dependencies(dependency_config, config):

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -3,8 +3,9 @@ from typing import Dict
 
 import pytest
 
-from ape.exceptions import NetworkError
+from ape.exceptions import ConfigError, NetworkError
 from ape.managers.config import DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT, DeploymentConfigCollection
+from tests.functional.conftest import DEPENDENCY_PROJECT_PATH
 
 
 def test_integer_deployment_addresses(networks):
@@ -42,12 +43,12 @@ def _create_deployments(ecosystem_name: str = "ethereum", network_name: str = "l
     }
 
 
-def test_default_provider_not_found(temp_config, config, networks):
+def test_default_provider_not_found(temp_config, networks):
     provider_name = "DOES_NOT_EXIST"
     network_name = "local"
     eth_config = {"ethereum": {network_name: {"default_provider": provider_name}}}
 
-    with temp_config(eth_config, config):
+    with temp_config(eth_config):
         with pytest.raises(
             NetworkError, match=f"Provider '{provider_name}' not found in network '{network_name}'."
         ):
@@ -59,5 +60,19 @@ def test_transaction_acceptance_timeout(temp_config, config, networks):
     assert config.transaction_acceptance_timeout == DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT
     new_value = DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT + 10
     timeout_config = {"transaction_acceptance_timeout": new_value}
-    with temp_config(timeout_config, config):
+    with temp_config(timeout_config):
         assert config.transaction_acceptance_timeout == new_value
+
+
+def test_dependencies_bad_type(temp_config):
+    dependencies_config = {"dependencies": {"name": "baddep"}}
+    with pytest.raises(ConfigError):
+        with temp_config(dependencies_config):
+            assert True  # Shouldn't get here
+
+
+def test_dependencies(dependency_config, config):
+    assert len(config.dependencies) == 1
+    assert config.dependencies[0].name == "testdependency"
+    assert config.dependencies[0].contracts_folder == "source/v0.1"
+    assert config.dependencies[0].local == str(DEPENDENCY_PROJECT_PATH)

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -5,9 +5,16 @@ from typing import Dict
 import pytest
 from ethpm_types.manifest import PackageManifest
 
+import ape
+
 
 @pytest.fixture
-def dependencies_config():
+def project_manager():
+    return ape.project
+
+
+@pytest.fixture
+def oz_dependencies_config():
     def _create_oz_dependency(version: str) -> Dict:
         return {
             "name": "OpenZeppelin",
@@ -19,19 +26,19 @@ def dependencies_config():
 
 
 @pytest.fixture
-def already_downloaded_dependencies(temp_config, config, dependencies_config):
+def already_downloaded_dependencies(temp_config, config, oz_dependencies_config):
     manifests_directory = Path(__file__).parent / "data" / "manifests"
     oz_manifests = manifests_directory / "OpenZeppelin"
     oz_manifests_dest = config.packages_folder / "OpenZeppelin"
     shutil.copytree(oz_manifests, oz_manifests_dest)
-    with temp_config(dependencies_config, config):
+    with temp_config(oz_dependencies_config):
         yield
 
 
-def test_two_dependencies_with_same_name(already_downloaded_dependencies, project):
+def test_two_dependencies_with_same_name(already_downloaded_dependencies, project_manager):
     name = "OpenZeppelin"
-    oz_310 = project.dependencies[name]["3.1.0"]
-    oz_442 = project.dependencies[name]["4.4.2"]
+    oz_310 = project_manager.dependencies[name]["3.1.0"]
+    oz_442 = project_manager.dependencies[name]["4.4.2"]
 
     assert oz_310.version == "3.1.0"
     assert oz_310.name == name
@@ -39,6 +46,16 @@ def test_two_dependencies_with_same_name(already_downloaded_dependencies, projec
     assert oz_442.name == name
 
 
-def test_extract_manifest_type(project):
-    manifest = project.project_manager.extract_manifest()
+def test_extract_manifest_type(project_manager):
+    manifest = project_manager.extract_manifest()
     assert type(manifest) == PackageManifest
+
+
+def test_dependency_with_longer_contracts_folder(
+    dependency_config, config, mocker, project_manager
+):
+    spy = mocker.patch("ape.managers.project.types.yaml")
+    _ = project_manager.dependencies
+    assert spy.safe_dump.call_args, "Config file never created"
+    call_config = spy.safe_dump.call_args[0][0]
+    assert call_config["contracts_folder"] == "source/v0.1"

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -46,7 +46,8 @@ def test_two_dependencies_with_same_name(already_downloaded_dependencies, projec
     assert oz_442.name == name
 
 
-def test_extract_manifest_type(project_manager):
+def test_extract_manifest(dependency_config, project_manager):
+    # NOTE: Only setting dependency_config to ensure existence of project.
     manifest = project_manager.extract_manifest()
     assert type(manifest) == PackageManifest
 


### PR DESCRIPTION
### What I did

Issue preventing using `chainlink-brownie-contracts` as a dependency because of the need to set a more complex contracts folder path

e.g.

```yaml
dependencies:
  - name: chainlink
    github: smartcontractkit/chainlink-brownie-contracts
    version: 0.4.1
    contracts_folder: contracts/src/v0.4
```

### How I did it

Changed `path.name` to the suffix after the base path.

### How to verify it

can use the chainlink repo as a dep (have to also use https://github.com/ApeWorX/ape-solidity/pull/42)

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] New test cases have been added
