### PR TITLE
chore: pin evm-trace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,4 @@ repos:
 
 
 default_language_version:
-    python: python3.8
+    python: python3.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ write_to = "src/ape/version.py"
 # character.
 [tool.black]
 line-length = 100
-target-version = ['py37', 'py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310']
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
         # ** Dependencies maintained by Apeworx **
         "eip712>=0.1.1,<0.2",
         "ethpm-types>=0.3.2,<0.4",
-        "evm-trace>=0.1.0.a6",
+        "evm-trace==0.1.0.a7",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],


### PR DESCRIPTION
### What I did
Pinning evm-trace to 0.1.0a7 so that we can refactor tracing with out breaking the API layer.

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
