### PR TITLE
fix: pin protobuf version 3.20.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,9 @@ setup(
         "eip712>=0.1.4,<0.2",
         "ethpm-types>=0.3.7,<0.4",
         "evm-trace==0.1.0a10",
+        # NOTE: macOS M1 compatibility, should be removed once web3 updates its
+        # protobuf dependency
+        "protobuf==3.20.1",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],


### PR DESCRIPTION
### What I did
fixes: #1068

### How I did it
Pin protobuf ourselves to use the downgraded version (see https://github.com/protocolbuffers/protobuf/issues/10571)

### How to verify it
Follow project setup tests described in #1068, tests should run successfully without `ImportError`

### Checklist
- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
