### PR TITLE
feat: handle snake_case parent block hash in BlockAPI

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -65,8 +65,14 @@ class BlockAPI(BaseInterfaceModel):
 
     @root_validator(pre=True)
     def convert_parent_hash(cls, data):
-        if not data["parentHash"]:
-            data["parentHash"] = EMPTY_BYTES32
+        if "parent_hash" in data:
+            parent_hash = data["parent_hash"]
+        elif "parentHash" in data:
+            parent_hash = data["parentHash"]
+        else:
+            parent_hash = EMPTY_BYTES32
+
+        data["parentHash"] = parent_hash or EMPTY_BYTES32
         return data
 
     @validator("hash", "parent_hash", pre=True)

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -12,7 +12,7 @@ def connection(networks_connected_to_tester):
 
 
 @pytest.fixture
-def chain_at_block_5(chain, sender, receiver):
+def chain_at_block_5(chain):
     snapshot_id = chain.snapshot()
     chain.mine(5)
     yield chain
@@ -31,6 +31,9 @@ def test_snapshot_and_restore(chain, sender, receiver):
 
     assert chain.blocks[-1].number == end_range
 
+    # Increase receiver's balance
+    sender.transfer(receiver, "123 wei")
+
     # Show that we can also provide the snapshot ID as an argument.
     chain.restore(snapshot_ids[2])
     assert chain.blocks[-1].number == 2
@@ -43,7 +46,7 @@ def test_snapshot_and_restore(chain, sender, receiver):
     assert receiver.balance == initial_balance
 
 
-def test_snapshot_and_restore_unknown_snapshot_id(chain, sender, receiver):
+def test_snapshot_and_restore_unknown_snapshot_id(chain):
     _ = chain.snapshot()
     chain.mine()
     snapshot_id_2 = chain.snapshot()
@@ -60,7 +63,7 @@ def test_snapshot_and_restore_unknown_snapshot_id(chain, sender, receiver):
     assert "Unknown snapshot ID" in str(err.value)
 
 
-def test_snapshot_and_restore_no_snapshots(chain, sender, receiver):
+def test_snapshot_and_restore_no_snapshots(chain):
     chain._snapshots = []  # Ensure empty (gets set in test setup)
     with pytest.raises(ChainError) as err:
         chain.restore("{}")

--- a/tests/functional/test_ethereum.py
+++ b/tests/functional/test_ethereum.py
@@ -4,6 +4,7 @@ from hexbytes import HexBytes
 
 from ape.exceptions import OutOfGasError
 from ape.types import AddressType
+from ape_ethereum.ecosystem import Block
 from ape_ethereum.transactions import (
     Receipt,
     StaticFeeTransaction,
@@ -95,3 +96,16 @@ def test_whitespace_in_transaction_data():
     txn_dict = {"data": data}
     txn = StaticFeeTransaction.parse_obj(txn_dict)
     assert txn.data == data, "Whitespace should not be removed from data"
+
+
+def test_block_handles_snake_case_parent_hash(eth_tester_provider, sender, receiver):
+    # Transaction to change parent hash of next block
+    sender.transfer(receiver, "1 gwei")
+
+    # Replace 'parentHash' key with 'parent_hash'
+    latest_block = eth_tester_provider.get_block("latest")
+    latest_block_dict = eth_tester_provider.get_block("latest").dict()
+    latest_block_dict["parent_hash"] = latest_block_dict.pop("parentHash")
+
+    redefined_block = Block.parse_obj(latest_block_dict)
+    assert redefined_block.parent_hash == latest_block.parent_hash


### PR DESCRIPTION
### What I did

This just makes life a little easier elsewhere for me :)

Otherwise when initializing blocks using `kwargs`, you have to use camelCase and looks funny in the pythons
### How I did it

In BlockAPI validator, handle both snake_case and camelCase parent hash keys.

### How to verify it

I added a test

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
