### PR TITLE
fix: issue preventing importing local packages in ape console

### DIFF
--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -121,10 +121,10 @@ def console(project=None, verbose=None, extra_locals=None):
     if extra_locals:
         namespace.update(extra_locals)
 
+    sys.path.insert(0, getcwd())
     console_extras = load_console_extras(namespace)
 
     if console_extras:
         namespace.update(console_extras)
 
-    sys.path.insert(0, getcwd())
     IPython.embed(colors="Neutral", banner1=banner, user_ns=namespace)

--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -2,8 +2,10 @@ import faulthandler
 import inspect
 import io
 import logging
+import sys
 from importlib.machinery import SourceFileLoader
 from importlib.util import module_from_spec, spec_from_loader
+from os import getcwd
 from types import ModuleType
 from typing import Any, Dict
 
@@ -124,4 +126,5 @@ def console(project=None, verbose=None, extra_locals=None):
     if console_extras:
         namespace.update(console_extras)
 
+    sys.path.insert(0, getcwd())
     IPython.embed(colors="Neutral", banner1=banner, user_ns=namespace)

--- a/tests/integration/cli/projects/only-dependencies/dependency_in_project_only/importme.py
+++ b/tests/integration/cli/projects/only-dependencies/dependency_in_project_only/importme.py
@@ -1,0 +1,2 @@
+def import_me():
+    print("I was imported and then called")

--- a/tests/integration/cli/projects/only-dependencies/dependency_in_project_only/importme.py
+++ b/tests/integration/cli/projects/only-dependencies/dependency_in_project_only/importme.py
@@ -1,2 +1,2 @@
 def import_me():
-    print("I was imported and then called")
+    print("I was imported and then called")  # noqa: T001

--- a/tests/integration/cli/test_console.py
+++ b/tests/integration/cli/test_console.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ape import __all__
-from tests.integration.cli.utils import skip_projects
+from tests.integration.cli.utils import skip_projects, skip_projects_except
 
 # Simple single namespace example
 EXTRAS_SCRIPT_1 = """
@@ -35,7 +35,11 @@ def ape_init_extras():
 
 
 def no_console_error(result):
-    return "NameError" not in result.output and "AssertionError" not in result.output
+    return (
+        "NameError" not in result.output
+        and "AssertionError" not in result.output
+        and "ModuleNotFoundError" not in result.output
+    )
 
 
 def write_ape_console_extras(project, folder, contents):
@@ -129,6 +133,17 @@ def test_console_init_extras_return(project, folder, ape_cli, runner):
             ]
         ),
         catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert no_console_error(result), result.output
+
+
+@skip_projects_except(["only-dependencies"])
+def test_console_import_local_path(project, ape_cli, runner):
+    result = runner.invoke(
+        ape_cli,
+        ["console"],
+        input="\n".join(["from dependency_in_project_only.importme import import_me", "exit"]),
     )
     assert result.exit_code == 0, result.output
     assert no_console_error(result), result.output


### PR DESCRIPTION
### What I did

Thanks @banteg for bringing this is our attention.
This PR allows you to import local packages / folders in your ape console

### How I did it

Add cwd to the sys path before launching the console.

### How to verify it

Launch your console in a project that contains a folder with some python stuff in it.
Try importing the stuff from that module.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
