### PR TITLE
feat: add `--gas` flag to `ape test` command to output gas reports after tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,8 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+**/.DS_Store
+
 # setuptools-scm
 version.py
 

--- a/docs/userguides/testing.md
+++ b/docs/userguides/testing.md
@@ -279,7 +279,7 @@ ape test --network ethereum:local:hardhat --gas
 At the end of test suite, you will see tables such as:
 
 ```sh
-                            FundMe Gas
+                            FundMe.vy Gas
 
   Method           Times called    Min.    Max.    Mean   Median
  ────────────────────────────────────────────────────────────────
@@ -294,7 +294,7 @@ At the end of test suite, you will see tables such as:
  ───────────────────────────────────────────────────────
   to:test0              2   2400   9100   5750     5750
 
-                     TestContractVy Gas
+                     TestContract.Vy Gas
 
   Method      Times called    Min.    Max.    Mean   Median
  ───────────────────────────────────────────────────────────

--- a/docs/userguides/testing.md
+++ b/docs/userguides/testing.md
@@ -266,3 +266,37 @@ When you exit a provider's context, Ape **does not** disconnect the provider.
 When you re-enter that provider's context, Ape uses the previously-connected provider.
 At the end of the tests, Ape disconnects all the providers.
 Thus, you can enter and exit a provider's context as much as you need in tests.
+
+## Gas Reporting
+
+To include a gas report at the end of your tests, you can use the `--gas` flag.
+**NOTE**: This feature requires using a provider with tracing support, such as [ape-hardhat](https://github.com/ApeWorX/ape-hardhat).
+
+```bash
+ape test --network ethereum:local:hardhat --gas
+```
+
+At the end of test suite, you will see tables such as:
+
+```sh
+                            FundMe Gas
+
+  Method           Times called    Min.    Max.    Mean   Median
+ ────────────────────────────────────────────────────────────────
+  fund                        8   57198   91398   82848    91398
+  withdraw                    2   28307   38679   33493    33493
+  changeOnStatus              2   23827   45739   34783    34783
+  getSecret                   1   24564   24564   24564    24564
+
+                  Transferring ETH Gas
+
+  Method     Times called   Min.   Max.   Mean   Median
+ ───────────────────────────────────────────────────────
+  to:test0              2   2400   9100   5750     5750
+
+                     TestContractVy Gas
+
+  Method      Times called    Min.    Max.    Mean   Median
+ ───────────────────────────────────────────────────────────
+  setNumber              1   51021   51021   51021    51021
+```

--- a/docs/userguides/testing.md
+++ b/docs/userguides/testing.md
@@ -294,7 +294,7 @@ At the end of test suite, you will see tables such as:
  ───────────────────────────────────────────────────────
   to:test0              2   2400   9100   5750     5750
 
-                     TestContract.Vy Gas
+                     TestContract.vy Gas
 
   Method      Times called    Min.    Max.    Mean   Median
  ───────────────────────────────────────────────────────────

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -246,17 +246,15 @@ receipt.show_gas_report()
 It will output tables of contracts and methods with gas usages that look like this:
 
 ```bash
