### PR TITLE
docs: correctly command is "ape --verbosity DEBUG run"

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Learn more about scripting using Ape by following the [scripting guide](https://
 To enable debug logging, run your command with the `--verbosity` flag using `DEBUG` as the value:
 
 ```bash
-ape run --verbosity DEBUG
+ape --verbosity DEBUG run
 ```
 
 ### Networks


### PR DESCRIPTION
### What I did
When I tried to use the command "ape run --verbosity DEBUG" as you can see in README.md file I saw:

```
$ ape run --verbosity DEBUG
Usage: ape run [OPTIONS] COMMAND [ARGS]...
Try 'ape run -h' for help.

Error: No such option: --verbosity
```
--verbosity is the option of ape method as you can see at:

```
Usage: ape [OPTIONS] COMMAND [ARGS]...

Options:
  -v, --verbosity LVL  One of ERROR, WARNING, SUCCESS, INFO, or DEBUG
  --version            Show the version and exit.
  --config             Show configuration options (using `ape-config.yaml`)
  -h, --help           Show this message and exit...
```
### How I did it
I replaced the command "ape run --verbosity DEBUG" by "ape --verbosity DEBUG run" in README.md.
### How to verify it
```
$ ape --verbosity DEBUG run
Usage: ape run [OPTIONS] COMMAND [ARGS]...

  Run scripts from the "scripts/" folder of a project. A script must either
  define a ``main()`` method, or define a command named ``cli`` that is a
  ``click.Command`` or ``click.Group`` object. Scripts with only a ``main()``
  method will be called with a network option given to the command. Scripts
  with a ``cli`` command should import any mix-ins necessary to operate from
  the ``ape.cli`` package.

Options:
  -I, --interactive  Drop into interactive console session after running
  -h, --help         Show this message and exit.
```

### Checklist

- [x] All changes are completed
- [ ] New test cases have been added
- [x] Documentation has been updated
