### PR TITLE
fix: properly calling receipt transaction objects in tests

### DIFF
--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -91,7 +91,7 @@ def test_transfer_with_prompts(runner, receiver, keyfile_account):
     # "y\na\ny": yes sign, password, yes keep unlocked
     with runner.isolation("y\na\ny"):
         receipt = keyfile_account.transfer(receiver, "1 gwei")
-        assert receipt.transaction.receiver == receiver
+        assert receipt.receiver == receiver
 
     # "n": don't sign
     with runner.isolation(input="n\n"):
@@ -188,7 +188,7 @@ def test_send_transaction_without_enough_funds(sender, receiver):
 def test_send_transaction_sets_defaults(sender, receiver):
     receipt = sender.transfer(receiver, "1 GWEI", gas_limit=None, required_confirmations=None)
     assert receipt.gas_limit > 0
-    assert receipt.transaction.required_confirmations == 0
+    assert receipt.required_confirmations == 0
 
 
 def test_accounts_splice_access(test_accounts):
@@ -281,7 +281,7 @@ def test_unlock_with_passphrase_and_sign_transaction(runner, keyfile_account, re
     # y: yes, sign (note: unlocking makes the key available but is not the same as autosign).
     with runner.isolation(input="y\n"):
         receipt = keyfile_account.transfer(receiver, "1 gwei")
-        assert receipt.transaction.receiver == receiver
+        assert receipt.receiver == receiver
 
 
 def test_unlock_from_prompt_and_sign_transaction(runner, keyfile_account, receiver):
@@ -292,7 +292,7 @@ def test_unlock_from_prompt_and_sign_transaction(runner, keyfile_account, receiv
     # yes, sign the transaction
     with runner.isolation(input="y\n"):
         receipt = keyfile_account.transfer(receiver, "1 gwei")
-        assert receipt.transaction.receiver == receiver
+        assert receipt.receiver == receiver
 
 
 def test_custom_num_of_test_accts_config(test_accounts, temp_config):

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -97,8 +97,8 @@ def test_account_history(sender, receiver, chain):
     assert len(transactions_from_cache) == length_at_start + 1
 
     txn = transactions_from_cache[-1]
-    assert txn.transaction.sender == receipt.transaction.sender == sender
-    assert txn.transaction.receiver == receipt.transaction.receiver == receiver
+    assert txn.sender == receipt.sender == sender
+    assert txn.receiver == receipt.receiver == receiver
 
 
 def test_account_history_caches_sender_over_address_key(

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -322,7 +322,7 @@ def test_estimate_gas_cost_call_account_as_input(contract_instance, eth_tester_p
 
 def test_call_transact(vyper_contract_instance, owner):
     receipt = vyper_contract_instance.myNumber.transact(sender=owner)
-    assert receipt.transaction.sender == owner
+    assert receipt.sender == owner
     assert receipt.status == TransactionStatusEnum.NO_ERROR
 
 
@@ -330,7 +330,7 @@ def test_receipt(contract_instance, owner):
     receipt = contract_instance.receipt
     assert receipt.txn_hash == contract_instance.txn_hash
     assert receipt.contract_address == contract_instance.address
-    assert receipt.transaction.sender == owner
+    assert receipt.sender == owner
 
 
 def test_from_receipt_when_receipt_not_deploy(contract_instance, owner):


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

receipt.transactions attributes can be directly called, and these tests should reflect that.

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #1044 

### How I did it
<!-- Discuss the thought process behind the change -->

search and remove .transaction from receipt calls

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->
pytests still pass

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
