### PR TITLE
docs: improve error message when multiple events with same name defined

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -503,7 +503,8 @@ class ContractInstance(BaseAddress):
         for abi in self.contract_type.events:
             if abi.name in events:
                 raise ContractError(
-                    f"Multiple events with the same ABI defined in '{self.contract_type.name}'."
+                    f"Multiple events named '{abi.name}' in '{self.contract_type.name}'.\n"
+                    f"Could one be coming from a base class?"
                 )
 
             events[abi.name] = abi

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -504,7 +504,7 @@ class ContractInstance(BaseAddress):
             if abi.name in events:
                 raise ContractError(
                     f"Multiple events named '{abi.name}' in '{self.contract_type.name}'.\n"
-                    f"Could one be coming from a base class?"
+                    f"Could one be coming from an imported file?"
                 )
 
             events[abi.name] = abi


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #751 

### How I did it

Well, it does not actually resolve their error but gives more detail on how to fix it.
It seems problematic to have two events with the same name so I am guessing it is probably best to raise an error.

An alternative is to rename the events to `Initialized_0` and `Initialized_1` and so on (plus a WARNING), but that seems not ideal from the project's perspective.

Any other ideas? Is  `veYfi` able to rename `Gauge.Initialized` event?

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
