### PR TITLE
test: put type decoding test in test_type module

### DIFF
--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -1,29 +1,9 @@
 import pytest
-from ethpm_types.abi import EventABI
 
 from ape.exceptions import ProviderError, ProviderNotConnectedError
 from ape.types import LogFilter
 
 EXPECTED_CHAIN_ID = 61
-RAW_EVENT_ABI = """
-{
-  "anonymous": false,
-  "inputs": [
-    {
-      "indexed": true,
-      "name": "oldVersion",
-      "type": "address"
-    },
-    {
-      "indexed": true,
-      "name": "newVersion",
-      "type": "address"
-    }
-  ],
-  "name": "StrategyMigrated",
-  "type": "event"
-}
-"""
 
 
 def test_chain_id(eth_tester_provider):
@@ -108,15 +88,3 @@ def test_get_contract_logs_single_log_unmatched(contract_instance, owner, eth_te
     contract_instance.fooAndBar(sender=owner)  # Create logs
     logs = [log for log in eth_tester_provider.get_contract_logs(log_filter)]
     assert len(logs) == 0
-
-
-def test_topic_filter_encoding():
-    event_abi = EventABI.parse_raw(RAW_EVENT_ABI)
-    log_filter = LogFilter.from_event(
-        event=event_abi, search_topics={"newVersion": "0x8c44Cc5c0f5CD2f7f17B9Aca85d456df25a61Ae8"}
-    )
-    assert log_filter.topic_filter == [
-        "0x100b69bb6b504e1252e36b375233158edee64d071b399e2f81473a695fd1b021",
-        None,
-        "0x0000000000000000000000008c44cc5c0f5cd2f7f17b9aca85d456df25a61ae8",
-    ]

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -1,6 +1,7 @@
 import pytest
+from ethpm_types.abi import EventABI
 
-from ape.types import ContractLog
+from ape.types import ContractLog, LogFilter
 from ape.utils import ZERO_ADDRESS
 
 TXN_HASH = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa222222222222222222222222"
@@ -17,6 +18,25 @@ RAW_LOG = {
     "name": EVENT_NAME,
     "transaction_hash": TXN_HASH,
 }
+RAW_EVENT_ABI = """
+{
+  "anonymous": false,
+  "inputs": [
+    {
+      "indexed": true,
+      "name": "oldVersion",
+      "type": "address"
+    },
+    {
+      "indexed": true,
+      "name": "newVersion",
+      "type": "address"
+    }
+  ],
+  "name": "StrategyMigrated",
+  "type": "event"
+}
+"""
 
 
 @pytest.fixture
@@ -39,3 +59,15 @@ def test_contract_log_access(log):
     assert "bar" in log
     assert log.foo == log["foo"] == log.get("foo") == 0
     assert log.bar == log["bar"] == log.get("bar") == 1
+
+
+def test_topic_filter_encoding():
+    event_abi = EventABI.parse_raw(RAW_EVENT_ABI)
+    log_filter = LogFilter.from_event(
+        event=event_abi, search_topics={"newVersion": "0x8c44Cc5c0f5CD2f7f17B9Aca85d456df25a61Ae8"}
+    )
+    assert log_filter.topic_filter == [
+        "0x100b69bb6b504e1252e36b375233158edee64d071b399e2f81473a695fd1b021",
+        None,
+        "0x0000000000000000000000008c44cc5c0f5cd2f7f17b9aca85d456df25a61ae8",
+    ]


### PR DESCRIPTION
### What I did

Noticed this test did not test anything from the provider and was more about `ape.types.LogFilter` so I moved it.

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
