### PR TITLE
docs: fix web3 link and doc web3 prop

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -588,7 +588,7 @@ class TestProviderAPI(ProviderAPI):
 class Web3Provider(ProviderAPI, ABC):
     """
     A base provider mixin class that uses the
-    [web3.py](https://web3py.readthedocs.io/en/stable/) python package.
+    `web3.py <https://web3py.readthedocs.io/en/stable/>`__ python package.
     """
 
     _web3: Optional[Web3] = None
@@ -596,6 +596,10 @@ class Web3Provider(ProviderAPI, ABC):
 
     @property
     def web3(self) -> Web3:
+        """
+        Access to the ``web3`` object as if you did ``Web3(HTTPProvder(uri))``.
+        """
+
         if not self._web3:
             raise ProviderNotConnectedError()
 


### PR DESCRIPTION
### What I did

Noticed the link to web3.py was broken in the `Web3Provider` class doc.
Also think it is useful to include a doc str for the `web3` property so people know it is there.

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it

```sh
python build_docs.py
python -m http.server --directory "docs/_build/" --bind 127.0.0.1 1337
```

make sure link works
make sure can see `web3`  prop doc

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
