### PR TITLE
fix: incorrect log filters, broken logs with geth

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -339,7 +339,9 @@ class ContractEvent(ManagerAccessMixin):
 
     @property
     def log_filter(self):
-        return LogFilter.from_event(event=self.abi, addresses=[self.contract], start_block=0)
+        return LogFilter.from_event(
+            event=self.abi, addresses=[self.contract.address], start_block=0
+        )
 
     @singledispatchmethod
     def __getitem__(self, value) -> Union[ContractLog, List[ContractLog]]:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -339,7 +339,7 @@ class ContractEvent(ManagerAccessMixin):
 
     @property
     def log_filter(self):
-        return LogFilter(addresses=[self.contract], events=[self.abi])
+        return LogFilter.from_event(event=self.abi, addresses=[self.contract], start_block=0)
 
     @singledispatchmethod
     def __getitem__(self, value) -> Union[ContractLog, List[ContractLog]]:

--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -1,6 +1,6 @@
 import shutil
 from pathlib import Path
-from typing import Any, Dict, Iterator, Optional, Union
+from typing import Dict, Iterator, Optional, Union
 
 import ijson  # type: ignore
 import requests
@@ -24,7 +24,6 @@ from web3.exceptions import ExtraDataLengthError
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.middleware import geth_poa_middleware
 from web3.middleware.validation import MAX_EXTRADATA_LENGTH
-from web3.types import RPCEndpoint
 from yarl import URL
 
 from ape.api import PluginConfig, UpstreamProvider, Web3Provider

--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -295,18 +295,11 @@ class GethProvider(Web3Provider, UpstreamProvider):
 
     def get_call_tree(self, txn_hash: str, **root_node_kwargs) -> CallTreeNode:
         def _get_call_tree_from_parity():
-            response = self._make_request("trace_transaction", [txn_hash])
-            if "error" in response:
-                raise ProviderError(
-                    response["error"].get("message", f"Failed to get trace for '{txn_hash}'.")
-                )
-
-            raw_trace_list = response.get("result", [])
-
-            if not raw_trace_list:
+            result = self._make_request("trace_transaction", [txn_hash])
+            if not result:
                 raise ProviderError(f"Failed to get trace for '{txn_hash}'.")
 
-            traces = ParityTraceList.parse_obj(raw_trace_list)
+            traces = ParityTraceList.parse_obj(result)
             return get_calltree_from_parity_trace(traces)
 
         if "erigon" in self.client_version.lower():

--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -319,6 +319,3 @@ class GethProvider(Web3Provider, UpstreamProvider):
         except ValueError:
             frames = self.get_transaction_trace(txn_hash)
             return get_calltree_from_geth_trace(frames, **root_node_kwargs)
-
-    def _make_request(self, rpc: str, args: list) -> Any:
-        return self.web3.provider.make_request(RPCEndpoint(rpc), args)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,8 +120,8 @@ def networks_connected_to_tester():
 
 
 @pytest.fixture(scope="session")
-def ethereum(networks_connected_to_tester):
-    return networks_connected_to_tester.ethereum
+def ethereum(networks):
+    return networks.ethereum
 
 
 @pytest.fixture(scope="session")

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -127,5 +127,5 @@ def test_get_logs_when_connected_to_geth(vyper_contract_instance, eth_tester_pro
     vyper_contract_instance.setNumber(123, sender=owner)
     actual = vyper_contract_instance.NumberChange[-1]
     assert actual.event_name == "NumberChange"
-    assert actual.contract_address == "0xF7F78379391C5dF2Db5B66616d18fF92edB82022"
+    assert actual.contract_address == vyper_contract_instance.address
     assert actual.event_arguments["newNum"] == 123

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -17,13 +17,18 @@ def trace_response():
 
 
 @pytest.fixture
-def geth_provider(mock_network_api, mock_web3):
-    return create_geth(mock_network_api, mock_web3)
+def mock_network(mock_network_api, ethereum):
+    mock_network_api.name = LOCAL_NETWORK_NAME
+    mock_network_api.ecosystem = ethereum
+    return mock_network_api
+
+
+@pytest.fixture
+def geth_provider(mock_network, mock_web3):
+    return create_geth(mock_network, mock_web3)
 
 
 def create_geth(network, web3):
-    network.name = LOCAL_NETWORK_NAME
-    network.ecosystem.name = "ethereum"
     provider = GethProvider(
         name="geth",
         network=network,
@@ -71,18 +76,18 @@ def test_uri_default_value(geth_provider):
     assert geth_provider.uri == "http://localhost:8545"
 
 
-def test_uri_uses_value_from_config(mock_network_api, mock_web3, temp_config):
+def test_uri_uses_value_from_config(mock_network, mock_web3, temp_config):
     config = {"geth": {"ethereum": {"local": {"uri": "value/from/config"}}}}
     with temp_config(config):
-        provider = create_geth(mock_network_api, mock_web3)
+        provider = create_geth(mock_network, mock_web3)
         assert provider.uri == "value/from/config"
 
 
-def test_uri_uses_value_from_settings(mock_network_api, mock_web3, temp_config):
+def test_uri_uses_value_from_settings(mock_network, mock_web3, temp_config):
     # The value from the adhoc-settings is valued over the value from the config file.
     config = {"geth": {"ethereum": {"local": {"uri": "value/from/config"}}}}
     with temp_config(config):
-        provider = create_geth(mock_network_api, mock_web3)
+        provider = create_geth(mock_network, mock_web3)
         provider.provider_settings["uri"] = "value/from/settings"
         assert provider.uri == "value/from/settings"
 
@@ -98,11 +103,27 @@ def test_get_call_tree_erigon(mock_web3, geth_provider, trace_response):
     )
 
 
-def test_repr_disconnected(networks_connected_to_tester):
-    geth = networks_connected_to_tester.get_provider_from_choice("ethereum:local:geth")
+def test_repr_disconnected(networks):
+    geth = networks.get_provider_from_choice("ethereum:local:geth")
     assert repr(geth) == "<geth>"
 
 
 def test_repr_connected(mock_web3, geth_provider):
     mock_web3.eth.chain_id = 123
     assert repr(geth_provider) == "<geth chain_id=123>"
+
+
+def test_get_logs_when_connected_to_geth(
+    networks, vyper_contract_instance, eth_tester_provider, owner
+):
+    provider = create_geth(eth_tester_provider.network, eth_tester_provider.web3)
+    init_provider = networks.active_provider
+    networks.active_provider = provider
+
+    vyper_contract_instance.setNumber(123, sender=owner)
+    actual = vyper_contract_instance.NumberChange[0]
+    assert actual.event_name == "NumberChange"
+    assert actual.contract_address == "0xF7F78379391C5dF2Db5B66616d18fF92edB82022"
+    assert actual.event_arguments["newNum"] == 123
+
+    networks.active_provider = init_provider


### PR DESCRIPTION
### What I did
- fixed log fetching with geth provider, which had a `_make_request` before it was added to web3 provider with a different api. bug was introduced in #943.
- fixed `ContractEvent` instantiating a `LogFilter` with no search topics, which resulted in fetching all contract logs and not just the ones corresponding to the event.

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<img width="725" alt="Screen Shot 2022-08-10 at 21 16 39" src="https://user-images.githubusercontent.com/4562643/183976305-7ed6be15-ed19-4323-b27d-7a3a30f3d210.png">
<img width="591" alt="Screen Shot 2022-08-10 at 21 16 49" src="https://user-images.githubusercontent.com/4562643/183976313-9540bb2e-72a4-41e3-8357-0021f8be384b.png">


### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
