### PR TITLE
refactor: change datatypes and keep `signature` element in `TransactionAPI`

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -11,7 +11,7 @@ from tqdm import tqdm  # type: ignore
 from ape.api.explorers import ExplorerAPI
 from ape.exceptions import TransactionError
 from ape.logging import logger
-from ape.types import ContractLog, TransactionSignature
+from ape.types import AddressType, ContractLog, TransactionSignature
 from ape.utils import BaseInterfaceModel, abstractmethod, raises_not_implemented
 
 if TYPE_CHECKING:
@@ -27,8 +27,8 @@ class TransactionAPI(BaseInterfaceModel):
     """
 
     chain_id: int = Field(0, alias="chainId")
-    receiver: Optional[str] = Field(None, alias="to")
-    sender: Optional[str] = Field(None, alias="from")
+    receiver: Optional[AddressType] = Field(None, alias="to")
+    sender: Optional[AddressType] = Field(None, alias="from")
     gas_limit: Optional[int] = Field(None, alias="gas")
     nonce: Optional[int] = None  # NOTE: `Optional` only to denote using default behavior
     value: int = 0
@@ -40,7 +40,7 @@ class TransactionAPI(BaseInterfaceModel):
     # If left as None, will get set to the network's default required confirmations.
     required_confirmations: Optional[int] = Field(None, exclude=True)
 
-    signature: Optional[TransactionSignature] = Field(exclude=True)
+    signature: Optional[TransactionSignature]
 
     class Config:
         allow_population_by_field_name = True

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -1,6 +1,6 @@
 import sys
 import time
-from typing import IO, TYPE_CHECKING, Iterator, List, Optional, Union
+from typing import Any, IO, TYPE_CHECKING, Iterator, List, Optional, Union
 
 from ethpm_types import HexBytes
 from ethpm_types.abi import EventABI
@@ -27,6 +27,7 @@ class TransactionAPI(BaseInterfaceModel):
     """
 
     chain_id: int = Field(0, alias="chainId")
+    hash: Any = Field(None, alias="txn_hash")
     receiver: Optional[AddressType] = Field(None, alias="to")
     sender: Optional[AddressType] = Field(None, alias="from")
     gas_limit: Optional[int] = Field(None, alias="gas")


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

Add `hash` to the `TransactionAPI`. Define as a `bytes` datatype
Change `sender` and `receiver` to `AddressType` and do not exclude `signature` from `TransactionAPI`.
Forces quite a bit of refactoring to prevent breaking anything upstream.

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #967 
blocks: #680 

### How I did it
<!-- Discuss the thought process behind the change -->
We currently bring `receiver` and `sender` in as string values, but they are addresses, and they should be defined as such. And signature is important information that we would like to be able to query, so excluding isn't the best option here.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->
All tests have to pass

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
