### PR TITLE
test: verify receiver on `get_receipt()` call

### DIFF
--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -170,3 +170,11 @@ def test_connect_wrong_chain_id(mocker, ethereum, eth_tester_provider_geth):
     )
     with pytest.raises(NetworkMismatchError, match=expected_error_message):
         eth_tester_provider_geth.connect()
+
+
+def test_get_receipt(vyper_contract_instance, eth_tester_provider_geth, owner):
+    receipt = vyper_contract_instance.setNumber(123, sender=owner)
+    actual = eth_tester_provider_geth.get_receipt(receipt.txn_hash)
+    assert receipt.txn_hash == actual.txn_hash
+    assert actual.receiver == vyper_contract_instance.address
+    assert actual.sender == receipt.sender

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -71,6 +71,7 @@ def test_get_receipt_exists_with_timeout(eth_tester_provider, vyper_contract_ins
     receipt_from_invoke = vyper_contract_instance.setNumber(123, sender=owner)
     receipt_from_provider = eth_tester_provider.get_receipt(receipt_from_invoke.txn_hash, timeout=0)
     assert receipt_from_provider.txn_hash == receipt_from_invoke.txn_hash
+    assert receipt_from_provider.receiver == vyper_contract_instance.address
 
 
 def test_get_contracts_logs_all_logs(chain, contract_instance, owner, eth_tester_provider):


### PR DESCRIPTION
### What I did

Running into an issue where the `receiver` is missing on receipts. I think the issue from Hardhat but there was not an assertion anywhere for receiver so I am adding one to clear the name.

### How I did it

In our main positive test for `get_receipt()`, verify the receiver is the expected contract's address.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
