### PR TITLE
test: update test_parse_type() regex

### DIFF
--- a/tests/functional/utils/test_abi.py
+++ b/tests/functional/utils/test_abi.py
@@ -10,16 +10,16 @@ IDENT = r"(\w+(\[\])?)"
 # e.g. (int,) or (int, int) or (int, int,) etc.
 TUPLE = rf"(\({IDENT},(\s*{IDENT},?)*\))"
 
-# An optionally nested tuple.
+# Adding optional nesting to the tuple pattern.
 # e.g. (int,) or (int, int) or ((int,), int) etc.
-NESTED_TUPLE = rf"(\(({IDENT}|{TUPLE}),(\s*{IDENT}|{TUPLE},?)*\))"
+TUPLE = rf"(\(({IDENT}|{TUPLE}),(\s*({IDENT}|{TUPLE}),?)*\))"
 
 # The full type declaration pattern which matches:
 # - type identifier
 # - array declaration
 # - tuples of type/array
 # - tuples of type/array or tuples
-TYPE_DECL = rf"^({IDENT}|{TUPLE}|{NESTED_TUPLE})$"
+TYPE_DECL = rf"^({IDENT}|{TUPLE})$"
 
 
 @pytest.mark.fuzzing

--- a/tests/functional/utils/test_abi.py
+++ b/tests/functional/utils/test_abi.py
@@ -33,7 +33,7 @@ def test_parse_type(s):
     #   - (int[],)
     #   - (int, int,)
     #   - (int, int)
-    #   - (int, int, int,)
+    #   - (int, int, int)
     #   - (int, int, int,)
     #   - ((int, int), int)
     #   - ((int, int[],), int)

--- a/tests/functional/utils/test_abi.py
+++ b/tests/functional/utils/test_abi.py
@@ -3,18 +3,46 @@ from hypothesis import given, strategies
 
 from ape.utils import parse_type
 
+# An alphanumeric type identifier or array declaration.
+IDENT = r"(\w+(\[\])?)"
+
+# A tuple declaration with one or more items.
+# e.g. (int,) or (int, int) or (int, int,) etc.
+TUPLE = rf"(\({IDENT},(\s*{IDENT},?)*\))"
+
+# An optionally nested tuple.
+# e.g. (int,) or (int, int) or ((int,), int) etc.
+NESTED_TUPLE = rf"(\(({IDENT}|{TUPLE}),(\s*{IDENT}|{TUPLE},?)*\))"
+
+# The full type declaration pattern which matches:
+# - type identifier
+# - array declaration
+# - tuples of type/array
+# - tuples of type/array or tuples
+TYPE_DECL = rf"^({IDENT}|{TUPLE}|{NESTED_TUPLE})$"
+
 
 @pytest.mark.fuzzing
-@given(strategies.from_regex(r"\(*[\w|, []]*\)*"))
+@given(strategies.from_regex(TYPE_DECL))
 def test_parse_type(s):
-    # Example matching strings from above regex:
-    #   * (int, int)
-    #   * ((int, int), int)
-    #   * int
-    #   * uint256
-    #   * int[]
-    #   * (asd ) [] asdf ff 33 asdf
+    # Examples matching strings from above regex:
+    #   - int
+    #   - int[]
+    #   - uint256
+    #   - (int,)
+    #   - (int[],)
+    #   - (int, int,)
+    #   - (int, int)
+    #   - (int, int, int,)
+    #   - (int, int, int,)
+    #   - ((int, int), int)
+    #   - ((int, int[],), int)
     #
+    # Some examples of non-matching strings:
+    #   - [int,]
+    #   - (int ) [] asdf ff 33 asdf
+    #   - ,int
+    #   - int,
     # See tests in `tests_contracts` for specific ABI parsing tests.
 
     assert parse_type(s)


### PR DESCRIPTION
### What I did
The previous regex was allowing some invalid inputs such as `(,)` to get through.

### How I did it
Updated the regular expression to match expected Vyper decls like:
- type identifiers
- array declarations
- tuples of type/array
- tuples of type/array/tuple/etc

I split the various expected sub-patterns to their own variables so they're easier to read and can be commented on separately

### How to verify it

__NOTE:__ I used non-capturing groups (?:) on the regex site just to make the highlight colors a little less chaotic 👀 the groups in the Python code don't need to be non-capturing so I omitted them there

The regular expression (i.e. the value of `TYPE_DECL`) and some sample input are here:

https://regex101.com/r/dVmiYA/1

Screenshot for posterity, the non-highlighted text below shows invalid input that we don't want to use anyway:

<img width="703" alt="image" src="https://user-images.githubusercontent.com/108302637/183513383-798c37f0-6edb-4f07-afcf-f05d631c913b.png">

### Checklist
- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
