### PR TITLE
fix: ignore exceptions when given a contract type during `instance_at` / `Contract`

### DIFF
--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from ape.exceptions import ConversionError
 from ape.types import AddressType
 from ape.utils import BaseInterface, abstractmethod
 
@@ -25,7 +26,11 @@ class BaseAddress(BaseInterface):
         """
 
         convert = self.conversion_manager.convert
-        return convert(self, AddressType) == convert(other, AddressType)
+
+        try:
+            return convert(self, AddressType) == convert(other, AddressType)
+        except ConversionError:
+            return False
 
     def __dir__(self) -> List[str]:
         """

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -699,30 +699,39 @@ class ContractCache(BaseManager):
             :class:`~ape.contracts.base.ContractInstance`
         """
 
-        if contract_type and not isinstance(contract_type, ContractType):
-            raise TypeError("Expected type 'ContractType' for argument 'contract_type'.")
         try:
+            # Handles ENS domain names
             address = self.conversion_manager.convert(address, AddressType)
         except ConversionError:
             address = address
 
         address = self.provider.network.ecosystem.decode_address(address)
-        contract_type = self.get(address, default=contract_type)
-        if not txn_hash and contract_type:
+
+        try:
+            # Always attempt to get an existing contract type so that
+            # the caches update.
+            contract_type = self.get(address, default=contract_type)
+        except Exception as err:
+            if contract_type:
+                # If a default contract type was provided, don't error and use it.
+                logger.error(str(err))
+            else:
+                raise  # Current exception
+
+        if not contract_type:
+            raise ChainError(f"Failed to get contract type for address '{address}'.")
+        elif not isinstance(contract_type, ContractType):
+            raise TypeError(
+                f"Expected type '{ContractType.__name__}' for argument 'contract_type'."
+            )
+
+        if not txn_hash:
             # Check for txn_hash in deployments.
             deployments = self._deployments.get(contract_type.name) or []
             for deployment in deployments:
                 if deployment["address"] == address:
                     txn_hash = deployment.get("transaction_hash")
                     break
-
-        if not contract_type:
-            raise ChainError(f"Failed to get contract type for address '{address}'.")
-
-        elif not isinstance(contract_type, ContractType):
-            raise TypeError(
-                f"Expected type '{ContractType.__name__}' for argument 'contract_type'."
-            )
 
         return ContractInstance(address, contract_type, txn_hash=txn_hash)
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -708,8 +708,7 @@ class ContractCache(BaseManager):
         address = self.provider.network.ecosystem.decode_address(address)
 
         try:
-            # Always attempt to get an existing contract type so that
-            # the caches update.
+            # Always attempt to get an existing contract type to update caches
             contract_type = self.get(address, default=contract_type)
         except Exception as err:
             if contract_type:

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -285,5 +285,5 @@ def test_test_accounts_repr(test_accounts):
 
 
 def test_account_comparison_to_non_account(receiver):
-    # Before, would through a ConversionError. Expected to be False
+    # Before, would get a ConversionError.
     assert receiver != "foo"

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -282,3 +282,8 @@ def test_custom_num_of_test_accts_config(test_accounts, temp_config):
 def test_test_accounts_repr(test_accounts):
     actual = repr(test_accounts)
     assert all(a.address in actual for a in test_accounts)
+
+
+def test_account_comparison_to_non_account(receiver):
+    # Before, would through a ConversionError. Expected to be False
+    assert receiver != "foo"

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -275,7 +275,7 @@ def test_instance_at_when_given_name_as_contract_type(chain, contract_instance):
 
 
 def test_instance_at_uses_given_contract_type_when_retrieval_fails(mocker, chain, caplog):
-    # The manager always attempt retrieval so that default contact types can
+    # The manager always attempts retrieval so that default contact types can
     # get cached. However, sometimes an explorer plugin may fail. If given a contract-type
     # in that situation, we can use it and not fail and log the error instead.
     expected_contract_type = ContractType(contractName="foo", sourceId="foo.bar")

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -281,8 +281,16 @@ def test_instance_at_uses_given_contract_type_when_retrieval_fails(mocker, chain
     expected_contract_type = ContractType(contractName="foo", sourceId="foo.bar")
     new_address = "0x4a986a6dCA6dbf99bC3d17F8D71aFb0d60e740f8"
     expected_fail_message = "LOOK_FOR_THIS_FAIL_MESSAGE"
+    existing_fn = chain.contracts.get
+
+    def fn(addr, default=None):
+        if addr == new_address:
+            raise ValueError(expected_fail_message)
+
+        return existing_fn(addr, default=default)
+
     chain.contracts.get = mocker.MagicMock()
-    chain.contracts.get.side_effect = ValueError(expected_fail_message)
+    chain.contracts.get.side_effect = fn
 
     actual = chain.contracts.instance_at(new_address, contract_type=expected_contract_type)
     assert actual.contract_type == expected_contract_type


### PR DESCRIPTION
### What I did

Noticed that if my explorer breaks, which is does a lot during development, and if I don't have a cached contract type and I provide the contract type as a parameter, things don't work.

I'd expect things to still work since I am providing the contract type.

This makes things still work while refactoring / documenting the decisions as to why it is the way it is now.

Additionally, fixes a weird thing would happen when comparing `Address` classes to other non `Address` classes (minor fix but nice none-the-less)

### How I did it

In both cases, handle exceptions.

### How to verify it

* Install ape-etherscan
* Break it 
* Have a contract type locally that is deployed as well on a live network
* Try to create an instance using this contract type... Notice it won't work because of Etherscan.

See tests as examples too!

Also try comapring an address to something:

```python
account = accounts.test_accounts[0]
account == "foo"
>>> False
```
^ before it would raise `ConversionError`

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
