### PR TITLE
feat: track deployments

### DIFF
--- a/docs/userguides/publishing.md
+++ b/docs/userguides/publishing.md
@@ -1,0 +1,33 @@
+# Publishing
+
+Publishing smart-contract packages using Ape is influenced from [EIP-2678](https://eips.ethereum.org/EIPS/eip-2678) and uses the [ethpm-types](https://github.com/ApeWorX/ethpm-types) Python package extensively (which is also managed by the ApeWorX organization).
+This guide exists to walk through the steps of publishing your project.
+
+## Compilation
+
+First, your project must compile.
+
+```bash
+ape compile
+```
+
+To learn more about project compilation, follow [this guide](./compile.html).
+Once your project has successfully compiled, you will have the start of your `PackageManifest` generated in your project's `.build/` directory.
+
+## Tracking Deployments
+
+If your project contains delpoyments that you wish to include in its package manifest, use the [track_deployment()](../methoddocs/managers.html#ape.managers.project.manager.ProjectManager.track_deployment) method.
+Example:
+
+```python
+from ape import accounts, project
+
+account = accounts.load("mainnet-account")
+
+# Assume your project has a contract named 'MyContract' with constructor that accepts argument '123'.
+contract = project.MyContract.deploy(123, sender=account)
+project.track_deployment(contract)
+```
+
+**NOTE**: If the contract is already deployed, you can use the [.at()](../methoddocs/contracts.html#ape.contracts.base.ContractContainer.at) method on the contract container to get an instance first.
+For more information on accessing contract instances, follow [this guide](./contracts.html).

--- a/docs/userguides/publishing.md
+++ b/docs/userguides/publishing.md
@@ -16,7 +16,7 @@ Once your project has successfully compiled, you will have the start of your `Pa
 
 ## Tracking Deployments
 
-If your project contains delpoyments that you wish to include in its package manifest, use the [track_deployment()](../methoddocs/managers.html#ape.managers.project.manager.ProjectManager.track_deployment) method.
+If your project contains deployments that you wish to include in its package manifest, use the [track_deployment()](../methoddocs/managers.html#ape.managers.project.manager.ProjectManager.track_deployment) method.
 Example:
 
 ```python
@@ -29,5 +29,13 @@ contract = project.MyContract.deploy(123, sender=account)
 project.track_deployment(contract)
 ```
 
-**NOTE**: If the contract is already deployed, you can use the [.at()](../methoddocs/contracts.html#ape.contracts.base.ContractContainer.at) method on the contract container to get an instance first.
+If the contract is already deployed, you can use [Contract](../methoddocs/ape.html#ape.Contract) to get a contract instance:
+
+```python
+from ape import Contract, project
+
+contract = Contract("0x12c17f958d2ee523a2206206994597c13d831e34")
+project.track_deployment(contract)
+```
+
 For more information on accessing contract instances, follow [this guide](./contracts.html).

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -164,7 +164,14 @@ class ProjectManager(BaseManager):
         return self.config_manager.meta  # type: ignore
 
     @property
-    def package_deployments(self) -> Dict[BIP122_URI, Dict[str, EthPMContractInstance]]:
+    def tracked_deployments(self) -> Dict[BIP122_URI, Dict[str, EthPMContractInstance]]:
+        """
+        Deployments that have been explicitly tracked via
+        :meth:`~ape.managers.project.manager.ProjectManager.track_deployment`.
+        These deployments will be included in the final package manifest upon publication
+        of this package.
+        """
+
         deployments: Dict[BIP122_URI, Dict[str, EthPMContractInstance]] = {}
         if not self._package_deployments_folder.is_dir():
             return deployments
@@ -219,7 +226,7 @@ class ProjectManager(BaseManager):
         manifest = self._project.create_manifest()
         manifest.meta = self.meta
         manifest.compilers = self.compiler_data
-        manifest.deployments = self.package_deployments
+        manifest.deployments = self.tracked_deployments
         return manifest
 
     @property

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -5,11 +5,13 @@ from typing import Dict, List, Optional, Type, Union
 from ethpm_types import Compiler
 from ethpm_types import ContractInstance as EthPMContractInstance
 from ethpm_types import ContractType, PackageManifest, PackageMeta
+from ethpm_types.contract_type import BIP122_URI
 
 from ape.api import DependencyAPI, ProjectAPI
 from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.contracts import ContractContainer, ContractInstance, ContractNamespace
 from ape.exceptions import ProjectError
+from ape.logging import logger
 from ape.managers.base import BaseManager
 from ape.managers.project.types import ApeProject, BrownieProject
 
@@ -109,15 +111,6 @@ class ProjectManager(BaseManager):
 
         return self.path / "interfaces"
 
-    def extract_manifest(self) -> PackageManifest:
-        """
-        Extracts a package manifest from the project
-
-        Returns:
-            ethpm_types.manifest.PackageManifest
-        """
-        return self._project.create_manifest()
-
     @property
     def scripts_folder(self) -> Path:
         """
@@ -161,6 +154,35 @@ class ProjectManager(BaseManager):
         return compilers
 
     @property
+    def meta(self) -> PackageMeta:
+        """
+        Metadata about the active project as per EIP
+        https://eips.ethereum.org/EIPS/eip-2678#the-package-meta-object
+        Use when publishing your package manifest.
+        """
+
+        return self.config_manager.meta  # type: ignore
+
+    @property
+    def package_deployments(self) -> Dict[BIP122_URI, Dict[str, EthPMContractInstance]]:
+        deployments: Dict[BIP122_URI, Dict[str, EthPMContractInstance]] = {}
+        if not self._package_deployments_folder.is_dir():
+            return deployments
+
+        for ecosystem_path in [x for x in self._package_deployments_folder.iterdir() if x.is_dir()]:
+            ecosystem_deployments = {}
+            for deploymenth_path in [x for x in ecosystem_path.iterdir() if x.suffix == ".json"]:
+                ethpm_instance = EthPMContractInstance.parse_raw(deploymenth_path.read_text())
+                ecosystem_deployments[deploymenth_path.stem] = ethpm_instance
+
+            if ecosystem_deployments:
+                bip122_chain_id = ecosystem_path.name
+                uri = BIP122_URI(f"blockchain://{bip122_chain_id}/block/{ethpm_instance.block}")
+                deployments[uri] = ecosystem_deployments
+
+        return deployments
+
+    @property
     def project_types(self) -> List[Type[ProjectAPI]]:
         """
         The available :class:`~ape.api.project.ProjectAPI` types available,
@@ -183,7 +205,26 @@ class ProjectManager(BaseManager):
                 self.path, self.contracts_folder
             )
 
-        return self._cached_projects[self.path.name]
+        project = self._cached_projects[self.path.name]
+        project.path = self.path
+        return project
+
+    def extract_manifest(self) -> PackageManifest:
+        """
+        Extracts a package manifest from the project
+
+        Returns:
+            ethpm_types.manifest.PackageManifest
+        """
+        manifest = self._project.create_manifest()
+        manifest.meta = self.meta
+        manifest.compilers = self.compiler_data
+        manifest.deployments = self.package_deployments
+        return manifest
+
+    @property
+    def _package_deployments_folder(self) -> Path:
+        return self._project._cache_folder / "deployments"
 
     def get_project(
         self,
@@ -472,16 +513,28 @@ class ProjectManager(BaseManager):
                 f"at block_number={block_number} is unknown."
             )
 
+        block_hash = block_hash_bytes.hex()
         artifact = EthPMContractInstance(
             address=contract.address,
-            block=block_hash_bytes.hex(),
+            block=block_hash,
             contractType=contract_name,
             transaction=contract.txn_hash,
             runtimeBytecode=contract.contract_type.runtime_bytecode,
         )
-        deployments_folder = self._project._cache_folder / "deployments"
-        deployments_folder.mkdir(exist_ok=True)
-        destination = deployments_folder / f"{contract.address}.json"
+
+        block_0_hash = self.provider.get_block(0).hash
+        if not block_0_hash:
+            raise ProjectError("Chain missing hash for block 0 (required for BIP-122 chain ID).")
+
+        bip122_chain_id = block_0_hash.hex()
+        deployments_folder = self._package_deployments_folder / bip122_chain_id
+        deployments_folder.mkdir(exist_ok=True, parents=True)
+        destination = deployments_folder / f"{contract_name}.json"
+
+        if destination.exists():
+            logger.warning("Deployment already tracked. Re-tracking.")
+            destination.unlink()
+
         destination.write_text(artifact.json())
 
     def _get_contract(self, name: str) -> Optional[ContractContainer]:
@@ -489,15 +542,6 @@ class ProjectManager(BaseManager):
             return self.chain_manager.contracts.get_container(self.contracts[name])
 
         return None
-
-    @property
-    def meta(self) -> PackageMeta:
-        """
-        Metadata about the active project as per EIP
-        https://eips.ethereum.org/EIPS/eip-2678#the-package-meta-object
-        Use when publishing your package manifest.
-        """
-        return self.config_manager.meta  # type: ignore
 
     # def publish_manifest(self):
     #     manifest = self.manifest.dict()

--- a/src/ape/utils/github.py
+++ b/src/ape/utils/github.py
@@ -42,7 +42,7 @@ class GithubClient:
     @cached_property
     def available_plugins(self) -> Set[str]:
         """
-        The available ``ape`` plugins, found from looking at the ``ApeWorx`` Github organization.
+        The available ``ape`` plugins, found from looking at the ``ApeWorX`` Github organization.
 
         Returns:
             Set[str]: The plugin names as ``'ape_plugin_name'`` (module-like).

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -14,6 +14,7 @@ from hexbytes import HexBytes
 
 import ape
 from ape.api import EcosystemAPI, NetworkAPI, TransactionAPI
+from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.contracts import ContractContainer, ContractInstance
 from ape.exceptions import ChainError, ContractLogicError
 from ape.logging import LogLevel
@@ -389,3 +390,10 @@ def use_debug(logger):
     logger.set_level(LogLevel.DEBUG)
     yield
     logger.set_level(initial_level)
+
+
+@pytest.fixture
+def dummy_live_network(chain):
+    chain.provider.network.name = "rinkeby"
+    yield
+    chain.provider.network.name = LOCAL_NETWORK_NAME

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -6,7 +6,6 @@ import pytest
 from hexbytes import HexBytes
 
 import ape
-from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.contracts import ContractInstance
 from ape.exceptions import APINotImplementedError, ChainError, ConversionError
 
@@ -14,13 +13,6 @@ from ape.exceptions import APINotImplementedError, ChainError, ConversionError
 @pytest.fixture(scope="module", autouse=True)
 def connection(networks_connected_to_tester):
     yield
-
-
-@pytest.fixture
-def dummy_live_network(chain):
-    chain.provider.network.name = "rinkeby"
-    yield
-    chain.provider.network.name = LOCAL_NETWORK_NAME
 
 
 @pytest.fixture

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -7,6 +7,8 @@ import yaml
 from ethpm_types import ContractInstance as EthPMContractInstance
 from ethpm_types.manifest import PackageManifest
 
+from ape import Contract
+from ape.exceptions import ProjectError
 from ape.managers.project import BrownieProject
 
 
@@ -30,6 +32,36 @@ def already_downloaded_dependencies(temp_config, config, oz_dependencies_config)
     shutil.copytree(oz_manifests, oz_manifests_dest)
     with temp_config(oz_dependencies_config):
         yield
+
+
+@pytest.fixture
+def bip122_chain_id(eth_tester_provider):
+    return eth_tester_provider.get_block(0).hash.hex()
+
+
+@pytest.fixture
+def base_deployments_path(project_manager, bip122_chain_id):
+    return project_manager._project._cache_folder / "deployments" / bip122_chain_id
+
+
+@pytest.fixture
+def deployment_path(vyper_contract_instance, base_deployments_path):
+    file_name = f"{vyper_contract_instance.contract_type.name}.json"
+    return base_deployments_path / file_name
+
+
+@pytest.fixture
+def contract_block_hash(eth_tester_provider, vyper_contract_instance):
+    block_number = vyper_contract_instance.receipt.block_number
+    return eth_tester_provider.get_block(block_number).hash.hex()
+
+
+@pytest.fixture
+def clean_deployments(base_deployments_path):
+    if base_deployments_path.is_dir():
+        shutil.rmtree(str(base_deployments_path))
+
+    yield
 
 
 def test_two_dependencies_with_same_name(already_downloaded_dependencies, project_manager):
@@ -105,21 +137,90 @@ def test_brownie_project_configure(config, base_projects_directory):
 
 
 def test_track_deployment(
-    project_manager, vyper_contract_instance, dummy_live_network, eth_tester_provider
+    clean_deployments,
+    project_manager,
+    vyper_contract_instance,
+    eth_tester_provider,
+    deployment_path,
+    contract_block_hash,
+    dummy_live_network,
+    bip122_chain_id,
 ):
-    build_folder = project_manager._project._cache_folder / "deployments"
-    expected_location = build_folder / f"{vyper_contract_instance.address}.json"
-    expected_block = eth_tester_provider.get_block(
-        vyper_contract_instance.receipt.block_number
-    ).hash.hex()
-    if expected_location.is_file():
-        expected_location.unlink()
-
+    contract = vyper_contract_instance
+    receipt = contract.receipt
+    name = contract.contract_type.name
+    address = vyper_contract_instance.address
     project_manager.track_deployment(vyper_contract_instance)
+    expected_block_hash = eth_tester_provider.get_block(receipt.block_number).hash.hex()
+    expected_uri = f"blockchain://{bip122_chain_id}/block/{expected_block_hash}"
+    expected_name = contract.contract_type.name
+    expected_code = contract.contract_type.runtime_bytecode
+    actual_from_file = EthPMContractInstance.parse_raw(deployment_path.read_text())
+    actual_from_class = project_manager.package_deployments[expected_uri][name]
+    assert actual_from_file.address == actual_from_class.address == address
+    assert actual_from_file.contract_type == actual_from_class.contract_type == expected_name
+    assert actual_from_file.transaction == actual_from_class.transaction == receipt.txn_hash
+    assert actual_from_file.runtime_bytecode == actual_from_class.runtime_bytecode == expected_code
+    assert len(project_manager.package_deployments) == 1
 
-    actual = EthPMContractInstance.parse_raw(expected_location.read_text())
-    assert actual.address == vyper_contract_instance.address
-    assert actual.block == expected_block
-    assert actual.contract_type == vyper_contract_instance.contract_type.name
-    assert actual.transaction == vyper_contract_instance.txn_hash
-    assert actual.runtime_bytecode == vyper_contract_instance.contract_type.runtime_bytecode
+
+def test_track_deployment_from_previously_deployed_contract(
+    clean_deployments,
+    project_manager,
+    vyper_contract_container,
+    eth_tester_provider,
+    dummy_live_network,
+    owner,
+    base_deployments_path,
+    bip122_chain_id,
+):
+    receipt = owner.deploy(vyper_contract_container, required_confirmations=0).receipt
+    address = receipt.contract_address
+    contract = Contract(address)
+    name = contract.contract_type.name
+    project_manager.track_deployment(contract)
+    path = base_deployments_path / f"{contract.contract_type.name}.json"
+    expected_block_hash = eth_tester_provider.get_block(receipt.block_number).hash.hex()
+    expected_uri = f"blockchain://{bip122_chain_id}/block/{expected_block_hash}"
+    expected_name = contract.contract_type.name
+    expected_code = contract.contract_type.runtime_bytecode
+    actual_from_file = EthPMContractInstance.parse_raw(path.read_text())
+    actual_from_class = project_manager.package_deployments[expected_uri][name]
+    assert actual_from_file.address == actual_from_class.address == address
+    assert actual_from_file.contract_type == actual_from_class.contract_type == expected_name
+    assert actual_from_file.transaction == actual_from_class.transaction == receipt.txn_hash
+    assert actual_from_file.runtime_bytecode == actual_from_class.runtime_bytecode == expected_code
+    assert len(project_manager.package_deployments) == 1
+
+
+def test_track_deployment_from_unknown_contract_missing_txn_hash(
+    clean_deployments,
+    project_manager,
+    vyper_contract_instance,
+    dummy_live_network,
+):
+    contract = Contract(vyper_contract_instance.address)
+    with pytest.raises(
+        ProjectError,
+        match=f"Contract '{contract.contract_type.name}' transaction receipt is unknown.",
+    ):
+        project_manager.track_deployment(contract)
+
+
+def test_track_deployment_from_unknown_contract_given_txn_hash(
+    clean_deployments,
+    project_manager,
+    vyper_contract_instance,
+    dummy_live_network,
+    base_deployments_path,
+):
+    address = vyper_contract_instance.address
+    txn_hash = vyper_contract_instance.txn_hash
+    contract = Contract(address, txn_hash=txn_hash)
+    project_manager.track_deployment(contract)
+    path = base_deployments_path / f"{contract.contract_type.name}.json"
+    actual = EthPMContractInstance.parse_raw(path.read_text())
+    assert actual.address == address
+    assert actual.contract_type == contract.contract_type.name
+    assert actual.transaction == txn_hash
+    assert actual.runtime_bytecode == contract.contract_type.runtime_bytecode

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -80,6 +80,9 @@ def test_extract_manifest(dependency_config, project_manager):
     manifest = project_manager.extract_manifest()
     assert type(manifest) == PackageManifest
     assert type(manifest.compilers) == list
+    assert manifest.meta == project_manager.meta
+    assert manifest.compilers == project_manager.compiler_data
+    assert manifest.deployments == project_manager.package_deployments
 
 
 def test_meta(temp_config, project_manager):

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -82,7 +82,7 @@ def test_extract_manifest(dependency_config, project_manager):
     assert type(manifest.compilers) == list
     assert manifest.meta == project_manager.meta
     assert manifest.compilers == project_manager.compiler_data
-    assert manifest.deployments == project_manager.package_deployments
+    assert manifest.deployments == project_manager.tracked_deployments
 
 
 def test_meta(temp_config, project_manager):
@@ -159,12 +159,12 @@ def test_track_deployment(
     expected_name = contract.contract_type.name
     expected_code = contract.contract_type.runtime_bytecode
     actual_from_file = EthPMContractInstance.parse_raw(deployment_path.read_text())
-    actual_from_class = project_manager.package_deployments[expected_uri][name]
+    actual_from_class = project_manager.tracked_deployments[expected_uri][name]
     assert actual_from_file.address == actual_from_class.address == address
     assert actual_from_file.contract_type == actual_from_class.contract_type == expected_name
     assert actual_from_file.transaction == actual_from_class.transaction == receipt.txn_hash
     assert actual_from_file.runtime_bytecode == actual_from_class.runtime_bytecode == expected_code
-    assert len(project_manager.package_deployments) == 1
+    assert len(project_manager.tracked_deployments) == 1
 
 
 def test_track_deployment_from_previously_deployed_contract(
@@ -188,12 +188,12 @@ def test_track_deployment_from_previously_deployed_contract(
     expected_name = contract.contract_type.name
     expected_code = contract.contract_type.runtime_bytecode
     actual_from_file = EthPMContractInstance.parse_raw(path.read_text())
-    actual_from_class = project_manager.package_deployments[expected_uri][name]
+    actual_from_class = project_manager.tracked_deployments[expected_uri][name]
     assert actual_from_file.address == actual_from_class.address == address
     assert actual_from_file.contract_type == actual_from_class.contract_type == expected_name
     assert actual_from_file.transaction == actual_from_class.transaction == receipt.txn_hash
     assert actual_from_file.runtime_bytecode == actual_from_class.runtime_bytecode == expected_code
-    assert len(project_manager.package_deployments) == 1
+    assert len(project_manager.tracked_deployments) == 1
 
 
 def test_track_deployment_from_unknown_contract_missing_txn_hash(


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #530 

### How I did it
<!-- Discuss the thought process behind the change -->

* Build the `EthPMContractInstance` artifact in the new `track_deployment()` method.
* Have it store the build artifact in `<project>/.build/deployments/<bip122-chain-id>/<contract-name>.json`.

### How to verify it

In an Ape project, run:

```python
from ape import accounts, project

acct = accounts.load("metamask0")
contract = project.MyContract.at("0x...")
project.track_deployment(contract)
```

The ensure the build artifact is present in the `deployments` list

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
