### PR TITLE
feat: error msg to say missing compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+contracts/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -376,7 +376,7 @@ class ProjectManager(BaseManager):
                 if missing_exts:
                     message = (
                         f"{message} Could it be from one of the missing compilers for extensions:"
-                        + f"{', '.join(missing_exts)}"
+                        + ', '.join(missing_exts)
                     )
 
                 raise AttributeError(message) from err

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -375,7 +375,7 @@ class ProjectManager(BaseManager):
                 missing_exts = self.extensions_with_missing_compilers([])
                 if missing_exts:
                     message = (
-                        f"{message} Could it be from one of the missing compilers for extensions:"
+                        f"{message} Could it be from one of the missing compilers for extensions: "
                         + ", ".join(missing_exts)
                     )
 

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -368,7 +368,15 @@ class ProjectManager(BaseManager):
 
             # Fixes anomaly when accessing non-ContractType attributes.
             # Returns normal attribute if exists. Raises 'AttributeError' otherwise.
-            return self.__getattribute__(attr_name)  # type: ignore
+            try:
+                return self.__getattribute__(attr_name)  # type: ignore
+            except AttributeError as err:
+                message = f"ProjectManager has no attribute or contract named '{attr_name}'."
+                missing_exts = self.extensions_with_missing_compilers([])
+                if missing_exts:
+                    message = f"{message} Could it be from one of the missing compilers for extensions: {', '.join(missing_exts)}"
+
+                raise AttributeError(message) from err
 
         return contract
 

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -404,7 +404,9 @@ class ProjectManager(BaseManager):
 
         return contract
 
-    def extensions_with_missing_compilers(self, extensions: Optional[List[str]]) -> List[str]:
+    def extensions_with_missing_compilers(
+        self, extensions: Optional[List[str]] = None
+    ) -> List[str]:
         """
         All file extensions in the ``contracts/`` directory (recursively)
         that do not correspond to a registered compiler.
@@ -417,6 +419,8 @@ class ProjectManager(BaseManager):
             List[str]: A list of file extensions found in the ``contracts/`` directory
             that do not have associated compilers installed.
         """
+        extensions = extensions or []
+
         extensions_found = []
 
         def _append_extensions_in_dir(directory: Path):

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -376,7 +376,7 @@ class ProjectManager(BaseManager):
                 if missing_exts:
                     message = (
                         f"{message} Could it be from one of the missing compilers for extensions: "
-                        + ", ".join(missing_exts)
+                        + f'{", ".join(sorted(missing_exts))}?'
                     )
 
                 raise AttributeError(message) from err

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -376,7 +376,7 @@ class ProjectManager(BaseManager):
                 if missing_exts:
                     message = (
                         f"{message} Could it be from one of the missing compilers for extensions:"
-                        + ', '.join(missing_exts)
+                        + ", ".join(missing_exts)
                     )
 
                 raise AttributeError(message) from err

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -374,7 +374,10 @@ class ProjectManager(BaseManager):
                 message = f"ProjectManager has no attribute or contract named '{attr_name}'."
                 missing_exts = self.extensions_with_missing_compilers([])
                 if missing_exts:
