### PR TITLE
feat: handle contract genesis receipts during account history caching

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -349,6 +349,7 @@ class AccountHistory(BaseManager):
         explorer_receipts = (
             [r for r in explorer.get_account_transactions(address_key)] if explorer else []
         )
+
         for receipt in explorer_receipts:
             if receipt.txn_hash not in [r.txn_hash for r in self._map.get(address_key, [])]:
                 if receipt.sender.upper() == "GENESIS":
@@ -391,12 +392,7 @@ class AccountHistory(BaseManager):
               :meth:`~ape.managers.chain.AccountHistory.__getitem__`.
         """
 
-        if txn_receipt.sender.upper() == "GENESIS":
-            # Cache genesis transactions as contract address
-            address = txn_receipt.receiver
-        else:
-            address = self.conversion_manager.convert(txn_receipt.sender, AddressType)
-
+        address = self.conversion_manager.convert(txn_receipt.sender, AddressType)
         if address not in self._map:
             self._map[address] = [txn_receipt]
             return

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -107,8 +107,7 @@ def test_account_history_handles_contract_genesis(
     # the word 'GENESIS' and the hash has 'GENESIS' prefixed in front.
     # This test makes sure we can handle such receipt.
     contract = sender.deploy(vyper_contract_container)
-    mock_network = mocker.MagicMock()
-    mock_explorer = mocker.MagicMock()
+    network = ethereum.local
     genesis_receipt = Receipt(
         block_number=0,
         gas_price=0,
@@ -125,11 +124,11 @@ def test_account_history_handles_contract_genesis(
         if address == contract.address:
             yield from [genesis_receipt]
 
+    mock_explorer = mocker.MagicMock()
     mock_explorer.get_account_transactions.side_effect = get_txns_patch
-    mock_network.explorer = mock_explorer
-    mock_network.ecosystem = ethereum
-    eth_tester_provider.network = mock_network
+    network.__dict__["explorer"] = mock_explorer
 
+    eth_tester_provider.network = network
     actual = [t for t in chain.account_history[contract.address]]
 
     assert len(actual) == 1


### PR DESCRIPTION
### What I did

**Whilst working on Publishing**, noticed that it bugs out when getting receipts from contract addresses during the genesis receipt.

Allow using chain.account_history to cache genesis receipts from contracts

### How I did it

When the sender is `GENESIS`, set the sender to the contract address.

### How to verify it

Use an explorer plugin like `ape-etherscan` to get the first receipt of a contract.

```python
chain.account_history[<contract-address>]
```

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
