### PR TITLE
feat: better estimate fee support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 In the latest release, Ape requires:
 
 -   Linux or macOS
--   Python 3.7.X or later
+-   Python 3.7.2 or later
 
 **Windows**:
 
 1.  Install Windows Subsystem Linux
     [(WSL)](https://docs.microsoft.com/en-us/windows/wsl/install)
 2.  Choose Ubuntu 20.04 OR Any other Linux Distribution with Python
-    3.7.X or later
+    3.7.2 or later
 
-Please make sure you are using Python 3.7.X or later.
+Please make sure you are using Python 3.7.2 or later.
 
 Check your python command by entering
 

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -130,3 +130,15 @@ In your `ape-config.yaml` file, add the following:
 ```yaml
 transaction_acceptance_timeout: 600  # 5 minutes
 ```
+
+## Estimate Fees
+
+To estimate the fees on a transaction without sending it, use the `as_transaction()` method to get a reference to a transaction API object.
+Then, use the `ProviderAPI.estimate_gas_cost()` method with the transaction as the argument.
+
+(Assume I have a contract instance named `contract_a` that has a method named `methodToCall`)
+
+```bash
+txn = contract_a.methodToCall.as_transaction(1, sender=accounts.load("me"))
+estimated_fees = provider.estimate_gas_cost(txn)
+```

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -180,6 +180,25 @@ class ContractTransactionHandler(ManagerAccessMixin):
         abis = sorted(self.abis, key=lambda abi: len(abi.inputs or []))
         return abis[-1].signature
 
+    def as_transaction(self, *args, **kwargs) -> TransactionAPI:
+        """
+        Get a :class:`~ape.api.transactions.TransactionAPI`
+        for this contract method invocation. This is useful
+        for simulations or estimating fees without sending
+        the transaction.
+
+        Args:
+            *args: The contract method invocation arguments.
+
+        Returns:
+            :class:`~ape.api.transactions.TransactionAPI`
+        """
+
+        contract_transaction = self._as_transaction(*args)
+        transaction = contract_transaction.serialize_transaction(*args, **kwargs)
+        self.provider.prepare_transaction(transaction)
+        return transaction
+
     @property
     def call(self) -> ContractCallHandler:
         """
@@ -195,6 +214,10 @@ class ContractTransactionHandler(ManagerAccessMixin):
         return self.conversion_manager.convert(v, tuple)
 
     def __call__(self, *args, **kwargs) -> ReceiptAPI:
+        contract_transaction = self._as_transaction(*args)
+        return contract_transaction(*args, **kwargs)
+
+    def _as_transaction(self, *args) -> ContractTransaction:
         if not self.contract.is_contract:
             network = self.provider.network.name
             raise _get_non_contract_error(self.contract.address, network)
@@ -205,7 +228,7 @@ class ContractTransactionHandler(ManagerAccessMixin):
         return ContractTransaction(  # type: ignore
             abi=selected_abi,
             address=self.contract.address,
-        )(*args, **kwargs)
+        )
 
 
 class ContractEvent(ManagerAccessMixin):

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -189,6 +189,8 @@ class ContractTransactionHandler(ManagerAccessMixin):
 
         Args:
             *args: The contract method invocation arguments.
+            **kwargs: Transaction kwargs, such as value or
+              sender.
 
         Returns:
             :class:`~ape.api.transactions.TransactionAPI`

--- a/tests/functional/test_contracts.py
+++ b/tests/functional/test_contracts.py
@@ -423,3 +423,9 @@ def test_contract_two_events_with_same_name(owner, networks_connected_to_tester)
     assert event_from_impl_contract.abi.signature == expected_sig_from_impl
     event_from_interface = impl_instance.get_event_by_signature(expected_sig_from_interface)
     assert event_from_interface.abi.signature == expected_sig_from_interface
+
+
+def test_estimating_fees(solidity_contract_instance, eth_tester_provider, owner):
+    transaction = solidity_contract_instance.setNumber.as_transaction(10, sender=owner)
+    estimated_fees = eth_tester_provider.estimate_gas_cost(transaction)
+    assert estimated_fees > 0


### PR DESCRIPTION
### What I did

Allows you to estimate fees of a transaction without sending it.

### How I did it

Add a `as_transaction()` method to the `ContractTransactionHandler` that can create a `TransactionAPI` object from which you can pass to `provider.estimate_gas_cost()`.

Am open to alternative designs!

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
