### PR TITLE
feat!: add access list transaction type, add transaction api txn_hash, fix block transaction query

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -1,6 +1,7 @@
 import time
 from typing import TYPE_CHECKING, Iterator, List, Optional, Union
 
+from ethpm_types import HexBytes
 from ethpm_types.abi import EventABI
 from pydantic.fields import Field
 from tqdm import tqdm  # type: ignore
@@ -77,7 +78,7 @@ class TransactionAPI(BaseInterfaceModel):
         return f"{self.__class__.__name__}:\n  {params}"
 
     @abstractmethod
-    def txn_hash(self):
+    def txn_hash(self) -> HexBytes:
         """
         The hash of the transaction.
         """

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -1,8 +1,6 @@
 import time
 from typing import TYPE_CHECKING, Iterator, List, Optional, Union
 
-from eth_utils import keccak
-from ethpm_types import HexBytes
 from ethpm_types.abi import EventABI
 from pydantic.fields import Field
 from tqdm import tqdm  # type: ignore
@@ -78,9 +76,11 @@ class TransactionAPI(BaseInterfaceModel):
         params = "\n  ".join(f"{k}: {v}" for k, v in data.items())
         return f"{self.__class__.__name__}:\n  {params}"
 
-    @property
+    @abstractmethod
     def txn_hash(self):
-        return HexBytes(keccak(self.serialize_transaction()))
+        """
+        The hash of the transaction.
+        """
 
 
 class ConfirmationsProgressBar:

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -1,6 +1,8 @@
 import time
 from typing import TYPE_CHECKING, Iterator, List, Optional, Union
 
+from eth_utils import keccak
+from ethpm_types import HexBytes
 from ethpm_types.abi import EventABI
 from pydantic.fields import Field
 from tqdm import tqdm  # type: ignore
@@ -75,6 +77,10 @@ class TransactionAPI(BaseInterfaceModel):
             data["data"] = "0x" + bytes(data["data"]).hex()
         params = "\n  ".join(f"{k}: {v}" for k, v in data.items())
         return f"{self.__class__.__name__}:\n  {params}"
+
+    @property
+    def txn_hash(self):
+        return HexBytes(keccak(self.serialize_transaction()))
 
 
 class ConfirmationsProgressBar:

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -127,7 +127,6 @@ class BaseInterfaceModel(BaseInterface, BaseModel):
         keep_untouched = (cached_property, singledispatchmethod)
         arbitrary_types_allowed = True
         underscore_attrs_are_private = True
-        anystr_strip_whitespace = True
         copy_on_model_validation = False
 
     def __dir__(self) -> List[str]:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -8,7 +8,14 @@ from eth_abi import encode_abi as abi_encode
 from eth_abi.abi import decode_abi, decode_single
 from eth_abi.exceptions import InsufficientDataBytes
 from eth_typing import HexStr
-from eth_utils import add_0x_prefix, hexstr_if_str, keccak, to_bytes, to_checksum_address
+from eth_utils import (
+    add_0x_prefix,
+    decode_hex,
+    hexstr_if_str,
+    keccak,
+    to_bytes,
+    to_checksum_address,
+)
 from ethpm_types.abi import ABIType, ConstructorABI, EventABI, EventABIType, MethodABI
 from hexbytes import HexBytes
 
