### PR TITLE
feat!: allow transaction raise on fail

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -77,7 +77,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         self,
         txn: TransactionAPI,
         send_everything: bool = False,
-        raise_on_fail: bool = False,
+        raise_on_fail: bool = True,
     ) -> ReceiptAPI:
         """
         Make a transaction call.
@@ -437,7 +437,7 @@ class ImpersonatedAccount(AccountAPI):
         self,
         txn: TransactionAPI,
         send_everything: bool = False,
-        raise_on_fail: bool = False,
+        raise_on_fail: bool = True,
     ) -> ReceiptAPI:
         txn = self.prepare_transaction(txn)
         return self.provider.send_transaction(txn, raise_on_fail=raise_on_fail)

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -73,19 +73,27 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
           :class:`~ape.types.signatures.TransactionSignature` (optional): The signed transaction.
         """
 
-    def call(self, txn: TransactionAPI, send_everything: bool = False) -> ReceiptAPI:
+    def call(
+        self,
+        txn: TransactionAPI,
+        send_everything: bool = False,
+        raise_on_fail: bool = False,
+    ) -> ReceiptAPI:
         """
         Make a transaction call.
 
         Raises:
             :class:`~ape.exceptions.AccountsError`: When the nonce is invalid or the sender does
               not have enough funds.
-            :class:`~ape.exceptions.TransactionError`: When the required confirmations are negative.
+            :class:`~ape.exceptions.TransactionError`: When the required confirmations
+              are negative or on transaction failure if ``raise_on_fail`` is ``True``.
             :class:`~ape.exceptions.SignatureError`: When the user does not sign the transaction.
 
         Args:
             txn (:class:`~ape.api.transactions.TransactionAPI`): An invoke-transaction.
             send_everything (bool): ``True`` will send the difference from balance and fee.
+            raise_on_fail (bool): ``True`` will cause failed transactions to raise
+              `~ape.exceptions.TransactionError`.
 
         Returns:
             :class:`~ape.api.transactions.ReceiptAPI`
@@ -109,7 +117,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         if not txn.signature:
             raise SignatureError("The transaction was not signed.")
 
-        return self.provider.send_transaction(txn)
+        return self.provider.send_transaction(txn, raise_on_fail=raise_on_fail)
 
     @cached_property
     def _convert(self) -> Callable:
@@ -425,6 +433,11 @@ class ImpersonatedAccount(AccountAPI):
     def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:
         return None
 
-    def call(self, txn: TransactionAPI, send_everything: bool = False) -> ReceiptAPI:
+    def call(
+        self,
+        txn: TransactionAPI,
+        send_everything: bool = False,
+        raise_on_fail: bool = False,
+    ) -> ReceiptAPI:
         txn = self.prepare_transaction(txn)
-        return self.provider.send_transaction(txn)
+        return self.provider.send_transaction(txn, raise_on_fail=raise_on_fail)

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -331,7 +331,7 @@ class ProviderAPI(BaseInterfaceModel):
         """
 
     @abstractmethod
-    def send_transaction(self, txn: TransactionAPI, raise_on_fail: bool = False) -> ReceiptAPI:
+    def send_transaction(self, txn: TransactionAPI, raise_on_fail: bool = True) -> ReceiptAPI:
         """
         Send a transaction to the network.
 
@@ -840,7 +840,7 @@ class Web3Provider(ProviderAPI, ABC):
         txn_hash: str,
         required_confirmations: int = 0,
         timeout: Optional[int] = None,
-        raise_on_fail: bool = False,
+        raise_on_fail: bool = True,
     ) -> ReceiptAPI:
         """
         Get the information about a transaction from a transaction hash.
@@ -933,7 +933,7 @@ class Web3Provider(ProviderAPI, ABC):
 
         return self._make_request("eth_getLogs", [filter_params])
 
-    def send_transaction(self, txn: TransactionAPI, raise_on_fail: bool = False) -> ReceiptAPI:
+    def send_transaction(self, txn: TransactionAPI, raise_on_fail: bool = True) -> ReceiptAPI:
         try:
             txn_hash = self.web3.eth.send_raw_transaction(txn.serialize_transaction())
         except ValueError as err:

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -342,7 +342,7 @@ class ProviderAPI(BaseInterfaceModel):
         Args:
             txn (:class:`~ape.api.transactions.TransactionAPI`): The transaction to send.
             raise_on_fail (bool): ``True`` will cause failed transactions to raise
