### PR TITLE
fix: issue when awaiting confirmations on a failed transaction

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -209,9 +209,14 @@ class ReceiptAPI(BaseInterfaceModel):
         """
         # Wait for nonce from provider to increment.
         sender_nonce = self.provider.get_nonce(self.sender)
+        iterations_timeout = 20
+        iteration = 0
         while sender_nonce == self.nonce:  # type: ignore
             time.sleep(1)
             sender_nonce = self.provider.get_nonce(self.sender)
+            iteration += 1
+            if iteration == iterations_timeout:
+                raise TransactionError(message="Timeout waiting for sender's nonce to increase.")
 
         if self.required_confirmations == 0:
             # The transaction might not yet be confirmed but

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -207,10 +207,18 @@ class ReceiptAPI(BaseInterfaceModel):
         Returns:
             :class:`~ape.api.ReceiptAPI`: The receipt that is now confirmed.
         """
+
+        try:
+            self.raise_for_status()
+        except TransactionError:
+            # Skip waiting for confirmations when the transaction has failed.
+            return self
+
         # Wait for nonce from provider to increment.
         sender_nonce = self.provider.get_nonce(self.sender)
         iterations_timeout = 20
         iteration = 0
+
         while sender_nonce == self.nonce:  # type: ignore
             time.sleep(1)
             sender_nonce = self.provider.get_nonce(self.sender)


### PR DESCRIPTION
### What I did

Before, you could get into a state where a txn was **never** accepted onto the blockchain and it stalled forever waiting for the user's nonce to increase. **I noticed this while experimenting with Anvil, as rinkeby fork is failing when running the subprocess provider (e.g. not running the process manually).**

### How I did it

* Check for a failed receipt for waiting.
* Add timeout logic to waiting just in case.

### How to verify it

I don't really know, tbh, but the errors in foundry are a lot nicer now.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
