### PR TITLE
feat: add `supports_tracing()` calculated property to `ProviderAPI` and `Web3ProviderAPI`

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -250,7 +250,14 @@ class ProviderAPI(BaseInterfaceModel):
             NotImplementedError: When the provider does not implement
               `EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__ typed transactions.
         """
-        raise NotImplementedError("priority_fee is not implemented by this provider")
+        raise APINotImplementedError("priority_fee is not implemented by this provider")
+
+    @property
+    def supports_tracing(self) -> bool:
+        """
+        ``True`` when the provider can provide transaction traces.
+        """
+        return False
 
     @property
     def base_fee(self) -> int:
@@ -635,6 +642,17 @@ class Web3Provider(ProviderAPI, ABC):
             return False
 
         return run_until_complete(self._web3.isConnected())
+
+    @cached_property
+    def supports_tracing(self) -> bool:
+        try:
+            self.get_call_tree(None)
+        except APINotImplementedError:
+            return False
+        except Exception:
+            return True
+
+        return True
 
     def update_settings(self, new_settings: dict):
         self.disconnect()

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -170,3 +170,7 @@ def test_connect_wrong_chain_id(mocker, ethereum, eth_tester_provider_geth):
     )
     with pytest.raises(NetworkMismatchError, match=expected_error_message):
         eth_tester_provider_geth.connect()
+
+
+def test_supports_tracing(eth_tester_provider_geth):
+    assert eth_tester_provider_geth.supports_tracing

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -135,3 +135,7 @@ def test_get_contract_logs_single_log_unmatched(
     )
     logs = [log for log in eth_tester_provider.get_contract_logs(log_filter)]
     assert len(logs) == 0
+
+
+def test_supports_tracing(eth_tester_provider):
+    assert not eth_tester_provider.supports_tracing


### PR DESCRIPTION
### What I did

It is nice to have a more convenient way to check if provider supports tracing. This helps me in my gas reporting efforts but I think will come in handy elsewhere, so opening it up separately.

### How I did it

Check for `APINotImplementedError` when calling `get_call_tree()`. If it fails with that, no tracing. Any other result indicates a tracing implementation.

### How to verify it

Launch console using various providers calling `provider.supports_tracing` and making sure it is expected.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
