### PR TITLE
fix: prevent unnecessary API call when decoding events from ABI

### DIFF
--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -187,7 +187,7 @@ class Receipt(ReceiptAPI):
             Union[List[Union[EventABI, "ContractEvent"]], Union[EventABI, "ContractEvent"]]
         ] = None,
     ) -> Iterator[ContractLog]:
-        if abi:
+        if abi is not None:
             if not isinstance(abi, (list, tuple)):
                 abi = [abi]
 

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -27,7 +27,8 @@ def test_decode_logs_specify_abi(invoke_receipt, vyper_contract_instance):
     assert logs[0].transaction_index == 0
 
 
-def test_decode_logs_specify_abi_as_event(invoke_receipt, vyper_contract_instance):
+def test_decode_logs_specify_abi_as_event(mocker, invoke_receipt, vyper_contract_instance, eth_tester_provider):
+    spy = mocker.spy(eth_tester_provider.web3.eth, "get_logs")
     abi = vyper_contract_instance.NumberChange
     logs = [log for log in invoke_receipt.decode_logs(abi=abi)]
     assert len(logs) == 1
@@ -35,6 +36,10 @@ def test_decode_logs_specify_abi_as_event(invoke_receipt, vyper_contract_instanc
     assert logs[0].event_name == "NumberChange"
     assert logs[0].log_index == 0
     assert logs[0].transaction_index == 0
+
+    # Tests against a bug where the API was called unnecessarily
+    assert spy.call_count == 0
+
 
 
 def test_decode_logs_with_ds_notes(ds_note_test_contract, owner):

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -27,7 +27,9 @@ def test_decode_logs_specify_abi(invoke_receipt, vyper_contract_instance):
     assert logs[0].transaction_index == 0
 
 
-def test_decode_logs_specify_abi_as_event(mocker, invoke_receipt, vyper_contract_instance, eth_tester_provider):
+def test_decode_logs_specify_abi_as_event(
+    mocker, invoke_receipt, vyper_contract_instance, eth_tester_provider
+):
     spy = mocker.spy(eth_tester_provider.web3.eth, "get_logs")
     abi = vyper_contract_instance.NumberChange
     logs = [log for log in invoke_receipt.decode_logs(abi=abi)]
@@ -39,7 +41,6 @@ def test_decode_logs_specify_abi_as_event(mocker, invoke_receipt, vyper_contract
 
     # Tests against a bug where the API was called unnecessarily
     assert spy.call_count == 0
-
 
 
 def test_decode_logs_with_ds_notes(ds_note_test_contract, owner):


### PR DESCRIPTION
### What I did

Noticed while upgrading the starknet plugin that we were making an unnecessarily API call sometimes, in the cases where the user passes in EventABI objects

### How I did it

check if not None instead of if truthy, This prevents the `__len__` call which makes an API call (note: the `__len__` method making an API call seems unexpected and maybe should be re-visited)

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
