### PR TITLE
refactor: use `is_file()` and `is_dir()` over `exists()` whenever makes sense

### DIFF
--- a/src/ape/cli/paramtype.py
+++ b/src/ape/cli/paramtype.py
@@ -29,4 +29,4 @@ class AllFilePaths(Path):
         path = super().convert(value, param, ctx)
 
         # NOTE: Return the path if it does not exist so it can be resolved downstream.
-        return get_all_files_in_directory(path) if path.exists() else [path]
+        return get_all_files_in_directory(path) if path.is_dir() else [path]

--- a/src/ape/cli/utils.py
+++ b/src/ape/cli/utils.py
@@ -18,7 +18,7 @@ class Abort(click.ClickException):
         if not message:
             caller = getframeinfo(stack()[1][0])
             file_path = Path(caller.filename)
-            location = file_path.name if file_path.exists() else caller.filename
+            location = file_path.name if file_path.is_file() else caller.filename
             message = f"Operation aborted in {location}::{caller.function} on line {caller.lineno}."
 
         super().__init__(message)

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -882,7 +882,7 @@ class ContractCache(BaseManager):
     def _load_deployments_cache(self) -> Dict:
         return (
             json.loads(self._deployments_mapping_cache.read_text())
-            if self._deployments_mapping_cache.exists()
+            if self._deployments_mapping_cache.is_file()
             else {}
         )
 

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -139,7 +139,7 @@ class ConfigManager(BaseInterfaceModel):
 
         configs = {}
         config_file = self.PROJECT_FOLDER / CONFIG_FILE_NAME
-        user_config = load_config(config_file) if config_file.exists() else {}
+        user_config = load_config(config_file) if config_file.is_file() else {}
         self.name = configs["name"] = user_config.pop("name", "")
         self.version = configs["version"] = user_config.pop("version", "")
         meta_dict = user_config.pop("meta", {})

--- a/src/ape/managers/project/dependency.py
+++ b/src/ape/managers/project/dependency.py
@@ -137,7 +137,7 @@ class LocalDependency(DependencyAPI):
     @property
     def path(self) -> Path:
         given_path = Path(self.local).absolute()
-        if not given_path.exists():
+        if not given_path.is_dir():
             raise ProjectError(f"No project exists at path '{given_path}'.")
 
         return given_path

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -488,9 +488,11 @@ class ProjectManager(BaseManager):
             Dict[str, ``ContractType``]: A dictionary of contract names to their
             types for each compiled contract.
         """
-        self._load_dependencies()
 
-        if not self.contracts_folder.exists():
+        # NOTE: Always load dependencies even when there is no contracts folder.
+        #  This is to support projects that only use dependencies.
+        self._load_dependencies()
+        if not self.contracts_folder.is_dir():
             return {}
 
         in_source_cache = self.contracts_folder / ".cache"

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -496,7 +496,7 @@ class ProjectManager(BaseManager):
             return {}
 
         in_source_cache = self.contracts_folder / ".cache"
-        if not use_cache and in_source_cache.exists():
+        if not use_cache and in_source_cache.is_dir():
             shutil.rmtree(str(in_source_cache))
 
         file_paths = [file_paths] if isinstance(file_paths, Path) else file_paths

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -84,7 +84,7 @@ class ProjectManager(BaseManager):
             List[pathlib.Path]: A list of a source file paths in the project.
         """
         files: List[Path] = []
-        if not self.contracts_folder.exists():
+        if not self.contracts_folder.is_dir():
             return files
 
         for extension in self.compiler_manager.registered_compilers:
@@ -99,7 +99,7 @@ class ProjectManager(BaseManager):
         in the project. ``False`` otherwise.
         """
 
-        return not self.contracts_folder.exists() or not self.contracts_folder.iterdir()
+        return not self.contracts_folder.is_dir() or not self.contracts_folder.iterdir()
 
     @property
     def interfaces_folder(self) -> Path:
@@ -568,7 +568,7 @@ class ProjectManager(BaseManager):
         deployments_folder.mkdir(exist_ok=True, parents=True)
         destination = deployments_folder / f"{contract_name}.json"
 
-        if destination.exists():
+        if destination.is_file():
             logger.debug("Deployment already tracked. Re-tracking.")
             destination.unlink()
 

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -21,7 +21,7 @@ class BaseProject(ProjectAPI):
 
     @property
     def is_valid(self) -> bool:
-        if self.config_file.exists():
+        if self.config_file.is_file():
             return True
 
         logger.warning(
@@ -42,7 +42,7 @@ class BaseProject(ProjectAPI):
         """
         files: List[Path] = []
 
