### PR TITLE
feat: adds `chain.get_receipt()` method

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Iterator, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Iterator, List, Optional, Type, Union
 
 import click
 from eip712.messages import SignableMessage as EIP712SignableMessage
@@ -9,7 +9,7 @@ from ape.exceptions import AccountsError, AliasAlreadyInUseError, SignatureError
 from ape.logging import logger
 from ape.types import AddressType, MessageSignature, SignableMessage, TransactionSignature
 from ape.types.signatures import _Signature
-from ape.utils import BaseInterfaceModel, abstractmethod, cached_property
+from ape.utils import BaseInterfaceModel, abstractmethod
 
 from .address import BaseAddress
 from .transactions import ReceiptAPI, TransactionAPI
@@ -111,10 +111,6 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
 
         return self.provider.send_transaction(txn)
 
-    @cached_property
-    def _convert(self) -> Callable:
-        return self.conversion_manager.convert
-
     def transfer(
         self,
         account: Union[str, AddressType, BaseAddress],
@@ -134,21 +130,24 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
             :class:`~ape.api.transactions.ReceiptAPI`
         """
 
+        receiver = self.conversion_manager.convert(account, AddressType)
         txn = self.provider.network.ecosystem.create_transaction(
-            sender=self.address, receiver=self._convert(account, AddressType), **kwargs
+            sender=self.address, receiver=receiver, **kwargs
         )
 
         if data:
-            txn.data = self._convert(data, bytes)
+            txn.data = self.conversion_manager.convert(data, bytes)
 
-        if value:
-            if "send_everything" in kwargs and kwargs["send_everything"]:
-                raise AccountsError("Cannot use 'send_everything=True' with 'VALUE'.")
-            txn.value = self._convert(value, int)
+        if value and "send_everything" in kwargs and kwargs["send_everything"]:
+            raise AccountsError("Cannot use 'send_everything=True' with 'VALUE'.")
+
+        elif value:
+            txn.value = self.conversion_manager.convert(value, int)
             return self.call(txn)
 
         elif not kwargs.get("send_everything"):
             raise AccountsError("Must provide 'VALUE' or use 'send_everything=True'")
+
         else:
             return self.call(txn, send_everything=True)
 
@@ -161,7 +160,9 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
 
         Args:
             contract (:class:`~ape.contracts.ContractContainer`):
-                The type of contract to deploy.
+              The type of contract to deploy.
+            publish (bool): Set to ``True`` to attempt explorer contract verification.
+              Defaults to ``False``.
 
         Returns:
             :class:`~ape.contracts.ContractInstance`: An instance of the deployed contract.

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -135,13 +135,13 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
             sender=self.address, receiver=receiver, **kwargs
         )
 
-        if data:
-            txn.data = self.conversion_manager.convert(data, bytes)
-
         if value and "send_everything" in kwargs and kwargs["send_everything"]:
             raise AccountsError("Cannot use 'send_everything=True' with 'VALUE'.")
 
-        elif value:
+        if data:
+            txn.data = self.conversion_manager.convert(data, bytes)
+
+        if value:
             txn.value = self.conversion_manager.convert(value, int)
             return self.call(txn)
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -273,7 +273,7 @@ class ProviderAPI(BaseInterfaceModel):
             NotImplementedError: When this provider does not implement
               `EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__.
         """
-        raise NotImplementedError("base_fee is not implemented by this provider")
+        raise APINotImplementedError("base_fee is not implemented by this provider")
 
     @abstractmethod
     def get_block(self, block_id: BlockID) -> BlockAPI:
@@ -610,7 +610,7 @@ class Web3Provider(ProviderAPI, ABC):
     @property
     def web3(self) -> Web3:
         """
-        Access to the ``web3`` object as if you did ``Web3(HTTPProvder(uri))``.
+        Access to the ``web3`` object as if you did ``Web3(HTTPProvider(uri))``.
         """
 
         if not self._web3:
@@ -853,6 +853,10 @@ class Web3Provider(ProviderAPI, ABC):
 
         if required_confirmations < 0:
             raise TransactionError(message="Required confirmations cannot be negative.")
+
+        cached_receipt = self.chain_manager.account_history.get_receipt(txn_hash)
+        if cached_receipt:
+            return cached_receipt
 
         timeout = (
             timeout if timeout is not None else self.provider.network.transaction_acceptance_timeout

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -610,7 +610,7 @@ class ContractInstance(BaseAddress):
         """
 
         if not self._cached_receipt and self.txn_hash:
-            receipt = self.provider.get_receipt(self.txn_hash)
+            receipt = self.chain_manager.get_receipt(self.txn_hash)
             self._cached_receipt = receipt
             return receipt
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1092,3 +1092,12 @@ class ChainManager(BaseManager):
             amount = int(amount, 16)
 
         return self.provider.set_balance(account, amount)
+
+    def get_receipt(self, transaction_hash: str) -> ReceiptAPI:
+        cached_receipt = self.chain_manager.account_history.get_receipt(transaction_hash)
+        if cached_receipt:
+            return cached_receipt
+
+        receipt = self.provider.get_receipt(transaction_hash)
+        self.chain_manager.account_history.append(receipt)
+        return receipt

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -3,7 +3,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from pathlib import Path
-from typing import Callable, Collection, Dict, Iterator, List, Optional, Tuple, Union, cast
+from typing import Collection, Dict, Iterator, List, Optional, Tuple, Union, cast
 
 import pandas as pd
 from ethpm_types import ContractType
@@ -17,7 +17,6 @@ from ape.exceptions import ChainError, ConversionError, UnknownSnapshotError
 from ape.logging import logger
 from ape.managers.base import BaseManager
 from ape.types import AddressType, BlockID, SnapshotID
-from ape.utils import cached_property
 
 
 class BlockContainer(BaseManager):
@@ -330,12 +329,10 @@ class AccountHistory(BaseManager):
     A container mapping account addresses to the transaction from the active session.
     """
 
-    _map: Dict[AddressType, List[ReceiptAPI]] = {}
+    _address_list_map: Dict[AddressType, List[ReceiptAPI]] = {}
 
-    @cached_property
-    def _convert(self) -> Callable:
-
-        return self.conversion_manager.convert
+    # Faciliates faster look-ups.
+    _hash_to_receipt_map: Dict[str, ReceiptAPI] = {}
 
     def __getitem__(self, address: Union[BaseAddress, AddressType, str]) -> List[ReceiptAPI]:
         """
@@ -349,7 +346,7 @@ class AccountHistory(BaseManager):
             are no recorded transactions, returns an empty list.
         """
 
-        address_key: AddressType = self._convert(address, AddressType)
+        address_key: AddressType = self.conversion_manager.convert(address, AddressType)
         explorer = self.provider.network.explorer
         explorer_receipts = (
             [r for r in explorer.get_account_transactions(address_key)] if explorer else []
@@ -359,10 +356,10 @@ class AccountHistory(BaseManager):
             # NOTE: Cache the receipt by its sender and not by the address sent to the explorer API
             #  because explorers return various receipts when given contract addresses.
             sender: AddressType = receipt.sender  # type: ignore
-            if receipt.txn_hash not in [r.txn_hash for r in self._map.get(sender, [])]:
+            if receipt.txn_hash not in [r.txn_hash for r in self._address_list_map.get(sender, [])]:
                 self.append(receipt)
 
-        return self._map.get(address_key, [])
+        return self._address_list_map.get(address_key, [])
 
     def __iter__(self) -> Iterator[AddressType]:
         """
@@ -372,7 +369,7 @@ class AccountHistory(BaseManager):
             List[str]
         """
 
-        yield from self._map
+        yield from self._address_list_map
 
     def items(self) -> Iterator[Tuple[AddressType, List[ReceiptAPI]]]:
         """
@@ -381,7 +378,10 @@ class AccountHistory(BaseManager):
         Returns:
             Iterator[Tuple[``AddressType``, :class:`~ape.api.transactions.ReceiptAPI`]]
         """
-        yield from self._map.items()
+        yield from self._address_list_map.items()
+
+    def values(self) -> Iterator[List[ReceiptAPI]]:
+        yield from self._address_list_map.values()
 
     def append(self, txn_receipt: ReceiptAPI):
         """
@@ -397,16 +397,16 @@ class AccountHistory(BaseManager):
               :meth:`~ape.managers.chain.AccountHistory.__getitem__`.
         """
 
-        address = self._convert(txn_receipt.sender, AddressType)
-        if address not in self._map:
-            self._map[address] = [txn_receipt]
+        self._hash_to_receipt_map[txn_receipt.txn_hash] = txn_receipt
+        address = self.conversion_manager.convert(txn_receipt.sender, AddressType)
+        if address not in self._address_list_map:
+            self._address_list_map[address] = [txn_receipt]
             return
 
-        if txn_receipt.txn_hash in [r.txn_hash for r in self._map[address]]:
+        if txn_receipt.txn_hash in [r.txn_hash for r in self._address_list_map[address]]:
             logger.warning(f"Transaction '{txn_receipt.txn_hash}' already known.")
-            return
 
-        self._map[address].append(txn_receipt)
+        self._address_list_map[address].append(txn_receipt)
 
     def revert_to_block(self, block_number: int):
         """
@@ -416,10 +416,27 @@ class AccountHistory(BaseManager):
             block_number (int): The block number to revert to.
         """
 
-        self._map = {
+        self._address_list_map = {
             a: [r for r in receipts if r.block_number <= block_number]
             for a, receipts in self.items()
         }
+        self._hash_to_receipt_map = {
+            h: r for h, r in self._hash_to_receipt_map.items() if r.block_number <= block_number
+        }
+
+    def get_receipt(self, transaction_hash: str) -> Optional[ReceiptAPI]:
+        """
+        Get a receipt from the history by its transaction hash.
+
+        Args:
+            transaction_hash (str): The hash of the transaction.
+
+        Returns:
+            Optional[:class:`~ape.api.transactions.ReceiptAPI`]: The receipt, if it
+              is present in the transaction history. Else, ``None``.
+        """
+
+        return self._hash_to_receipt_map.get(transaction_hash)
 
 
 class ContractCache(BaseManager):

--- a/src/ape_test/providers.py
+++ b/src/ape_test/providers.py
@@ -136,7 +136,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         if txn.gas_limit is not None and receipt.ran_out_of_gas:
             raise OutOfGasError()
 
-        self._try_track_receipt(receipt)
+        self.chain_manager.account_history.append(receipt)
         return receipt
 
     def snapshot(self) -> SnapshotID:

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -67,6 +67,14 @@ def test_snapshot_and_restore(chain, sender, receiver, vyper_contract_instance, 
     assert receiver.balance == initial_balance
 
 
+def test_get_receipt_from_account_history(chain, vyper_contract_instance, owner):
+    expected = vyper_contract_instance.setNumber(3, sender=owner)
+    actual = chain.account_history.get_receipt(expected.txn_hash)
+    assert actual.txn_hash == expected.txn_hash
+    assert actual.sender == expected.sender
+    assert actual.receiver == expected.receiver
+
+
 def test_snapshot_and_restore_unknown_snapshot_id(chain):
     _ = chain.snapshot()
     chain.mine()

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -72,19 +72,11 @@ def test_get_receipt_not_exists_with_timeout(eth_tester_provider):
         eth_tester_provider.get_receipt(unknown_txn, timeout=0)
 
 
-def test_get_receipt_exists_with_timeout(
-    mocker, eth_tester_provider, vyper_contract_instance, owner
-):
+def test_get_receipt_exists_with_timeout(eth_tester_provider, vyper_contract_instance, owner):
     receipt_from_invoke = vyper_contract_instance.setNumber(123, sender=owner)
-    eth = eth_tester_provider.web3.eth
-    rpc_spy = mocker.spy(eth, "get_transaction")
-
     receipt_from_provider = eth_tester_provider.get_receipt(receipt_from_invoke.txn_hash, timeout=0)
     assert receipt_from_provider.txn_hash == receipt_from_invoke.txn_hash
     assert receipt_from_provider.receiver == vyper_contract_instance.address
-
-    # Ensure that it used the cache (no RPC made)
-    assert not rpc_spy.call_count
 
 
 def test_get_contracts_logs_all_logs(chain, contract_instance, owner, eth_tester_provider):

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -72,11 +72,19 @@ def test_get_receipt_not_exists_with_timeout(eth_tester_provider):
         eth_tester_provider.get_receipt(unknown_txn, timeout=0)
 
 
-def test_get_receipt_exists_with_timeout(eth_tester_provider, vyper_contract_instance, owner):
+def test_get_receipt_exists_with_timeout(
+    mocker, eth_tester_provider, vyper_contract_instance, owner
+):
     receipt_from_invoke = vyper_contract_instance.setNumber(123, sender=owner)
+    eth = eth_tester_provider.web3.eth
+    rpc_spy = mocker.spy(eth, "get_transaction")
+
     receipt_from_provider = eth_tester_provider.get_receipt(receipt_from_invoke.txn_hash, timeout=0)
     assert receipt_from_provider.txn_hash == receipt_from_invoke.txn_hash
     assert receipt_from_provider.receiver == vyper_contract_instance.address
+
+    # Ensure that it used the cache (no RPC made)
+    assert not rpc_spy.call_count
 
 
 def test_get_contracts_logs_all_logs(chain, contract_instance, owner, eth_tester_provider):


### PR DESCRIPTION
### What I did

**I almost have a solid end-to-end on gas reporting in tests.**
However - this is one bit of logic I'd like to extract to its own PR to have it reviewed on its own...

Adds another index to the `AccountHistory` such that we can **rapidly** look up a cached `Receipt` by its `transaction_hash`. Then, attempts to do this in `chain.get_receipt()` so save an RPC call.

**NOTE**: The transactions presently in the `AccountHistory` should all be valid on exist on the chain. Because, when we restore to an older snapshot, we remove those transactions. If the provider cannot find the receipt, it will use the RPC call method instead. Any receipts send by your accounts will for sure be already cached!!! This greatly speeds up testing and will **definitely speed up the gas reporting work I am doing**.

### How I did it

* Add a second map that allows looking up receipts by txn hash in `AccountHistory`.
* Check this map during `get_receipt()` call in `Web3Provider`.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
