### PR TITLE
feat: required param in network option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ exclude =
 	venv*
 	docs
 	build
+	.eggs
 per-file-ignores =
     # Need signal handler before imports
     src/ape/__init__.py: E402

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -91,6 +91,8 @@ def network_option(
     ecosystem: Optional[Union[List[str], str]] = None,
     network: Optional[Union[List[str], str]] = None,
     provider: Optional[Union[List[str], str]] = None,
+    required: bool = False,
+    **kwargs,
 ):
     """
     A ``click.option`` for specifying a network.
@@ -98,16 +100,19 @@ def network_option(
     Args:
         default (Optional[str]): Optionally, change which network to
           use as the default. Defaults to how ``ape`` normally
-          selects a default network.
+          selects a default network unless ``required=True``, then defaults to ``None``.
         ecosystem (Optional[Union[List[str], str]]): Filter the options by ecosystem.
           Defaults to getting all ecosystems.
         network (Optional[Union[List[str], str]]): Filter the options by network.
           Defaults to getting all networks in ecosystems.
         provider (Optional[Union[List[str], str]]): Filter the options by provider.
           Defaults to getting all providers in networks.
+        required (bool): Whether the option is required. Defaults to ``False``.
+          When set to ``True``, the default value is ``None``.
+        kwargs: Additional overrides to ``click.option``.
     """
 
-    if not default:
+    if default is None and not required:
         if ecosystem:
             default = ecosystem[0] if isinstance(ecosystem, (list, tuple)) else ecosystem
         else:
@@ -122,6 +127,8 @@ def network_option(
         help="Override the default network and provider. (see `ape networks list` for options)",
         show_default=True,
         show_choices=False,
+        required=required,
+        **kwargs,
     )
 
 

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -148,3 +148,14 @@ def test_network_option_adhoc(runner, network_cmd, network_input):
     result = runner.invoke(network_cmd, ["--network", network_input])
     assert result.exit_code == 0, result.output
     assert OUTPUT_FORMAT.format(network_input) in result.output
+
+
+def test_network_option_make_required(runner):
+    @click.command()
+    @network_option(required=True)
+    def cmd(network):
+        click.echo(OUTPUT_FORMAT.format(network))
+
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == 2
+    assert "Error: Missing option '--network'." in result.output


### PR DESCRIPTION
### What I did

Add `required` parameter to `network_option`.

### How I did it

self explanatory!

### How to verify it

You can now require the user to input a value when they use the `--network` flag

```python
import click
from ape.cli import network_option


@click.command()
@network_option(required=True)
def cmd(network)
    print(network)
```

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
