### PR TITLE
feat: custom exceptions for when block and transaction not found

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -19,6 +19,7 @@ from evm_trace import CallTreeNode, TraceFrame
 from hexbytes import HexBytes
 from pydantic import Field, root_validator, validator
 from web3 import Web3
+from web3.exceptions import BlockNotFound
 from web3.exceptions import ContractLogicError as Web3ContractLogicError
 from web3.exceptions import TimeExhausted
 from web3.types import RPCEndpoint
@@ -29,6 +30,7 @@ from ape.api.query import BlockTransactionQuery
 from ape.api.transactions import ReceiptAPI, TransactionAPI
 from ape.exceptions import (
     APINotImplementedError,
+    BlockNotFoundError,
     ContractLogicError,
     ProviderError,
     ProviderNotConnectedError,
@@ -36,6 +38,7 @@ from ape.exceptions import (
     SubprocessError,
     SubprocessTimeoutError,
     TransactionError,
+    TransactionNotFoundError,
     VirtualMachineError,
 )
 from ape.logging import logger
@@ -273,6 +276,10 @@ class ProviderAPI(BaseInterfaceModel):
         Args:
             block_id (:class:`~ape.types.BlockID`): The ID of the block to get.
                 Can be ``"latest"``, ``"earliest"``, ``"pending"``, a block hash or a block number.
+
+        Raises:
+            :class:`~ape.exceptions.BlockNotFoundError`: Likely the exception raised when a block
+              is not found (depends on implementation).
 
         Returns:
             :class:`~ape.types.BlockID`: The block for the given ID.
@@ -722,7 +729,11 @@ class Web3Provider(ProviderAPI, ABC):
         if isinstance(block_id, str) and block_id.isnumeric():
             block_id = int(block_id)
 
-        block_data = dict(self.web3.eth.get_block(block_id))
+        try:
+            block_data = dict(self.web3.eth.get_block(block_id))
+        except BlockNotFound as err:
+            raise BlockNotFoundError(block_id) from err
+
         return self.network.ecosystem.decode_block(block_data)
 
     def get_nonce(self, address: str, **kwargs) -> int:
@@ -813,6 +824,10 @@ class Web3Provider(ProviderAPI, ABC):
             timeout (Optional[int]): The amount of time to wait for a receipt
               before timing out.
 
+        Raises:
+            :class:`~ape.exceptions.TransactionNotFoundError`: Likely the exception raised
+              when the transaction receipt is not found (depends on implementation).
+
         Returns:
             :class:`~api.providers.ReceiptAPI`:
             The receipt of the transaction with the given hash.
@@ -830,7 +845,7 @@ class Web3Provider(ProviderAPI, ABC):
                 HexBytes(txn_hash), timeout=timeout
             )
         except TimeExhausted as err:
-            raise ProviderError(f"Transaction '{txn_hash}' not found.") from err
+            raise TransactionNotFoundError(txn_hash) from err
 
         txn = dict(self.web3.eth.get_transaction(txn_hash))  # type: ignore
         receipt = self.network.ecosystem.decode_receipt(

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -6,7 +6,7 @@ from eth_utils import humanize_hash
 if TYPE_CHECKING:
     from ape.api.networks import NetworkAPI
     from ape.api.providers import SubprocessProvider
-    from ape.types import SnapshotID
+    from ape.types import BlockID, SnapshotID
 
 
 class ApeException(Exception):
@@ -186,6 +186,29 @@ class ProviderError(ApeException):
     """
     Raised when a problem occurs when using providers.
     """
+
+
+class BlockNotFoundError(ProviderError):
+    """
+    Raised when unable to find a block.
+    """
+
+    def __init__(self, block_id: "BlockID"):
+        if isinstance(block_id, bytes):
+            block_id_str = block_id.hex()
+        else:
+            block_id_str = str(block_id)
+
+        super().__init__(f"Block with ID '{block_id_str}' not found.")
+
+
+class TransactionNotFoundError(ProviderError):
+    """
+    Raised when unable to find a transaction.
+    """
+
+    def __init__(self, txn_hash: str):
+        super().__init__(f"Transaction '{txn_hash}' not found.")
 
 
 class NetworkMismatchError(ProviderError):

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -1,10 +1,19 @@
 from pathlib import Path
+from typing import cast
 
 import pytest
+from eth_typing import HexStr
 from web3.exceptions import ContractLogicError as Web3ContractLogicError
 
 from ape.api.networks import LOCAL_NETWORK_NAME
-from ape.exceptions import ContractLogicError, NetworkMismatchError, TransactionError
+from ape.exceptions import (
+    BlockNotFoundError,
+    ContractLogicError,
+    NetworkMismatchError,
+    TransactionError,
+    TransactionNotFoundError,
+)
+from ape_ethereum.ecosystem import Block
 from ape_geth import GethProvider
 from tests.functional.data.python import TRACE_RESPONSE
 
@@ -170,3 +179,26 @@ def test_connect_wrong_chain_id(mocker, ethereum, eth_tester_provider_geth):
     )
     with pytest.raises(NetworkMismatchError, match=expected_error_message):
         eth_tester_provider_geth.connect()
+
+
+@pytest.mark.parametrize("block_id", (0, "0", "0x0", HexStr("0x0")))
+def test_get_block(eth_tester_provider_geth, block_id):
+    block = cast(Block, eth_tester_provider_geth.get_block(block_id))
+
+    # Each parameter is the same as requesting the first block.
+    assert block.number == 0
+    assert block.base_fee == 1000000000
+    assert block.gas_used == 0
+
+
+def test_get_block_not_found(eth_tester_provider_geth):
+    latest_block = eth_tester_provider_geth.get_block("latest")
+    block_id = latest_block.number + 1000
+    with pytest.raises(BlockNotFoundError, match=f"Block with ID '{block_id}' not found."):
+        eth_tester_provider_geth.get_block(block_id)
+
+
+def test_get_receipt_not_exists_with_timeout(eth_tester_provider_geth):
+    unknown_txn = "0x053cba5c12172654d894f66d5670bab6215517a94189a9ffc09bc40a589ec04d"
+    with pytest.raises(TransactionNotFoundError, match=f"Transaction '{unknown_txn}' not found"):
+        eth_tester_provider_geth.get_receipt(unknown_txn, timeout=0)


### PR DESCRIPTION
### What I did

I need a reliable way to know if a transaction or a block is not found without relying on 3rd part exceptions.
* Adds custom exception `BlockNotFoundError(ProviderError)`
* Adds custom exception `TransactionNotFoundError(ProviderError)`

### How I did it

* Except `web3.exception.BlockNotFound` in `Web3Provider` and then raise our own.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
