### PR TITLE
fix: bug when cached sources contain deleted references

### DIFF
--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -95,8 +95,7 @@ class BaseProject(ProjectAPI):
             cached_contract_types = manifest.contract_types or {}
             cached_source_reference_paths = {
                 source_id: [
-                    self.contracts_folder.joinpath(Path(s))
-                    for s in getattr(source, "references", []) or []
+                    self.contracts_folder.joinpath(Path(s)) for s in source.references or []
                 ]
                 for source_id, source in cached_sources.items()
             }
@@ -115,6 +114,8 @@ class BaseProject(ProjectAPI):
                 for name, contract_type in cached_contract_types.items()
                 if contract_type.source_id not in deleted_source_ids
             }
+            # TODO:
+            # cached_source_reference_paths = {p for p in }
 
             def does_need_compiling(source_path: Path) -> bool:
                 source_id = str(get_relative_path(source_path, self.contracts_folder))
@@ -144,7 +145,9 @@ class BaseProject(ProjectAPI):
             # NOTE: Recompile all dependent sources for a changed source
             while paths_to_compile:
                 source_id = str(get_relative_path(paths_to_compile.pop(), self.contracts_folder))
-                ref_paths = cached_source_reference_paths.get(source_id, [])
+                ref_paths = [
+                    s for s in cached_source_reference_paths.get(source_id, []) if s.is_file()
+                ]
                 referenced_paths.extend(ref_paths)
                 paths_to_compile.update(ref_paths)
 

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -114,8 +114,6 @@ class BaseProject(ProjectAPI):
                 for name, contract_type in cached_contract_types.items()
                 if contract_type.source_id not in deleted_source_ids
             }
-            # TODO:
-            # cached_source_reference_paths = {p for p in }
 
             def does_need_compiling(source_path: Path) -> bool:
                 source_id = str(get_relative_path(source_path, self.contracts_folder))

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -1,3 +1,3 @@
-def test_get_imports_only_includes_sources_from_compiler(project, compilers):
+def test_get_imports(project, compilers):
     # See ape-solidity for better tests
     assert not compilers.get_imports(project.source_paths)

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -96,7 +96,7 @@ def manifest_with_non_existent_sources(
 def _make_new_contract(existing_contract: ContractType, name: str):
     source_text = existing_contract.json()
     source_text = source_text.replace(f"{existing_contract.name}.vy", f"{name}.json")
-    source_text = source_text.replace(existing_contract.name, name)
+    source_text = source_text.replace(existing_contract.name or "", name)
     return ContractType.parse_raw(source_text)
 
 


### PR DESCRIPTION
### What I did

```greentext
> be me
> dont compile project for long time. get told about bug. now try to compile again
> *dies*
> realize that it is failing because there are references in the cached manifest pointing to the sources that no longer exist
> by references, I don't mean deleted source files... we handle those fine.. I mean that a file has "changes" but also in the cached manifest, it has reference entries but those point to non-existent files. that is what is missing.
> fix bug easily
> write a test but that takes a little while but feel good about it
```

### How I did it

Filter out deleted files.
Add test

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
