### PR TITLE
feat: assert on dev revert messages

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -61,7 +61,7 @@ class TransactionAPI(BaseInterfaceModel):
         to submit the transaction.
         """
         if self.max_fee is None:
-            raise TransactionError(message="Max fee must not be null.")
+            raise TransactionError(message="Max fee must not be null.", txn=self)
 
         return self.value + self.max_fee
 
@@ -279,7 +279,7 @@ class ReceiptAPI(BaseInterfaceModel):
                 iteration += 1
                 if iteration == iterations_timeout:
                     raise TransactionError(
-                        message="Timeout waiting for sender's nonce to increase."
+                        message="Timeout waiting for sender's nonce to increase.", txn=self
                     )
 
         if self.required_confirmations == 0:

--- a/src/ape_test/_cli.py
+++ b/src/ape_test/_cli.py
@@ -1,4 +1,5 @@
 import sys
+from unittest import mock
 
 import click
 import pytest
@@ -14,7 +15,9 @@ from ape.cli import ape_cli_context
 @ape_cli_context()
 @click.argument("pytest_args", nargs=-1, type=click.UNPROCESSED)
 def cli(cli_ctx, pytest_args):
-    return_code = pytest.main([*pytest_args], ["ape_test"])
+    with mock.patch.dict("os.environ", {"APE_TESTING": "1"}):
+        return_code = pytest.main([*pytest_args], ["ape_test"])
+
     if return_code:
         # only exit with non-zero status to make testing easier
         sys.exit(return_code)


### PR DESCRIPTION
### What I did

Add dev message assertions to `ape.reverts()`

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: APE-43

### How I did it

Adds `txn` property to `TransactionError` exceptions. This transaction is then utilized by the `RevertsContextManager`to fetch the transaction trace and find out the originating contract (receiver).

A `dev_message` (mutually exclusive with `expected_message`) was added to `RevertsContextManager`. When supplied, the exception is inspected for a transaction and the transaction trace is inspected. If the trace or contract source cannot be retrieved for any reason, the manager raises `AssertionError`. If a dev message is not found, `AssertionError` is raised. Finally, if a dev message is found but does not match the expectation, this also raises `AssertionError`

### How to verify it

Test project available at https://github.com/helloibis/ape-revert-test-project

### Caveats

- Does not currently work with Solidity (APE-298) or Cairo (APE-299)
- Requires use of a provider that supports tracing (such as Hardhat)
  - Cannot be used with the test `LocalProvider`
- May not work when JSON format contracts are supplied to Vyper, but still testing this
- Cannot support non-local sources currently

### Checklist
- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated