### PR TITLE
fix: warning from using LegacyVersion

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 from ethpm_types import Checksum, Compiler, ContractType, PackageManifest, Source
 from ethpm_types.manifest import PackageName
 from ethpm_types.utils import compute_checksum
-from packaging import version as version_util
+from packaging.version import InvalidVersion, Version
 from pydantic import ValidationError
 
 from ape.exceptions import APINotImplementedError, ProjectError
@@ -231,10 +231,13 @@ class DependencyAPI(BaseInterfaceModel):
     @property
     def _target_manifest_cache_file(self) -> Path:
         version_id = self.version_id
-        if isinstance(
-            version_util.parse(version_id), version_util.Version
-        ) and not version_id.startswith("v"):
-            version_id = f"v{version_id}"
+
+        try:
+            _ = Version(version_id)  # Will raise if can't parse
+            if not version_id.startswith("v"):
+                version_id = f"v{version_id}"
+        except InvalidVersion:
+            pass
 
         name = self.name
         return self.config_manager.packages_folder / name / version_id / f"{name}.json"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,11 @@ def project_manager():
 
 
 @pytest.fixture(scope="session")
+def dependency_manager(project_manager):
+    return project_manager.dependency_manager
+
+
+@pytest.fixture(scope="session")
 def keyparams():
     # NOTE: password is 'a'
     return {

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -1,0 +1,62 @@
+import shutil
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+
+@pytest.fixture
+def oz_dependencies_config():
+    def _create_oz_dependency(version: str) -> Dict:
+        return {
+            "name": "OpenZeppelin",
+            "version": version,
+            "github": "OpenZeppelin/openzeppelin-contracts",
+        }
+
+    return {"dependencies": [_create_oz_dependency("3.1.0"), _create_oz_dependency("4.4.2")]}
+
+
+@pytest.fixture
+def already_downloaded_dependencies(temp_config, config, oz_dependencies_config):
+    manifests_directory = Path(__file__).parent / "data" / "manifests"
+    oz_manifests = manifests_directory / "OpenZeppelin"
+    oz_manifests_dest = config.packages_folder / "OpenZeppelin"
+    shutil.copytree(oz_manifests, oz_manifests_dest)
+    with temp_config(oz_dependencies_config):
+        yield
+
+
+def test_two_dependencies_with_same_name(already_downloaded_dependencies, project_manager):
+    name = "OpenZeppelin"
+    oz_310 = project_manager.dependencies[name]["3.1.0"]
+    oz_442 = project_manager.dependencies[name]["4.4.2"]
+
+    assert oz_310.version == "3.1.0"
+    assert oz_310.name == name
+    assert oz_442.version == "4.4.2"
+    assert oz_442.name == name
+
+
+def test_dependency_with_longer_contracts_folder(
+    dependency_config, config, mocker, project_manager
+):
+    spy = mocker.patch("ape.managers.project.types.yaml")
+    _ = project_manager.dependencies
+    assert spy.safe_dump.call_args, "Config file never created"
+    call_config = spy.safe_dump.call_args[0][0]
+    assert call_config["contracts_folder"] == "source/v0.1"
+
+
+def test_dependency_with_non_version_version_id(recwarn, dependency_manager):
+    dependency_config = {
+        "github": "apeworx/testfoobartest",
+        "name": "foobar",
+        "branch": "main",
+    }
+    dependency = dependency_manager.decode_dependency(dependency_config)
+    _ = dependency.cached_manifest
+
+    # Tests against bug where we tried creating version objects ot of branch names
+    # thus causing warnings to show in `ape test` runs.
+    assert DeprecationWarning not in [w.category for w in recwarn.list]

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -57,6 +57,6 @@ def test_dependency_with_non_version_version_id(recwarn, dependency_manager):
     dependency = dependency_manager.decode_dependency(dependency_config)
     _ = dependency.cached_manifest
 
-    # Tests against bug where we tried creating version objects ot of branch names
+    # Tests against bug where we tried creating version objects out of branch names,
     # thus causing warnings to show in `ape test` runs.
     assert DeprecationWarning not in [w.category for w in recwarn.list]

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -1,45 +1,7 @@
-import shutil
-from pathlib import Path
-from typing import Dict
-
-import pytest
 import yaml
 from ethpm_types.manifest import PackageManifest
 
 from ape.managers.project import BrownieProject
-
-
-@pytest.fixture
-def oz_dependencies_config():
-    def _create_oz_dependency(version: str) -> Dict:
-        return {
-            "name": "OpenZeppelin",
-            "version": version,
-            "github": "OpenZeppelin/openzeppelin-contracts",
-        }
-
-    return {"dependencies": [_create_oz_dependency("3.1.0"), _create_oz_dependency("4.4.2")]}
-
-
-@pytest.fixture
-def already_downloaded_dependencies(temp_config, config, oz_dependencies_config):
-    manifests_directory = Path(__file__).parent / "data" / "manifests"
-    oz_manifests = manifests_directory / "OpenZeppelin"
-    oz_manifests_dest = config.packages_folder / "OpenZeppelin"
-    shutil.copytree(oz_manifests, oz_manifests_dest)
-    with temp_config(oz_dependencies_config):
-        yield
-
-
-def test_two_dependencies_with_same_name(already_downloaded_dependencies, project_manager):
-    name = "OpenZeppelin"
-    oz_310 = project_manager.dependencies[name]["3.1.0"]
-    oz_442 = project_manager.dependencies[name]["4.4.2"]
-
-    assert oz_310.version == "3.1.0"
-    assert oz_310.name == name
-    assert oz_442.version == "4.4.2"
-    assert oz_442.name == name
 
 
 def test_extract_manifest(dependency_config, project_manager):
@@ -65,16 +27,6 @@ def test_meta(temp_config, project_manager):
         assert project_manager.meta.description == "test"
         assert project_manager.meta.keywords == ["testing"]
         assert "https://apeworx.io" in project_manager.meta.links["apeworx.io"]
-
-
-def test_dependency_with_longer_contracts_folder(
-    dependency_config, config, mocker, project_manager
-):
-    spy = mocker.patch("ape.managers.project.types.yaml")
-    _ = project_manager.dependencies
-    assert spy.safe_dump.call_args, "Config file never created"
-    call_config = spy.safe_dump.call_args[0][0]
-    assert call_config["contracts_folder"] == "source/v0.1"
 
 
 def test_brownie_project_configure(config, base_projects_directory):


### PR DESCRIPTION
### What I did

Another distracting warning that kept appearing in my ape tests from using a dependency that used a branch.
The warning would be about the use of `LegacyVersion` which `packaging.parse()` will return if the given param is not a PEP440 version ID (such as the string `"main"`).

### How I did it

To remedy, instead of using `parse()`, we attempt to init a `Version()` directly and catch the error when it fails. Then, the warning never arrives. This also is slightly more efficient.

### How to verify it

When you run tests in a project that use a dependency that uses a branch n GitHub, you don't get the `LegacyVersion` warning.

See the test I added!

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
