### PR TITLE
fix: load config as early as possible

### DIFF
--- a/src/ape/__init__.py
+++ b/src/ape/__init__.py
@@ -13,6 +13,7 @@ config = _ManagerAccessMixin.config_manager
 """
 The active configs for the current project. See :class:`ape.managers.config.ConfigManager`.
 """
+config.load()
 
 # Main types we export for the user
 compilers = _ManagerAccessMixin.compiler_manager

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -122,6 +122,7 @@ class ConfigManager(BaseInterfaceModel):
 
     @property
     def _plugin_configs(self) -> Dict[str, PluginConfig]:
+        default_contracts_folder = self.PROJECT_FOLDER / "contracts"
         project_name = self.PROJECT_FOLDER.stem
         if project_name in self._cached_configs:
             cache = self._cached_configs[project_name]
@@ -131,7 +132,7 @@ class ConfigManager(BaseInterfaceModel):
             self.meta = PackageMeta.parse_obj(cache.get("meta", {}))
             self.dependencies = cache.get("dependencies", [])
             self.deployments = cache.get("deployments", {})
-            self.contracts_folder = cache.get("contracts_folder", self.PROJECT_FOLDER / "contracts")
+            self.contracts_folder = cache.get("contracts_folder") or default_contracts_folder
             return cache
 
         # First, load top-level configs. Then, load all the plugin configs.
@@ -167,7 +168,7 @@ class ConfigManager(BaseInterfaceModel):
         contracts_folder = (
             Path(user_config.pop("contracts_folder")).expanduser().resolve()
             if "contracts_folder" in user_config
-            else self.PROJECT_FOLDER / "contracts"
+            else default_contracts_folder
         )
         self.contracts_folder = configs["contracts_folder"] = contracts_folder
 


### PR DESCRIPTION
### What I did

I hit a race condition where `contracts_folder` was `None` because the config didn't load in time based on what I was doing (writing tests inside of `ape-etherscan`).

This PR makes the config load the same time the Ape application is loaded.

### How I did it

Add `config.load()` to the `__init__.py` of ape

### How to verify it

I am curious of the repercussions of this.
I am also curious about possible better places to do this.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
