### PR TITLE
fix: allow ecosystems to still load when default provider or network not found

### DIFF
--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -7,6 +7,7 @@ from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI
 from ape.exceptions import NetworkError
 
 from .base import BaseManager
+from ..logging import logger
 
 
 class NetworkManager(BaseManager):
@@ -115,7 +116,10 @@ class NetworkManager(BaseManager):
 
                     default_provider = network_config["default_provider"]
                     if default_provider:
-                        network.set_default_provider(default_provider)
+                        try:
+                            network.set_default_provider(default_provider)
+                        except NetworkError as err:
+                            logger.error(str(err))
 
             ecosystem_dict[plugin_name] = ecosystem
 
@@ -240,7 +244,6 @@ class NetworkManager(BaseManager):
             ecosystem_items = {n: e for n, e in ecosystem_items.items() if n in ecosystem_filter}
 
         for ecosystem_name, ecosystem in ecosystem_items.items():
-
             network_items = ecosystem.networks
             if network_filter:
                 network_items = {n: net for n, net in network_items.items() if n in network_filter}

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -6,8 +6,8 @@ from ape.api import EcosystemAPI, ProviderAPI, ProviderContextManager
 from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI
 from ape.exceptions import NetworkError
 
-from .base import BaseManager
 from ..logging import logger
+from .base import BaseManager
 
 
 class NetworkManager(BaseManager):

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -5,8 +5,8 @@ import yaml
 from ape.api import EcosystemAPI, ProviderAPI, ProviderContextManager
 from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI
 from ape.exceptions import NetworkError
-
 from ape.logging import logger
+
 from .base import BaseManager
 
 

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -102,7 +102,11 @@ class NetworkManager(BaseManager):
             ecosystem_config = self.config_manager.get_config(plugin_name).dict()
             default_network = ecosystem_config.get("default_network", LOCAL_NETWORK_NAME)
 
-            ecosystem.set_default_network(default_network)
+            try:
+                ecosystem.set_default_network(default_network)
+            except NetworkError as err:
+                message = f"Failed setting default network: {err}"
+                logger.error(message)
 
             if ecosystem_config:
                 for network_name, network in ecosystem.networks.items():

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -6,7 +6,7 @@ from ape.api import EcosystemAPI, ProviderAPI, ProviderContextManager
 from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI
 from ape.exceptions import NetworkError
 
-from ..logging import logger
+from ape.logging import logger
 from .base import BaseManager
 
 
@@ -119,7 +119,8 @@ class NetworkManager(BaseManager):
                         try:
                             network.set_default_provider(default_provider)
                         except NetworkError as err:
-                            logger.error(str(err))
+                            message = f"Failed setting default provider: {err}"
+                            logger.error(message)
 
             ecosystem_dict[plugin_name] = ecosystem
 

--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -215,20 +215,19 @@ class GethProvider(Web3Provider, UpstreamProvider):
             if not self._web3.isConnected():
                 self._geth.disconnect()
                 raise ConnectionError("Unable to connect to locally running geth.")
+        elif "geth" in self.client_version.lower():
+            logger.info(f"Connecting to existing Geth node at '{self._clean_uri}'.")
+        elif "erigon" in self.client_version.lower():
+            logger.info(f"Connecting to existing Erigon node at '{self._clean_uri}'.")
+            self.concurrency = 8
+            self.block_page_size = 40_000
+        elif "nethermind" in self.client_version.lower():
+            logger.info(f"Connecting to existing Nethermind node at '{self._clean_uri}'.")
+            self.concurrency = 32
+            self.block_page_size = 50_000
         else:
-            if "geth" in self.client_version.lower():
-                logger.info(f"Connecting to existing Geth node at '{self._clean_uri}'.")
-            elif "erigon" in self.client_version.lower():
-                logger.info(f"Connecting to existing Erigon node at '{self._clean_uri}'.")
-                self.concurrency = 8
-                self.block_page_size = 40_000
-            elif "nethermind" in self.client_version.lower():
-                logger.info(f"Connecting to existing Nethermind node at '{self._clean_uri}'.")
-                self.concurrency = 32
-                self.block_page_size = 50_000
-            else:
-                client_name = self.client_version.split("/")[0]
-                logger.warning(f"Connecting Geth plugin to non-Geth client '{client_name}'.")
+            client_name = self.client_version.split("/")[0]
+            logger.warning(f"Connecting Geth plugin to non-Geth client '{client_name}'.")
 
         self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
 