@@ -24,7 +31,7 @@ from ape.api import (
 from ape.api.networks import LOCAL_NETWORK_NAME, ProxyInfoAPI
 from ape.contracts.base import ContractCall
 from ape.exceptions import DecodingError, TransactionError
-from ape.types import AddressType, ContractLog, RawAddress
+from ape.types import AddressType, ContractLog, RawAddress, TransactionSignature
 from ape.utils import LogInputABICollection, Struct, StructParser, is_array, returns_array
 from ape_ethereum.transactions import (
     BaseTransaction,
@@ -445,6 +452,16 @@ class Ethereum(EcosystemAPI):
                 required_confirmations = active_provider.network.required_confirmations
 
             kwargs["required_confirmations"] = required_confirmations
+
+        if "input" in kwargs:
+            kwargs["data"] = decode_hex(kwargs.pop("input"))
+
+        if all(field in kwargs for field in ("v", "r", "s")):
+            kwargs["signature"] = TransactionSignature(  # type: ignore
+                v=kwargs["v"],
+                r=bytes(kwargs["r"]),
+                s=bytes(kwargs["s"]),
+            )
 
         return txn_class(**kwargs)  # type: ignore
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -34,6 +34,7 @@ from ape.exceptions import DecodingError, TransactionError
 from ape.types import AddressType, ContractLog, RawAddress, TransactionSignature
 from ape.utils import LogInputABICollection, Struct, StructParser, is_array, returns_array
 from ape_ethereum.transactions import (
+    AccessListTransaction,
     BaseTransaction,
     DynamicFeeTransaction,
     Receipt,
@@ -419,6 +420,7 @@ class Ethereum(EcosystemAPI):
         transaction_types = {
             TransactionType.STATIC: StaticFeeTransaction,
             TransactionType.DYNAMIC: DynamicFeeTransaction,
+            TransactionType.ACCESS_LIST: AccessListTransaction,
         }
 
         if "type" in kwargs:
@@ -452,6 +454,9 @@ class Ethereum(EcosystemAPI):
                 required_confirmations = active_provider.network.required_confirmations
 
             kwargs["required_confirmations"] = required_confirmations
+
+        if isinstance(kwargs.get("chainId"), str):
+            kwargs["chainId"] = int(kwargs["chainId"], 16)
 
         if "input" in kwargs:
             kwargs["data"] = decode_hex(kwargs.pop("input"))

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -36,6 +36,7 @@ class TransactionType(Enum):
     """
 
     STATIC = "0x00"
+    ACCESS_LIST = "0x01"  # EIP-2930
     DYNAMIC = "0x02"  # EIP-1559
 
 

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -6,8 +6,8 @@ from eth_account._utils.legacy_transactions import (
     encode_transaction,
     serializable_unsigned_transaction_from_dict,
 )
-from eth_utils import to_int
-from hexbytes import HexBytes
+from eth_utils import keccak, to_int
+from ethpm_types import HexBytes
 from pydantic import BaseModel, Field, root_validator, validator
 
 from ape.api import ReceiptAPI, TransactionAPI
@@ -62,6 +62,10 @@ class BaseTransaction(TransactionAPI):
             raise SignatureError("Recovered signer doesn't match sender!")
 
         return signed_txn
+
+    @property
+    def txn_hash(self):
+        return HexBytes(keccak(self.serialize_transaction()))
 
 
 class StaticFeeTransaction(BaseTransaction):

--- a/tests/functional/test_ethereum.py
+++ b/tests/functional/test_ethereum.py
@@ -106,3 +106,10 @@ def test_parse_output_type(s):
     # See tests in `tests_contracts` for specific ABI parsing tests.
 
     assert parse_output_type(s)
+
+
+def test_whitespace_in_transaction_data():
+    data = b"Should not clip whitespace\t\n"
+    txn_dict = {"data": data}
+    txn = StaticFeeTransaction.parse_obj(txn_dict)
+    assert txn.data == data, "Whitespace should not be removed from data"

--- a/tests/functional/test_ethereum.py
+++ b/tests/functional/test_ethereum.py
@@ -20,6 +20,12 @@ def test_create_static_fee_transaction(ethereum, type_kwarg):
     assert txn.type == TransactionType.STATIC.value
 
 
+@pytest.mark.parametrize("type_kwarg", (1, "0x01", b"\x01", "1", "01", HexBytes("0x01")))
+def test_create_access_list_transaction(ethereum, type_kwarg):
+    txn = ethereum.create_transaction(type=type_kwarg)
+    assert txn.type == TransactionType.ACCESS_LIST.value
+
+
 @pytest.mark.parametrize("type_kwarg", (None, 2, "0x02", b"\x02", "2", "02", HexBytes("0x02")))
 def test_create_dynamic_fee_transaction(ethereum, type_kwarg):
     txn = ethereum.create_transaction(type=type_kwarg)

--- a/tests/functional/test_ethereum.py
+++ b/tests/functional/test_ethereum.py
@@ -74,6 +74,18 @@ def test_receipt_raise_for_status_out_of_gas_error(mocker):
         receipt.raise_for_status()
 
 
+def test_txn_hash(owner, eth_tester_provider):
+    txn = StaticFeeTransaction()
+    txn = owner.prepare_transaction(txn)
+    txn.signature = owner.sign_transaction(txn)
+
+    actual = txn.txn_hash.hex()
+    receipt = eth_tester_provider.send_transaction(txn)
+    expected = receipt.txn_hash
+
+    assert actual == expected
+
+
 @pytest.mark.fuzzing
 @given(strategies.from_regex(r"\(*[\w|, []]*\)*"))
 def test_parse_output_type(s):


### PR DESCRIPTION
### What I did
- correctly instantiate transactions coming from `BlockTransactionQuery`, previously they were missing `data` and `signature`
- add `txn_hash` property to `TransactionAPI`
- add `AccessListTransaction` type and optional access list for `DynamicFeeTransaction`
- fix a bug with whitespace bytes being stripped when parsing txn data

### How I did it

### How to verify it
`chain.blocks[height].transactions` should yield transactions with correct calculated `txn_hash`

### Checklist

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
