### PR TITLE
fix: broken url

### DIFF
--- a/docs/userguides/projects.md
+++ b/docs/userguides/projects.md
@@ -21,7 +21,7 @@ See the [configuration guide](./config.html) for a more detailed explanation of 
 
 Your project may require plugins.
 To install plugins, use the `ape plugins install .` command.
-Learn more about configuring your project's required plugins by following [this guide](./installing_plugins.md).
+Learn more about configuring your project's required plugins by following [this guide](./installing_plugins.html).
 
 ## Compiling Contracts
 


### PR DESCRIPTION
correct url ends in .html , not .md

### What I did
Fixed a typo

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
- before: https://docs.apeworx.io/ape/stable/userguides/installing_plugins.md
- after: https://docs.apeworx.io/ape/stable/userguides/installing_plugins.html

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
