### PR TITLE
docs: add root level namespace to console guide

### DIFF
--- a/docs/userguides/console.md
+++ b/docs/userguides/console.md
@@ -9,6 +9,34 @@ In [1]: chain.blocks.head.timestamp
 Out[1]: 1647323479
 ```
 
+## Ape Namespace
+
+Your console comes with pre-initialized root ape objects in your namespace.
+
+| Name       | Class                                                                                                      |
+|:----------:|:----------------------------------------------------------------------------------------------------------:|
+| `accounts` | [AccountManager](../methoddocs/managers.html?highlight=accounts#module-ape.managers.accounts)              | 
+| `networks` | [NetworkManager](../methoddocs/managers.html?highlight=networks#module-ape.managers.networks)              | 
+| `chain`    | [ChainManager](../methoddocs/managers.html?highlight=chain#module-ape.managers.chain)                      | 
+| `project`  | [ProjectManager](../methoddocs/managers.html?highlight=project#module-ape.managers.project.manager)        | 
+| `query`    | [QueryManager](../methoddocs/managers.html?highlight=query#module-ape.managers.query)                      |
+| `convert`  | [convert](../methoddocs/managers.html?highlight=query#ape.managers.converters.AddressAPIConverter.convert) |
+
+You can access them as if they are already initialized:
+
+First, launch the console:
+
+```bash
+ape console
+```
+
+Then, type the name of the item and you will see its Python representation:
+
+```python
+In [1]: networks
+Out[1]: <NetworkManager active_provider=<test chain_id=61>>
+```
+
 ## Namespace Extras
 
 You can also create scripts to be included in the console namespace by adding a file (`ape_console_extras.py`) to your root project directory.  All non-internal symbols from this file will be included in the console namespace.  Internal symbols are prefixed by an underscore (`_`).


### PR DESCRIPTION
### What I did

Adds root level namespace items to console guide

### How I did it

A markdown table with links pointing to method docs

### How to verify it

links work
<img width="669" alt="Screen Shot 2022-06-02 at 07 55 19" src="https://user-images.githubusercontent.com/19540978/171633935-12f0ec63-337a-42cc-8195-170b9f952b37.png">


### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
