### PR TITLE
fix: use `get_repo` cache in `GithubClient` when calling `get_release()`

### DIFF
--- a/src/ape/utils/github.py
+++ b/src/ape/utils/github.py
@@ -66,7 +66,7 @@ class GithubClient:
         Returns:
             github.GitRelease.GitRelease
         """
-        repo = self._client.get_repo(repo_path)
+        repo = self.get_repo(repo_path)
 
         if version == "latest":
             return repo.get_latest_release()

--- a/tests/functional/utils/test_github.py
+++ b/tests/functional/utils/test_github.py
@@ -56,6 +56,10 @@ class TestGithubClient:
         # Test that we used the given tag.
         mock_repo.get_release.assert_called_once_with("0.1.0")
 
+        # Ensure that it uses the repo cache the second time
+        github_client_with_mocks.get_release("test/path", "0.1.0")
+        assert github_client_with_mocks._client.get_repo.call_count == 1
+
     def test_get_release_when_tag_fails_tries_with_v(
         self, mock_release, github_client_with_mocks, mock_repo
     ):

--- a/tests/functional/utils/test_github.py
+++ b/tests/functional/utils/test_github.py
@@ -5,6 +5,19 @@ from github import UnknownObjectException
 
 from ape.utils.github import GithubClient, GitRemoteCallbacks
 
+REPO_PATH = "test/path"
+
+
+@pytest.fixture(autouse=True)
+def clear_repo_cache(github_client_with_mocks):
+    def clear():
+        if REPO_PATH in github_client_with_mocks._repo_cache:
+            del github_client_with_mocks._repo_cache[REPO_PATH]
+
+    clear()
+    yield
+    clear()
+
 
 @pytest.fixture
 def mock_client(mocker):
@@ -51,13 +64,13 @@ class TestGithubClient:
         assert GitRemoteCallbacks.current_objects_cloned == 62
 
     def test_get_release(self, github_client_with_mocks, mock_repo):
-        github_client_with_mocks.get_release("test/path", "0.1.0")
+        github_client_with_mocks.get_release(REPO_PATH, "0.1.0")
 
         # Test that we used the given tag.
         mock_repo.get_release.assert_called_once_with("0.1.0")
 
         # Ensure that it uses the repo cache the second time
-        github_client_with_mocks.get_release("test/path", "0.1.0")
+        github_client_with_mocks.get_release(REPO_PATH, "0.1.0")
         assert github_client_with_mocks._client.get_repo.call_count == 1
 
     def test_get_release_when_tag_fails_tries_with_v(
@@ -72,7 +85,7 @@ class TestGithubClient:
             return mock_release
 
         mock_repo.get_release.side_effect = side_effect
-        actual = github_client_with_mocks.get_release("test/path", "v0.1.0")
+        actual = github_client_with_mocks.get_release(REPO_PATH, "v0.1.0")
         assert actual == mock_release
 
     def test_get_release_when_tag_fails_tries_without_v(
@@ -87,5 +100,5 @@ class TestGithubClient:
             return mock_release
 
         mock_repo.get_release.side_effect = side_effect
-        actual = github_client_with_mocks.get_release("test/path", "0.1.0")
+        actual = github_client_with_mocks.get_release(REPO_PATH, "0.1.0")
         assert actual == mock_release


### PR DESCRIPTION
### What I did

Seeking ways to make less GH calls because we are suddenly 429ing all over.

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
