### PR TITLE
fix: issue with error handling during proxy contract detection

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -609,7 +609,10 @@ class Web3Provider(ProviderAPI, ABC):
         return self.web3.eth.get_storage_at(address, slot)  # type: ignore
 
     def send_call(self, txn: TransactionAPI) -> bytes:
-        return self.web3.eth.call(txn.dict())
+        try:
+            return self.web3.eth.call(txn.dict())
+        except ValueError as err:
+            raise self.get_virtual_machine_error(err) from err
 
     def get_transaction(self, txn_hash: str, required_confirmations: int = 0) -> ReceiptAPI:
         if required_confirmations < 0:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -241,7 +241,16 @@ class Ethereum(EcosystemAPI):
             # avoid recursion
             if target != "0x0000000000000000000000000000000000000000":
                 return ProxyInfo(type=ProxyType.Delegate, target=target)
-        except (DecodingError, ContractLogicError, AssertionError):
+
+        except ValueError as err:
+            vm_error = self.provider.get_virtual_machine_error(err)
+            if isinstance(vm_error, ContractLogicError):
+                pass
+
+            # Raise the un-expected error.
+            raise
+
+        except (DecodingError, AssertionError):
             pass
 
         return None

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -236,21 +236,15 @@ class Ethereum(EcosystemAPI):
         )
         try:
             proxy_type = ContractCall(proxy_type_abi, address)()
-            assert proxy_type in [1, 2], "proxyType not permitted by eip-897"
+            if proxy_type not in (1, 2):
+                raise ValueError(f"ProxyType '{proxy_type}' not permitted by EIP-897.")
+
             target = ContractCall(implementation_abi, address)()
             # avoid recursion
             if target != "0x0000000000000000000000000000000000000000":
                 return ProxyInfo(type=ProxyType.Delegate, target=target)
 
-        except ValueError as err:
-            vm_error = self.provider.get_virtual_machine_error(err)
-            if isinstance(vm_error, ContractLogicError):
-                pass
-
-            # Raise the un-expected error.
-            raise
-
-        except (DecodingError, AssertionError):
+        except (DecodingError, ContractLogicError, ValueError):
             pass
 
         return None


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #772 

### How I did it
<!-- Discuss the thought process behind the change -->
* move error handling logic for VM stuff to base Web3 provider to share code amongst all providers. This was not possible before but now it is since the newly added API method for getting the VM error.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
