### PR TITLE
fix: handle repr on network API when no connected

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -67,6 +67,9 @@ class EcosystemAPI(BaseInterfaceModel):
 
     _default_network: str = LOCAL_NETWORK_NAME
 
+    def __repr__(self) -> str:
+        return f"<{self.name}>"
+
     @classmethod
     @abstractmethod
     def decode_address(cls, raw_address: RawAddress) -> AddressType:
@@ -568,7 +571,13 @@ class NetworkAPI(BaseInterfaceModel):
         )
 
     def __repr__(self) -> str:
-        return f"<{self.name} chain_id={self.chain_id}>"
+        try:
+            chain_id = self.chain_id
+        except ProviderNotConnectedError:
+            chain_id = None
+
+        content = f"{self.name} chain_id={self.chain_id}" if chain_id is not None else self.name
+        return f"<{content}>"
 
     @property
     def config(self) -> PluginConfig:
@@ -592,15 +601,7 @@ class NetworkAPI(BaseInterfaceModel):
         :py:attr:`ape.api.providers.ProviderAPI.chain_id`.
         """
 
-        provider = self.ecosystem.network_manager.active_provider
-
-        if not provider:
-            message = (
-                "Cannot determine 'chain_id', please make sure you are connected to a provider."
-            )
-            raise NetworkError(message)
-
-        return provider.chain_id
+        return self.provider.chain_id
 
     @property
     def network_id(self) -> int:

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -574,9 +574,11 @@ class NetworkAPI(BaseInterfaceModel):
         try:
             chain_id = self.chain_id
         except ProviderNotConnectedError:
+            # Only happens on local networks
             chain_id = None
 
-        content = f"{self.name} chain_id={self.chain_id}" if chain_id is not None else self.name
+        network_key = f"{self.ecosystem.name}:{self.name}"
+        content = f"{network_key} chain_id={self.chain_id}" if chain_id is not None else network_key
         return f"<{content}>"
 
     @property

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -29,7 +29,10 @@ class NetworkManager(BaseManager):
     _ecosystems_by_project: Dict[str, Dict[str, EcosystemAPI]] = {}
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} active_provider={repr(self.active_provider)}>"
+        provider = self.active_provider
+        class_name = self.__class__.__name__
+        content = f"{class_name} active_provider={repr(provider)}" if provider else class_name
+        return f"<{content}>"
 
     @property
     def active_provider(self) -> Optional[ProviderAPI]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,14 @@ def networks_connected_to_tester():
         yield ape.networks
 
 
+@pytest.fixture
+def networks_disconnected(networks):
+    provider = networks.active_provider
+    networks.active_provider = None
+    yield networks
+    networks.active_provider = provider
+
+
 @pytest.fixture(scope="session")
 def ethereum(networks_connected_to_tester):
     return networks_connected_to_tester.ethereum

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -113,9 +113,14 @@ def test_get_call_tree_erigon(mock_web3, geth_provider, trace_response):
     )
 
 
-def test_repr_disconnected(networks):
+def test_repr_on_local_network_and_disconnected(networks):
     geth = networks.get_provider_from_choice("ethereum:local:geth")
     assert repr(geth) == "<geth>"
+
+
+def test_repr_on_live_network_and_disconnected(networks):
+    geth = networks.get_provider_from_choice("ethereum:rinkeby:geth")
+    assert repr(geth) == "<geth chain_id=4>"
 
 
 def test_repr_connected(mock_web3, geth_provider):

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -135,21 +135,22 @@ def test_get_provider_when_not_found(networks):
     assert "'test' is not a valid provider for network 'rinkeby-fork'" in str(err.value)
 
 
-def test_repr(networks_connected_to_tester):
+def test_repr_connected_to_local(networks_connected_to_tester):
     actual = repr(networks_connected_to_tester)
     expected = f"<NetworkManager active_provider=<test chain_id={CHAIN_ID}>>"
     assert actual == expected
 
     # Check individual network
     actual = repr(networks_connected_to_tester.provider.network)
-    expected = f"<local chain_id={CHAIN_ID}>"
+    expected = f"<ethereum:local chain_id={CHAIN_ID}>"
     assert actual == expected
 
 
 def test_repr_disconnected(networks_disconnected):
     assert repr(networks_disconnected) == "<NetworkManager>"
     assert repr(networks_disconnected.ethereum) == "<ethereum>"
-    assert repr(networks_disconnected.ethereum.local) == "<local>"
+    assert repr(networks_disconnected.ethereum.local) == "<ethereum:local>"
+    assert repr(networks_disconnected.ethereum.rinkeby) == "<ethereum:rinkeby chain_id=4>"
 
 
 def test_get_provider_from_choice_adhoc_provider(networks_connected_to_tester):

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -114,7 +114,7 @@ def test_get_network_choices_filter_network(networks):
 def test_get_network_choices_filter_provider(networks):
     actual = {c for c in networks.get_network_choices(provider_filter="test")}
     expected = {"::test", ":local", "ethereum:local", "ethereum:local:test", "ethereum"}
-    assert actual == expected
+    assert all(e in actual for e in expected)
 
 
 def test_get_provider_when_no_default(network_with_no_providers):
@@ -144,6 +144,12 @@ def test_repr(networks_connected_to_tester):
     actual = repr(networks_connected_to_tester.provider.network)
     expected = f"<local chain_id={CHAIN_ID}>"
     assert actual == expected
+
+
+def test_repr_disconnected(networks_disconnected):
+    assert repr(networks_disconnected) == "<NetworkManager>"
+    assert repr(networks_disconnected.ethereum) == "<ethereum>"
+    assert repr(networks_disconnected.ethereum.local) == "<local>"
 
 
 def test_get_provider_from_choice_adhoc_provider(networks_connected_to_tester):


### PR DESCRIPTION
### What I did

While testing Blake's work, noticed this issue and it was bugging me so fixed it right quick.

### How I did it

Catch non connected error and it is ok!

### How to verify it

See tests

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
