### PR TITLE
fix: filter sources when passing to compiler methods

### DIFF
--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -111,7 +111,7 @@ class CompilerManager(BaseManager):
         return contract_types_dict  # type: ignore
 
     def get_imports(
-        self, contract_filepaths: List[Path], base_path: Optional[Path]
+        self, contract_filepaths: List[Path], base_path: Optional[Path] = None
     ) -> Dict[str, List[str]]:
         """
         Combine import dicts from all compilers, where the key is a contract's source_id
@@ -127,6 +127,7 @@ class CompilerManager(BaseManager):
             Dict[str, List[str]]: A dictionary like ``{source_id: [import_source_id, ...], ...}``
         """
         imports_dict: Dict[str, List[str]] = {}
+        base_path = base_path or self.project_manager.contracts_folder
 
         for ext, compiler in self.registered_compilers.items():
             try:

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -128,11 +128,10 @@ class CompilerManager(BaseManager):
         """
         imports_dict: Dict[str, List[str]] = {}
 
-        for _, compiler in self.registered_compilers.items():
+        for ext, compiler in self.registered_compilers.items():
             try:
-                imports = compiler.get_imports(
-                    contract_filepaths=contract_filepaths, base_path=base_path
-                )
+                sources = [p for p in contract_filepaths if p.suffix == ext]
+                imports = compiler.get_imports(contract_filepaths=sources, base_path=base_path)
             except NotImplementedError:
                 imports = None
 

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -163,10 +163,9 @@ class ProjectManager(BaseManager):
                     raise (ProjectError(f"Unable to create version map for '{ext}'."))
 
                 version = versions[0]
-                filtered_paths = [p for p in self.source_paths if p.suffix == ext]
-                version_map = {version: filtered_paths}
+                version_map = {version: sources}
 
-            settings = compiler.get_compiler_settings(self.source_paths, contracts_folder)
+            settings = compiler.get_compiler_settings(sources, contracts_folder)
 
             for version, paths in version_map.items():
                 version_settings = settings.get(version, {}) if version and settings else {}

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -1,0 +1,3 @@
+def test_get_imports_only_includes_sources_from_compiler(project, compilers):
+    # See ape-solidity for better tests
+    assert not compilers.get_imports(project.source_paths)

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -182,3 +182,8 @@ def test_track_deployment_from_unknown_contract_given_txn_hash(
     assert actual.contract_type == contract.contract_type.name
     assert actual.transaction == txn_hash
     assert actual.runtime_bytecode == contract.contract_type.runtime_bytecode
+
+
+def test_compiler_data(project):
+    # See ape-solidity / ape-vyper for better tests
+    assert not project.compiler_data


### PR DESCRIPTION
### What I did

There are a couple places in core ape where we forget to filter sources paths being passed to the compilers.

### How I did it

* Filters sources by suffix before passing to compiler methods.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
