### PR TITLE
fix: check sender for already-cached receipt instead of address key

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -359,7 +359,8 @@ class AccountHistory(BaseManager):
 
             # NOTE: Cache the receipt by its sender and not by the address sent to the explorer API
             #  because explorers return various receipts when given contract addresses.
-            if receipt.txn_hash not in [r.txn_hash for r in self._map.get(receipt.sender, [])]:
+            sender: AddressType = receipt.sender  # type: ignore
+            if receipt.txn_hash not in [r.txn_hash for r in self._map.get(sender, [])]:
                 self.append(receipt)
 
         return self._map.get(address_key, [])

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -356,7 +356,10 @@ class AccountHistory(BaseManager):
             [r for r in explorer.get_account_transactions(address_key)] if explorer else []
         )
         for receipt in explorer_receipts:
-            if receipt.txn_hash not in [r.txn_hash for r in self._map.get(address_key, [])]:
+
+            # NOTE: Cache the receipt by its sender and not by the address sent to the explorer API
+            #  because explorers return various receipts when given contract addresses.
+            if receipt.txn_hash not in [r.txn_hash for r in self._map.get(receipt.sender, [])]:
                 self.append(receipt)
 
         return self._map.get(address_key, [])

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -8,6 +8,7 @@ from hexbytes import HexBytes
 import ape
 from ape.contracts import ContractInstance
 from ape.exceptions import APINotImplementedError, ChainError, ConversionError
+from ape_ethereum.transactions import Receipt, TransactionStatusEnum
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -97,6 +98,45 @@ def test_account_history(sender, receiver, chain):
     txn = transactions_from_cache[-1]
     assert txn.sender == receipt.sender == sender
     assert txn.receiver == receipt.receiver == receiver
+
+
+def test_account_history_caches_sender_over_address_key(
+    mocker, chain, eth_tester_provider, sender, vyper_contract_container, ethereum
+):
+    # When getting receipts from the explorer for contracts, it includes transactions
+    # made to the contract. This test shows we cache by sender and not address key.
+    contract = sender.deploy(vyper_contract_container)
+    network = ethereum.local
+    known_receipt = Receipt(
+        block_number=10,
+        gas_price=11,
+        gas_used=12,
+        gas_limit=13,
+        status=TransactionStatusEnum.NO_ERROR.value,
+        receiver=contract.address,
+        txn_hash="0x98d2aee8617897b5983314de1d6ff44d1f014b09575b47a88267971beac97b2b",
+        sender=sender.address,
+        value=10000000000000000000000,
+    )
+
+    # The receipt is already known and cached by the sender.
+    chain.account_history.append(known_receipt)
+
+    # We ask for receipts from the contract, but it returns ones sent to the contract.
+    def get_txns_patch(address):
+        if address == contract.address:
+            yield from [known_receipt]
+
+    mock_explorer = mocker.MagicMock()
+    mock_explorer.get_account_transactions.side_effect = get_txns_patch
+    network.__dict__["explorer"] = mock_explorer
+    eth_tester_provider.network = network
+
+    # Previously, this would error because the receipt was cached with the wrong sender
+    actual = [t for t in chain.account_history[contract.address]]
+
+    # Actual is 0 because the receipt was cached under the sender.
+    assert len(actual) == 0
 
 
 def test_iterate_blocks(chain_that_mined_5):


### PR DESCRIPTION
### What I did

When you ask for receipts using an explorer for a contract address, you get back transactions made to the contract as well. This would cause a collisional error via a caching mistake because of a faulty check before caching where we checked for the contract address instead of the sender. This caused errors.

This PR fixes the check to use the sender instead. Now, there are no more errors.
I added a test to be sure. This test fails when undoing the single line of source change.

### How I did it

Use `receipt.sender` instead of `address_key`.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
