### PR TITLE
feat: local networks default to max gas-limit

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -135,6 +135,7 @@ class EthereumConfig(PluginConfig):
     local: NetworkConfig = NetworkConfig(
         default_provider="test",
         transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
+        gas_limit="max",
     )  # type: ignore
     default_network: str = LOCAL_NETWORK_NAME
 

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -59,7 +59,7 @@ def test_network_gas_limit_default(config):
     eth_config = config.get_config("ethereum")
 
     assert eth_config.rinkeby.gas_limit == "auto"
-    assert eth_config.local.gas_limit == "auto"
+    assert eth_config.local.gas_limit == "max"
 
 
 def _rinkeby_with_gas_limit(gas_limit: GasLimit) -> dict:
@@ -83,7 +83,7 @@ def test_network_gas_limit_string_config(gas_limit, config, temp_config):
         assert actual.rinkeby.gas_limit == gas_limit
 
         # Local configuration is unaffected
-        assert actual.local.gas_limit == "auto"
+        assert actual.local.gas_limit == "max"
 
 
 @pytest.mark.parametrize("gas_limit", (1234, "1234", 0x4D2, "0x4D2"))
@@ -96,7 +96,7 @@ def test_network_gas_limit_numeric_config(gas_limit, config, temp_config):
         assert actual.rinkeby.gas_limit == 1234
 
         # Local configuration is unaffected
-        assert actual.local.gas_limit == "auto"
+        assert actual.local.gas_limit == "max"
 
 
 def test_network_gas_limit_invalid_numeric_string(config, temp_config):


### PR DESCRIPTION
### What I did

Updated local config to use max gas limit

### How I did it
Set `EthereumConfig.local` to `gas_limit="max"`

### How to verify it
Shown in tests that the local config uses "max" by default

### Checklist
- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