-              `~ape.exceptions.TransactionError`.
+              `~ape.exceptions.TransactionError`.  Defaults to ``True``.
 
         Returns:
             :class:`~ape.api.transactions.ReceiptAPI`

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -840,7 +840,7 @@ class Web3Provider(ProviderAPI, ABC):
         txn_hash: str,
         required_confirmations: int = 0,
         timeout: Optional[int] = None,
-        raise_on_fail: bool = True,
+        raise_on_fail: bool = False,
     ) -> ReceiptAPI:
         """
         Get the information about a transaction from a transaction hash.
@@ -851,6 +851,8 @@ class Web3Provider(ProviderAPI, ABC):
               to wait before returning the receipt.
             timeout (Optional[int]): The amount of time to wait for a receipt
               before timing out.
+            raise_on_fail (bool): Whether an exception should be raised if the
+              transaction failed.
 
         Raises:
             :class:`~ape.exceptions.TransactionNotFoundError`: Likely the exception raised
@@ -948,7 +950,6 @@ class Web3Provider(ProviderAPI, ABC):
         receipt = self.get_receipt(
             txn_hash.hex(),
             required_confirmations=required_confirmations,
-            raise_on_fail=raise_on_fail,
         )
 
         if raise_on_fail:

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -852,7 +852,7 @@ class Web3Provider(ProviderAPI, ABC):
             timeout (Optional[int]): The amount of time to wait for a receipt
               before timing out.
             raise_on_fail (bool): Whether an exception should be raised if the
-              transaction failed.
+              transaction failed. Defaults to ``False``.
 
         Raises:
             :class:`~ape.exceptions.TransactionNotFoundError`: Likely the exception raised

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -41,9 +41,6 @@ class TransactionAPI(BaseInterfaceModel):
     # If left as None, will get set to the network's default required confirmations.
     required_confirmations: Optional[int] = Field(None, exclude=True)
 
-    # If true, will cause a TransactionError to be raised if the transaction fails.
-    _raise_on_fail: bool = False
-
     signature: Optional[TransactionSignature] = Field(exclude=True)
 
     class Config:

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -254,8 +254,8 @@ class ReceiptAPI(BaseInterfaceModel):
         Wait for a transaction to be considered confirmed.
 
         Args:
-            raise_on_fail (bool): If true, causes a TransactionError to be
-                                  raised if the transaction has failed.
+            raise_on_fail (bool): If ``True``, causes a :class:`~ape.exceptions.TransactionError`
+              to be raised if the transaction has failed.
 
         Returns:
             :class:`~ape.api.ReceiptAPI`: The receipt that is now confirmed.

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -249,7 +249,7 @@ class ReceiptAPI(BaseInterfaceModel):
         :class:`~api.providers.TransactionStatusEnum`.
         """
 
-    def await_confirmations(self, raise_on_fail: bool = True) -> "ReceiptAPI":
+    def await_confirmations(self, raise_on_fail: bool = False) -> "ReceiptAPI":
         """
         Wait for a transaction to be considered confirmed.
 

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -249,7 +249,7 @@ class ReceiptAPI(BaseInterfaceModel):
         :class:`~api.providers.TransactionStatusEnum`.
         """
 
-    def await_confirmations(self, raise_on_fail: bool = False) -> "ReceiptAPI":
+    def await_confirmations(self, raise_on_fail: bool = True) -> "ReceiptAPI":
         """
         Wait for a transaction to be considered confirmed.
 

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -41,6 +41,9 @@ class TransactionAPI(BaseInterfaceModel):
     # If left as None, will get set to the network's default required confirmations.
     required_confirmations: Optional[int] = Field(None, exclude=True)
 
+    # If true, will cause a TransactionError to be raised if the transaction fails.
+    _raise_on_fail: bool = False
+
     signature: Optional[TransactionSignature] = Field(exclude=True)
 
     class Config:
@@ -249,19 +252,19 @@ class ReceiptAPI(BaseInterfaceModel):
         :class:`~api.providers.TransactionStatusEnum`.
         """
 
-    def await_confirmations(self) -> "ReceiptAPI":
+    def await_confirmations(self, raise_on_fail: bool = False) -> "ReceiptAPI":
         """
         Wait for a transaction to be considered confirmed.
+
+        Args:
+            raise_on_fail (bool): If true, causes a TransactionError to be
+                                  raised if the transaction has failed.
 
         Returns:
             :class:`~ape.api.ReceiptAPI`: The receipt that is now confirmed.
         """
