### PR TITLE
feat: strip uri credentials from logs

### DIFF
--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -214,6 +214,10 @@ class GethProvider(Web3Provider, UpstreamProvider):
                 logger.info(f"Connecting to existing Erigon node at '{self.uri}'.")
                 self.concurrency = 8
                 self.block_page_size = 40_000
+            elif "nethermind" in self.client_version.lower():
+                logger.info(f"Connecting to existing Nethermind node at '{self.uri}'.")
+                self.concurrency = 32
+                self.block_page_size = 50_000
             else:
                 network_name = self.client_version.split("/")[0]
                 logger.warning(f"Connecting Geth plugin to non-Geth network '{network_name}'.")

--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -1,7 +1,6 @@
 import shutil
 from pathlib import Path
 from typing import Any, Dict, Iterator, Optional, Union
-from urllib.parse import urlparse
 
 from eth_utils import to_wei
 from evm_trace import (
@@ -24,6 +23,7 @@ from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.middleware import geth_poa_middleware
 from web3.middleware.validation import MAX_EXTRADATA_LENGTH
 from web3.types import RPCEndpoint
+from yarl import URL
 
 from ape.api import PluginConfig, UpstreamProvider, Web3Provider
 from ape.api.networks import LOCAL_NETWORK_NAME
@@ -164,6 +164,10 @@ class GethProvider(Web3Provider, UpstreamProvider):
         return network_config.get("uri", DEFAULT_SETTINGS["uri"])
 
     @property
+    def _clean_uri(self) -> str:
+        return str(URL(self.uri).with_user(None).with_password(None))
+
+    @property
     def connection_str(self) -> str:
         return self.uri
 
@@ -177,14 +181,14 @@ class GethProvider(Web3Provider, UpstreamProvider):
                 raise ProviderError(
                     f"When running on network '{self.network.name}', "
                     f"the Geth plugin expects the Geth process to already "
-                    f"be running on '{self.uri}'."
+                    f"be running on '{self._clean_uri}'."
                 )
 
             # Start an ephemeral geth process.
-            parsed_uri = urlparse(self.uri)
+            parsed_uri = URL(self.uri)
 
-            if parsed_uri.hostname not in ("localhost", "127.0.0.1"):
-                raise ConnectionError(f"Unable to connect web3 to {parsed_uri.hostname}.")
+            if parsed_uri.host not in ("localhost", "127.0.0.1"):
+                raise ConnectionError(f"Unable to connect web3 to {parsed_uri.host}.")
 
             if not shutil.which("geth"):
                 raise GethNotInstalledError()
@@ -197,7 +201,7 @@ class GethProvider(Web3Provider, UpstreamProvider):
 
             self._geth = EphemeralGeth(
                 self.data_folder,
-                parsed_uri.hostname,
+                parsed_uri.host,
                 parsed_uri.port,
                 mnemonic,
                 number_of_accounts=num_of_accounts,
@@ -209,18 +213,18 @@ class GethProvider(Web3Provider, UpstreamProvider):
                 raise ConnectionError("Unable to connect to locally running geth.")
         else:
             if "geth" in self.client_version.lower():
-                logger.info(f"Connecting to existing Geth node at '{self.uri}'.")
+                logger.info(f"Connecting to existing Geth node at '{self._clean_uri}'.")
             elif "erigon" in self.client_version.lower():
-                logger.info(f"Connecting to existing Erigon node at '{self.uri}'.")
+                logger.info(f"Connecting to existing Erigon node at '{self._clean_uri}'.")
                 self.concurrency = 8
                 self.block_page_size = 40_000
             elif "nethermind" in self.client_version.lower():
-                logger.info(f"Connecting to existing Nethermind node at '{self.uri}'.")
+                logger.info(f"Connecting to existing Nethermind node at '{self._clean_uri}'.")
                 self.concurrency = 32
                 self.block_page_size = 50_000
             else:
-                network_name = self.client_version.split("/")[0]
-                logger.warning(f"Connecting Geth plugin to non-Geth network '{network_name}'.")
+                client_name = self.client_version.split("/")[0]
+                logger.warning(f"Connecting Geth plugin to non-Geth client '{client_name}'.")
 
         self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
 


### PR DESCRIPTION
### what was wrong
when using a connection uri which contains `user:pass`, it was output as plain text:
```
INFO: Connecting to existing Erigon node at 'https://bunny:carrot123@bunny-server.com/'.
```

### how i fixed it
added `GethProvider._clean_uri` which strips username and password from connection string and use it when we print it. the `yarl` package i import is a dependency to `web3`.

now it's printed like this:
```
INFO: Connecting to existing Erigon node at 'https://bunny-server.com/'.
```

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
