### PR TITLE
feat!: publish contracts to explorer

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,8 +18,8 @@
    userguides/console
    userguides/contracts
    userguides/testing
-   userguides/scripts   
-   
+   userguides/scripts
+   userguides/publishing
 ```
 
 ```{eval-rst}

--- a/docs/userguides/publishing.md
+++ b/docs/userguides/publishing.md
@@ -39,3 +39,21 @@ project.track_deployment(contract)
 ```
 
 For more information on accessing contract instances, follow [this guide](./contracts.html).
+
+## Publishing to Explorer
+
+If you want to publish your contracts to an explorer, you can use the [publish_contract](../methoddocs/api.html#ape.explorers.ExplorerAPI.publish_contract) on the ``ExplorerAPI``.
+
+```python
+from ape import networks
+
+networks.provider.network.explorer.publish_contract("0x123...")
+```
+
+If you want to automatically publish the source code upon deployment, you can use the `publish=` kwarg on the deploy methods:
+
+```python
+from ape import accounts, project
+
+accounts.deploy(project.MyContract, publish=True)
+```

--- a/src/ape/api/compiler.py
+++ b/src/ape/api/compiler.py
@@ -24,12 +24,14 @@ class CompilerAPI(BaseInterfaceModel):
         ...
 
     @abstractmethod
-    def get_versions(self, all_paths: List[Path]) -> Set[str]:
+    def get_versions(self, all_paths: List[Path], with_commit_hash: bool = False) -> Set[str]:
         """
         Retrieve the set of available compiler versions for this plugin to compile ``all_paths``.
 
         Args:
             all_paths (List[pathlib.Path]): The list of paths.
+            with_commit_hash (bool): Set to ``True`` to include commit hashes
+              on the versions, if possible. Defaults to ``False``.
 
         Returns:
             Set[str]: A set of available compiler versions.
@@ -85,9 +87,25 @@ class CompilerAPI(BaseInterfaceModel):
 
     @raises_not_implemented
     def get_version_map(
-        self, contract_filepaths: List[Path], base_path: Optional[Path] = None
+        self,
+        contract_filepaths: List[Path],
+        base_path: Optional[Path] = None,
+        with_commit_hash: bool = False,
     ) -> Dict[Version, Set[Path]]:
-        pass
+        """
+        Get a map of versions to source paths.
+
+        Args:
+            contract_filepaths (List[Path]): Input source paths. Defaults to all source paths
+              per compiler.
+            base_path (Path): The base path of sources. Defaults to the project's
+              ``contracts_folder``.
+            with_commit_hash (bool): Set to ``True`` to include commit hashes on versions,
+              if possible. Defaults to ``False``.
+
+        Returns:
+            Dict[Version, Set[Path]]
+        """
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {self.name}>"

--- a/src/ape/api/explorers.py
+++ b/src/ape/api/explorers.py
@@ -66,3 +66,12 @@ class ExplorerAPI(BaseInterfaceModel):
         Returns:
             Iterator[:class:`~ape.api.transactions.ReceiptAPI`]
         """
+
+    @abstractmethod
+    def publish_contract(self, address: AddressType):
+        """
+        Publish a contract to the explorer.
+
+        Args:
+            address (``AddressType``): The address of the deployed contract.
+        """

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -19,6 +19,7 @@ from ape.exceptions import (
     ProviderNotConnectedError,
     SignatureError,
 )
+from ape.logging import logger
 from ape.types import AddressType, ContractLog, RawAddress
 from ape.utils import (
     DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT,
@@ -859,6 +860,22 @@ class NetworkAPI(BaseInterfaceModel):
             return self.use_provider(self.default_provider, provider_settings=provider_settings)
 
         raise NetworkError(f"No providers for network '{self.name}'.")
+
+    def publish_contract(self, address: AddressType):
+        """
+        A convenience method to publish a contract to the explorer.
+
+        Raises:
+            :class:`~ape.exceptions.NetworkError`: When there is no explorer for this network.
+
+        Args:
+            address (``AddressType``): The address of the contract.
+        """
+        if not self.explorer:
+            raise NetworkError("Unable to publish contract - no explorer plugin installed.")
+
+        logger.info(f"Publishing and verifying contract using '{self.explorer.name}'.")
+        self.explorer.publish_contract(address)
 
 
 def create_network_type(chain_id: int, network_id: int) -> Type[NetworkAPI]:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import click
 import pandas as pd
+from eth_typing import HexAddress, HexStr
 from ethpm_types import ContractType
 from ethpm_types.abi import ConstructorABI, EventABI, MethodABI
 from hexbytes import HexBytes
@@ -860,7 +861,7 @@ class ContractContainer(ManagerAccessMixin):
 
         return constructor.serialize_transaction(*args, **kwargs)
 
-    def deploy(self, *args, **kwargs) -> ContractInstance:
+    def deploy(self, publish: bool = False, *args, **kwargs) -> ContractInstance:
         txn = self(*args, **kwargs)
 
         if "sender" in kwargs and isinstance(kwargs["sender"], AccountAPI):
@@ -879,6 +880,11 @@ class ContractContainer(ManagerAccessMixin):
         logger.success(f"Contract '{contract_name}' deployed to: {styled_address}")
         instance = ContractInstance.from_receipt(receipt, self.contract_type)
         self.chain_manager.contracts.cache_deployment(instance)
+
+        if publish:
+            address = AddressType(HexAddress(HexStr(receipt.contract_address)))
+            self.provider.network.publish_contract(address)
+
         return instance
 
 


### PR DESCRIPTION
### What I did

Allow publishing contracts to explorer.

### How I did it

* Add API methods
* Adjust compiler versions in manifest during extraction

Related PRs:

https://github.com/ApeWorX/ape-etherscan/pull/38
https://github.com/ApeWorX/ape-solidity/pull/71

### How to verify it

Have all PRs installed and do:

```python
contract = project.TestContractSol.deploy(sender=owner, publish=True)
```

Should see output like:

```sh
etherscan URL: https://rinkeby.etherscan.io/tx/0x08e2fbaa265a426d5be6edf004c170f315c25219cb372ae52b2308faf46cfb14
Confirmations (2/2): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:35<00:00, 17.94s/it]
INFO: Confirmed 0x08e2fbaa265a426d5be6edf004c170f315c25219cb372ae52b2308faf46cfb14 (total fees paid = 1928449836782875)
SUCCESS: Contract 'TestContractSol' deployed to: 0x46461249d3174485eF795a10fDD10Ddf36ff8aae
INFO: Contract verification status: Pending in queue
INFO: Contract verification status: Pending in queue
INFO: Contract verification status: Pending in queue
SUCCESS: Contract verification successful!
```

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
