### PR TITLE
fix: issue preventing provider context manager from switching in test fixtures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: v0.971
     hooks:
     -   id: mypy
-        additional_dependencies: [types-PyYAML, types-requests]
+        additional_dependencies: [types-PyYAML, types-requests, types-pkg-resources]
 
 
 default_language_version:

--- a/docs/userguides/testing.md
+++ b/docs/userguides/testing.md
@@ -225,24 +225,25 @@ The easiest way to achieve this is to use the `networks` provider context-manage
 
 ```python
 # Switch to Fantom mid test
-from ape import networks
-
-
-with networks.fantom.local.use_provider("test") as provider:
-    print(f"Using provider {provider.name}")
-
-""" or """
-
-with networks.parse_network_choice("fantom:local:test") as provider:
-    print(f"Using provider {provider.name}")
+def test_my_fantom_test(networks):
+    # The test starts in 1 ecosystem but switches to another
+    assert networks.provider.network.ecosystem.name == "ethereum"
+    
+    with networks.fantom.local.use_provider("test") as provider:
+        assert provider.network.ecosystem.name == "fantom"
+    
+    # You can also use the context manager like this:
+    with networks.parse_network_choice("fantom:local:test") as provider:
+       assert provider.network.ecosystem.name == "fantom"
 ```
 
-You can also create fixtures to assist:
+Use fixtures to assist as well:
 
 ```python
 import pytest
 
-@pytest.fixture(scope="module")
+
+@pytest.fixture
 def stark_contract(networks, project):
     with networks.parse_network_choice("starknet:local"):
         yield project.MyStarknetContract.deploy()

--- a/docs/userguides/testing.md
+++ b/docs/userguides/testing.md
@@ -217,3 +217,39 @@ def test_account_balance(project, owner, receiver, nft):
     expect = quantity
     assert actual == expect
 ```
+
+## Multi-chain Testing
+
+The Ape framework supports connecting to alternative providers in tests.
+The easiest way to achieve this is to use the `networks` provider context-manager.
+
+```python
+# Switch to Fantom mid test
+from ape import networks
+
+
+with networks.fantom.local.use_provider("test") as provider:
+    print(f"Using provider {provider.name}")
+
+""" or """
+
+with networks.parse_network_choice("fantom:local:test") as provider:
+    print(f"Using provider {provider.name}")
+```
+
+You can also create fixtures to assist:
+
+```python
+import pytest
+
+@pytest.fixture(scope="module")
+def stark_contract(networks, project):
+    with networks.parse_network_choice("starknet:local"):
+        yield project.MyStarknetContract.deploy()
+
+
+def test_starknet_thing(stark_contract, stark_account):
+    # Uses the starknet connection via the stark_contract fixture
+    receipt = stark_contract.my_method(sender=stark_account)
+    assert not receipt.failed
+```

--- a/docs/userguides/testing.md
+++ b/docs/userguides/testing.md
@@ -237,7 +237,7 @@ def test_my_fantom_test(networks):
        assert provider.network.ecosystem.name == "fantom"
 ```
 
-Use fixtures to assist as well:
+You can also set the network context in a context-manager pytest fixture:
 
 ```python
 import pytest
@@ -256,6 +256,6 @@ def test_starknet_thing(stark_contract, stark_account):
 ```
 
 When you exit a provider's context, Ape **does not** disconnect the provider.
-When you re-enter that provider's context, Ape finds the provider in its list of connected providers and sets it as the active provider.
+When you re-enter that provider's context, Ape uses the previously-connected provider.
 At the end of the tests, Ape disconnects all the providers.
-Thus, you can enter and exit a provider's context as much as you need in tests and it will always use the same provider.
+Thus, you can enter and exit a provider's context as much as you need in tests.

--- a/docs/userguides/testing.md
+++ b/docs/userguides/testing.md
@@ -254,3 +254,8 @@ def test_starknet_thing(stark_contract, stark_account):
     receipt = stark_contract.my_method(sender=stark_account)
     assert not receipt.failed
 ```
+
+When you exit a provider's context, Ape **does not** disconnect the provider.
+When you re-enter that provider's context, Ape finds the provider in its list of connected providers and sets it as the active provider.
+At the end of the tests, Ape disconnects all the providers.
+Thus, you can enter and exit a provider's context as much as you need in tests and it will always use the same provider.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ addopts = "-p no:ape_test"  # NOTE: Prevents the ape plugin from activating on o
 python_files = "test_*.py"
 testpaths = "tests"
 markers = "fuzzing: Run Hypothesis fuzz test suite"
+asyncio_mode = "auto"
 
 [tool.isort]
 line_length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ addopts = "-p no:ape_test"  # NOTE: Prevents the ape plugin from activating on o
 python_files = "test_*.py"
 testpaths = "tests"
 markers = "fuzzing: Run Hypothesis fuzz test suite"
-asyncio_mode = "auto"
 
 [tool.isort]
 line_length = 100

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
         "pygit2>=1.7.2,<2.0",
         "pyyaml>=0.2.5",
         "py-geth>=3.6.0",