-                           DAI Gas
-┏━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┓
-┃ Method    ┃ Times called ┃ Min.  ┃ Max.  ┃ Mean  ┃ Median ┃
-┡━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━┩
-│ balanceOf │ 4            │ 1302  │ 1302  │ 1302  │ 1302   │
-│ transfer  │ 5            │ 6974  │ 30374 │ 20174 │ 26174  │
-│ allowance │ 1            │ 1377  │ 1377  │ 1377  │ 1377   │
-│ approve   │ 1            │ 22414 │ 22414 │ 22414 │ 22414  │
-│ burn      │ 1            │ 11946 │ 11946 │ 11946 │ 11946  │
-│ mint      │ 1            │ 25845 │ 25845 │ 25845 │ 25845  │
-└───────────┴──────────────┴───────┴───────┴───────┴────────┘
+                            DAI Gas
+
+  Method           Times called    Min.    Max.    Mean   Median
+ ────────────────────────────────────────────────────────────────
+  balanceOf                   4   1302    13028   1302    1302
+  allowance                   2   1377    1377    1337    1337
+│ approve                     1   22414   22414   22414   22414
+│ burn                        1   11946   11946   11946   11946
+│ mint                        1   25845   25845   25845   25845
 ```
 
 ## Estimate Gas Cost

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -175,6 +175,10 @@ class ReceiptAPI(BaseInterfaceModel):
         return value
 
     @property
+    def call_tree(self) -> Optional[Any]:
+        return None
+
+    @property
     def failed(self) -> bool:
         """
         Whether the receipt represents a failing transaction.

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -67,13 +67,6 @@ class PytestApeFixtures(ManagerAccessMixin):
 
         return self.project_manager
 
-    def _isolation(self) -> Iterator[None]:
-        """
-        Isolation logic used to implement isolation fixtures for each pytest scope.
-        """
-        with self._isolation_context():
-            yield
-
     @contextmanager
     def _isolation_context(self):
         snapshot_id = self._snapshot()
@@ -81,10 +74,10 @@ class PytestApeFixtures(ManagerAccessMixin):
         if snapshot_id:
             self._restore(snapshot_id)
 
-    def _func_isolation(self) -> Iterator[None]:
+    def _isolation(self) -> Iterator[None]:
         """
-        When tracing support is available, will also
-        assist in capturing receipts.
+        Isolation logic used to implement isolation fixtures for each pytest scope.
+        When tracing support is available, will also assist in capturing receipts.
         """
 
         with self._isolation_context():
@@ -108,7 +101,7 @@ class PytestApeFixtures(ManagerAccessMixin):
     _package_isolation = pytest.fixture(_isolation, scope="package")
     _module_isolation = pytest.fixture(_isolation, scope="module")
     _class_isolation = pytest.fixture(_isolation, scope="class")
-    _function_isolation = pytest.fixture(_func_isolation, scope="function")
+    _function_isolation = pytest.fixture(_isolation, scope="function")
 
     @allow_disconnected
     def _snapshot(self) -> Optional[SnapshotID]:

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -129,9 +129,7 @@ class PytestApeFixtures(ManagerAccessMixin):
         if snapshot_id not in self.chain_manager._snapshots:
             return
 
-        _silence_connection_failure(
-            lambda: self.chain_manager.restore(snapshot_id)
-        )
+        _silence_connection_failure(lambda: self.chain_manager.restore(snapshot_id))
 
     def _get_block_number(self) -> Optional[int]:
         return _silence_connection_failure(lambda: self.provider.get_block("latest").number)
@@ -187,7 +185,7 @@ class ReceiptCapture(ManagerAccessMixin):
         # Ensure call_tree is cached
         call_tree = receipt.call_tree
         do_track_gas = track_gas if track_gas is not None else self._track_gas
-        if do_track_gas:
+        if do_track_gas and call_tree:
             parser = CallTraceParser(receipt)
             gas_report = parser._get_rich_gas_report(call_tree)
             if self.gas_report:

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -101,7 +101,7 @@ class PytestApeFixtures(ManagerAccessMixin):
 
             if start_block is not None and self._using_traces:
                 stop_block = self._get_block_number()
-                if stop_block is not None:
+                if stop_block is not None and start_block <= stop_block:
                     self.receipt_capture.capture_range(start_block, stop_block)
 
     # isolation fixtures

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 from typing import Dict, Iterator, List, Optional
 
 import pytest
@@ -67,25 +66,22 @@ class PytestApeFixtures(ManagerAccessMixin):
 
         return self.project_manager
 
-    @contextmanager
-    def _isolation_context(self):
-        snapshot_id = self._snapshot()
-        yield snapshot_id
-        if snapshot_id:
-            self._restore(snapshot_id)
-
     def _isolation(self) -> Iterator[None]:
         """
         Isolation logic used to implement isolation fixtures for each pytest scope.
         When tracing support is available, will also assist in capturing receipts.
         """
 
-        with self._isolation_context():
-            if self._using_traces:
-                with self.receipt_capture:
-                    yield
-            else:
+        snapshot_id = self._snapshot()
+
+        if self._using_traces:
+            with self.receipt_capture:
                 yield
+        else:
+            yield
+
+        if snapshot_id:
+            self._restore(snapshot_id)
 
     # isolation fixtures
     _session_isolation = pytest.fixture(_isolation, scope="session")

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -7,7 +7,7 @@ from rich import print as rich_print
 
 import ape
 from ape.api import ProviderContextManager
-from ape.logging import logger, LogLevel
+from ape.logging import LogLevel, logger
 from ape.pytest.contextmanagers import RevertsContextManager
 from ape.pytest.fixtures import ReceiptCapture
 from ape.utils import ManagerAccessMixin, parse_gas_table

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -170,6 +170,7 @@ class PytestApeRunner(ManagerAccessMixin):
             else:
                 terminalreporter.write_line(f"{LogLevel.WARNING.name}: No gas usage data found.")
 
+    def pytest_unconfigure(self):
         if self._provider_is_connected:
             self._provider_context.disconnect_all()
             self._provider_is_connected = False

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -3,12 +3,14 @@ from pathlib import Path
 import click
 import pytest
 from _pytest.config import Config as PytestConfig
+from rich import print as rich_print
 
 import ape
 from ape.api import ProviderContextManager
 from ape.logging import logger
 from ape.pytest.contextmanagers import RevertsContextManager
-from ape.utils import ManagerAccessMixin
+from ape.pytest.fixtures import ReceiptCapture
+from ape.utils import ManagerAccessMixin, parse_gas_table
 from ape_console._cli import console
 
 
@@ -16,8 +18,10 @@ class PytestApeRunner(ManagerAccessMixin):
     def __init__(
         self,
         pytest_config: PytestConfig,
+        receipt_capture: ReceiptCapture,
     ):
         self.pytest_config = pytest_config
+        self.receipt_capture = receipt_capture
         self._provider_is_connected = False
         ape.reverts = RevertsContextManager  # type: ignore
 
@@ -38,7 +42,6 @@ class PytestApeRunner(ManagerAccessMixin):
         """
 
         if self.pytest_config.getoption("interactive") and report.failed:
-
             capman = self.pytest_config.pluginmanager.get_plugin("capturemanager")
             if capman:
                 capman.suspend_global_capture(in_=True)
@@ -153,14 +156,18 @@ class PytestApeRunner(ManagerAccessMixin):
             self._provider_context.push_provider()
             self._provider_is_connected = True
 
-    def pytest_sessionfinish(self):
+    def pytest_terminal_summary(self, terminalreporter):
         """
-        Called after whole test run finished, right before returning the exit
-        status to the system.
+        Add a section to terminal summary reporting.
+        When ``--gas`` is active, outputs the gas profile report.
+        """
+        if self.pytest_config.getoption("--gas"):
+            terminalreporter.section("Gas Profile")
+            gas_report = self.receipt_capture.gas_report
+            if gas_report:
+                tables = parse_gas_table(gas_report)
+                rich_print(*tables)
 
-        **NOTE**: This hook fires even when exceptions occur, so we cannot
-        assume the provider successfully connected.
-        """
         if self._provider_is_connected:
             self._provider_context.disconnect_all()
             self._provider_is_connected = False

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -7,7 +7,7 @@ from rich import print as rich_print
 
 import ape
 from ape.api import ProviderContextManager
-from ape.logging import logger
+from ape.logging import logger, LogLevel
 from ape.pytest.contextmanagers import RevertsContextManager
 from ape.pytest.fixtures import ReceiptCapture
 from ape.utils import ManagerAccessMixin, parse_gas_table
@@ -167,6 +167,8 @@ class PytestApeRunner(ManagerAccessMixin):
             if gas_report:
                 tables = parse_gas_table(gas_report)
                 rich_print(*tables)
+            else:
+                terminalreporter.write_line(f"{LogLevel.WARNING.name}: No gas usage data found.")
 
         if self._provider_is_connected:
             self._provider_context.disconnect_all()

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -55,6 +55,12 @@ and otherwise you can provide a numeric value.
 """
 
 
+GasReport = Dict[str, Dict[str, List[int]]]
+"""
+A gas report in Ape.
+"""
+
+
 TopicFilter = List[Union[Optional[HexStr], List[Optional[HexStr]]]]
 
 

--- a/src/ape/utils/__init__.py
+++ b/src/ape/utils/__init__.py
@@ -49,7 +49,7 @@ from ape.utils.testing import (
     GeneratedDevAccount,
     generate_dev_accounts,
 )
-from ape.utils.trace import CallTraceParser, TraceStyles
+from ape.utils.trace import CallTraceParser, TraceStyles, parse_gas_table
 
 __all__ = [
     "abstractmethod",
@@ -82,6 +82,7 @@ __all__ = [
     "load_config",
     "LogInputABICollection",
     "ManagerAccessMixin",
+    "parse_gas_table",
     "parse_type",
     "raises_not_implemented",
     "returns_array",

--- a/src/ape/utils/__init__.py
+++ b/src/ape/utils/__init__.py
@@ -25,6 +25,7 @@ from ape.utils.misc import (
     USER_AGENT,
     ZERO_ADDRESS,
     add_padding_to_strings,
+    allow_disconnected,
     cached_property,
     extract_nested_value,
     gas_estimation_error_message,
@@ -54,6 +55,7 @@ from ape.utils.trace import CallTraceParser, TraceStyles, parse_gas_table
 __all__ = [
     "abstractmethod",
     "add_padding_to_strings",
+    "allow_disconnected",
     "BaseInterface",
     "BaseInterfaceModel",
     "cached_property",

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -3,7 +3,7 @@ import json
 import sys
 from functools import cached_property, lru_cache, singledispatchmethod
 from pathlib import Path
-from typing import Any, Coroutine, Dict, List, Mapping, Optional
+from typing import Any, Callable, Coroutine, Dict, List, Mapping, Optional
 
 import requests
 import yaml
@@ -12,7 +12,7 @@ from importlib_metadata import PackageNotFoundError, distributions, packages_dis
 from importlib_metadata import version as version_metadata
 from tqdm.auto import tqdm  # type: ignore
 
-from ape.exceptions import APINotImplementedError
+from ape.exceptions import APINotImplementedError, ProviderNotConnectedError
 from ape.logging import logger
 from ape.utils.os import expand_environment_variables
 
@@ -292,7 +292,35 @@ def run_until_complete(item: Any) -> Any:
     return loop.run_until_complete(item)
 
 
+def allow_disconnected(fn: Callable):
+    """
+    A decorator that instead of raising :class:`~ape.exceptions.ProviderNotConnectedError`
+    warns and returns ``None``.
+
+    Usage example::
+
+        from typing import Optional
+        from ape.types import SnapshotID
+        from ape.utils import return_none_when_disconnected
+
+        @allow_disconnected
+        def try_snapshot(self) -> Optional[SnapshotID]:
+            return self.chain.snapshot()
+
+    """
+
+    def inner(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except ProviderNotConnectedError:
+            logger.warning("Provider is not connected.")
+            return None
+
+    return inner
+
+
 __all__ = [
+    "allow_disconnected",
     "cached_property",
     "extract_nested_value",
     "gas_estimation_error_message",

--- a/src/ape/utils/trace.py
+++ b/src/ape/utils/trace.py
@@ -153,7 +153,7 @@ class CallTraceParser(ManagerAccessMixin):
 
                 call_signature = str(
                     _MethodTraceSignature(
-                        contract_id or address,
+                        contract_id,
                         method.name or f"<{selector}>",  # type: ignore
                         arguments,
                         return_value,
@@ -175,7 +175,7 @@ class CallTraceParser(ManagerAccessMixin):
                     }
                     call_signature += f" {json.dumps(extra_info, indent=self._indent)}"
             elif contract_id != address:
-                call_signature = next(TreeRepresentation.make_tree(call)).title  # type: ignore
+                call_signature = next(TreeRepresentation.make_tree(call)).title
                 call_signature = call_signature.replace(address, contract_id)
                 call_signature = _dim_default_gas(call_signature)
         else:

--- a/src/ape/utils/trace.py
+++ b/src/ape/utils/trace.py
@@ -326,12 +326,12 @@ class CallTraceParser(ManagerAccessMixin):
         selector = calltree.calldata[:4]
         contract_id = self._get_contract_id(address, contract_type=contract_type)
 
-        if contract_id == _ETH_TRANSFER:
-            receiver_id = address
-            if receiver_id in self.account_manager:
-                receiver_id = self.account_manager[receiver_id].alias
-
+        if contract_id == _ETH_TRANSFER and address in self.account_manager:
+            receiver_id = self.account_manager[address].alias or address
             method_id = f"to:{receiver_id}"
+
+        elif contract_id == _ETH_TRANSFER:
+            method_id = f"to:{address}"
 
         elif contract_type:
             method_abi = _get_method_abi(selector, contract_type)

--- a/src/ape/utils/trace.py
+++ b/src/ape/utils/trace.py
@@ -334,6 +334,9 @@ class CallTraceParser(ManagerAccessMixin):
             method_id = f"to:{address}"
 
         elif contract_type:
+            # NOTE: Use source ID when possible to distinguish between sources with the same
+            #  symbol or contract name.
+            contract_id = contract_type.source_id or contract_id
             method_abi = _get_method_abi(selector, contract_type)
             method_id = selector.hex() if not method_abi else method_abi.name
 

--- a/tests/functional/utils/test_trace.py
+++ b/tests/functional/utils/test_trace.py
@@ -110,7 +110,7 @@ def assert_trace(capsys):
             parts = line.split(" ")
             for part in [p.strip() for p in parts if p.strip()]:
                 part = part.strip()
-                assert part in actual, f"Could not find '{part}' in expected"
+                assert part in actual, f"Could not find '{part}' in expected\n{output}"
 
     return assert_trace
 

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -44,3 +44,10 @@ def test_fixture_docs(ape_test_runner, project):
         # The doc str of the fixture shows in the CLI output
         doc_str = fixture.__doc__.strip()
         assert doc_str in result.output
+
+
+@skip_projects_except(["test"])
+def test_gas_flag(ape_test_runner, project):
+    # NOTE: See `ape-hardhat` for better gas reporting tests.
+    result = ape_test_runner.invoke(["--help"])
+    assert "--gas" in result.output


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #350 

### How I did it

* Add `--gas` flag to `ape test` command
* In function isolation fixture, build the tree on each incoming receipt
* In terminal reporting pytest hook, output the gas report

### How to verify it

1. Make sure to use a provider like `ape-hardhat` or `ape-foundry` that supports tracing.
2. Go to your project with tests
3. Run `ape test --gas` or however you run your tests, just include `--gas`.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
