### PR TITLE
fix: issue where account would remain unlocked when disabling auto-sign

### DIFF
--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -141,12 +141,15 @@ class KeyfileAccount(AccountAPI):
             passphrase (Optional[str]): Optionally provide the passphrase.
               If not provided, you will be prompted to enter it.
         """
-        self.unlock(passphrase=passphrase)
-
         if enabled:
+            self.unlock(passphrase=passphrase)
             logger.warning("Danger! This account will now sign any transaction its given.")
 
         self.__autosign = enabled
+        if not enabled:
+            # Re-lock if was turning off
+            self.locked = True
+            self.__cached_key = None
 
     def _prompt_for_passphrase(self, message: Optional[str] = None, **kwargs):
         message = message or f"Enter passphrase to unlock '{self.alias}'"

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -143,7 +143,7 @@ class KeyfileAccount(AccountAPI):
         """
         if enabled:
             self.unlock(passphrase=passphrase)
-            logger.warning("Danger! This account will now sign any transaction its given.")
+            logger.warning("Danger! This account will now sign any transaction it's given.")
 
         self.__autosign = enabled
         if not enabled:

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -142,7 +142,10 @@ class KeyfileAccount(AccountAPI):
               If not provided, you will be prompted to enter it.
         """
         self.unlock(passphrase=passphrase)
-        logger.warning("Danger! This account will now sign any transaction its given.")
+
+        if enabled:
+            logger.warning("Danger! This account will now sign any transaction its given.")
+
         self.__autosign = enabled
 
     def _prompt_for_passphrase(self, message: Optional[str] = None, **kwargs):

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -178,16 +178,27 @@ def test_accounts_contains(accounts, test_accounts):
     assert test_accounts[0].address in accounts
 
 
-def test_autosign_messages(temp_ape_account):
+def test_autosign_messages(runner, temp_ape_account):
     temp_ape_account.set_autosign(True, passphrase="a")
     message = encode_defunct(text="Hello Apes!")
     signature = temp_ape_account.sign_message(message)
     assert temp_ape_account.check_signature(message, signature)
 
+    # Re-enable prompted signing
+    temp_ape_account.set_autosign(False)
+    with runner.isolation(input="y\na\n"):
+        signature = temp_ape_account.sign_message(message)
+        assert temp_ape_account.check_signature(message, signature)
 
-def test_autosign_transactions(temp_ape_account, receiver):
+
+def test_autosign_transactions(runner, temp_ape_account, receiver):
     temp_ape_account.set_autosign(True, passphrase="a")
     assert temp_ape_account.transfer(receiver, "1 gwei")
+
+    # Re-enable prompted signing
+    temp_ape_account.set_autosign(False)
+    with runner.isolation(input="y\na\n"):
+        assert temp_ape_account.transfer(receiver, "1 gwei")
 
 
 def test_impersonate_not_implemented(accounts):


### PR DESCRIPTION
### What I did

* Only unlock when enabling
* Only warn when enabling
* Only re-lock if disabling

**NOTE**: I think we consider keeping `unlock()` and `set_autosign()` separated. It would be a breaking change or I would have done it now. The reason is because it is weird if you unlock an account, turn autosign on, sign something, disable autosign, and now your account is suddenly re-locked. It is a strange side-effect in that scenario, but generally rare for the use-case if just enabling autosign for automated testnet deploy scripts etc.

### How I did it

if statements everywhere!

### How to verify it

see tests

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
