### PR TITLE
feat: added optional waiting for tx to finish

### DIFF
--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -92,6 +92,18 @@ contract.fundMyContract(value="1 gwei", type="0x0", sender=sender)
 
 When declaring `type="0x0"` and _not_ specifying a `gas_price`, the `gas_price` gets set using the provider's estimation.
 
+## Waiting for confirmations
+
+When you send a transaction to a network, you can chose to wait X blocks for the transaction to confirm, like so:
+
+```python
+receipt = provider.send_transaction(txn)
+receipt.await_confirmations(2)
+```
+
+This example will wait 2 blocks for the transaction to be confirmed. 
+
+
 ## Transaction Logs
 
 To get logs that occurred during a transaction, you can use the [ContractEvent.from_receipt(receipt)](../methoddocs/contracts.html?highlight=contractevent#ape.contracts.base.ContractEvent.from_receipt) and access your data from the [ContractLog](../methoddocs/types.html#ape.types.ContractLog) objects that it returns.

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -251,7 +251,6 @@ class ReceiptAPI(BaseInterfaceModel):
         except TransactionError:
             # Skip waiting for confirmations when the transaction has failed.
             return self
-        breakpoint()
         # Wait for nonce from provider to increment.
         sender_nonce = self.provider.get_nonce(self.sender)
         iterations_timeout = 20

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -34,6 +34,22 @@ def test_txn_hash(owner, eth_tester_provider):
     assert actual == expected
 
 
+def test_await_confirmations(owner, eth_tester_provider):
+    # Arrange
+    txn = StaticFeeTransaction()
+    txn = owner.prepare_transaction(txn)
+    txn.signature = owner.sign_transaction(txn)
+
+    # Act
+    receipt = eth_tester_provider.send_transaction(txn)
+    receipt_number = receipt.await_confirmations(0)
+    receipt_number_keyword = receipt.await_confirmations(confirmations=0)
+    receipt_blank = receipt.await_confirmations()
+
+    # Assert
+    assert receipt_number == receipt_number_keyword == receipt_blank
+
+
 def test_whitespace_in_transaction_data():
     data = b"Should not clip whitespace\t\n"
     txn_dict = {"data": data}


### PR DESCRIPTION
### What I did
I added a field that you could optionally populate to wait for a tx.

Now, you could be able to do all the following:

```python
receipt = <some_tx_here>

receipt.await_confirmations(0)
receipt.await_confirmations(confirmations=0)
receipt.await_confirmations(0)
```

### How I did it
Basically, just modified the `await_confirmations` to take an optional input parameter. 

### How to verify it
```python
tx = some_contract.some_function_call(sender=account)
tx.await_confirmations(5)
```

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] New test cases have been added
- [x] Documentation has been updated

### Notes

I'm not sure the best way to test confirmations... I've tested on some different chains that the numbers do work, but I'm not sure how to spin up a new local environment in the tests here... Looking for any help/thoughts. 
