### PR TITLE
fix: strange error when getting logs from multiple addresses when addresses list empty

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -616,8 +616,13 @@ class ContractCache(BaseManager):
 
         addresses = [self.conversion_manager.convert(a, AddressType) for a in addresses]
         contract_types = {}
-        num_threads = concurrency if concurrency is not None else min(len(addresses), 4)
-        with ThreadPoolExecutor(num_threads) as pool:
+        default_max_threads = 4
+        max_threads = (
+            concurrency
+            if concurrency is not None
+            else min(len(addresses), default_max_threads) or default_max_threads
+        )
+        with ThreadPoolExecutor(max_workers=max_threads) as pool:
             for address, contract_type in pool.map(get_contract_type, addresses):
                 if contract_type is None:
                     continue

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -603,6 +603,9 @@ class ContractCache(BaseManager):
             Dict[AddressType, ContractType]: A mapping of addresses to their respective
             contract types.
         """
+        if not addresses:
+            logger.warning("No addresses provided.")
+            return {}
 
         def get_contract_type(address: AddressType):
             address = self.conversion_manager.convert(address, AddressType)
@@ -614,7 +617,14 @@ class ContractCache(BaseManager):
             else:
                 return address, contract_type
 
-        addresses = [self.conversion_manager.convert(a, AddressType) for a in addresses]
+        converted_addresses: List[AddressType] = []
+        for address in converted_addresses:
+            if not self.conversion_manager.is_type(address, AddressType):
+                converted_address = self.conversion_manager.convert(address, AddressType)
+                converted_addresses.append(converted_address)
+            else:
+                converted_addresses.append(address)
+
         contract_types = {}
         default_max_threads = 4
         max_threads = (

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -493,6 +493,13 @@ def test_contracts_get_multiple(vyper_contract_instance, solidity_contract_insta
     )
 
 
+def test_contracts_get_multiple_no_addresses(chain, caplog):
+    contract_map = chain.contracts.get_multiple([])
+    assert not contract_map
+    assert caplog.records[-1].levelname == "WARNING"
+    assert "No addresses provided." in caplog.records[-1].message
+
+
 def test_contracts_get_all_include_non_contract_address(vyper_contract_instance, chain, owner):
     actual = chain.contracts.get_multiple((vyper_contract_instance.address, owner.address))
     assert len(actual) == 1


### PR DESCRIPTION
### What I did

Ran into a concurrency failure because the address list was empty.
Make fail early to prevent such failure.
Also never let `max_thread` be < 0 just to be extra safe.
Additionally, only convert non-AddressTypes as a perf

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
