### PR TITLE
feat: support querying properties of Blocks and Events

### DIFF
--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -49,7 +49,7 @@ def validate_and_expand_columns(columns: List[str], Model: Type[BaseInterfaceMod
         if len(selected_fields) > 0:
             return list(selected_fields)
 
-    raise ValueError(f"No valid fields in '{columns}'.")
+    raise ValueError(f"No valid fields in {columns}.")
 
 
 def extract_fields(item, columns):

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -1,3 +1,4 @@
+from functools import partial
 from itertools import islice
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
@@ -9,7 +10,7 @@ from hexbytes import HexBytes
 
 from ape.api import AccountAPI, ReceiptAPI, TransactionAPI
 from ape.api.address import BaseAddress
-from ape.api.query import ContractEventQuery
+from ape.api.query import ContractEventQuery, extract_fields
 from ape.exceptions import ArgumentsLengthError, ChainError, ContractError
 from ape.logging import logger
 from ape.types import AddressType, ContractLog, LogFilter
@@ -443,9 +444,8 @@ class ContractEvent(ManagerAccessMixin):
         contract_events = self.query_manager.query(
             contract_event_query, engine_to_use=engine_to_use
         )
-        return pd.DataFrame(
-            columns=contract_event_query.columns, data=[val.dict() for val in contract_events]
-        )
+        data = map(partial(extract_fields, columns=columns), contract_events)
+        return pd.DataFrame(columns=columns, data=data)
 
     def range(
         self,

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1,6 +1,7 @@
 import json
 import time
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from pathlib import Path
 from typing import Callable, Collection, Dict, Iterator, List, Optional, Tuple, Union, cast
 
@@ -10,7 +11,7 @@ from ethpm_types import ContractType
 from ape.api import BlockAPI, ReceiptAPI
 from ape.api.address import BaseAddress
 from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI, ProxyInfoAPI
-from ape.api.query import BlockQuery, validate_and_expand_columns
+from ape.api.query import BlockQuery, extract_fields, validate_and_expand_columns
 from ape.contracts import ContractContainer, ContractInstance
 from ape.exceptions import ChainError, ConversionError, UnknownSnapshotError
 from ape.logging import logger
@@ -139,17 +140,15 @@ class BlockContainer(BaseManager):
             )
 
         query = BlockQuery(
-            columns=list(self.head.__fields__),
+            columns=columns,
             start_block=start_block,
             stop_block=stop_block,
             step=step,
         )
 
         blocks = self.query_manager.query(query, engine_to_use=engine_to_use)
-        # NOTE: Allow any columns from ecosystem's BlockAPI class
-        # TODO: fetch the block fields from EcosystemAPI
-        columns = validate_and_expand_columns(columns, list(self.head.__fields__))  # type: ignore
-        blocks = map(lambda val: val.dict(by_alias=False), blocks)  # type: ignore
+        columns = validate_and_expand_columns(columns, self.head.__class__)  # type: ignore
+        blocks = map(partial(extract_fields, columns=columns), blocks)
         return pd.DataFrame(columns=columns, data=blocks)
 
     def range(

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 from ape.api.query import validate_and_expand_columns
+from ape.utils import BaseInterfaceModel
 from ape_test.providers import CHAIN_ID
 
 
@@ -60,31 +61,21 @@ def test_transaction_contract_event_query(contract_instance, owner, eth_tester_p
     assert df_events.event_name[0] == "FooHappened"
 
 
+class TestModel(BaseInterfaceModel):
+    number: int
+    timestamp: int
+
+
 def test_column_expansion():
-    all_fields = [
-        "chain_id",
-        "receiver",
-        "sender",
-        "gas_limit",
-        "nonce",
-        "value",
-        "data",
-        "type",
-        "max_fee",
-        "max_priority_fee",
-        "required_confirmations",
-        "signature",
-    ]
-    columns = validate_and_expand_columns(["*"], all_fields)
-    assert columns == all_fields
+    columns = validate_and_expand_columns(["*"], TestModel)
+    assert columns == list(TestModel.__fields__)
 
 
 def test_column_validation(eth_tester_provider):
-    all_fields = ["number", "timestamp"]
     with pytest.raises(ValueError, match="Unrecognized field 'numbr'"):
-        validate_and_expand_columns(["numbr"], all_fields)
+        validate_and_expand_columns(["numbr"], TestModel)
 
     with pytest.raises(
         ValueError, match=r"Duplicate fields in \['number', 'timestamp', 'number'\]"
     ):
-        validate_and_expand_columns(["number", "timestamp", "number"], all_fields)
+        validate_and_expand_columns(["number", "timestamp", "number"], TestModel)

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 import pandas as pd
+import pytest
 
 from ape.api.query import validate_and_expand_columns
 from ape.utils import BaseInterfaceModel
@@ -72,8 +73,13 @@ def test_column_expansion():
 
 
 def test_column_validation(eth_tester_provider, caplog):
-    with caplog.at_level(logging.WARNING):
+    with pytest.raises(ValueError) as exc_info:
         validate_and_expand_columns(["numbr"], Model)
+    assert exc_info.value.args[0] == "No valid fields in ['numbr']."
+    caplog.clear()
+
+    with caplog.at_level(logging.WARNING):
+        validate_and_expand_columns(["numbr", "timestamp"], Model)
 
     assert len(caplog.records) == 1
     assert "Unrecognized field(s) 'numbr'" in caplog.records[0].msg


### PR DESCRIPTION
### What I did
Refactor how dataframes are pulled from the query plugin system (pulls attributes from objects instead of using Pydantic's `.dict` method)

This allows querying objects that don't appear in a model's Pydantic schema

Also refactored how `validate_and_expand_columns` works so that you pass a model instead of a list of fields

### How I did it
slight abuse of MRO and `vars`

### How to verify it

`df = chain.blocks.query("transactions")`

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