-
-        try:
+        if raise_on_fail:
             self.raise_for_status()
-        except TransactionError:
-            # Skip waiting for confirmations when the transaction has failed.
-            return self
 
         iterations_timeout = 20
         iteration = 0

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -209,7 +209,7 @@ class ContractTransaction(ManagerAccessMixin):
         )
 
     def __call__(self, *args, **kwargs) -> ReceiptAPI:
-        raise_on_fail = kwargs.pop("raise_on_fail", False)
+        raise_on_fail = kwargs.pop("raise_on_fail", True)
 
         txn = self.serialize_transaction(*args, **kwargs)
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -209,12 +209,14 @@ class ContractTransaction(ManagerAccessMixin):
         )
 
     def __call__(self, *args, **kwargs) -> ReceiptAPI:
+        raise_on_fail = kwargs.pop("raise_on_fail", False)
+
         txn = self.serialize_transaction(*args, **kwargs)
 
         if "sender" in kwargs and isinstance(kwargs["sender"], AccountAPI):
-            return kwargs["sender"].call(txn)
+            return kwargs["sender"].call(txn, raise_on_fail=raise_on_fail)
 
-        return self.provider.send_transaction(txn)
+        return self.provider.send_transaction(txn, raise_on_fail=raise_on_fail)
 
 
 class ContractTransactionHandler(ManagerAccessMixin):

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -124,7 +124,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         except TransactionFailed as err:
             raise self.get_virtual_machine_error(err, sender=txn.sender) from err
 
-    def send_transaction(self, txn: TransactionAPI, raise_on_fail: bool = False) -> ReceiptAPI:
+    def send_transaction(self, txn: TransactionAPI, raise_on_fail: bool = True) -> ReceiptAPI:
         try:
             txn_hash = self.web3.eth.send_raw_transaction(txn.serialize_transaction())
         except (ValidationError, TransactionFailed) as err:

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -131,8 +131,14 @@ class LocalProvider(TestProviderAPI, Web3Provider):
             raise self.get_virtual_machine_error(err, sender=txn.sender) from err
 
         receipt = self.get_receipt(
-            txn_hash.hex(), required_confirmations=txn.required_confirmations or 0
+            txn_hash.hex(),
+            required_confirmations=txn.required_confirmations or 0,
+            raise_on_fail=txn._raise_on_fail,
         )
+
+        if txn._raise_on_fail:
+            receipt.raise_for_status()
+
         if txn.gas_limit is not None and receipt.ran_out_of_gas:
             raise OutOfGasError()
 

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -133,7 +133,6 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         receipt = self.get_receipt(
             txn_hash.hex(),
             required_confirmations=txn.required_confirmations or 0,
-            raise_on_fail=raise_on_fail,
         )
 
         if raise_on_fail:

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -124,7 +124,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         except TransactionFailed as err:
             raise self.get_virtual_machine_error(err, sender=txn.sender) from err
 
-    def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
+    def send_transaction(self, txn: TransactionAPI, raise_on_fail: bool = False) -> ReceiptAPI:
         try:
             txn_hash = self.web3.eth.send_raw_transaction(txn.serialize_transaction())
         except (ValidationError, TransactionFailed) as err:
@@ -133,10 +133,10 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         receipt = self.get_receipt(
             txn_hash.hex(),
             required_confirmations=txn.required_confirmations or 0,
-            raise_on_fail=txn._raise_on_fail,
+            raise_on_fail=raise_on_fail,
         )
 
-        if txn._raise_on_fail:
+        if raise_on_fail:
             receipt.raise_for_status()
 
         if txn.gas_limit is not None and receipt.ran_out_of_gas:

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -124,7 +124,7 @@ def test_get_failed_receipt(owner, vyper_contract_instance, eth_tester_provider)
     assert receipt.failed
 
 
