### PR TITLE
fix: correct type of block ID in abstractmethod

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -290,7 +290,8 @@ class ProviderAPI(BaseInterfaceModel):
             The receipt of the transaction with the given hash.
         """
 
-    @abstractmethod
+    # TODO: After 0.2.8 release, make this @abstractmethod
+    @raises_not_implemented
     def get_transactions_by_block(self, block_id: BlockID) -> Iterator[TransactionAPI]:
         """
         Get the information about a set of transactions from a block.

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -291,12 +291,12 @@ class ProviderAPI(BaseInterfaceModel):
         """
 
     @abstractmethod
-    def get_transactions_by_block(self, block_id: HexBytes) -> Iterator[TransactionAPI]:
+    def get_transactions_by_block(self, block_id: BlockID) -> Iterator[TransactionAPI]:
         """
         Get the information about a set of transactions from a block.
 
         Args:
-            block_id (HexBytes): The hash of a block.
+            block_id (:class:`~ape.types.BlockID`): The ID of the block.
 
         Returns:
             Iterator[:class: `~ape.api.transactions.TransactionAPI`]


### PR DESCRIPTION
### What I did

The type of `block_id` does not seem to match the implementing behavior

### How I did it
changed it!

### How to verify it
Tell me I am wrong if I am

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
