### PR TITLE
docs: better warning when multiple installation paths

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ exclude =
 	venv*
 	docs
 	build
-    .eggs
+	.eggs
 per-file-ignores =
     # Need signal handler before imports
     src/ape/__init__.py: E402

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ exclude =
 	venv*
 	docs
 	build
+    .eggs
 per-file-ignores =
     # Need signal handler before imports
     src/ape/__init__.py: E402

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,11 @@ extras_require = {
         "types-PyYAML",  # NOTE: Needed due to mypy typeshed
         "types-requests",  # NOTE: Needed due to mypy typeshed
         "types-pkg-resources",  # NOTE: Needed due to mypy typeshed
+        "pandas-stubs==1.2.0.62",  # NOTE: Needed due to mypy typeshed
         "flake8>=4.0.1,<5.0",  # Style linter
         "flake8-breakpoint>=1.1.0,<2.0.0",  # detect breakpoints left in code
         "flake8-print>=4.0.0,<5.0.0",  # detect print statements left in code
         "isort>=5.10.1,<6.0",  # Import sorting linter
-        "pandas-stubs==1.2.0.62",  # NOTE: Needed due to mypy types
     ],
     "doc": [
         "myst-parser>=0.17.0,<0.18",  # Tools for parsing markdown files in the docs
@@ -99,7 +99,7 @@ setup(
         "ipython>=7.31.1,<8",
         "packaging>=20.9,<21",
         "pandas>=1.3.0,<2",
-        "pluggy>=0.13.1,<1",
+        "pluggy>=1.0.0,<2",
         "pydantic>=1.9.0,<2",
         "pygit2>=1.7.2,<2",
         "PyGithub>=1.54,<2",

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -8,7 +8,7 @@ from typing import Any, Coroutine, Dict, List, Mapping, Optional
 import requests
 import yaml
 from hexbytes import HexBytes
-from importlib_metadata import PackageNotFoundError, packages_distributions
+from importlib_metadata import PackageNotFoundError, distributions, packages_distributions
 from importlib_metadata import version as version_metadata
 from tqdm.auto import tqdm  # type: ignore
 
@@ -46,6 +46,23 @@ def get_distributions():
     return packages_distributions()
 
 
+@lru_cache(maxsize=None)
+def _get_distributions(pkg_name: str) -> List:
+    """
+    Get a mapping of top-level packages to their distributions.
+    """
+
+    distros = []
+    all_distros = distributions()
+    for dist in all_distros:
+        package_names = (dist.read_text("top_level.txt") or "").split()
+        for name in package_names:
+            if name == pkg_name:
+                distros.append(dist)
+
+    return distros
+
+
 def get_package_version(obj: Any) -> str:
     """
     Get the version of a single package.
@@ -65,16 +82,25 @@ def get_package_version(obj: Any) -> str:
         obj = obj.__name__
 
     # Reduce module string to base package
-    # NOTE: Assumed that string input is module name e.g. ``__name__``
+    # NOTE: Assumed that string input is module name e.g. `__name__`
     pkg_name = obj.split(".")[0]
 
     # NOTE: In case the distribution and package name differ
-    dists = get_distributions()
-    if pkg_name in dists:
-        # NOTE: Shouldn't really be more than 1, but never know
-        if len(dists[pkg_name]) != 1:
-            logger.warning(f"duplicate pkg_name '{pkg_name}'")
-        pkg_name = dists[pkg_name][0]
+    dists = _get_distributions(pkg_name)
+    if dists:
+        num_packages = len(dists)
+        pkg_name = dists[0].metadata["Name"]
+
+        if num_packages != 1:
+            # Warn that there are more than 1 packages with this name,
+            # which can lead to odd behaviors.
+            found_paths = [str(d._path) for d in dists if hasattr(d, "_path")]
+            found_paths_str = ",\n\t".join(found_paths)
+            message = f"Found {num_packages} packages named '{pkg_name}'."
+            if found_paths:
+                message = f"{message}\nInstallation paths:\n\t{found_paths_str}"
+
+            logger.warning(message)
 
     try:
         return str(version_metadata(pkg_name))

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -92,7 +92,7 @@ def get_package_version(obj: Any) -> str:
         pkg_name = dists[0].metadata["Name"]
 
         if num_packages != 1:
-            # Warn that there are more than 1 packages with this name,
+            # Warn that there are more than 1 package with this name,
             # which can lead to odd behaviors.
             found_paths = [str(d._path) for d in dists if hasattr(d, "_path")]
             found_paths_str = ",\n\t".join(found_paths)

--- a/tests/functional/utils/test_misc.py
+++ b/tests/functional/utils/test_misc.py
@@ -1,7 +1,13 @@
 import pytest
+from packaging.version import Version
 
 from ape.exceptions import APINotImplementedError
-from ape.utils.misc import add_padding_to_strings, extract_nested_value, raises_not_implemented
+from ape.utils.misc import (
+    add_padding_to_strings,
+    extract_nested_value,
+    get_package_version,
+    raises_not_implemented,
+)
 
 
 def test_extract_nested_value():
@@ -34,3 +40,9 @@ def test_raises_not_implemented():
         "method not supported."
     )
     assert isinstance(err.value, NotImplementedError)
+
+
+def test_get_package_version():
+    version = get_package_version("ape")
+    # Fails if invalid version
+    assert Version(version)


### PR DESCRIPTION
### What I did

I am working through an environment issue today that is blocking me on everything.
I was also getting a warning about duplicate package names, I thought it might be related to my env issue, so I explored it.
Turns out, I somehow had an egg install of ape that I could not get rid of. It would appear everytime I did an editable install of ape because the egg file was in the ape directory, so it gave me warning: `WARNING: duplicate pkg_name 'ape'` or something... I wanted more info to help me debug it so I made it say this instead:

```
WARNING: Found 2 packages named 'eth-ape'.
Installation paths:
        /Users/jules/virtualenvs/alien/lib/python3.7/site-packages/eth_ape-0.4.4.dev1+ge33d2ca0.d20220815.dist-info,
        /Users/jules/PycharmProjects/ape/src/eth_ape.egg-info
```

Now I know exactly what is going on, I see the egg file and can delete it.

### How I did it

* Redefine `_get_distributions()` to be similar but keep track of more info on the distro object besides the name.
* Check for `_path` attr and adjust warning message to include path locations.

### How to verify it

Create an egg (From root ape dir):

```python
python setup.py bdist_egg
```

Run:

```sh
ape
```

Checkout the warning.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