-def test_get_failed_receipt_raise(owner, vyper_contract_instance, eth_tester_provider):
+def test_contract_method_raise_on_fail(owner, vyper_contract_instance, eth_tester_provider):
     # Setting to '5' always fails.
     with pytest.raises(TransactionError):
         vyper_contract_instance.setNumber(5, sender=owner, gas_limit=100000, raise_on_fail=True)

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -121,20 +121,20 @@ def test_decode_logs_unspecified_abi_gets_all_logs(owner, contract_instance):
 def test_get_failed_receipt(owner, vyper_contract_instance, eth_tester_provider):
     # Setting to '5' always fails.
     transaction = vyper_contract_instance.setNumber.as_transaction(
-        5, sender=owner, gas_limit=100000, _raise_on_fail=False
+        5, sender=owner, gas_limit=100000
     )
-    receipt = owner.call(transaction)
+    receipt = owner.call(transaction, raise_on_fail=False)
     assert receipt.failed
 
 
 def test_get_failed_receipt_raise(owner, vyper_contract_instance, eth_tester_provider):
     # Setting to '5' always fails.
     transaction = vyper_contract_instance.setNumber.as_transaction(
-        5, sender=owner, gas_limit=100000, _raise_on_fail=True
+        5, sender=owner, gas_limit=100000
     )
 
     with pytest.raises(TransactionError):
-        owner.call(transaction)
+        owner.call(transaction, raise_on_fail=True)
 
 
 def test_receipt_raise_for_status_out_of_gas_error(mocker, ethereum):

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -120,21 +120,14 @@ def test_decode_logs_unspecified_abi_gets_all_logs(owner, contract_instance):
 
 def test_get_failed_receipt(owner, vyper_contract_instance, eth_tester_provider):
     # Setting to '5' always fails.
-    transaction = vyper_contract_instance.setNumber.as_transaction(
-        5, sender=owner, gas_limit=100000
-    )
-    receipt = owner.call(transaction, raise_on_fail=False)
+    receipt = vyper_contract_instance.setNumber(5, sender=owner, gas_limit=100000)
     assert receipt.failed
 
 
 def test_get_failed_receipt_raise(owner, vyper_contract_instance, eth_tester_provider):
     # Setting to '5' always fails.
-    transaction = vyper_contract_instance.setNumber.as_transaction(
-        5, sender=owner, gas_limit=100000
-    )
-
     with pytest.raises(TransactionError):
-        owner.call(transaction, raise_on_fail=True)
+        vyper_contract_instance.setNumber(5, sender=owner, gas_limit=100000, raise_on_fail=True)
 
 
 def test_receipt_raise_for_status_out_of_gas_error(mocker, ethereum):

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -120,14 +120,25 @@ def test_decode_logs_unspecified_abi_gets_all_logs(owner, contract_instance):
 
 def test_get_failed_receipt(owner, vyper_contract_instance, eth_tester_provider):
     # Setting to '5' always fails.
-    receipt = vyper_contract_instance.setNumber(5, sender=owner, gas_limit=100000)
+    receipt = vyper_contract_instance.setNumber(
+        5,
+        sender=owner,
+        gas_limit=100000,
+        raise_on_fail=False,
+    )
+
     assert receipt.failed
 
 
 def test_contract_method_raise_on_fail(owner, vyper_contract_instance, eth_tester_provider):
     # Setting to '5' always fails.
     with pytest.raises(TransactionError):
-        vyper_contract_instance.setNumber(5, sender=owner, gas_limit=100000, raise_on_fail=True)
+        vyper_contract_instance.setNumber(
+            5,
+            sender=owner,
+            gas_limit=100000,
+            raise_on_fail=True,
+        )
 
 
 def test_receipt_raise_for_status_out_of_gas_error(mocker, ethereum):


### PR DESCRIPTION
### What I did

Begin adding in parameters to facilitate explicitly raising on transaction failure. We'll need transactions that fail to deliberately raise an exception for `RevertsContextManager`. That functionality is a dependency for the tracing ticket #251.

### How I did it

Adding `raise_on_fail: bool` parameter to the following:
- `ReceiptAPI.await_confirmations()` (default `False`)
- `ProviderAPI.get_receipt()` (default `False`)
- `ProviderAPI.send_transaction()` (default `True`)
- `AccountAPI.call()` (default `True`)
- `ImpersonatedAccount.call()` (default `True`)
- `Web3Provider.send_transaction()` (default `True`)
- `ContractTransaction.__call__()` (default `True`)
- `LocalProvider.send_transaction()` (default `True`)

### How to verify it

Added a test against flipping this parameter when calling the contract function to ensure that the transaction causes an exception rather than just returning a failed receipt

### Checklist
- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