-        "requests>=2.25.1,<3.0",
+        "requests>=2.28.1,<3.0",
         "importlib-metadata",
         "singledispatchmethod ; python_version<'3.8'",
         "IPython>=7.31.1",

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ extras_require = {
         "mypy>=0.971,<1.0",  # Static type analyzer
         "types-PyYAML",  # NOTE: Needed due to mypy typeshed
         "types-requests",  # NOTE: Needed due to mypy typeshed
+        "types-pkg-resources",  # NOTE: Needed due to mypy typeshed
         "flake8>=4.0.1,<5.0",  # Style linter
         "flake8-breakpoint>=1.1.0,<2.0.0",  # detect breakpoints left in code
         "flake8-print>=4.0.0,<5.0.0",  # detect print statements left in code

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -485,6 +485,8 @@ class ProviderContextManager:
             self.connected_providers[provider_object_id] = self.provider
             self.network_manager.active_provider = self.provider
 
+        return self.provider
+
     def pop_provider(self):
         if not self.connected_providers or not self.provider_stack:
             return

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -475,12 +475,12 @@ class ProviderContextManager:
         self.provider_stack.append(provider_object_id)
 
         if provider_object_id in self.connected_providers:
-            # Provider already connected and known
+            # Already connected and known
             connected_provider = self.connected_providers[provider_object_id]
             self.network_manager.active_provider = connected_provider
 
         else:
-            # Already connected but and unknown
+            # Already connected and unknown
             self.connected_providers[provider_object_id] = self.provider
             self.network_manager.active_provider = self.provider
 

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -463,14 +463,15 @@ class ProviderContextManager:
         self.network_manager = network_manager
 
     def __enter__(self, *args, **kwargs):
-        self.connect()
-        return self.provider
+        return self.push_provider()
 
     def __exit__(self, *args, **kwargs):
-        self.disconnect()
+        self.pop_provider()
 
-    def connect(self):
-        self.provider.connect()
+    def push_provider(self):
+        if not self.provider.is_connected:
+            self.provider.connect()
+
         provider_object_id = self.get_provider_id(self.provider)
         self.provider_stack.append(provider_object_id)
 
@@ -484,7 +485,7 @@ class ProviderContextManager:
             self.connected_providers[provider_object_id] = self.provider
             self.network_manager.active_provider = self.provider
 
-    def disconnect(self):
+    def pop_provider(self):
         if not self.connected_providers or not self.provider_stack:
             return
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -139,6 +139,13 @@ class ProviderAPI(BaseInterfaceModel):
         Disconnect from a provider, such as tear-down a process or quit an HTTP session.
         """
 
+    @property
+    def is_connected(self) -> bool:
+        """
+        ``True`` if currently connected to the provider. ``False`` otherwise.
+        """
+        return self.chain_id is not None
+
     @abstractmethod
     def update_settings(self, new_settings: dict):
         """
@@ -618,6 +625,10 @@ class Web3Provider(ProviderAPI, ABC):
 
         return base_fee
 
+    @property
+    def is_connected(self) -> bool:
+        return self._web3 is not None and self._web3.isConnected()
+
     def update_settings(self, new_settings: dict):
         self.disconnect()
         self.provider_settings.update(new_settings)
@@ -829,14 +840,6 @@ class SubprocessProvider(ProviderAPI):
     @abstractmethod
     def process_name(self) -> str:
         """The name of the process, such as ``Hardhat node``."""
-
-    @property
-    @abstractmethod
-    def is_connected(self) -> bool:
-        """
-        ``True`` if the process is running and connected.
-        ``False`` otherwise.
-        """
 
     @abstractmethod
     def build_command(self) -> List[str]:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -926,7 +926,7 @@ class ChainManager(BaseManager):
             snapshot_id (Optional[:class:`~ape.types.SnapshotID`]): The snapshot ID. Defaults
               to the most recent snapshot ID.
         """
-        if not self._snapshots:
+        if snapshot_id is None and not self._snapshots:
             raise ChainError("There are no snapshots to revert to.")
         elif snapshot_id is None:
             snapshot_id = self._snapshots.pop()

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -3,6 +3,7 @@ from typing import Iterator, List
 import pytest
 
 from ape.api import TestAccountAPI
+from ape.exceptions import ProviderNotConnectedError
 from ape.logging import logger
 from ape.managers.chain import ChainManager
 from ape.managers.networks import NetworkManager
@@ -57,6 +58,10 @@ class PytestApeFixtures(ManagerAccessMixin):
         snapshot_id = None
         try:
             snapshot_id = self.chain_manager.snapshot()
+        except ProviderNotConnectedError:
+            logger.warning("Provider became disconnected mid-test.")
+            pass
+
         except NotImplementedError:
             if not self._warned_for_unimplemented_snapshot:
                 logger.warning(
@@ -68,7 +73,11 @@ class PytestApeFixtures(ManagerAccessMixin):
         yield
 
         if snapshot_id is not None and snapshot_id in self.chain_manager._snapshots:
-            self.chain_manager.restore(snapshot_id)
+            try:
+                self.chain_manager.restore(snapshot_id)
+            except ProviderNotConnectedError:
+                logger.warning("Provider became disconnected mid-test.")
+                pass
 
     # isolation fixtures
     _session_isolation = pytest.fixture(_isolation, scope="session")

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -5,11 +5,11 @@ import pytest
 from _pytest.config import Config as PytestConfig
 
 import ape
+from ape.api import ProviderContextManager
 from ape.logging import logger
+from ape.pytest.contextmanagers import RevertsContextManager
 from ape.utils import ManagerAccessMixin
 from ape_console._cli import console
-
-from .contextmanagers import RevertsContextManager
 
 
 class PytestApeRunner(ManagerAccessMixin):
@@ -25,6 +25,10 @@ class PytestApeRunner(ManagerAccessMixin):
     def _network_choice(self) -> str:
         # The option the user providers via --network (or the default).
         return self.pytest_config.getoption("network")
+
+    @property
+    def _provider_context(self) -> ProviderContextManager:
+        return self.network_manager.parse_network_choice(self._network_choice)
 
     def pytest_exception_interact(self, report, call):
         """
@@ -146,10 +150,7 @@ class PytestApeRunner(ManagerAccessMixin):
 
         # Only start provider if collected tests.
         if not outcome.get_result() and session.items and not self.network_manager.active_provider:
-            self.network_manager.active_provider = self.network_manager.get_provider_from_choice(
-                self._network_choice
-            )
-            self.network_manager.active_provider.connect()
+            self._provider_context.connect()
             self._provider_is_connected = True
 
     def pytest_sessionfinish(self):
@@ -161,5 +162,5 @@ class PytestApeRunner(ManagerAccessMixin):
         assume the provider successfully connected.
         """
         if self._provider_is_connected:
-            self.chain_manager.provider.disconnect()
+            self._provider_context.disconnect_all()
             self._provider_is_connected = False

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -150,7 +150,7 @@ class PytestApeRunner(ManagerAccessMixin):
 
         # Only start provider if collected tests.
         if not outcome.get_result() and session.items and not self.network_manager.active_provider:
-            self._provider_context.connect()
+            self._provider_context.push_provider()
             self._provider_is_connected = True
 
     def pytest_sessionfinish(self):

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -136,8 +136,13 @@ def gas_estimation_error_message(tx_error: Exception) -> str:
         str: An error message explaining that the gas failed and that the transaction
         will likely revert.
     """
+    txn_error_text = str(tx_error)
+    if txn_error_text.endswith("."):
+        # Strip period from initial error so it looks better.
+        txn_error_text = txn_error_text[:-1]
+
     return (
-        f"Gas estimation failed: '{tx_error}'. This transaction will likely revert. "
+        f"Gas estimation failed: '{txn_error_text}'. This transaction will likely revert. "
         "If you wish to broadcast, you must set the gas limit manually."
     )
 

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -47,8 +47,8 @@ class LocalProvider(TestProviderAPI, Web3Provider):
     def chain_id(self) -> int:
         if self.cached_chain_id is not None:
             return self.cached_chain_id
-        elif hasattr(self.web3, "eth"):
-            chain_id = self.web3.eth.chain_id
+        elif self._web3 and hasattr(self._web3, "eth"):
+            chain_id = self._web3.eth.chain_id
         else:
             default_value = API_ENDPOINTS["eth"]["chainId"]()
             chain_id = int(default_value, 16)

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -23,6 +23,9 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         )
 
     def connect(self):
