### PR TITLE
refactor: Use `AddressType` instead of `str` when possible

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -206,12 +206,12 @@ class ProviderAPI(BaseInterfaceModel):
         """
 
     @abstractmethod
-    def get_nonce(self, address: str) -> int:
+    def get_nonce(self, address: AddressType) -> int:
         """
         Get the number of times an account has transacted.
 
         Args:
-            address (str): The address of the account.
+            address (``AddressType``): The address of the account.
 
         Returns:
             int

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -28,8 +28,8 @@ class TransactionAPI(BaseInterfaceModel):
     """
 
     chain_id: int = Field(0, alias="chainId")
-    receiver: Optional[str] = Field(None, alias="to")
-    sender: Optional[str] = Field(None, alias="from")
+    receiver: Optional[AddressType] = Field(None, alias="to")
+    sender: Optional[AddressType] = Field(None, alias="from")
     gas_limit: Optional[int] = Field(None, alias="gas")
     nonce: Optional[int] = None  # NOTE: `Optional` only to denote using default behavior
     value: int = 0

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -574,7 +574,7 @@ class ContractInstance(BaseAddress):
 
     def __init__(
         self,
-        address: Union[AddressType, str],
+        address: AddressType,
         contract_type: ContractType,
         txn_hash: Optional[str] = None,
     ) -> None:
@@ -631,7 +631,7 @@ class ContractInstance(BaseAddress):
             ``AddressType``
         """
 
-        return self.provider.network.ecosystem.decode_address(self._address)
+        return self._address
 
     @cached_property
     def _view_methods_(self) -> Dict[str, ContractCallHandler]:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -705,7 +705,7 @@ class ContractCache(BaseManager):
         """
 
         if self.conversion_manager.is_type(address, AddressType):
-            contract_address: AddressType = address  # type: ignore
+            contract_address = cast(AddressType, address)
         else:
             try:
                 contract_address = self.conversion_manager.convert(address, AddressType)

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -680,7 +680,7 @@ class ContractCache(BaseManager):
 
     def instance_at(
         self,
-        address: Union[str, "AddressType"],
+        address: AddressType,
         contract_type: Optional[ContractType] = None,
         txn_hash: Optional[str] = None,
     ) -> ContractInstance:
@@ -709,8 +709,6 @@ class ContractCache(BaseManager):
             address = self.conversion_manager.convert(address, AddressType)
         except ConversionError:
             address = address
-
-        address = self.provider.network.ecosystem.decode_address(address)
 
         try:
             # Always attempt to get an existing contract type to update caches

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -680,7 +680,7 @@ class ContractCache(BaseManager):
 
     def instance_at(
         self,
-        address: AddressType,
+        address: Union[str, AddressType],
         contract_type: Optional[ContractType] = None,
         txn_hash: Optional[str] = None,
     ) -> ContractInstance:
@@ -704,12 +704,17 @@ class ContractCache(BaseManager):
             :class:`~ape.contracts.base.ContractInstance`
         """
 
-        if not self.conversion_manager.is_type(address, AddressType):
-            address = self.conversion_manager.convert(address, AddressType)
+        if self.conversion_manager.is_type(address, AddressType):
+            contract_address: AddressType = address  # type: ignore
+        else:
+            try:
+                contract_address = self.conversion_manager.convert(address, AddressType)
+            except ConversionError as err:
+                raise ValueError(f"Unknown address value '{contract_address}'.") from err
 
         try:
             # Always attempt to get an existing contract type to update caches
-            contract_type = self.get(address, default=contract_type)
+            contract_type = self.get(contract_address, default=contract_type)
         except Exception as err:
             if contract_type:
                 # If a default contract type was provided, don't error and use it.
@@ -718,7 +723,7 @@ class ContractCache(BaseManager):
                 raise  # Current exception
 
         if not contract_type:
-            raise ChainError(f"Failed to get contract type for address '{address}'.")
+            raise ChainError(f"Failed to get contract type for address '{contract_address}'.")
         elif not isinstance(contract_type, ContractType):
             raise TypeError(
                 f"Expected type '{ContractType.__name__}' for argument 'contract_type'."
@@ -728,11 +733,11 @@ class ContractCache(BaseManager):
             # Check for txn_hash in deployments.
             deployments = self._deployments.get(contract_type.name) or []
             for deployment in deployments:
-                if deployment["address"] == address:
+                if deployment["address"] == contract_address:
                     txn_hash = deployment.get("transaction_hash")
                     break
 
-        return ContractInstance(address, contract_type, txn_hash=txn_hash)
+        return ContractInstance(contract_address, contract_type, txn_hash=txn_hash)
 
     def get_deployments(self, contract_container: ContractContainer) -> List[ContractInstance]:
         """

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -710,7 +710,7 @@ class ContractCache(BaseManager):
             try:
                 contract_address = self.conversion_manager.convert(address, AddressType)
             except ConversionError as err:
-                raise ValueError(f"Unknown address value '{contract_address}'.") from err
+                raise ValueError(f"Unknown address value '{address}'.") from err
 
         try:
             # Always attempt to get an existing contract type to update caches

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -704,11 +704,8 @@ class ContractCache(BaseManager):
             :class:`~ape.contracts.base.ContractInstance`
         """
 
-        try:
-            # Handles ENS domain names
+        if not self.conversion_manager.is_type(address, AddressType):
             address = self.conversion_manager.convert(address, AddressType)
-        except ConversionError:
-            address = address
 
         try:
             # Always attempt to get an existing contract type to update caches

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -294,10 +294,9 @@ def test_instance_at(chain, contract_instance):
 
 def test_instance_at_unknown_hex_str(chain, contract_instance):
     # Fails when decoding Ethereum address and NOT conversion error.
-    with pytest.raises(ValueError):
-        chain.contracts.instance_at(
-            "0x1402b10CA274cD76C441e16C844223F79D3566De12bb12b0aebFE41aDFAe302"
-        )
+    hex_str = "0x1402b10CA274cD76C441e16C844223F79D3566De12bb12b0aebFE41aDFAe302"
+    with pytest.raises(ValueError, match=f"Unknown address value '{hex_str}'."):
+        chain.contracts.instance_at(hex_str)
 
 
 def test_instance_at_when_given_contract_type(chain, contract_instance):


### PR DESCRIPTION
### What I did

* Changes `txn.sender` and `txn.receiver` to be `AddressType` instead of `str`
* Changes `chain.contract.instance_at()` to only accept `AddressType` and not `str`
* Changes `ContractInstance` to only accept `AddressType` and not `str`
* Removed unneeded calls to `decode_address()`

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
