### PR TITLE
fix: issue where setting a config item would remove defaults of the other items

### DIFF
--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, BaseSettings
 
@@ -22,14 +22,35 @@ class PluginConfig(BaseSettings):
     a config API must register a subclass of this class.
     """
 
-    def __getitem__(self, attr_name: str) -> Any:
+    @classmethod
+    def from_overrides(cls, overrides: Dict) -> "PluginConfig":
+        default_values = cls().dict()
+
+        def update(root: Dict, value_map: Dict):
+            for key, val in value_map.items():
+                if key in root:
+                    if isinstance(val, dict):
+                        root[key] = update(root[key], val)
+                    else:
+                        root[key] = val
+
+            return root
+
+        return cls(**update(default_values, overrides))
+
+    def __getattr__(self, attr_name: str) -> Any:
         # allow hyphens in plugin config files
         attr_name = attr_name.replace("-", "_")
+        return super().__getattribute__(attr_name)
 
-        if not hasattr(self, attr_name):
-            raise AttributeError(f"{self.__class__.__name__} has no attr '{attr_name}'")
+    def __getitem__(self, item: str) -> Any:
+        return self.__dict__[item]
 
-        return getattr(self, attr_name)
+    def __contains__(self, key: str) -> bool:
+        return key in self.__dict__
+
+    def get(self, key: str, default: Optional[Any] = None) -> Any:
+        return self.__dict__.get(key, default)
 
 
 class GenericConfig(PluginConfig):

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -581,7 +581,7 @@ class NetworkAPI(BaseInterfaceModel):
 
     @property
     def _network_config(self) -> Dict:
-        return self.config.dict().get(self.name, {})
+        return self.config.get(self.name, {})
 
     @property
     def chain_id(self) -> int:

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -182,7 +182,7 @@ class ConfigManager(BaseInterfaceModel):
             user_override = user_config.pop(plugin_name, {})
             if config_class != ConfigDict:
                 # NOTE: Will raise if improperly provided keys
-                config = config_class(**user_override)  # type: ignore
+                config = config_class.from_overrides(user_override)  # type: ignore
             else:
                 # NOTE: Just use it directly as a dict if `ConfigDict` is passed
                 config = user_override
@@ -274,4 +274,6 @@ class ConfigManager(BaseInterfaceModel):
         self.PROJECT_FOLDER = initial_project_folder
         self.contracts_folder = initial_contracts_folder
         self.project_manager.path = initial_project_folder
-        os.chdir(initial_project_folder)
+
+        if initial_project_folder.is_dir():
+            os.chdir(initial_project_folder)

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -5,6 +5,7 @@ import pytest
 
 from ape.exceptions import NetworkError
 from ape.managers.config import DeploymentConfigCollection
+from ape_ethereum.ecosystem import NetworkConfig
 from tests.functional.conftest import PROJECT_WITH_LONG_CONTRACTS_FOLDER
 
 
@@ -43,6 +44,16 @@ def _create_deployments(ecosystem_name: str = "ethereum", network_name: str = "l
     }
 
 
+def test_ethereum_network_configs(config, temp_config):
+    eth_config = {"ethereum": {"rinkeby": {"default_provider": "test"}}}
+    with temp_config(eth_config):
+        actual = config.get_config("ethereum")
+        assert actual.rinkeby.default_provider == "test"
+
+        # Ensure that non-updated fields remain unaffected
+        assert actual.rinkeby.block_time == 15
+
+
 def test_default_provider_not_found(temp_config, networks):
     provider_name = "DOES_NOT_EXIST"
     network_name = "local"
@@ -61,3 +72,14 @@ def test_dependencies(dependency_config, config):
     assert config.dependencies[0].name == "testdependency"
     assert config.dependencies[0].contracts_folder == "source/v0.1"
     assert config.dependencies[0].local == str(PROJECT_WITH_LONG_CONTRACTS_FOLDER)
+
+
+def test_config_access():
+    config = NetworkConfig()
+    assert "default_provider" in config
+    assert (
+        config.default_provider
+        == config["default_provider"]
+        == getattr(config, "default-provider")
+        == "geth"
+    )


### PR DESCRIPTION
### What I did

During testing today, noticed that if I set a `default_provider` in my `ape-config.yaml` file, it would remove the default value of `block_time` that gets set in the ecosystem plugin.

It has to do with Pydantic models updating from keys where the value is a dict. It replace all the values instead of updating the sub-dicts individually.

### How I did it

Recursively update PluginConfig from user overrides. Made a helper class method for this (`from_overrides()`.

### How to verify it

Have a config file like this:

```yaml
ethereum:
  rinkeby:
    default_provider: alchemy
```

Launch a rinkeby console `ape console --network ethereum:rinkeby:infura`

Before my changes:

```python
In [2]: provider.network.block_time
Out[2]: 0
```

After my changes 

```python
In [2]: provider.network.block_time
Out[2]: 15
```

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
