### PR TITLE
fix: bug where plugin config would not update when default was empty dict

### DIFF
--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -28,11 +28,10 @@ class PluginConfig(BaseSettings):
 
         def update(root: Dict, value_map: Dict):
             for key, val in value_map.items():
-                if key in root:
-                    if isinstance(val, dict):
-                        root[key] = update(root[key], val)
-                    else:
-                        root[key] = val
+                if key in root and isinstance(val, dict):
+                    root[key] = update(root[key], val)
+                else:
+                    root[key] = val
 
             return root
 

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 import pytest
 
+from ape.api import PluginConfig
 from ape.exceptions import NetworkError
 from ape.managers.config import DeploymentConfigCollection
 from ape_ethereum.ecosystem import NetworkConfig
@@ -83,3 +84,16 @@ def test_config_access():
         == getattr(config, "default-provider")
         == "geth"
     )
+
+
+def test_plugin_config_updates_when_default_is_empty_dict():
+    class SubConfig(PluginConfig):
+        foo: int = 0
+        bar: int = 1
+
+    class MyConfig(PluginConfig):
+        sub: Dict[str, Dict[str, SubConfig]] = {}
+
+    overrides = {"sub": {"baz": {"test": {"foo": 5}}}}
+    actual = MyConfig.from_overrides(overrides)
+    assert actual.sub == {"baz": {"test": SubConfig(foo=5, bar=1)}}


### PR DESCRIPTION
### What I did

This unfortunately is causing issues in `ape-hardhat` right now.

### How I did it

Allows keys not present in case that subkeys are dicts instead of classes.

### How to verify it

See test!

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
