### PR TITLE
feat: custom not implemented exception

### DIFF
--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -14,6 +14,12 @@ class ApeException(Exception):
     """
 
 
+class APINotImplementedError(ApeException, NotImplementedError):
+    """
+    An error raised when an API class does not implement an abstract method.
+    """
+
+
 class AccountsError(ApeException):
     """
     Raised when a problem occurs when using accounts.

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -10,6 +10,7 @@ from importlib_metadata import PackageNotFoundError, packages_distributions
 from importlib_metadata import version as version_metadata
 from tqdm.auto import tqdm  # type: ignore
 
+from ape.exceptions import APINotImplementedError
 from ape.logging import logger
 from ape.utils.os import expand_environment_variables
 
@@ -223,7 +224,7 @@ def raises_not_implemented(fn):
     """
 
     def inner(*args, **kwargs):
-        raise NotImplementedError(
+        raise APINotImplementedError(
             f"Attempted to call method '{fn.__qualname__}', method not supported."
         )
 

--- a/tests/functional/utils/test_misc.py
+++ b/tests/functional/utils/test_misc.py
@@ -1,4 +1,7 @@
-from ape.utils.misc import add_padding_to_strings, extract_nested_value
+import pytest
+
+from ape.exceptions import APINotImplementedError
+from ape.utils.misc import add_padding_to_strings, extract_nested_value, raises_not_implemented
 
 
 def test_extract_nested_value():
@@ -16,3 +19,18 @@ def test_add_spacing_to_strings():
     expected = ["foo         ", "address     ", "ethereum    "]
     actual = add_padding_to_strings(string_list, extra_spaces=4)
     assert actual == expected
+
+
+def test_raises_not_implemented():
+    @raises_not_implemented
+    def unimplemented_api_method():
+        pass
+
+    with pytest.raises(APINotImplementedError) as err:
+        unimplemented_api_method()
+
+    assert str(err.value) == (
+        "Attempted to call method 'test_raises_not_implemented.<locals>.unimplemented_api_method', "
+        "method not supported."
+    )
+    assert isinstance(err.value, NotImplementedError)


### PR DESCRIPTION
### What I did

This comment: https://github.com/ApeWorX/ape/pull/746#discussion_r893026642
made me realize that the output for not implemented API methods was not very good.

This PR improves that experience!

### How I did it

Make a custom exception that is both an `ApeException` and the stdlib exception `NotImplementedError`.

### How to verify it

* Test that the output shows the API method
* Test that the error is also a `NotImplementedError`

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
