### PR TITLE
fix: detect contracts folder automatically when default in local dependencies

### DIFF
--- a/tests/integration/cli/projects/with-dependencies/ape-config.yaml
+++ b/tests/integration/cli/projects/with-dependencies/ape-config.yaml
@@ -12,3 +12,6 @@ dependencies:
 
   - name: containing_sub_dependencies
     local: ./containing_sub_dependencies
+
+  - name: renamed_contracts_folder_specified_in_config
+    local: ./renamed_contracts_folder_specified_in_config

--- a/tests/integration/cli/projects/with-dependencies/renamed_contracts_folder_specified_in_config/ape-config.yaml
+++ b/tests/integration/cli/projects/with-dependencies/renamed_contracts_folder_specified_in_config/ape-config.yaml
@@ -1,0 +1,1 @@
+contracts_folder: my_contracts

--- a/tests/integration/cli/projects/with-dependencies/renamed_contracts_folder_specified_in_config/my_contracts/renamed_contracts_folder_specified_in_config.json
+++ b/tests/integration/cli/projects/with-dependencies/renamed_contracts_folder_specified_in_config/my_contracts/renamed_contracts_folder_specified_in_config.json
@@ -1,0 +1,3 @@
+[
+    {"name":"foo","type":"fallback", "stateMutability":"nonpayable"}
+]

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -176,6 +176,7 @@ def test_compile_with_dependency(ape_cli, runner, project, contract_path):
         "renamed_contracts_folder",
         "containing_sub_dependencies",
         "renamed_complex_contracts_folder",
+        "renamed_contracts_folder_specified_in_config",
     ):
         assert name in project.dependencies
         assert type(project.dependencies[name]["local"]["name"]) == ContractContainer


### PR DESCRIPTION
### What I did

Noticed it was kind of awkward when using local dependencies when you control both projects and they are both ape projects to have to specify the contracts folder in both places. Instead, attempt to read an `ape-config.yaml` and detect it automatically!

### How I did it

With the help of pydantic root validator as well as the `load_config` util method.

### How to verify it

I added a test!
But also, I am working on converting dsnote to be an ape project: https://github.com/unparalleled-js/ds-note
and I need this for tests.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
