### PR TITLE
feat: add `ape` to console namespace

### DIFF
--- a/docs/userguides/console.md
+++ b/docs/userguides/console.md
@@ -21,6 +21,7 @@ Your console comes with pre-initialized root ape objects in your namespace.
 | `project`  | [ProjectManager](../methoddocs/managers.html?highlight=project#module-ape.managers.project.manager)        | 
 | `query`    | [QueryManager](../methoddocs/managers.html?highlight=query#module-ape.managers.query)                      |
 | `convert`  | [convert](../methoddocs/managers.html?highlight=query#ape.managers.converters.AddressAPIConverter.convert) |
+| `ape`      | [ape](../methoddocs/ape.html)                                                                              |
 
 You can access them as if they are already initialized:
 

--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -113,6 +113,7 @@ def console(project=None, verbose=None, extra_locals=None):
             faulthandler.enable()  # NOTE: In case we segfault
 
     namespace = {component: getattr(ape, component) for component in ape.__all__}
+    namespace["ape"] = ape
 
     if extra_locals:
         namespace.update(extra_locals)


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

As it is good practice to explicitly use the `np.` and `pd.` namespaces in larger scripts using numpy/pandas, some users prefer always using the ape prefix as in `ape.networks`, `ape.accounts` etc. for more clarity.

Having the `ape` name available by default in the console allows for sending code from script to console easily and using the same syntax/habits in both.

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
