### PR TITLE
fix: disable console history in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,17 @@ ape.config.DATA_FOLDER = Path(mkdtemp()).resolve()
 ape.config.PROJECT_FOLDER = Path(mkdtemp()).resolve()
 
 
+@pytest.fixture(autouse=True)
+def setenviron(monkeypatch):
+    """
+    Sets the APE_TESTING environment variable during tests.
+
+    With this variable set fault handling and IPython command history logging
+    will be disabled in the ape console.
+    """
+    monkeypatch.setenv("APE_TESTING", "1")
+
+
 @pytest.fixture(scope="session")
 def config():
     yield ape.config


### PR DESCRIPTION
### What I did

Prevents IPython from spawning history collection threads when running the test suite

fixes: #881 

### How I did it

Add an auto-used fixture to patch an `APE_TESTING` environment variable in while testing. The IPython embedded instance launches with history disabled if this environment variable is set.

### How to verify it

If the tests weren't failing from "too many open files", you can change the soft limit on your machine with this.

```shell
$ ulimit -n  # check current value so you can restore it later
...
$ ulimit -Sn 256  # set value to what was default in #881's repro steps
$ pytest tests/integration
```

This should produce a failure without these changes 

### Checklist
- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
