### PR TITLE
fix: issue with editable plugins

### DIFF
--- a/src/ape/plugins/__init__.py
+++ b/src/ape/plugins/__init__.py
@@ -129,7 +129,7 @@ class PluginManager:
             editable_key = "__editable___"
             if name.startswith(f"{editable_key}ape_"):
                 # Handle strange editable install behavior
-                pattern = rf"{editable_key}(\w*)(_\d+_\d+_\d+a?\d*_dev\d+_[a-z|\d]{{8}}_finder)"
+                pattern = rf"{editable_key}(\w*)(_\d+_\d+_\d+a?\d*_dev\d+_\w*_finder)"
                 match = re.match(pattern, name)
                 if not match:
                     continue


### PR DESCRIPTION
### What I did

Editable plugin installation was giving me another issue with a value like this:

```
__editable___ape_starknet_0_4_0a2_dev0_gf91d85b_d20220818_finder
```

so this PR handles that.
**NOTE**: This is not really a user facing bug, only someone who develops plugins would hit this. There is not really an easy way to test this.

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
