### PR TITLE
test: ensure contract log str and repr work

### DIFF
--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -189,12 +189,15 @@ class ContractLog(BaseModel):
 
         return convert(value, AddressType)
 
+    @property
+    def _event_args_str(self) -> str:
+        return " ".join(f"{key}={val}" for key, val in self.event_arguments.items())
+
     def __str__(self) -> str:
-        args = " ".join(f"{key}={val}" for key, val in self.event_arguments.items())
-        return f"{self.event_name} {args}"
+        return f"{self.event_name}({self._event_args_str})"
 
     def __repr__(self) -> str:
-        return f"<{str(self)}>"
+        return f"<{self.event_name} {self._event_args_str}>"
 
     def __getattr__(self, item: str) -> Any:
         """

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -193,6 +193,9 @@ class ContractLog(BaseModel):
         args = " ".join(f"{key}={val}" for key, val in self.event_arguments.items())
         return f"{self.event_name} {args}"
 
+    def __repr__(self) -> str:
+        return f"<{str(self)}>"
+
     def __getattr__(self, item: str) -> Any:
         """
         Access properties from the log via ``.`` access.

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -76,6 +76,16 @@ def test_contract_log_serialization_with_hex_strings_and_non_checksum_addresses(
     assert obj.transaction_index == TXN_INDEX
 
 
+def test_contract_log_str(log):
+    obj = ContractLog.parse_obj(log.dict())
+    assert str(obj) == "MyEvent foo=0 bar=1"
+
+
+def test_contract_log_repr(log):
+    obj = ContractLog.parse_obj(log.dict())
+    assert repr(obj) == "<MyEvent foo=0 bar=1>"
+
+
 def test_contract_log_access(log):
     assert "foo" in log
     assert "bar" in log

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -78,7 +78,7 @@ def test_contract_log_serialization_with_hex_strings_and_non_checksum_addresses(
 
 def test_contract_log_str(log):
     obj = ContractLog.parse_obj(log.dict())
-    assert str(obj) == "MyEvent foo=0 bar=1"
+    assert str(obj) == "MyEvent(foo=0 bar=1)"
 
 
 def test_contract_log_repr(log):


### PR DESCRIPTION
### What I did

Adds missing tests that ensure `str()` and `repr()` work, as it was brought up by the community.
Now we know it for sure works in the latest.

### How I did it

Add tests.
Add `repr` method to `ContractLog`.

### How to verify it

tests

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