-                    message = f"{message} Could it be from one of the missing compilers for extensions: {', '.join(missing_exts)}"
+                    message = (
+                        f"{message} Could it be from one of the missing compilers for extensions:"
+                        + f"{', '.join(missing_exts)}"
+                    )
 
                 raise AttributeError(message) from err
 

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -422,8 +422,6 @@ class ProjectManager(BaseManager):
             List[str]: A list of file extensions found in the ``contracts/`` directory
             that do not have associated compilers installed.
         """
-        extensions = extensions or []
-
         extensions_found = []
 
         def _append_extensions_in_dir(directory: Path):

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -34,6 +34,8 @@ BASE_PROJECTS_DIRECTORY = (Path(__file__).parent / "data" / "projects").absolute
 PROJECT_WITH_LONG_CONTRACTS_FOLDER = BASE_PROJECTS_DIRECTORY / "LongContractsFolder"
 DS_NOTE_TEST_CONTRACT_TYPE = _get_raw_contract("ds_note_test")
 APE_PROJECT_FOLDER = BASE_PROJECTS_DIRECTORY / "ApeProject"
+BASE_SOURCES_DIRECTORY = (Path(__file__).parent / "data/sources").absolute()
+
 
 
 class _ContractLogicError(ContractLogicError):
@@ -176,6 +178,18 @@ def project_with_contract(config):
     project_source_dir = APE_PROJECT_FOLDER
     project_dest_dir = config.PROJECT_FOLDER / project_source_dir.name
     copy_tree(project_source_dir.as_posix(), project_dest_dir.as_posix())
+
+    with config.using_project(project_dest_dir) as project:
+        yield project
+
+
+@pytest.fixture
+def project_with_source_files_contract(config):
+    bases_source_dir = BASE_SOURCES_DIRECTORY
+    project_source_dir = APE_PROJECT_FOLDER
+    project_dest_dir = config.PROJECT_FOLDER / project_source_dir.name
+    copy_tree(project_source_dir.as_posix(), project_dest_dir.as_posix())
+    copy_tree(bases_source_dir.as_posix(), project_dest_dir.as_posix() + "/contracts/")
 
     with config.using_project(project_dest_dir) as project:
         yield project

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -37,7 +37,6 @@ APE_PROJECT_FOLDER = BASE_PROJECTS_DIRECTORY / "ApeProject"
 BASE_SOURCES_DIRECTORY = (Path(__file__).parent / "data/sources").absolute()
 
 
-
 class _ContractLogicError(ContractLogicError):
     pass
 

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -7,6 +7,7 @@ def test_missing_compilers_without_source_files(project):
     result = project.extensions_with_missing_compilers()
     assert result == []
 
+
 def test_missing_compilers_with_source_files(project_with_source_files_contract):
     result = project_with_source_files_contract.extensions_with_missing_compilers()
-    assert result == ['.sol', '.vy']
+    assert result == [".sol", ".vy"]

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_get_imports(project, compilers):
     # See ape-solidity for better tests
     assert not compilers.get_imports(project.source_paths)
@@ -12,3 +15,12 @@ def test_missing_compilers_with_source_files(project_with_source_files_contract)
     result = project_with_source_files_contract.extensions_with_missing_compilers()
     assert ".vy" in result
     assert ".sol" in result
+
+
+def test_missing_compilers_error_message(project_with_source_files_contract, sender):
+    with pytest.raises(AttributeError) as err:
+        project_with_source_files_contract.ContractA.deploy(sender=sender)
+    assert (
+        err.value.args[0]
+        == "ProjectManager has no attribute or contract named 'ContractA'. Could it be from one of the missing compilers for extensions:.sol, .vy"
+    )

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -3,6 +3,10 @@ def test_get_imports(project, compilers):
     assert not compilers.get_imports(project.source_paths)
 
 
-def test_extensions_with_missing_compilers(project, compilers):
+def test_missing_compilers_without_source_files(project):
     result = project.extensions_with_missing_compilers()
     assert result == []
+
+def test_missing_compilers_with_source_files(project_with_source_files_contract):
+    result = project_with_source_files_contract.extensions_with_missing_compilers()
+    assert result == ['.sol', '.vy']

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -18,9 +18,11 @@ def test_missing_compilers_with_source_files(project_with_source_files_contract)
 
 
 def test_missing_compilers_error_message(project_with_source_files_contract, sender):
+    missing_exts = project_with_source_files_contract.extensions_with_missing_compilers()
     expected = (
         "ProjectManager has no attribute or contract named 'ContractA'. "
-        "Could it be from one of the missing compilers for extensions: .sol, .vy"
+        "Could it be from one of the missing compilers for extensions: "
+        f'{", ".join(sorted(missing_exts))}?'
     )
     with pytest.raises(AttributeError, match=expected):
         project_with_source_files_contract.ContractA.deploy(sender=sender)

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -22,5 +22,5 @@ def test_missing_compilers_error_message(project_with_source_files_contract, sen
         "ProjectManager has no attribute or contract named 'ContractA'. "
         "Could it be from one of the missing compilers for extensions: .sol, .vy"
     )
-    with pytest.raises(AttributeError, match=expected) as err:
+    with pytest.raises(AttributeError, match=expected):
         project_with_source_files_contract.ContractA.deploy(sender=sender)

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -10,4 +10,5 @@ def test_missing_compilers_without_source_files(project):
 
 def test_missing_compilers_with_source_files(project_with_source_files_contract):
     result = project_with_source_files_contract.extensions_with_missing_compilers()
-    assert result == [".sol", ".vy"]
+    assert ".vy" in result 
+    assert ".sol" in result

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -18,9 +18,10 @@ def test_missing_compilers_with_source_files(project_with_source_files_contract)
 
 
 def test_missing_compilers_error_message(project_with_source_files_contract, sender):
+    expected = (
+        "ProjectManager has no attribute or contract named 'ContractA'. "
+        "Could it be from one of the missing compilers for extensions:.sol, .vy"
+    )
     with pytest.raises(AttributeError) as err:
         project_with_source_files_contract.ContractA.deploy(sender=sender)
-    assert (
-        err.value.args[0]
-        == "ProjectManager has no attribute or contract named 'ContractA'. Could it be from one of the missing compilers for extensions:.sol, .vy"
-    )
+    assert err.value.args[0] == expected

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -10,5 +10,5 @@ def test_missing_compilers_without_source_files(project):
 
 def test_missing_compilers_with_source_files(project_with_source_files_contract):
     result = project_with_source_files_contract.extensions_with_missing_compilers()
-    assert ".vy" in result 
+    assert ".vy" in result
     assert ".sol" in result

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -22,6 +22,5 @@ def test_missing_compilers_error_message(project_with_source_files_contract, sen
         "ProjectManager has no attribute or contract named 'ContractA'. "
         "Could it be from one of the missing compilers for extensions: .sol, .vy"
     )
-    with pytest.raises(AttributeError) as err:
+    with pytest.raises(AttributeError, match=expected) as err:
         project_with_source_files_contract.ContractA.deploy(sender=sender)
-    assert err.value.args[0] == expected

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -1,3 +1,8 @@
 def test_get_imports(project, compilers):
     # See ape-solidity for better tests
     assert not compilers.get_imports(project.source_paths)
+
+
+def test_extensions_with_missing_compilers(project, compilers):
+    result = project.extensions_with_missing_compilers()
+    assert result == []

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -20,7 +20,7 @@ def test_missing_compilers_with_source_files(project_with_source_files_contract)
 def test_missing_compilers_error_message(project_with_source_files_contract, sender):
     expected = (
         "ProjectManager has no attribute or contract named 'ContractA'. "
-        "Could it be from one of the missing compilers for extensions:.sol, .vy"
+        "Could it be from one of the missing compilers for extensions: .sol, .vy"
     )
     with pytest.raises(AttributeError) as err:
         project_with_source_files_contract.ContractA.deploy(sender=sender)


### PR DESCRIPTION
### What I did
added error message in case compiler extensions are missing

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #964
fixes: APE-273

### How I did it
If the attribute throws an error then it checks the missing extensions and shows them as the error message

### How to verify it
building tests soon

### Checklist

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