--- a/src/ape_geth/providers.py
+++ b/src/ape_geth/providers.py
@@ -216,13 +216,13 @@ class GethProvider(Web3Provider, UpstreamProvider):
                 self._geth.disconnect()
                 raise ConnectionError("Unable to connect to locally running geth.")
         elif "geth" in self.client_version.lower():
-            logger.info(f"Connecting to existing Geth node at '{self._clean_uri}'.")
+            self._log_connection("Geth")
         elif "erigon" in self.client_version.lower():
-            logger.info(f"Connecting to existing Erigon node at '{self._clean_uri}'.")
+            self._log_connection("Erigon")
             self.concurrency = 8
             self.block_page_size = 40_000
         elif "nethermind" in self.client_version.lower():
-            logger.info(f"Connecting to existing Nethermind node at '{self._clean_uri}'.")
+            self._log_connection("Nethermind")
             self.concurrency = 32
             self.block_page_size = 50_000
         else:
@@ -310,3 +310,6 @@ class GethProvider(Web3Provider, UpstreamProvider):
         except ValueError:
             frames = self.get_transaction_trace(txn_hash)
             return get_calltree_from_geth_trace(frames, **root_node_kwargs)
+
+    def _log_connection(self, client_name: str):
+        logger.info(f"Connecting to existing {client_name} node at '{self._clean_uri}'.")

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -4,7 +4,6 @@ from typing import Dict
 import pytest
 
 from ape.api import PluginConfig
-from ape.exceptions import NetworkError
 from ape.managers.config import DeploymentConfigCollection
 from ape_ethereum.ecosystem import NetworkConfig
 from tests.functional.conftest import PROJECT_WITH_LONG_CONTRACTS_FOLDER
@@ -53,19 +52,6 @@ def test_ethereum_network_configs(config, temp_config):
 
         # Ensure that non-updated fields remain unaffected
         assert actual.rinkeby.block_time == 15