+        if self._web3 is not None:
+            return
+
         self._web3 = Web3(EthereumTesterProvider(ethereum_tester=self._tester))
         self._web3.middleware_onion.add(simple_cache_middleware)
 

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -47,7 +47,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
     def chain_id(self) -> int:
         if self.cached_chain_id is not None:
             return self.cached_chain_id
-        elif self._web3 and hasattr(self._web3, "eth"):
+        elif hasattr(self._web3, "eth"):
             chain_id = self._web3.eth.chain_id
         else:
             default_value = API_ENDPOINTS["eth"]["chainId"]()

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -47,8 +47,8 @@ class LocalProvider(TestProviderAPI, Web3Provider):
     def chain_id(self) -> int:
         if self.cached_chain_id is not None:
             return self.cached_chain_id
-        elif hasattr(self._web3, "eth"):
-            chain_id = self._web3.eth.chain_id
+        elif hasattr(self.web3, "eth"):
+            chain_id = self.web3.eth.chain_id
         else:
             default_value = API_ENDPOINTS["eth"]["chainId"]()
             chain_id = int(default_value, 16)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,12 +68,12 @@ def project(config):
     yield ape.Project(config.PROJECT_FOLDER)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def project_manager():
     return ape.project
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def keyparams():
     # NOTE: password is 'a'
     return {
@@ -97,7 +97,7 @@ def keyparams():
     }
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def temp_accounts_path(config):
     path = Path(config.DATA_FOLDER) / "accounts"
     path.mkdir(exist_ok=True, parents=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,3 +111,28 @@ def temp_accounts_path(config):
 @pytest.fixture
 def runner(project):
     yield CliRunner()
+
+
+@pytest.fixture(scope="session")
+def networks_connected_to_tester():
+    with ape.networks.parse_network_choice("::test"):
+        yield ape.networks
+
+
+@pytest.fixture(scope="session")
+def ethereum(networks_connected_to_tester):
+    return networks_connected_to_tester.ethereum
+
+
+@pytest.fixture(scope="session")
+def eth_tester_provider(networks_connected_to_tester):
+    yield networks_connected_to_tester.active_provider
+
+
+@pytest.fixture
+def isolation(chain):
+    snapshot = chain.snapshot()
+    yield
+
+    if snapshot:
+        chain.restore(snapshot)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -50,23 +50,6 @@ def pytest_collection_finish(session):
         yield
 
 
-# @pytest.hookimpl(hookwrapper=True)
-# def pytest_runtest_protocol(item, nextitem):
-#     module_name = item.module.__name__
-#     prefix = "tests.functional"
-#
-#     if module_name.startswith(prefix):
-#         snapshot_id = ape.chain.snapshot()
-#         yield
-#
-#         try:
-#             ape.chain.restore(snapshot_id)
-#         except (HeaderNotFound, ChainError, ProviderNotConnectedError):
-#             pass
-#     else:
-#         yield
-
-
 @pytest.fixture
 def mock_network_api(mocker):
     mock = mocker.MagicMock(spec=NetworkAPI)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -35,8 +35,6 @@ BASE_PROJECTS_DIRECTORY = (Path(__file__).parent / "data" / "projects").absolute
 PROJECT_WITH_LONG_CONTRACTS_FOLDER = BASE_PROJECTS_DIRECTORY / "LongContractsFolder"
 DS_NOTE_TEST_CONTRACT_TYPE = _get_raw_contract("ds_note_test")
 APE_PROJECT_FOLDER = BASE_PROJECTS_DIRECTORY / "ApeProject"
-SOLIDITY_CONTRACT_ADDRESS = "0xBcF7FFFD8B256Ec51a36782a52D0c34f6474D951"
-VYPER_CONTRACT_ADDRESS = "0x274b028b03A250cA03644E6c578D81f019eE1323"
 
 
 class _ContractLogicError(ContractLogicError):
@@ -90,12 +88,12 @@ def test_accounts(accounts):
     return accounts.test_accounts
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def sender(test_accounts):
     return test_accounts[0]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def receiver(test_accounts):
     return test_accounts[1]
 
@@ -105,7 +103,7 @@ def owner(test_accounts):
     return test_accounts[2]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def keyfile_account(sender, keyparams, temp_accounts_path, eth_tester_provider):
     test_keyfile_path = temp_accounts_path / f"{ALIAS}.json"
     yield _make_keyfile_account(temp_accounts_path, ALIAS, keyparams, sender)
@@ -114,7 +112,7 @@ def keyfile_account(sender, keyparams, temp_accounts_path, eth_tester_provider):
         test_keyfile_path.unlink()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def second_keyfile_account(sender, keyparams, temp_accounts_path, eth_tester_provider):
     test_keyfile_path = temp_accounts_path / f"{ALIAS_2}.json"
     yield _make_keyfile_account(temp_accounts_path, ALIAS_2, keyparams, sender)
@@ -133,7 +131,7 @@ def _make_keyfile_account(base_path: Path, alias: str, params: Dict, funder):
     test_keyfile_path.write_text(json.dumps(params))
 
     acct = ape.accounts.load(alias)
-    funder.transfer(acct, "1 ETH")  # Auto-fund this account
+    funder.transfer(acct, "25 ETH")  # Auto-fund this account
     return acct
 
 
@@ -392,3 +390,10 @@ def remove_disk_writes_deployments(chain):
 
     if chain.contracts._deployments_mapping_cache.exists():
         chain.contracts._deployments_mapping_cache.unlink()
+
+
+@pytest.fixture
+def isolation(chain):
+    snapshot = chain.snapshot()
+    yield
+    chain.restore(snapshot)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -9,14 +9,13 @@ from typing import Dict, Optional
 
 import pytest
 import yaml
-from eth.exceptions import HeaderNotFound
 from ethpm_types import ContractType
 from hexbytes import HexBytes
 
 import ape
 from ape.api import EcosystemAPI, NetworkAPI, TransactionAPI
 from ape.contracts import ContractContainer, ContractInstance
-from ape.exceptions import ChainError, ContractLogicError, ProviderNotConnectedError
+from ape.exceptions import ChainError, ContractLogicError
 from ape.managers.config import CONFIG_FILE_NAME
 from ape.types import AddressType, ContractLog
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -68,22 +68,6 @@ def mock_transaction(mocker):
 
 
 @pytest.fixture(scope="session")
-def networks_connected_to_tester():
-    with ape.networks.parse_network_choice("::test"):
-        yield ape.networks
-
-
-@pytest.fixture(scope="session")
-def ethereum(networks_connected_to_tester):
-    return networks_connected_to_tester.ethereum
-
-
-@pytest.fixture(scope="session")
-def eth_tester_provider(networks_connected_to_tester):
-    yield networks_connected_to_tester.active_provider
-
-
-@pytest.fixture(scope="session")
 def test_accounts(accounts):
     return accounts.test_accounts
 
@@ -390,10 +374,3 @@ def remove_disk_writes_deployments(chain):
 
     if chain.contracts._deployments_mapping_cache.exists():
         chain.contracts._deployments_mapping_cache.unlink()
-
-
-@pytest.fixture
-def isolation(chain):
-    snapshot = chain.snapshot()
-    yield
-    chain.restore(snapshot)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -51,21 +51,21 @@ def pytest_collection_finish(session):
         yield
 
 
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_protocol(item, nextitem):
-    module_name = item.module.__name__
-    prefix = "tests.functional"
-
-    if module_name.startswith(prefix):
-        snapshot_id = ape.chain.snapshot()
-        yield
-
-        try:
-            ape.chain.restore(snapshot_id)
-        except (HeaderNotFound, ChainError, ProviderNotConnectedError):
-            pass
-    else:
-        yield
+# @pytest.hookimpl(hookwrapper=True)
+# def pytest_runtest_protocol(item, nextitem):
+#     module_name = item.module.__name__
+#     prefix = "tests.functional"
+#
+#     if module_name.startswith(prefix):
+#         snapshot_id = ape.chain.snapshot()
+#         yield
+#
+#         try:
+#             ape.chain.restore(snapshot_id)
+#         except (HeaderNotFound, ChainError, ProviderNotConnectedError):
+#             pass
+#     else:
+#         yield
 
 
 @pytest.fixture
@@ -308,7 +308,7 @@ def ds_note():
 
 
 @pytest.fixture
-def chain_at_block_5(chain):
+def chain_that_mined_5(chain):
     snapshot_id = chain.snapshot()
     chain.mine(5)
     yield chain

--- a/tests/functional/data/projects/ApeProject/ape-config.yaml
+++ b/tests/functional/data/projects/ApeProject/ape-config.yaml
@@ -1,1 +1,1 @@
-contract_folder: ./contracts
+contracts_folder: ./contracts

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -43,11 +43,13 @@ def test_snapshot_and_restore(chain, sender, receiver, vyper_contract_instance, 
     receipt_to_lose = vyper_contract_instance.setNumber(3, sender=owner)
 
     # Increase receiver's balance
+    account_nonce = sender.nonce
     sender.transfer(receiver, "123 wei")
 
     # Show that we can also provide the snapshot ID as an argument.
     restore_index = 2
     chain.restore(snapshot_ids[restore_index])
+    assert sender.nonce == account_nonce
 
     assert chain.blocks[-1].number == start_block + restore_index
 
@@ -87,12 +89,12 @@ def test_snapshot_and_restore_no_snapshots(chain):
 
 
 def test_account_history(sender, receiver, chain):
-    assert not chain.account_history[sender]
+    length_at_start = len(chain.account_history[sender])
     receipt = sender.transfer(receiver, "1 wei")
     transactions_from_cache = chain.account_history[sender]
-    assert len(transactions_from_cache) == 1
+    assert len(transactions_from_cache) == length_at_start + 1
 
-    txn = transactions_from_cache[0]
+    txn = transactions_from_cache[-1]
     assert txn.sender == receipt.sender == sender
     assert txn.receiver == receipt.receiver == receiver
 

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -38,6 +38,7 @@ def test_snapshot_and_restore(chain, sender, receiver, vyper_contract_instance, 
         chain.mine()
 
     # Since this receipt is after snapshotting, it will be gone after restoring
+
     assert chain.blocks[-1].number == start_block + blocks_to_mine
     receipt_to_lose = vyper_contract_instance.setNumber(3, sender=owner)
 
@@ -47,17 +48,16 @@ def test_snapshot_and_restore(chain, sender, receiver, vyper_contract_instance, 
     # Show that we can also provide the snapshot ID as an argument.
     restore_index = 2
     chain.restore(snapshot_ids[restore_index])
+
     assert chain.blocks[-1].number == start_block + restore_index
 
     # Verify we lost and kept the expected transaction hashes from the account history
     assert receipt_to_keep.txn_hash in [x.txn_hash for x in chain.account_history[owner]]
     assert receipt_to_lose.txn_hash not in [x.txn_hash for x in chain.account_history[owner]]
 
-    # Head back to the initial block.
-    while chain.blocks[-1].number != 0:
-        chain.restore()
-
-    assert chain.blocks[-1].number == 0
+    # Head back to the start block
+    chain.restore(snapshot_ids[0])
+    assert chain.blocks[-1].number == start_block
     assert receiver.balance == initial_balance
 
 
@@ -97,24 +97,29 @@ def test_account_history(sender, receiver, chain):
     assert txn.receiver == receipt.receiver == receiver
 
 
-def test_iterate_blocks(chain_at_block_5):
-    expected_number_of_blocks = 6  # chain_at_block_5: [0, 1, 2, 3, 4, 5] (len=6)
-    blocks = [b for b in chain_at_block_5.blocks]
-    assert len(blocks) == expected_number_of_blocks, "Blocks are mined after fixture set"
+def test_iterate_blocks(chain_that_mined_5):
+    blocks = [b for b in chain_that_mined_5.blocks]
+    assert len(blocks) >= 5  # Because mined 5 blocks so is at least 5
 
-    expected_number = 0
+    iterator = blocks[0].number
     for block in blocks:
-        assert block.number == expected_number
-        expected_number += 1
+        assert block.number == iterator
+        iterator += 1
 
 
-def test_blocks_range(chain_at_block_5):
-    expected_number_of_blocks = 3  # Expecting blocks [0, 1, 2]
-    blocks = [b for b in chain_at_block_5.blocks.range(3)]
-    assert len(blocks) == expected_number_of_blocks
+def test_blocks_range(chain_that_mined_5):
+    # The number of the block before mining the 5
+    start_block = len(chain_that_mined_5.blocks) - 5
+    num_to_get = 3  # Expecting blocks [s, s+1, s+2]
+    blocks = [b for b in chain_that_mined_5.blocks.range(start_block, start_block + num_to_get)]
+    assert len(blocks) == num_to_get
 
-    expected_number = 0
-    prev_block_hash = HexBytes("0x0000000000000000000000000000000000000000000000000000000000000000")
+    expected_number = start_block
+    prev_block_hash = (
+        HexBytes("0x0000000000000000000000000000000000000000000000000000000000000000")
+        if start_block == 0
+        else chain_that_mined_5.blocks[start_block - 1].hash
+    )
     for block in blocks:
         assert block.number == expected_number
         expected_number += 1
@@ -122,35 +127,36 @@ def test_blocks_range(chain_at_block_5):
         prev_block_hash = block.hash
 
 
-def test_blocks_range_too_high_stop(chain_at_block_5):
-    len_plus_1 = len(chain_at_block_5.blocks) + 1
+def test_blocks_range_too_high_stop(chain_that_mined_5):
+    num_blocks = len(chain_that_mined_5.blocks)
+    num_blocks_add_1 = num_blocks + 1
     with pytest.raises(ChainError) as err:
         # Have to run through generator to trigger code in definition.
-        _ = [_ for _ in chain_at_block_5.blocks.range(len_plus_1)]
+        _ = [_ for _ in chain_that_mined_5.blocks.range(num_blocks_add_1)]
 
     assert str(err.value) == (
-        f"'stop={len_plus_1}' cannot be greater than the chain length (6). "
+        f"'stop={num_blocks_add_1}' cannot be greater than the chain length ({num_blocks}). "
         f"Use 'poll_blocks()' to wait for future blocks."
     )
 
 
-def test_block_range_with_step(chain_at_block_5):
-    blocks = [b for b in chain_at_block_5.blocks.range(3, step=2)]
+def test_block_range_with_step(chain_that_mined_5):
+    blocks = [b for b in chain_that_mined_5.blocks.range(3, step=2)]
     assert len(blocks) == 2
     assert blocks[0].number == 0
     assert blocks[1].number == 2
 
 
-def test_block_range_negative_start(chain_at_block_5):
+def test_block_range_negative_start(chain_that_mined_5):
     with pytest.raises(ValueError) as err:
-        _ = [b for b in chain_at_block_5.blocks.range(-1, 3, step=2)]
+        _ = [b for b in chain_that_mined_5.blocks.range(-1, 3, step=2)]
 
     assert "ensure this value is greater than or equal to 0" in str(err.value)
 
 
-def test_block_range_out_of_order(chain_at_block_5):
+def test_block_range_out_of_order(chain_that_mined_5):
     with pytest.raises(ValueError) as err:
-        _ = [b for b in chain_at_block_5.blocks.range(3, 1, step=2)]
+        _ = [b for b in chain_that_mined_5.blocks.range(3, 1, step=2)]
 
     assert "stop_block: '0' cannot be less than start_block: '3'." in str(err.value)
 
@@ -365,34 +371,37 @@ def test_get_multiple_deployments_live(
 
 def test_contract_cache_mapping_updated_on_many_deployments(owner, project_with_contract, chain):
     # Arrange / Act
-    starting_contracts_list = chain.contracts.get_deployments(project_with_contract.ApeContract0)
-    initial_deployed_contract = owner.deploy(project_with_contract.ApeContract0)
+    initial_contracts = chain.contracts.get_deployments(project_with_contract.ApeContract0)
+    expected_first_contract = owner.deploy(project_with_contract.ApeContract0)
 
     owner.deploy(project_with_contract.ApeContract0)
     owner.deploy(project_with_contract.ApeContract0)
-    final_deployed_contract = owner.deploy(project_with_contract.ApeContract0)
+    expected_last_contract = owner.deploy(project_with_contract.ApeContract0)
 
-    my_contracts_list = chain.contracts.get_deployments(project_with_contract.ApeContract0)
-    initial_contract_index = len(my_contracts_list) - len(starting_contracts_list) - 4
+    actual_contracts = chain.contracts.get_deployments(project_with_contract.ApeContract0)
+    first_index = len(initial_contracts)  # next index before deploys from this test
+    actual_first_contract = actual_contracts[first_index].address
+    actual_last_contract = actual_contracts[-1].address
 
     # Assert
-    assert len(my_contracts_list) - len(starting_contracts_list) == 4
-    assert final_deployed_contract.address == my_contracts_list[-1].address
-    assert my_contracts_list[initial_contract_index].address == initial_deployed_contract.address
+    fail_msg = f"Check deployments: {', '.join([c.address for c in actual_contracts])}"
+    assert len(actual_contracts) - len(initial_contracts) == 4, fail_msg
+    assert actual_first_contract == expected_first_contract.address, fail_msg
+    assert actual_last_contract == expected_last_contract.address, fail_msg
 
 
-def test_poll_blocks_stop_block_not_in_future(chain_at_block_5):
-    bad_stop_block = chain_at_block_5.blocks.height
+def test_poll_blocks_stop_block_not_in_future(chain_that_mined_5):
+    bad_stop_block = chain_that_mined_5.blocks.height
 
     with pytest.raises(ValueError) as err:
-        _ = [x for x in chain_at_block_5.blocks.poll_blocks(stop_block=bad_stop_block)]
+        _ = [x for x in chain_that_mined_5.blocks.poll_blocks(stop_block=bad_stop_block)]
 
     assert str(err.value) == "'stop' argument must be in the future."
 
 
-def test_poll_blocks(chain_at_block_5, eth_tester_provider, owner, PollDaemon):
+def test_poll_blocks(chain_that_mined_5, eth_tester_provider, owner, PollDaemon):
     blocks = Queue(maxsize=3)
-    poller = chain_at_block_5.blocks.poll_blocks()
+    poller = chain_that_mined_5.blocks.poll_blocks()
 
     with PollDaemon("blocks", poller, blocks.put, blocks.full):
         # Sleep first to ensure listening before mining.
@@ -408,9 +417,9 @@ def test_poll_blocks(chain_at_block_5, eth_tester_provider, owner, PollDaemon):
 
 
 def test_poll_blocks_timeout(
-    vyper_contract_instance, chain_at_block_5, eth_tester_provider, owner, PollDaemon
+    vyper_contract_instance, chain_that_mined_5, eth_tester_provider, owner, PollDaemon
 ):
-    poller = chain_at_block_5.blocks.poll_blocks(new_block_timeout=1)
+    poller = chain_that_mined_5.blocks.poll_blocks(new_block_timeout=1)
 
     with pytest.raises(ChainError) as err:
         with PollDaemon("blocks", poller, lambda x: None, lambda: False):

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -445,5 +445,5 @@ def test_revert(chain, owner, vyper_contract_instance):
     snapshot_id = chain.snapshot()
     receipt_to_lose = vyper_contract_instance.setNumber(3, sender=owner)
     chain.restore(snapshot_id)
-    assert receipt_to_keep.txn_hash not in [chain.account_history[owner]]
-    assert receipt_to_lose.txn_hash not in [chain.account_history[owner]]
+    assert receipt_to_keep.txn_hash in [x.txn_hash for x in chain.account_history[owner]]
+    assert receipt_to_lose.txn_hash not in [x.txn_hash for x in chain.account_history[owner]]

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -438,3 +438,12 @@ def test_contracts_get_non_contract_address(chain, owner):
 def test_contracts_get_attempts_to_convert(chain):
     with pytest.raises(ConversionError):
         chain.contracts.get("test.eth")
+
+
+def test_revert(chain, owner, vyper_contract_instance):
+    receipt_to_keep = vyper_contract_instance.setNumber(3, sender=owner)
+    snapshot_id = chain.snapshot()
+    receipt_to_lose = vyper_contract_instance.setNumber(3, sender=owner)
+    chain.restore(snapshot_id)
+    assert receipt_to_keep.txn_hash not in [chain.account_history[owner]]
+    assert receipt_to_lose.txn_hash not in [chain.account_history[owner]]

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -83,7 +83,7 @@ def test_snapshot_and_restore_unknown_snapshot_id(chain):
 def test_snapshot_and_restore_no_snapshots(chain):
     chain._snapshots = []  # Ensure empty (gets set in test setup)
     with pytest.raises(ChainError) as err:
-        chain.restore("{}")
+        chain.restore()
 
     assert "There are no snapshots to revert to." in str(err.value)
 

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -1,13 +1,10 @@
 from ape import Contract
 
-from .conftest import SOLIDITY_CONTRACT_ADDRESS, VYPER_CONTRACT_ADDRESS
-
 
 def test_deploy(
     sender, contract_container, networks_connected_to_tester, project, chain, clean_contracts_cache
 ):
     contract = contract_container.deploy(sender=sender, something_else="IGNORED")
-    assert contract.address in (SOLIDITY_CONTRACT_ADDRESS, VYPER_CONTRACT_ADDRESS)
 
     # Verify can reload same contract from cache
     contract_from_cache = Contract(contract.address)

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -190,9 +190,9 @@ def test_contract_logs_range_only_stop(contract_instance, owner, chain):
 
 
 def test_poll_logs_stop_block_not_in_future(
-    chain_at_block_5, vyper_contract_instance, eth_tester_provider
+    chain_that_mined_5, vyper_contract_instance, eth_tester_provider
 ):
-    bad_stop_block = chain_at_block_5.blocks.height
+    bad_stop_block = chain_that_mined_5.blocks.height
 
     with pytest.raises(ValueError) as err:
         _ = [x for x in vyper_contract_instance.NumberChange.poll_logs(stop_block=bad_stop_block)]

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -9,14 +9,15 @@ from ape.exceptions import ChainError
 from ape.utils import ZERO_ADDRESS
 from ape_ethereum.transactions import TransactionStatusEnum
 
-from .conftest import SOLIDITY_CONTRACT_ADDRESS
+from .conftest import TEST_ADDRESS
 
 MATCH_TEST_CONTRACT = re.compile(r"<TestContract((Sol)|(Vy))")
 
 
-def test_init_at_unknown_address():
+def test_init_at_unknown_address(networks_connected_to_tester):
+    _ = networks_connected_to_tester  # Need fixture or else get ProviderNotConnectedError
     with pytest.raises(ChainError):
-        Contract(SOLIDITY_CONTRACT_ADDRESS)
+        Contract(TEST_ADDRESS)
 
 
 def test_init_specify_contract_type(

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -2,7 +2,6 @@ from contextlib import contextmanager
 
 import pytest
 
-from ape.api import ProviderAPI
 from ape.exceptions import NetworkError
 
 

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -3,24 +3,23 @@ import time
 import pandas as pd
 import pytest
 
-from ape import chain
 from ape.api.query import validate_and_expand_columns
-from ape.types import ContractLog
 
 
-def test_basic_query(eth_tester_provider):
+def test_basic_query(chain, eth_tester_provider):
     chain.mine(3)
-    df1 = chain.blocks.query("*")
-    assert list(df1["number"].values) == [0, 1, 2, 3]
-    df2 = chain.blocks.query("number", "timestamp")
-    assert len(df2) == 4
+    blocks_df0 = chain.blocks.query("*")
+    blocks_df1 = chain.blocks.query("number", "timestamp")
+
+    assert list(blocks_df0["number"].values)[:4] == [0, 1, 2, 3]
+    assert len(blocks_df1) == len(chain.blocks)
     assert (
-        df2.iloc[3]["timestamp"]
-        >= df2.iloc[2]["timestamp"]
-        >= df2.iloc[1]["timestamp"]
-        >= df2.iloc[0]["timestamp"]
+        blocks_df1.iloc[3]["timestamp"]
+        >= blocks_df1.iloc[2]["timestamp"]
+        >= blocks_df1.iloc[1]["timestamp"]
+        >= blocks_df1.iloc[0]["timestamp"]
     )
-    assert list(df1.columns) == [
+    assert list(blocks_df0.columns) == [
         "num_transactions",
         "hash",
         "number",
@@ -35,15 +34,16 @@ def test_basic_query(eth_tester_provider):
     ]
 
 
-def test_relative_block_query(eth_tester_provider):
+def test_relative_block_query(chain, eth_tester_provider):
+    start_block = chain.blocks.height
     chain.mine(10)
     df = chain.blocks.query("*", start_block=-8, stop_block=-2)
     assert len(df) == 7
-    assert df.number.min() == chain.blocks[-8].number == 3
-    assert df.number.max() == chain.blocks[-2].number == 9
+    assert df.number.min() == chain.blocks[-8].number == start_block + 3
+    assert df.number.max() == chain.blocks[-2].number == start_block + 9
 
 
-def test_block_transaction_query(eth_tester_provider, sender, receiver):
+def test_block_transaction_query(chain, eth_tester_provider, sender, receiver):
     sender.transfer(receiver, 100)
     query = chain.blocks[-1].transactions
     assert len(query) == 1
@@ -57,9 +57,6 @@ def test_transaction_contract_event_query(contract_instance, owner, eth_tester_p
     df_events = contract_instance.FooHappened.query("*", start_block=-1)
     assert isinstance(df_events, pd.DataFrame)
     assert df_events.event_name[0] == "FooHappened"
-    events = list(contract_instance.FooHappened.range(start_or_stop=0))
-    assert isinstance(events[0], ContractLog)
-    assert "FooHappened" in events[0].dict().values()
 
 
 def test_column_expansion():
@@ -83,9 +80,10 @@ def test_column_expansion():
 
 def test_column_validation(eth_tester_provider):
     all_fields = ["number", "timestamp"]
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match="Unrecognized field 'numbr'"):
         validate_and_expand_columns(["numbr"], all_fields)
-    assert "Unrecognized field 'numbr'" in str(err.value)
-    with pytest.raises(ValueError) as err:
+
+    with pytest.raises(
+        ValueError, match=r"Duplicate fields in \['number', 'timestamp', 'number'\]"
+    ):
         validate_and_expand_columns(["number", "timestamp", "number"], all_fields)
-    assert "Duplicate fields in ['number', 'timestamp', 'number']" in str(err.value)

--- a/tests/integration/cli/projects/test/contracts/MyContract.json
+++ b/tests/integration/cli/projects/test/contracts/MyContract.json
@@ -1,0 +1,72 @@
+[
+  {
+    "type": "event",
+    "name": "NumberChange",
+    "inputs": [
+      {
+        "name": "prevNum",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "newNum",
+        "type": "uint256",
+        "indexed": true
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "constructor",
+    "stateMutability": "nonpayable",
+    "inputs": []
+  },
+  {
+    "type": "function",
+    "name": "setNumber",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "num",
+        "type": "uint256"
+      }
+    ],
+    "outputs": []
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ]
+  },
+  {
+    "type": "function",
+    "name": "myNumber",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "function",
+    "name": "prevNumber",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  }
+]

--- a/tests/integration/cli/projects/test/tests/test_networks.py
+++ b/tests/integration/cli/projects/test/tests/test_networks.py
@@ -1,0 +1,10 @@
+def test_networks_context_does_not_disconnect(networks):
+    assert networks.provider.web3
+
+    context = networks.ethereum.local.use_provider("test")
+
+    with context as provider:
+        assert provider
+
+    # Ensure we are still connected
+    assert networks.provider.web3

--- a/tests/integration/cli/projects/with-contracts/tests/test_contract.py
+++ b/tests/integration/cli/projects/with-contracts/tests/test_contract.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def owner(accounts):
+    return accounts[0]
+
+
+@pytest.fixture(scope="module")
+def contract_from_fixture(project, owner):
+    return owner.deploy(project.Contract)
+
+
+def test_contract_interaction_in_tests(project, contract_from_fixture, owner):
+    contract_in_test = owner.deploy(project.Contract)
+    contract_in_test.setNumber(123, sender=owner)
+    actual = contract_in_test.myNumber()
+    assert actual == 123
+
+    contract_from_fixture.setNumber(456, sender=owner)
+    actual = contract_from_fixture.myNumber()
+    assert actual == 456

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -21,10 +21,11 @@ skip_non_compilable_projects = skip_projects(
 
 @skip_projects(
     [
-        "unregistered-contracts",
-        "multiple-interfaces",
         "geth",
+        "multiple-interfaces",
         "only-dependencies",
+        "test",
+        "unregistered-contracts",
         "with-dependencies",
         "with-contracts",
     ]

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -1,21 +1,23 @@
 from .utils import skip_projects_except
 
-projects_with_tests = skip_projects_except(["test"])
+projects_with_tests = skip_projects_except(["test", "with-contracts"])
 
 
 @projects_with_tests
 def test_test(ape_cli, runner, project):
     # test cases implicitly test built-in isolation
 
-    result = runner.invoke(ape_cli, ["test"])
+    result = runner.invoke(ape_cli, ["test"], catch_exceptions=False)
     assert result.exit_code == 0, result.output
 
 
 @projects_with_tests
 def test_test_isolation_disabled(ape_cli, runner, project):
     # check the disable isolation option actually disables built-in isolation
-    result = runner.invoke(ape_cli, ["test", "--disable-isolation", "--setup-show"])
-    assert result.exit_code == 1
+    result = runner.invoke(
+        ape_cli, ["test", "--disable-isolation", "--setup-show"], catch_exceptions=False
+    )
+    assert result.exit_code == (1 if project.path.name == "test" else 0)
     assert "F _function_isolation" not in result.output
 
 

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -1,6 +1,14 @@
+import pytest
+
 from .utils import skip_projects_except
 
 projects_with_tests = skip_projects_except(["test", "with-contracts"])
+
+
+@pytest.fixture(autouse=True, scope="module")
+def reset_provider(eth_tester_provider):
+    eth_tester_provider.disconnect()
+    eth_tester_provider.connect()
 
 
 @projects_with_tests


### PR DESCRIPTION
### What I did

Fixes issue where the provider context as not properly handling multiple providers.

### How I did it

* Don't disconnect providers until very end of test run
* Manage a stack of provider IDs to keep track of the order of provider to pop / push... However! If the provider was previously added, it is already connected and remains so, only the stack ID changes.

### How to verify it

See these tests: https://github.com/unparalleled-js/ape-demo-starknet/tree/main/tests

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
