### PR TITLE
feat: show SubprocessProvider process logs in debug output

### DIFF
--- a/src/ape/utils/__init__.py
+++ b/src/ape/utils/__init__.py
@@ -33,6 +33,7 @@ from ape.utils.misc import (
     stream_response,
 )
 from ape.utils.os import get_all_files_in_directory, get_relative_path, use_temp_sys_path
+from ape.utils.process import JoinableQueue, spawn
 from ape.utils.testing import (
     DEFAULT_NUMBER_OF_TEST_ACCOUNTS,
     DEFAULT_TEST_MNEMONIC,
@@ -65,6 +66,7 @@ __all__ = [
     "is_array",
     "is_named_tuple",
     "is_struct",
+    "JoinableQueue",
     "load_config",
     "LogInputABICollection",
     "ManagerAccessMixin",
@@ -72,6 +74,7 @@ __all__ = [
     "raises_not_implemented",
     "returns_array",
     "singledispatchmethod",
+    "spawn",
     "stream_response",
     "Struct",
     "StructParser",

--- a/src/ape/utils/process.py
+++ b/src/ape/utils/process.py
@@ -1,0 +1,49 @@
+import queue
+import threading
+import time
+
+from ape.exceptions import SubprocessTimeoutError
+
+
+class JoinableQueue(queue.Queue):
+    """
+    A queue that can be joined, useful for multi-processing.
+    Borrowed from the ``py-geth`` library.
+    """
+
+    def __iter__(self):
+        while True:
+            item = self.get()
+
+            is_stop_iteration_type = isinstance(item, type) and issubclass(item, StopIteration)
+            if isinstance(item, StopIteration) or is_stop_iteration_type:
+                return
+
+            elif isinstance(item, Exception):
+                raise item
+
+            elif isinstance(item, type) and issubclass(item, Exception):
+                raise item
+
+            yield item
+
+    def join(self, timeout=None):
+        with SubprocessTimeoutError(timeout) as _timeout:
+            while not self.empty():
+                time.sleep(0)
+                _timeout.check()
+
+
+def spawn(target, *args, **kwargs):
+    """
+    Spawn a new daemon thread. Borrowed from the ``py-geth`` library.
+    """
+
+    thread = threading.Thread(
+        target=target,
+        args=args,
+        kwargs=kwargs,
+    )
+    thread.daemon = True
+    thread.start()
+    return thread


### PR DESCRIPTION
### What I did

Leverage process logs in `SubprocessProvider`.

So when we do `-v debug` in a script or console, we see the output from the subprocess in our normal ape logs

### How I did it

daemon queue thingy ma-bobs. Idk I just copy code on the internet.

### How to verify it

use hardhat, starknet, or foundry with `-v debug` and watch for expected HTTP request logs

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
