### PR TITLE
feat: add `receipt` / `txn_hash` to `ContractInstance`

### DIFF
--- a/docs/userguides/contracts.md
+++ b/docs/userguides/contracts.md
@@ -55,7 +55,7 @@ def main():
 or
 
 ```python
-from ape import project, chain, accounts
+from ape import project, accounts
 
 def main():
   account = accounts.test_accounts[0]

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -21,7 +21,7 @@ def deploy():
     return account.deploy(project.MyContract)
 ```
 
-To get the receipt of a `deploy` transaction, use the `.receipt` property on the contract instance:
+To get the receipt of a `deploy` transaction, use the [ContractInstance.receipt](../methoddocs/contracts.html#ape.contracts.base.ContractInstance.receipt) property:
 
 ```python
 from ape import accounts, project

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -18,6 +18,7 @@ from ape import accounts, project
 
 def deploy():
     account = accounts.load("MyAccount")
+    # Assume you have a contract named `MyContract` in your project's contracts folder.
     return account.deploy(project.MyContract)
 ```
 

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -21,6 +21,19 @@ def deploy():
     return account.deploy(project.MyContract)
 ```
 
+To get the receipt of a `deploy` transaction, use the `.receipt` property on the contract instance:
+
+```python
+from ape import accounts, project
+
+dev = accounts.load("dev")
+contract = project.MyContract.deploy(sender=dev)
+
+# The receipt is available on the contract instance and has the expected sender.
+receipt = contract.receipt
+assert receipt.sender == dev
+```
+
 ### Deployment from Ape Console
 
 Deploying from [ape console](./console.html) allows you to interact with a contract in real time. You can also use the `--network` flag to connect a live network. 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -589,7 +589,8 @@ class ContractInstance(BaseAddress):
         address = receipt.contract_address
         if not address:
             raise ContractError(
-                "Receipt missing 'contract_address' field. Was this from a deploy transaction?"
+                "Receipt missing 'contract_address' field. "
+                "Was this from a deploy transaction (e.g. `project.MyContract.deploy()`)?"
             )
 
         instance = cls(

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -572,10 +572,50 @@ class ContractInstance(BaseAddress):
         contract = a.deploy(project.MyContract)  # The result of 'deploy()' is a ContractInstance
     """
 
-    def __init__(self, address: AddressType, contract_type: ContractType) -> None:
+    def __init__(
+        self,
+        address: Union[AddressType, str],
+        contract_type: ContractType,
+        txn_hash: Optional[str] = None,
+    ) -> None:
         super().__init__()
         self._address = address
         self.contract_type = contract_type
+        self.txn_hash = txn_hash
+        self._cached_receipt: Optional[ReceiptAPI] = None
+
+    @classmethod
+    def from_receipt(cls, receipt: ReceiptAPI, contract_type: ContractType) -> "ContractInstance":
+        address = receipt.contract_address
+        if not address:
+            raise ContractError(
+                "Receipt missing 'contract_address' field. Was this from a deploy transaction?"
+            )
+
+        instance = cls(
+            address=address,
+            contract_type=contract_type,
+            txn_hash=receipt.txn_hash,
+        )
+        instance._cached_receipt = receipt
+        return instance
+
+    @property
+    def receipt(self) -> Optional[ReceiptAPI]:
+        """
+        The receipt associated with deploying the contract instance,
+        if it is known and exists.
+        """
+
+        if not self._cached_receipt and self.txn_hash:
+            receipt = self.provider.get_transaction(self.txn_hash)
+            self._cached_receipt = receipt
+            return receipt
+
+        elif self._cached_receipt:
+            return self._cached_receipt
+
+        return None
 
     def __repr__(self) -> str:
         contract_name = self.contract_type.name or "Unnamed contract"
@@ -589,7 +629,8 @@ class ContractInstance(BaseAddress):
         Returns:
             ``AddressType``
         """
-        return self._address
+
+        return self.provider.network.ecosystem.decode_address(self._address)
 
     @cached_property
     def _view_methods_(self) -> Dict[str, ContractCallHandler]:
@@ -774,7 +815,7 @@ class ContractContainer(ManagerAccessMixin):
 
         return self.chain_manager.contracts.get_deployments(self)
 
-    def at(self, address: AddressType) -> ContractInstance:
+    def at(self, address: AddressType, txn_hash: Optional[str] = None) -> ContractInstance:
         """
         Get a contract at the given address.
 
@@ -789,12 +830,16 @@ class ContractContainer(ManagerAccessMixin):
               **NOTE**: Things will not work as expected if the contract is not actually
               deployed to this address or if the contract at the given address has
               a different ABI than :attr:`~ape.contracts.ContractContainer.contract_type`.
+            txn_hash (str): The hash of the transaction that deployed the contract, if
+              available. Defaults to ``None``.
 
         Returns:
             :class:`~ape.contracts.ContractInstance`
         """
 
-        return self.chain_manager.contracts.instance_at(address, self.contract_type)
+        return self.chain_manager.contracts.instance_at(
+            address, self.contract_type, txn_hash=txn_hash
+        )
 
     def __call__(self, *args, **kwargs) -> TransactionAPI:
         args = self.conversion_manager.convert(args, tuple)
@@ -826,16 +871,12 @@ class ContractContainer(ManagerAccessMixin):
         if not receipt.contract_address:
             raise ContractError(f"'{receipt.txn_hash}' did not create a contract.")
 
-        address = click.style(receipt.contract_address, bold=True)
+        styled_address = click.style(receipt.contract_address, bold=True)
         contract_name = self.contract_type.name or "<Unnamed Contract>"
-        logger.success(f"Contract '{contract_name}' deployed to: {address}")
-
-        contract_instance = ContractInstance(
-            address=receipt.contract_address,  # type: ignore
-            contract_type=self.contract_type,
-        )
-        self.chain_manager.contracts[contract_instance.address] = contract_instance.contract_type
-        return contract_instance
+        logger.success(f"Contract '{contract_name}' deployed to: {styled_address}")
+        instance = ContractInstance.from_receipt(receipt, self.contract_type)
+        self.chain_manager.contracts.cache_deployment(instance)
+        return instance
 
 
 def _get_non_contract_error(address: str, network_name: str) -> ContractError:

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -45,8 +45,7 @@ class SignatureError(AccountsError):
 
 class ContractError(ApeException):
     """
-    Raised when issues occur when interacting with a contract
-    (calls or transactions).
+    Raised when issues occur with contracts.
     """
 
 

--- a/src/ape/utils/trace.py
+++ b/src/ape/utils/trace.py
@@ -132,7 +132,9 @@ class CallTraceParser:
             method = None
             contract_name = contract_type.name
             if "symbol" in contract_type.view_methods:
-                contract = self._receipt.chain_manager.contracts.instance_at(address, contract_type)
+                contract = self._receipt.chain_manager.contracts.instance_at(
+                    address, contract_type, txn_hash=self._receipt.txn_hash
+                )
 
                 try:
                     contract_name = contract.symbol() or contract_name

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -207,10 +207,10 @@ def project_with_contract(config):
 
 @pytest.fixture
 def clean_contracts_cache(chain):
-    original_cached_contracts = chain.contracts._local_contracts
-    chain.contracts._local_contracts = {}
+    original_cached_contracts = chain.contracts._local_contract_types
+    chain.contracts._local_contract_types = {}
     yield
-    chain.contracts._local_contracts = original_cached_contracts
+    chain.contracts._local_contract_types = original_cached_contracts
 
 
 @pytest.fixture
@@ -245,7 +245,7 @@ def mainnet_contract(chain):
             / f"{address}.json"
         )
         contract = ContractType.parse_file(path)
-        chain.contracts._local_contracts[address] = contract
+        chain.contracts._local_contract_types[address] = contract
         return contract
 
     return contract_getter

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -152,7 +152,7 @@ def vyper_contract_container(vyper_contract_type) -> ContractContainer:
 def vyper_contract_instance(
     owner, vyper_contract_container, networks_connected_to_tester
 ) -> ContractInstance:
-    return owner.deploy(vyper_contract_container)
+    return owner.deploy(vyper_contract_container, required_confirmations=0)
 
 
 @pytest.fixture(params=("solidity", "vyper"))

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -102,11 +102,16 @@ def test_transfer_using_type_0(sender, receiver):
 def test_deploy(owner, contract_container, chain, clean_contracts_cache):
     contract = owner.deploy(contract_container)
     assert contract.address
+    assert contract.txn_hash
+
+    # Deploy again to prove that we get the correct txn_hash below
+    owner.deploy(contract_container)
 
     # Verify can reload same contract from cache
     contract_from_cache = ape.Contract(contract.address)
     assert contract_from_cache.contract_type == contract.contract_type
     assert contract_from_cache.address == contract.address
+    assert contract_from_cache.txn_hash == contract.txn_hash
 
 
 def test_contract_calls(owner, contract_instance):

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -5,14 +5,13 @@ def test_deploy(
     sender, contract_container, networks_connected_to_tester, project, chain, clean_contracts_cache
 ):
     contract = contract_container.deploy(sender=sender, something_else="IGNORED")
+    assert contract.txn_hash
 
     # Verify can reload same contract from cache
     contract_from_cache = Contract(contract.address)
     assert contract_from_cache.contract_type == contract.contract_type
     assert contract_from_cache.address == contract.address
-
-    # Clean up for next test
-    del chain.contracts._local_contracts[contract_from_cache.address]
+    assert contract_from_cache.txn_hash == contract.txn_hash
 
 
 def test_deployment_property(chain, owner, project_with_contract, eth_tester_provider):

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -16,7 +16,9 @@ MATCH_TEST_CONTRACT = re.compile(r"<TestContract((Sol)|(Vy))")
 
 def test_init_at_unknown_address(networks_connected_to_tester):
     _ = networks_connected_to_tester  # Need fixture or else get ProviderNotConnectedError
-    with pytest.raises(ChainError):
+    with pytest.raises(
+        ChainError, match=f"Failed to get contract type for address '{TEST_ADDRESS}'."
+    ):
         Contract(TEST_ADDRESS)
 
 
@@ -286,3 +288,10 @@ def test_call_transact(vyper_contract_instance, owner):
     receipt = vyper_contract_instance.myNumber.transact(sender=owner)
     assert receipt.sender == owner
     assert receipt.status == TransactionStatusEnum.NO_ERROR
+
+
+def test_receipt(contract_instance, owner):
+    receipt = contract_instance.receipt
+    assert receipt.txn_hash == contract_instance.txn_hash
+    assert receipt.contract_address == contract_instance.address
+    assert receipt.sender == owner

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -5,7 +5,8 @@ from eth_utils import is_checksum_address
 from hexbytes import HexBytes
 
 from ape import Contract
-from ape.exceptions import ChainError
+from ape.contracts import ContractInstance
+from ape.exceptions import ChainError, ContractError
 from ape.utils import ZERO_ADDRESS
 from ape_ethereum.transactions import TransactionStatusEnum
 
@@ -295,3 +296,13 @@ def test_receipt(contract_instance, owner):
     assert receipt.txn_hash == contract_instance.txn_hash
     assert receipt.contract_address == contract_instance.address
     assert receipt.sender == owner
+
+
+def test_from_receipt_when_receipt_not_deploy(contract_instance, owner):
+    receipt = contract_instance.setNumber(123, sender=owner)
+    expected_err = (
+        "Receipt missing 'contract_address' field. "
+        "Was this from a deploy transaction (e.g. `project.MyContract.deploy()`)?"
+    )
+    with pytest.raises(ContractError, match=expected_err):
+        ContractInstance.from_receipt(receipt, contract_instance.contract_type)

--- a/tests/functional/utils/test_trace.py
+++ b/tests/functional/utils/test_trace.py
@@ -44,7 +44,7 @@ def full_contracts_cache(chain):
     for contract_type_file in mainnet_contracts_dir.iterdir():
         address = contract_type_file.stem
         contract_type = ContractType.parse_raw(contract_type_file.read_text())
-        chain.contracts._local_contracts[address] = contract_type
+        chain.contracts._local_contract_types[address] = contract_type
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### What I did

fixes: #806 

* Adds `txn_hash` to `ContractInstance` that gets set whenever possible, such as after deployments as well as if instantiating a contract that was previously deployed (using the `instance_at()` method).
* Adds `.receipt()` convenience property to the `ContractInstance`. Now, after you deploy, you have access to the receipt pretty immediate.

**This is needed to unblock my work for publishing deployments but is also kind of nice to have anyway and I think exists in Brownie.**

### How I did it

* Add `txn_hash` arguments to `contracts.instance_at()` and `contract.at()`
* Add `transaction_hash` key to the deployments cache
* Set the `txn_hash` automatically when calling `.deploy()`
* Have `instance_at()` try to look up the `txn_hash` when it is not provided (if it was from a deployment)
* Had to refactor a little bit 😅 but ultimately feels like a nice iteration.

### How to verify it

Make sure you can access the txn hash and receipt on a contract instance:

```python
assert contract.txn_hash
assert contract.receipt
```

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
