### PR TITLE
fix: update web3 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,12 +102,12 @@ setup(
         "traitlets>=5.3.0",
         # ** Dependencies maintained by Ethereum Foundation **
         "eth-abi>=3.0.1,<4",
-        "eth-account>=0.6.1,<0.7",
+        "eth-account>=0.7,<0.8",
         "eth-typing>=3.1,<4",
         "eth-utils>=2.0.0,<3",
         "hexbytes>=0.2.3,<1",
         "py-geth>=3.8.0,<4",
-        "web3[tester]==6.0.0b4",
+        "web3[tester]==6.0.0b6",
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.1.4,<0.2",
         "ethpm-types>=0.3.7,<0.4",

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -644,7 +644,7 @@ class Web3Provider(ProviderAPI, ABC):
         if self._web3 is None:
             return False
 
-        return run_until_complete(self._web3.isConnected())
+        return run_until_complete(self._web3.is_connected())
 
     @cached_property
     def supports_tracing(self) -> bool:

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -211,7 +211,7 @@ class GethProvider(Web3Provider, UpstreamProvider):
             )
             self._geth.connect()
 
-            if not self._web3.isConnected():
+            if not self._web3.is_connected():
                 self._geth.disconnect()
                 raise ConnectionError("Unable to connect to locally running geth.")
         elif "geth" in self.client_version.lower():


### PR DESCRIPTION
### What I did

Correct issue with the `protobuf` dependency of `web3.py` which was causing issues running tests on some macOS machines 

fixes: #1068

### How I did it

Update `web3.py` to [v6.0.0b6](https://web3py.readthedocs.io/en/latest/releases.html#v6-0-0-beta-6-2022-09-26) and `eth-account` to [v0.7.0](https://eth-account.readthedocs.io/en/latest/release_notes.html#eth-account-v0-7-0-2022-08-17)

The only breaking change that affected us seemed to be the `isConnected()` rename, I didn't run into any other issues so far with the updated dependencies but would be best to double check or chime in if there's a known reason preventing us from upgrading `eth-account`

### How to verify it

Attempting to launch `ape test` in a new project no longer results in `ImportError` (per #1068 reproduction steps)

### Checklist
- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