-
-
-def test_default_provider_not_found(temp_config, networks):
-    provider_name = "DOES_NOT_EXIST"
-    network_name = "local"
-    eth_config = {"ethereum": {network_name: {"default_provider": provider_name}}}
-
-    with temp_config(eth_config):
-        with pytest.raises(
-            NetworkError, match=f"Provider '{provider_name}' not found in network '{network_name}'."
-        ):
-            # Trigger re-loading the Ethereum config.
-            _ = networks.ecosystems
 
 
 def test_dependencies(dependency_config, config):

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -30,7 +30,7 @@ def test_deploy_and_publish_live_network_no_explorer(owner, project, contract_co
         contract_container.deploy(sender=owner, publish=True, required_confirmations=0)
 
 
-def test_deploy_and_publish(mocker, owner, contract_container, dummy_live_network):
+def test_deploy_and_publish(mocker, owner, project, contract_container, dummy_live_network):
     mock_explorer = mocker.MagicMock()
     dummy_live_network.__dict__["explorer"] = mock_explorer
     contract = contract_container.deploy(sender=owner, publish=True, required_confirmations=0)

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -30,7 +30,7 @@ def test_deploy_and_publish_live_network_no_explorer(owner, project, contract_co
         contract_container.deploy(sender=owner, publish=True, required_confirmations=0)
 
 
-def test_deploy_and_publish(mocker, owner, project, contract_container, dummy_live_network):
+def test_deploy_and_publish(mocker, owner, contract_container, dummy_live_network):
     mock_explorer = mocker.MagicMock()
     dummy_live_network.__dict__["explorer"] = mock_explorer
     contract = contract_container.deploy(sender=owner, publish=True, required_confirmations=0)

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -22,7 +22,8 @@ def test_deploy_and_publish_local_network(owner, contract_container):
         contract_container.deploy(sender=owner, publish=True)
 
 
-def test_deploy_and_publish_live_network_no_explorer(owner, contract_container, dummy_live_network):
+def test_deploy_and_publish_live_network_no_explorer(owner, project, contract_container, dummy_live_network):
+    _ = project  # Ensure active project for `track_deployment` to work
     dummy_live_network.__dict__["explorer"] = None
     expected_message = "Unable to publish contract - no explorer plugin installed."
     with pytest.raises(NetworkError, match=expected_message):

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -22,7 +22,9 @@ def test_deploy_and_publish_local_network(owner, contract_container):
         contract_container.deploy(sender=owner, publish=True)
 
 
-def test_deploy_and_publish_live_network_no_explorer(owner, project, contract_container, dummy_live_network):
+def test_deploy_and_publish_live_network_no_explorer(
+    owner, project, contract_container, dummy_live_network
+):
     _ = project  # Ensure active project for `track_deployment` to work
     dummy_live_network.__dict__["explorer"] = None
     expected_message = "Unable to publish contract - no explorer plugin installed."

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -212,7 +212,6 @@ def test_block_times(ethereum):
 
 
 def test_ecosystems_when_default_network_not_exists(temp_config, caplog, networks):
-    # If provider in config not exists, rest of ecosystems should still load
     bad_network = "NOT_EXISTS"
     config = {"ethereum": {"default_network": bad_network}}
     with temp_config(config):
@@ -226,7 +225,6 @@ def test_ecosystems_when_default_network_not_exists(temp_config, caplog, network
 
 
 def test_ecosystems_when_default_provider_not_exists(temp_config, caplog, networks):
-    # If provider in config not exists, rest of ecosystems should still load
     bad_provider = "NOT_EXISTS"
     config = {"ethereum": {"kovan": {"default_provider": bad_provider}}}
     with temp_config(config):

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -209,3 +209,14 @@ def test_parse_network_choice_multiple_contexts(get_provider_with_unused_chain_i
 
 def test_block_times(ethereum):
     assert ethereum.rinkeby.block_time == 15
+
+
+def test_ecosystems_when_provider_not_exists(temp_config, caplog, ethereum, networks):
+    # If provider in config not exists, rest of ecosystems should still load
+    bad_provider = "NOT_EXISTS"
+    config = {"ethereum": {"kovan": {"default_provider": bad_provider}}}
+    with temp_config(config):
+        assert networks.ecosystems
+
+    err = caplog.records[-1].message
+    assert err == f"Provider '{bad_provider}' not found in network 'kovan'."

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -211,7 +211,21 @@ def test_block_times(ethereum):
     assert ethereum.rinkeby.block_time == 15
 
 
-def test_ecosystems_when_provider_not_exists(temp_config, caplog, ethereum, networks):
+def test_ecosystems_when_default_network_not_exists(temp_config, caplog, networks):
+    # If provider in config not exists, rest of ecosystems should still load
+    bad_network = "NOT_EXISTS"
+    config = {"ethereum": {"default_network": bad_network}}
+    with temp_config(config):
+        assert networks.ecosystems
+
+    err = caplog.records[-1].message
+    assert err == (
+        f"Failed setting default network: "
+        f"'{bad_network}' is not a valid network for ecosystem 'ethereum'."
+    )
+
+
+def test_ecosystems_when_default_provider_not_exists(temp_config, caplog, networks):
     # If provider in config not exists, rest of ecosystems should still load
     bad_provider = "NOT_EXISTS"
     config = {"ethereum": {"kovan": {"default_provider": bad_provider}}}

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -219,4 +219,7 @@ def test_ecosystems_when_provider_not_exists(temp_config, caplog, ethereum, netw
         assert networks.ecosystems
 
     err = caplog.records[-1].message
-    assert err == f"Provider '{bad_provider}' not found in network 'kovan'."
+    assert err == (
+        f"Failed setting default provider: "
+        f"Provider '{bad_provider}' not found in network 'kovan'."
+    )


### PR DESCRIPTION
### What I did

If a provider plugin has a single bug in it currently, every core plugin that uses the `network_option` fails to load.
This is because the config loads in the plugin attempting to set the default but the default provider "does not exist" but it fails to load.

### How I did it

Instead of failing to return any ecosystems at all when attempting to set the default provider fails with a `NetworkError`, log the error and move on.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [ ] Documentation has been updated
