### PR TITLE
refactor!: warn instead of err when appending a known txn

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -403,7 +403,8 @@ class AccountHistory(BaseManager):
             return
 
         if txn_receipt.txn_hash in [r.txn_hash for r in self._map[address]]:
-            raise ChainError(f"Transaction '{txn_receipt.txn_hash}' already known.")
+            logger.warning(f"Transaction '{txn_receipt.txn_hash}' already known.")
+            return
 
         self._map[address].append(txn_receipt)
 


### PR DESCRIPTION
### What I did

It can be annoying when appending a known transaction and it error.
I think a warning is better so you don't fail everything.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
