### PR TITLE
refactor: change deployments_map contract type entries to be list of dicts instead of list of addresses

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -16,6 +16,8 @@ import ape
 from ape.api import EcosystemAPI, NetworkAPI, TransactionAPI
 from ape.contracts import ContractContainer, ContractInstance
 from ape.exceptions import ChainError, ContractLogicError
+from ape.logging import LogLevel
+from ape.logging import logger as _logger
 from ape.managers.config import CONFIG_FILE_NAME
 from ape.types import AddressType, ContractLog
 
@@ -374,3 +376,16 @@ def remove_disk_writes_deployments(chain):
 
     if chain.contracts._deployments_mapping_cache.exists():
         chain.contracts._deployments_mapping_cache.unlink()
+
+
+@pytest.fixture
+def logger():
+    return _logger
+
+
+@pytest.fixture
+def use_debug(logger):
+    initial_level = logger.level
+    logger.set_level(LogLevel.DEBUG)
+    yield
+    logger.set_level(initial_level)


### PR DESCRIPTION
### What I did

Changes the `deployments_map.json` entries to be a list of dictionaries rather than a list of addresses.
This will allow us to add more data to deployments, such as the `txn_hash`, which my be needed.

### How I did it

* When getting deployments, if it notices you are using the old schema, it will migrate it then
* I had to do some refactoring to achieve this nicely

### How to verify it

Case 0:
Deploy a contract to a testnet using main branch
Then, deploy a contract here. Make sure it worked and uses the new schema

Case 1:
Deploy a contract to a testnet using main branch
Call `get_deployments` here. Make sure it worked and uses the new schema.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