-        if not self.contracts_folder.exists():
+        if not self.contracts_folder.is_dir():
             return files
 
         for extension in self.compiler_manager.registered_compilers:
@@ -55,7 +55,7 @@ class BaseProject(ProjectAPI):
 
     def configure(self, **kwargs):
         # Don't override existing config file.
-        if self.config_file.exists():
+        if self.config_file.is_file():
             return
 
         config_data = {**kwargs}

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -88,7 +88,7 @@ class BaseProject(ProjectAPI):
             else:
                 manifest = PackageManifest()
 
-                if self.manifest_cachefile.exists():
+                if self.manifest_cachefile.is_file():
                     self.manifest_cachefile.unlink()
 
             cached_sources = manifest.sources or {}

--- a/src/ape/utils/github.py
+++ b/src/ape/utils/github.py
@@ -150,7 +150,7 @@ class GithubClient:
                                 to the downloaded package.
             target_path (path): A path in your local filesystem to save the downloaded package.
         """
-        if not target_path or not target_path.exists() or not target_path.is_dir():
+        if not target_path or not target_path.is_dir():
             raise ValueError(f"'target_path' must be a valid directory (got '{target_path}').")
 
         release = self.get_release(repo_path, version)

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -120,7 +120,7 @@ def load_config(path: Path, expand_envars=True, must_exist=False) -> Dict:
     Returns:
         Dict (dict): Configured settings parsed from a config file.
     """
-    if path.exists():
+    if path.is_file():
         contents = path.read_text()
         if expand_envars:
             contents = expand_environment_variables(contents)

