### PR TITLE
feat: added pandas back to chain

### DIFF
--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -69,9 +69,9 @@ class BlockQuery(_BaseBlockQuery):
 
     @classmethod
     def all_fields(cls) -> List[str]:
-        from .providers import BlockAPI
+        from ape_ethereum.ecosystem import Block
 
-        return list(BlockAPI.__fields__)
+        return list(Block.__fields__)
 
 
 class BlockTransactionQuery(_BaseQuery):

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -1,12 +1,10 @@
 from typing import Any, Dict, Iterator, List, Optional, Union
 
 from ethpm_types.abi import EventABI, MethodABI
-from pydantic import BaseModel, NonNegativeInt, PositiveInt, root_validator, validator
+from pydantic import BaseModel, NonNegativeInt, PositiveInt, root_validator
 
 from ape.types import AddressType
 from ape.utils import BaseInterfaceModel, abstractmethod
-
-from .transactions import TransactionAPI
 
 QueryType = Union[
     "BlockQuery",
@@ -17,32 +15,23 @@ QueryType = Union[
 ]
 
 
+def validate_and_expand_columns(columns: List[str], all_columns: List[str]) -> List[str]:
+    if len(columns) == 1 and columns[0] == "*":
+        return all_columns
+
+    else:
+        if len(set(columns)) != len(columns):
+            raise ValueError(f"Duplicate fields in {columns}")
+
+        for d in columns:
+            if d not in all_columns:
+                raise ValueError(f"Unrecognized field '{d}', must be one of {all_columns}")
+
+    return columns
+
+
 class _BaseQuery(BaseModel):
-
-    columns: List[str]
-
-    @classmethod
-    @abstractmethod
-    def all_fields(cls) -> List[str]:
-        """
-        Validates fields that are called during a block query.
-
-        Returns:
-            List[str]: list of keys to be returned during block query.
-        """
-
-    @validator("columns")
-    def check_columns(cls, data: List[str]) -> List[str]:
-        all_fields = cls.all_fields()
-        if len(data) == 1 and data[0] == "*":
-            return all_fields
-        else:
-            if len(set(data)) != len(data):
-                raise ValueError(f"Duplicate fields in {data}")
-            for d in data:
-                if d not in all_fields:
-                    raise ValueError(f"Unrecognized field '{d}', must be one of {all_fields}")
-        return data
+    pass
 
 
 class _BaseBlockQuery(_BaseQuery):
@@ -67,12 +56,6 @@ class BlockQuery(_BaseBlockQuery):
     blocks between ``start_block`` and ``stop_block``.
     """
 
-    @classmethod
-    def all_fields(cls) -> List[str]:
-        from ape_ethereum.ecosystem import Block
-
-        return list(Block.__fields__)
-
 
 class BlockTransactionQuery(_BaseQuery):
     """
@@ -81,10 +64,6 @@ class BlockTransactionQuery(_BaseQuery):
     """
 
     block_id: Any
-
-    @classmethod
-    def all_fields(cls) -> List[str]:
-        return list(TransactionAPI.__fields__)
 
 
 class AccountTransactionQuery(_BaseQuery):
@@ -107,10 +86,6 @@ class AccountTransactionQuery(_BaseQuery):
 
         return values
 
-    @classmethod
-    def all_fields(cls) -> List[str]:
-        return list(TransactionAPI.__fields__)
-
 
 class ContractEventQuery(_BaseBlockQuery):
     """
@@ -120,14 +95,6 @@ class ContractEventQuery(_BaseBlockQuery):
 
     contract: AddressType
     event: EventABI
-
-    @classmethod
-    def all_fields(cls) -> List[str]:
-        # TODO: Figure out how to get the event ABI as a class property
-        #   for the validator
-        return [
-            i.name for i in cls.event.inputs if i.name is not None
-        ]  # if i.name is not None just for mypy
 
 
 class ContractMethodQuery(_BaseBlockQuery):
@@ -139,12 +106,6 @@ class ContractMethodQuery(_BaseBlockQuery):
     contract: AddressType
     method: MethodABI
     method_args: Dict[str, Any]
-
-    @classmethod
-    def all_fields(cls) -> List[str]:
-        # TODO: Figure out how to get the method ABI as a class property
-        #   for the validator
-        return [o.name for o in cls.method.outputs if o.name is not None]  # just for mypy
 
 
 class QueryAPI(BaseInterfaceModel):

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -1,16 +1,10 @@
-from typing import Any, Dict, Iterator, Optional
-
-from pydantic import BaseModel
+from typing import Dict, Iterator, Optional
 
 from ape.api import QueryAPI, QueryType
-from ape.api.query import BlockQuery, BlockTransactionQuery, _BaseQuery
+from ape.api.query import BlockQuery, BlockTransactionQuery
 from ape.exceptions import QueryEngineError
 from ape.plugins import clean_plugin_name
 from ape.utils import ManagerAccessMixin, cached_property, singledispatchmethod
-
-
-def get_columns_from_item(query: _BaseQuery, item: BaseModel) -> Dict[str, Any]:
-    return {k: v for k, v in item.dict().items() if k in query.columns}
 
 
 class DefaultQueryProvider(QueryAPI):

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -7,23 +7,28 @@ from ape.api.query import AccountTransactionQuery, BlockQuery, BlockTransactionQ
 
 def test_basic_query(eth_tester_provider):
     chain.mine(3)
-    assert [i.number for i in chain.blocks.query("*")] == [0, 1, 2, 3]
-    x = [i for i in chain.blocks.query("number", "timestamp")]
-    assert len(x) == 4
-    assert x[3].timestamp > x[2].timestamp >= x[1].timestamp >= x[0].timestamp
-    columns = list(x[0].dict().keys())
-    assert columns == [
+    df1 = chain.blocks.query("*")
+    assert list(df1["number"].values) == [0, 1, 2, 3]
+    df2 = chain.blocks.query("number", "timestamp")
+    assert len(df2) == 4
+    assert (
+        df2.iloc[3]["timestamp"]
+        >= df2.iloc[2]["timestamp"]
+        >= df2.iloc[1]["timestamp"]
+        >= df2.iloc[0]["timestamp"]
+    )
+    assert list(df1.columns) == [
         "num_transactions",
         "hash",
         "number",
-        "parentHash",
+        "parent_hash",
         "size",
         "timestamp",
-        "gasLimit",
-        "gasUsed",
-        "baseFeePerGas",
+        "gas_limit",
+        "gas_used",
+        "base_fee",
         "difficulty",
-        "totalDifficulty",
+        "total_difficulty",
     ]
 
 

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -1,8 +1,7 @@
 import pytest
-from pydantic import ValidationError
 
 from ape import chain
-from ape.api.query import AccountTransactionQuery, BlockQuery, BlockTransactionQuery
+from ape.api.query import validate_and_expand_columns
 
 
 def test_basic_query(eth_tester_provider):
@@ -32,9 +31,16 @@ def test_basic_query(eth_tester_provider):
     ]
 
 
-def test_block_transaction_query_api():
-    query = BlockTransactionQuery(columns=["*"], block_id=0)
-    assert query.columns == [
+def test_block_transaction_query(eth_tester_provider, sender, receiver):
+    sender.transfer(receiver, 100)
+    query = chain.blocks[-1].transactions
+    assert len(query) == 1
+    assert query[0].value == 100
+    assert query[0].chain_id == 61
+
+
+def test_column_expansion():
+    all_fields = [
         "chain_id",
         "receiver",
         "sender",
@@ -48,34 +54,15 @@ def test_block_transaction_query_api():
         "required_confirmations",
         "signature",
     ]
+    columns = validate_and_expand_columns(["*"], all_fields)
+    assert columns == all_fields
 
 
-def test_block_transaction_query(eth_tester_provider, sender, receiver):
-    sender.transfer(receiver, 100)
-    query = chain.blocks[-1].transactions
-    assert len(query) == 1
-    assert query[0].value == 100
-    assert query[0].chain_id == 61
-
-
-def test_block_query(eth_tester_provider):
-    chain.mine(3)
-    with pytest.raises(ValidationError) as err:
-        BlockQuery(columns=["numbr"], start_block=0, stop_block=2)
+def test_column_validation(eth_tester_provider):
+    all_fields = ["number", "timestamp"]
+    with pytest.raises(ValueError) as err:
+        validate_and_expand_columns(["numbr"], all_fields)
     assert "Unrecognized field 'numbr'" in str(err.value)
-    with pytest.raises(ValidationError) as err:
-        BlockQuery(columns=["number", "timestamp", "number"], start_block=0, stop_block=2)
+    with pytest.raises(ValueError) as err:
+        validate_and_expand_columns(["number", "timestamp", "number"], all_fields)
     assert "Duplicate fields in ['number', 'timestamp', 'number']" in str(err.value)
-
-
-def test_account_query(eth_tester_provider):
-    chain.mine(3)
-    query_kwargs = dict(
-        account="0x0000000000000000000000000000000000000000", start_nonce=0, stop_nonce=2
-    )
-    with pytest.raises(ValidationError) as err:
-        AccountTransactionQuery(columns=["none"], **query_kwargs)
-    assert "Unrecognized field 'none'" in str(err.value)
-    with pytest.raises(ValidationError) as err:
-        AccountTransactionQuery(columns=["nonce", "chain_id", "nonce"], **query_kwargs)
-    assert "Duplicate fields in ['nonce', 'chain_id', 'nonce']" in str(err.value)


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

Pandas was removed from `DefaultQueryProvider`, and in turn pulled the dataframe functionality out of Ape all together.

Pandas was brought back into the fold in the chain manager

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #

### How I did it
<!-- Discuss the thought process behind the change -->

Instead of return the map from the `DefaultQueryProvider`, in `chain.blocks.query`, we are now pulling the map apart and injecting it into a dataframe.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

Run the tests for `test_query.py` and `test_chain.py`

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [ ] Documentation has been updated
