### PR TITLE
refactor: make stdout-logger only log debug, not info

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1054,7 +1054,7 @@ class SubprocessProvider(ProviderAPI):
         for line in self.stdout_queue:
             output = line.decode("utf8").strip()
             logger.debug(output)
-            self._stdout_logger.info(output)
+            self._stdout_logger.debug(output)
 
             if self.stdout_queue is not None:
                 self.stdout_queue.task_done()
@@ -1064,7 +1064,7 @@ class SubprocessProvider(ProviderAPI):
     def consume_stderr_queue(self):
         for line in self.stderr_queue:
             logger.debug(line.decode("utf8").strip())
-            self._stdout_logger.info(line)
+            self._stdout_logger.debug(line)
 
             if self.stderr_queue is not None:
                 self.stderr_queue.task_done()


### PR DESCRIPTION
Otherwise puts out a lot of noise:
![image](https://user-images.githubusercontent.com/3859395/187793418-cb567b80-44c0-4750-a75d-11a77ae5a1da.png)
