### PR TITLE
feat: allow relative indexing block numbers in query

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -121,8 +121,14 @@ class BlockContainer(BaseManager):
             pd.DataFrame
         """
 
+        if start_block < 0:
+            start_block = len(self) + start_block
+
         if stop_block is None:
             stop_block = self.height
+
+        elif stop_block < 0:
+            stop_block = len(self) + stop_block
 
         elif stop_block > len(self):
             raise ChainError(

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -31,6 +31,12 @@ def test_basic_query(eth_tester_provider):
     ]
 
 
+def test_relative_block_query(eth_tester_provider):
+    chain.mine(10)
+    df = chain.blocks.query("*", start_block=-8, stop_block=-2)
+    assert len(df) == 7
+
+
 def test_block_transaction_query(eth_tester_provider, sender, receiver):
     sender.transfer(receiver, 100)
     query = chain.blocks[-1].transactions

--- a/tests/functional/api/test_query.py
+++ b/tests/functional/api/test_query.py
@@ -35,6 +35,8 @@ def test_relative_block_query(eth_tester_provider):
     chain.mine(10)
     df = chain.blocks.query("*", start_block=-8, stop_block=-2)
     assert len(df) == 7
+    assert df.number.min() == chain.blocks[-8].number == 3
+    assert df.number.max() == chain.blocks[-2].number == 9
 
 
 def test_block_transaction_query(eth_tester_provider, sender, receiver):


### PR DESCRIPTION
### What I did
Allow relative indexing for start and stop block numbers in `chain.blocks.query`

```py
# Query the last 50 blocks
chain.blocks.query("*", stark_block=-50)

# Query the lat 20 blocks older than 30 behind head
chain.blocks.query("*", start_block=-50, stop_block=-30)
```

### How I did it
Make relative to absolute by adding `len(chain.blocks)`

### How to verify it
Try it out!

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