--- a/src/ape/utils/os.py
+++ b/src/ape/utils/os.py
@@ -85,7 +85,7 @@ def get_all_files_in_directory(
         pattern = re.compile(pattern)
 
     if path.is_dir():
-        all_files = [p for p in list(path.rglob("*.*")) if not p.is_dir() and p.exists()]
+        all_files = [p for p in list(path.rglob("*.*")) if p.is_file()]
 
         if pattern:
             return [f for f in all_files if pattern.match(f.name)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,7 @@ def temp_accounts_path(config):
 
     yield path
 
-    if path.exists():
+    if path.is_dir():
         shutil.rmtree(path)
 
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -91,7 +91,7 @@ def keyfile_account(sender, keyparams, temp_accounts_path, eth_tester_provider):
     test_keyfile_path = temp_accounts_path / f"{ALIAS}.json"
     yield _make_keyfile_account(temp_accounts_path, ALIAS, keyparams, sender)
 
-    if test_keyfile_path.exists():
+    if test_keyfile_path.is_file():
         test_keyfile_path.unlink()
 
 
@@ -100,14 +100,14 @@ def second_keyfile_account(sender, keyparams, temp_accounts_path, eth_tester_pro
     test_keyfile_path = temp_accounts_path / f"{ALIAS_2}.json"
     yield _make_keyfile_account(temp_accounts_path, ALIAS_2, keyparams, sender)
 
-    if test_keyfile_path.exists():
+    if test_keyfile_path.is_file():
         test_keyfile_path.unlink()
 
 
 def _make_keyfile_account(base_path: Path, alias: str, params: Dict, funder):
     test_keyfile_path = base_path / f"{alias}.json"
 
-    if test_keyfile_path.exists():
+    if test_keyfile_path.is_file():
         # Corrupted from a previous test
         test_keyfile_path.unlink()
 
@@ -345,12 +345,12 @@ def assert_log_values(contract_instance):
 
 @pytest.fixture
 def remove_disk_writes_deployments(chain):
-    if chain.contracts._deployments_mapping_cache.exists():
+    if chain.contracts._deployments_mapping_cache.is_file():
         chain.contracts._deployments_mapping_cache.unlink()
 
     yield
 
-    if chain.contracts._deployments_mapping_cache.exists():
+    if chain.contracts._deployments_mapping_cache.is_file():
         chain.contracts._deployments_mapping_cache.unlink()
 
 

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -23,7 +23,7 @@ def one_keyfile_account(keyfile_swap_paths, keyfile_account):
         yield keyfile_account
 
     else:
-        if dest_path.exists():
+        if dest_path.is_file():
             dest_path.unlink() if dest_path.is_file() else shutil.rmtree(dest_path)
 
         dest_path.mkdir()

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -118,12 +118,12 @@ def clean_cache(project):
     does not have a cached compilation.
     """
     cache_file = project._project.manifest_cachefile
-    if cache_file.exists():
+    if cache_file.is_file():
         cache_file.unlink()
 
     yield
 
-    if cache_file.exists():
+    if cache_file.is_file():
         cache_file.unlink()
 
 

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -16,7 +16,7 @@ GENERATE_VALID_INPUT = "\n".join(["random entropy", PASSWORD, PASSWORD])
 def temp_keyfile_path(temp_accounts_path):
     test_keyfile_path = temp_accounts_path / f"{ALIAS}.json"
 
-    if test_keyfile_path.exists():
+    if test_keyfile_path.is_file():
         # Corrupted from a previous test
         test_keyfile_path.unlink()
 
@@ -29,7 +29,7 @@ def temp_keyfile(temp_keyfile_path, keyparams):
 
     yield temp_keyfile_path
 
-    if temp_keyfile_path.exists():
+    if temp_keyfile_path.is_file():
         temp_keyfile_path.unlink()
 
 
@@ -40,13 +40,13 @@ def temp_account():
 
 @run_once
 def test_import(ape_cli, runner, temp_account, temp_keyfile_path):
-    assert not temp_keyfile_path.exists()
+    assert not temp_keyfile_path.is_file()
     # Add account from private keys
     result = runner.invoke(ape_cli, ["accounts", "import", ALIAS], input=IMPORT_VALID_INPUT)
     assert result.exit_code == 0, result.output
     assert temp_account.address in result.output
     assert ALIAS in result.output
-    assert temp_keyfile_path.exists()
+    assert temp_keyfile_path.is_file()
 
 
 @run_once
@@ -70,12 +70,12 @@ def test_import_account_instantiation_failure(mocker, ape_cli, runner, temp_acco
 
 @run_once
 def test_generate(ape_cli, runner, temp_keyfile_path):
-    assert not temp_keyfile_path.exists()
+    assert not temp_keyfile_path.is_file()
     # Generate new private key
     result = runner.invoke(ape_cli, ["accounts", "generate", ALIAS], input=GENERATE_VALID_INPUT)
     assert result.exit_code == 0, result.output
     assert ALIAS in result.output
-    assert temp_keyfile_path.exists()
+    assert temp_keyfile_path.is_file()
 
 
 @run_once
@@ -92,7 +92,7 @@ def test_generate_alias_already_in_use(ape_cli, runner, temp_account):
 @run_once
 def test_list(ape_cli, runner, temp_keyfile):
     # Check availability
-    assert temp_keyfile.exists()
+    assert temp_keyfile.is_file()
     result = runner.invoke(ape_cli, ["accounts", "list"], catch_exceptions=False)
     assert ALIAS in result.output
 
@@ -104,14 +104,14 @@ def test_list(ape_cli, runner, temp_keyfile):
 @run_once
 def test_list_all(ape_cli, runner, temp_keyfile):
     # Check availability
-    assert temp_keyfile.exists()
+    assert temp_keyfile.is_file()
     result = runner.invoke(ape_cli, ["accounts", "list", "--all"])
     assert ALIAS in result.output
 
 
 @run_once
 def test_change_password(ape_cli, runner, temp_keyfile):
-    assert temp_keyfile.exists()
+    assert temp_keyfile.is_file()
     # Delete Account (`N` for "Leave unlocked?")
     valid_input = [PASSWORD, "N", "b", "b"]
     result = runner.invoke(
@@ -124,8 +124,8 @@ def test_change_password(ape_cli, runner, temp_keyfile):
 
 @run_once
 def test_delete(ape_cli, runner, temp_keyfile):
-    assert temp_keyfile.exists()
+    assert temp_keyfile.is_file()
     # Delete Account
     result = runner.invoke(ape_cli, ["accounts", "delete", ALIAS], input=f"{PASSWORD}\n")
     assert result.exit_code == 0, result.output
-    assert not temp_keyfile.exists()
+    assert not temp_keyfile.is_file()


### PR DESCRIPTION
### What I did

Was debugging an issue with compiling and I fixed it in `ape-solidity` (about to open PR). Except while fixing that bug, also fixed all of these, so this is small PR to change `exists()` usage to be `is_file()` or `is_dir()` depending on the situation.

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
