### PR TITLE
fix: handle another strange edition of editable plugin installations not registering

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -695,7 +695,6 @@ class NetworkAPI(BaseInterfaceModel):
         from ape.plugins import clean_plugin_name
 
         providers = {}
-
         for plugin_name, plugin_tuple in self.plugin_manager.providers:
             ecosystem_name, network_name, provider_class = plugin_tuple
             provider_name = clean_plugin_name(provider_class.__module__.split(".")[0])

--- a/src/ape/plugins/__init__.py
+++ b/src/ape/plugins/__init__.py
@@ -16,9 +16,9 @@ from .pluggy_patch import PluginType, hookimpl, plugin_manager
 from .project import DependencyPlugin, ProjectPlugin
 from .query import QueryPlugin
 
-EDITABLE_KEY = "__editable___"
-EDITABLE_INSTALL_PATTERN = re.compile(
-    rf"{EDITABLE_KEY}(\w*)(_\d+_\d+_\d+a?\d*[_dev\d+_]?\w*_finder)"
+_EDITABLE_KEY = "__editable___"
+_EDITABLE_INSTALL_PATTERN = re.compile(
+    rf"{_EDITABLE_KEY}(\w*)(_\d+_\d+_\d+a?\d*[_dev\d+_]?\w*_finder)"
 )
 
 
@@ -126,11 +126,11 @@ def valid_impl(api_class: Any) -> bool:
 
 
 def _get_name_from_install(name: str):
-    if not name.startswith(f"{EDITABLE_KEY}ape_"):
+    if not name.startswith(f"{_EDITABLE_KEY}ape_"):
         return name
 
     # Handle strange editable install behavior
-    match = re.match(EDITABLE_INSTALL_PATTERN, name)
+    match = re.match(_EDITABLE_INSTALL_PATTERN, name)
     if not match:
         return name
 

--- a/src/ape/plugins/__init__.py
+++ b/src/ape/plugins/__init__.py
@@ -147,7 +147,11 @@ class PluginManager:
     def __init__(self) -> None:
         # NOTE: This actually loads the plugins, and should only be done once
         for _, name, ispkg in pkgutil.iter_modules():
-            name = _get_name_from_install(name)
+            new_name = _get_name_from_install(name)
+            if new_name != name:
+                # Was an editable install
+                name = new_name
+                ispkg = True
 
             if not name.startswith("ape_") or not ispkg:
                 continue

--- a/src/ape/plugins/__init__.py
+++ b/src/ape/plugins/__init__.py
@@ -125,7 +125,7 @@ def valid_impl(api_class: Any) -> bool:
     return len(api_class.__abstractmethods__) == 0
 
 
-def get_name_from_install(name: str):
+def _get_name_from_install(name: str):
     if not name.startswith(f"{EDITABLE_KEY}ape_"):
         return name
 
@@ -147,7 +147,7 @@ class PluginManager:
     def __init__(self) -> None:
         # NOTE: This actually loads the plugins, and should only be done once
         for _, name, ispkg in pkgutil.iter_modules():
-            name = get_name_from_install(name)
+            name = _get_name_from_install(name)
 
             if not name.startswith("ape_") or not ispkg:
                 continue

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ape.plugins import get_name_from_install
+from ape.plugins import _get_name_from_install
 
 EXPECTED_PLUGIN_NAME = "plugin_name"
 
@@ -15,5 +15,5 @@ EXPECTED_PLUGIN_NAME = "plugin_name"
 )
 def test_get_name_from_install_editable_examples(name):
     editable_name = f"__editable___ape_{name}_finder"
-    actual = get_name_from_install(editable_name)
+    actual = _get_name_from_install(editable_name)
     assert actual == f"ape_{EXPECTED_PLUGIN_NAME}"

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -1,0 +1,19 @@
+import pytest
+
+from ape.plugins import get_name_from_install
+
+EXPECTED_PLUGIN_NAME = "plugin_name"
+
+
+@pytest.mark.parametrize(
+    "name",
+    (
+        f"{EXPECTED_PLUGIN_NAME}_0_4_1_dev1_g048574f",
+        f"{EXPECTED_PLUGIN_NAME}_0_4_1_dev1_g791b83a_d20220817",
+        f"{EXPECTED_PLUGIN_NAME}_0_4_0",
+    ),
+)
+def test_get_name_from_install_editable_examples(name):
+    editable_name = f"__editable___ape_{name}_finder"
+    actual = get_name_from_install(editable_name)
+    assert actual == f"ape_{EXPECTED_PLUGIN_NAME}"


### PR DESCRIPTION
### What I did

I attempted to install `ape-arbitrum` in editable mode and hit the same issue.
After investigating, I noticed the value was `__editable___ape_arbitrum_0_4_0_finder` which was not handled properly.

### How I did it

Adjust regex.
Add tests.

### How to verify it

Tracking all variations in a test now.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
