### PR TITLE
refactor: breaking changes PR

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -441,7 +441,9 @@ class ContractEvent(ManagerAccessMixin):
         ) - required_confirmations
 
         for new_block in self.chain_manager.blocks.poll_blocks(
-            start=start_block, stop=stop_block, required_confirmations=required_confirmations
+            start_block=start_block,
+            stop_block=stop_block,
+            required_confirmations=required_confirmations,
         ):
             if new_block.number is None:
                 continue

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -182,9 +182,9 @@ class BlockContainer(BaseManager):
             )
         elif stop < start:
             raise ValueError(f"stop '{stop}' cannot be less than start '{start}'.")
-        elif stop < 0:
+        elif start < 0:
             raise ValueError(f"start '{start}' cannot be negative.")
-        elif start_or_stop < 0:
+        elif stop < 0:
             raise ValueError(f"stop '{stop}' cannot be negative.")
 
         # Note: the range `stop_block` is a non-inclusive stop, while the

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -195,8 +195,8 @@ class BlockContainer(BaseManager):
 
     def poll_blocks(
         self,
-        start: Optional[int] = None,
-        stop: Optional[int] = None,
+        start_block: Optional[int] = None,
+        stop_block: Optional[int] = None,
         required_confirmations: Optional[int] = None,
     ) -> Iterator[BlockAPI]:
         """
@@ -212,9 +212,9 @@ class BlockContainer(BaseManager):
                 print(f"New block found: number={new_block.number}")
 
         Args:
-            start (Optional[int]): The block number to start with. Defaults to the pending
+            start_block (Optional[int]): The block number to start with. Defaults to the pending
               block number.
-            stop (Optional[int]): Optionally set a future block number to stop at.
+            stop_block (Optional[int]): Optionally set a future block number to stop at.
               Defaults to never-ending.
             required_confirmations (Optional[int]): The amount of confirmations to wait
               before yielding the block. The more confirmations, the less likely a reorg will occur.
@@ -226,16 +226,16 @@ class BlockContainer(BaseManager):
         if required_confirmations is None:
             required_confirmations = self.network_confirmations
 
-        if stop is not None and stop <= self.chain_manager.blocks.height:
+        if stop_block is not None and stop_block <= self.chain_manager.blocks.height:
             raise ValueError("'stop' argument must be in the future.")
 
         # Get number of last block with the necessary amount of confirmations.
         latest_confirmed_block_number = self.height - required_confirmations
         has_yielded = False
 
-        if start is not None:
+        if start_block is not None:
             # Front-load historically confirmed blocks.
-            yield from self.range(start, latest_confirmed_block_number + 1)
+            yield from self.range(start_block, latest_confirmed_block_number + 1)
             has_yielded = True
 
         time.sleep(self.provider.network.block_time)
@@ -256,7 +256,7 @@ class BlockContainer(BaseManager):
 
                     yield block
 
-                    if stop and block.number == stop:
+                    if stop_block and block.number == stop_block:
                         return
 
                 has_yielded = True

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -152,7 +152,7 @@ class ScriptCommand(click.MultiCommand):
     short_help="Run scripts from the `scripts/` folder",
 )
 @click.option(
-    "-i",
+    "-I",
     "--interactive",
     is_flag=True,
     default=False,

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -123,6 +123,21 @@ def test_block_range_with_step(chain_at_block_5):
     assert blocks[1].number == 2
 
 
+def test_block_range_negative_start(chain_at_block_5):
+    with pytest.raises(ValueError) as err:
+        _ = [b for b in chain_at_block_5.blocks.range(-1, 3, step=2)]
+
+    assert str(err.value) == "start '-1' cannot be negative."
+
+
+def test_block_range_out_of_order(chain_at_block_5):
+    range
+    with pytest.raises(ValueError) as err:
+        _ = [b for b in chain_at_block_5.blocks.range(3, 1, step=2)]
+
+    assert str(err.value) == "stop '1' cannot be less than start '3'."
+
+
 def test_set_pending_timestamp(chain):
     start_timestamp = chain.pending_timestamp
     chain.pending_timestamp += 3600

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -6,6 +6,11 @@ from hexbytes import HexBytes
 from ape.exceptions import ChainError
 
 
+@pytest.fixture(scope="module", autouse=True)
+def connection(networks_connected_to_tester):
+    yield
+
+
 @pytest.fixture
 def chain_at_block_5(chain, sender, receiver):
     snapshot_id = chain.snapshot()


### PR DESCRIPTION
### What I did

* Renamed `start` and `stop` to `start_block` and `stop_block` respectively in `poll_logs` to lessen confusion between that in the `range()` methods (which use the slice approach for `start` and `stop`).
* make the `-i` flag capitalized like `-I` in the `ape run` CLI command so that it matches its equivalent in the `ape test` command, for consistency's sake since the flag does the same thing.

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
