### PR TITLE
fix: remove `ropsten`, `kovan`, and `rinkeby`.

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -103,28 +103,26 @@ class NetworkConfig(PluginConfig):
         return value
 
 
-def _create_fork_config(**kwargs) -> NetworkConfig:
+def _create_local_config(default_provider: Optional[str] = None, **kwargs) -> NetworkConfig:
     return _create_config(
-        default_provider=None,
+        required_confirmations=0,
+        default_provider=default_provider,
         transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
         **kwargs,
     )
 
 
-def _create_config(**kwargs) -> NetworkConfig:
-    # Put in own method to isolate type: ignore comments
-    return NetworkConfig(**kwargs)  # type: ignore
+def _create_config(required_confirmations: int = 2, **kwargs) -> NetworkConfig:
+    # Put in own method to isolate `type: ignore` comments
+    return NetworkConfig(required_confirmations=required_confirmations, **kwargs)  # type: ignore
 
 
 class EthereumConfig(PluginConfig):
-    mainnet: NetworkConfig = _create_config(required_confirmations=7, block_time=13)
-    mainnet_fork: NetworkConfig = _create_fork_config()
-    goerli: NetworkConfig = _create_config(required_confirmations=2, block_time=15)
-    goerli_fork: NetworkConfig = _create_fork_config()
-    local: NetworkConfig = _create_config(
-        default_provider="test",
-        transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
-    )
+    mainnet: NetworkConfig = _create_config(block_time=13)
+    mainnet_fork: NetworkConfig = _create_local_config()
+    goerli: NetworkConfig = _create_config(block_time=15)
+    goerli_fork: NetworkConfig = _create_local_config()
+    local: NetworkConfig = _create_local_config(default_provider="test")
     default_network: str = LOCAL_NETWORK_NAME
 
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -39,9 +39,6 @@ from ape_ethereum.transactions import (
 NETWORKS = {
     # chain_id, network_id
     "mainnet": (1, 1),
-    "ropsten": (3, 3),
-    "kovan": (42, 42),
-    "rinkeby": (4, 4),
     "goerli": (5, 5),
 }
 
@@ -87,7 +84,7 @@ class NetworkConfig(PluginConfig):
     class Config:
         smart_union = True
 
-    @validator("gas_limit", pre=True)
+    @validator("gas_limit", pre=True, allow_reuse=True)
     def validate_gas_limit(cls, value: GasLimit) -> GasLimit:
         if isinstance(value, str):
             if value.lower() in ("auto", "max"):
@@ -106,36 +103,28 @@ class NetworkConfig(PluginConfig):
         return value
 
 
+def _create_fork_config(**kwargs) -> NetworkConfig:
+    return _create_config(
+        default_provider=None,
+        transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
+        **kwargs,
+    )
+
+
+def _create_config(**kwargs) -> NetworkConfig:
+    # Put in own method to isolate type: ignore comments
+    return NetworkConfig(**kwargs)  # type: ignore
+
+
 class EthereumConfig(PluginConfig):
-    mainnet: NetworkConfig = NetworkConfig(required_confirmations=7, block_time=13)  # type: ignore
-    mainnet_fork: NetworkConfig = NetworkConfig(
-        default_provider=None,
-        transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
-    )  # type: ignore
-    ropsten: NetworkConfig = NetworkConfig(required_confirmations=12, block_time=15)  # type: ignore
-    ropsten_fork: NetworkConfig = NetworkConfig(
-        default_provider=None,
-        transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
-    )  # type: ignore
-    kovan: NetworkConfig = NetworkConfig(required_confirmations=2, block_time=4)  # type: ignore
-    kovan_fork: NetworkConfig = NetworkConfig(
-        default_provider=None,
-        transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
-    )  # type: ignore
-    rinkeby: NetworkConfig = NetworkConfig(required_confirmations=2, block_time=15)  # type: ignore
-    rinkeby_fork: NetworkConfig = NetworkConfig(
-        default_provider=None,
-        transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
-    )  # type: ignore
-    goerli: NetworkConfig = NetworkConfig(required_confirmations=2, block_time=15)  # type: ignore
-    goerli_fork: NetworkConfig = NetworkConfig(
-        default_provider=None,
-        transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
-    )  # type: ignore
-    local: NetworkConfig = NetworkConfig(
+    mainnet: NetworkConfig = _create_config(required_confirmations=7, block_time=13)
+    mainnet_fork: NetworkConfig = _create_fork_config()
+    goerli: NetworkConfig = _create_config(required_confirmations=2, block_time=15)
+    goerli_fork: NetworkConfig = _create_fork_config()
+    local: NetworkConfig = _create_config(
         default_provider="test",
         transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
-    )  # type: ignore
+    )
     default_network: str = LOCAL_NETWORK_NAME
 
 

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -248,7 +248,6 @@ class GethProvider(Web3Provider, UpstreamProvider):
                 else "Error getting chain id."
             )
 
-        # If network a custom PoA testnet
         if is_likely_poa():
             self._web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -248,8 +248,8 @@ class GethProvider(Web3Provider, UpstreamProvider):
                 else "Error getting chain id."
             )
 
-        # If network is goerli or a custom PoA testnet
-        if chain_id == 5 or is_likely_poa():
+        # If network a custom PoA testnet
+        if is_likely_poa():
             self._web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
         self.network.verify_chain_id(chain_id)

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -121,9 +121,6 @@ class EphemeralGeth(LoggingMixin, BaseGethProcess):
 class GethNetworkConfig(PluginConfig):
     # Make sure you are running the right networks when you try for these
     mainnet: dict = DEFAULT_SETTINGS.copy()
-    ropsten: dict = DEFAULT_SETTINGS.copy()
-    rinkeby: dict = DEFAULT_SETTINGS.copy()
-    kovan: dict = DEFAULT_SETTINGS.copy()
     goerli: dict = DEFAULT_SETTINGS.copy()
     # Make sure to run via `geth --dev` (or similar)
     local: dict = DEFAULT_SETTINGS.copy()
@@ -251,8 +248,8 @@ class GethProvider(Web3Provider, UpstreamProvider):
                 else "Error getting chain id."
             )
 
-        # If network is rinkeby, goerli, or kovan (PoA test-nets)
-        if chain_id in (4, 5, 42) or is_likely_poa():
+        # If network is goerli or a custom PoA testnet
+        if chain_id == 5 or is_likely_poa():
             self._web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
         self.network.verify_chain_id(chain_id)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -382,7 +382,7 @@ def use_debug(logger):
 
 @pytest.fixture
 def dummy_live_network(chain):
-    chain.provider.network.name = "rinkeby"
+    chain.provider.network.name = "goerli"
     yield chain.provider.network
     chain.provider.network.name = LOCAL_NETWORK_NAME
 

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -421,7 +421,7 @@ def test_get_deployments_live_migration(
     chain, owner, contract_0, dummy_live_network, caplog, use_debug
 ):
     contract = owner.deploy(contract_0, required_confirmations=0)
-    old_style_map = {"ethereum": {"rinkeby": {"ApeContract0": [contract.address]}}}
+    old_style_map = {"ethereum": {"goerli": {"ApeContract0": [contract.address]}}}
     chain.contracts._write_deployments_mapping(old_style_map)
     actual = chain.contracts.get_deployments(contract_0)
     assert actual == [contract]

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -1,6 +1,18 @@
 import pytest
 
 
+@pytest.fixture
+def skip_if_vyper_or_solidity_installed(compilers):
+    registered_compilers = compilers.registered_compilers
+    skip_msg = "Cannot have {0} plugin installed to run test!"
+    if ".vy" in registered_compilers:
+        pytest.skip(skip_msg.format("Vyper"))
+    elif ".sol":
+        pytest.skip(skip_msg.format("Solidity"))
+
+    yield
+
+
 def test_get_imports(project, compilers):
     # See ape-solidity for better tests
     assert not compilers.get_imports(project.source_paths)
@@ -11,13 +23,17 @@ def test_missing_compilers_without_source_files(project):
     assert result == []
 
 
-def test_missing_compilers_with_source_files(project_with_source_files_contract):
+def test_missing_compilers_with_source_files(
+    project_with_source_files_contract, skip_if_vyper_or_solidity_installed
+):
     result = project_with_source_files_contract.extensions_with_missing_compilers()
     assert ".vy" in result
     assert ".sol" in result
 
 
-def test_missing_compilers_error_message(project_with_source_files_contract, sender):
+def test_missing_compilers_error_message(
+    project_with_source_files_contract, sender, skip_if_vyper_or_solidity_installed
+):
     missing_exts = project_with_source_files_contract.extensions_with_missing_compilers()
     expected = (
         "ProjectManager has no attribute or contract named 'ContractA'. "
@@ -25,4 +41,6 @@ def test_missing_compilers_error_message(project_with_source_files_contract, sen
         f'{", ".join(sorted(missing_exts))}?'
     )
     with pytest.raises(AttributeError, match=expected):
-        project_with_source_files_contract.ContractA.deploy(sender=sender)
+        project_with_source_files_contract.ContractA.deploy(
+            sender.address, sender.address, sender=sender
+        )

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -46,26 +46,26 @@ def _create_deployments(ecosystem_name: str = "ethereum", network_name: str = "l
 
 
 def test_ethereum_network_configs(config, temp_config):
-    eth_config = {"ethereum": {"rinkeby": {"default_provider": "test"}}}
+    eth_config = {"ethereum": {"goerli": {"default_provider": "test"}}}
     with temp_config(eth_config):
         actual = config.get_config("ethereum")
-        assert actual.rinkeby.default_provider == "test"
+        assert actual.goerli.default_provider == "test"
 
         # Ensure that non-updated fields remain unaffected
-        assert actual.rinkeby.block_time == 15
+        assert actual.goerli.block_time == 15
 
 
 def test_network_gas_limit_default(config):
     eth_config = config.get_config("ethereum")
 
-    assert eth_config.rinkeby.gas_limit == "auto"
+    assert eth_config.goerli.gas_limit == "auto"
     assert eth_config.local.gas_limit == "auto"
 
 
-def _rinkeby_with_gas_limit(gas_limit: GasLimit) -> dict:
+def _goerli_with_gas_limit(gas_limit: GasLimit) -> dict:
     return {
         "ethereum": {
-            "rinkeby": {
+            "goerli": {
                 "default_provider": "test",
                 "gas_limit": gas_limit,
             }
@@ -75,12 +75,12 @@ def _rinkeby_with_gas_limit(gas_limit: GasLimit) -> dict:
 
 @pytest.mark.parametrize("gas_limit", ("auto", "max"))
 def test_network_gas_limit_string_config(gas_limit, config, temp_config):
-    eth_config = _rinkeby_with_gas_limit(gas_limit)
+    eth_config = _goerli_with_gas_limit(gas_limit)
 
     with temp_config(eth_config):
         actual = config.get_config("ethereum")
 
-        assert actual.rinkeby.gas_limit == gas_limit
+        assert actual.goerli.gas_limit == gas_limit
 
         # Local configuration is unaffected
         assert actual.local.gas_limit == "auto"
@@ -88,12 +88,12 @@ def test_network_gas_limit_string_config(gas_limit, config, temp_config):
 
 @pytest.mark.parametrize("gas_limit", (1234, "1234", 0x4D2, "0x4D2"))
 def test_network_gas_limit_numeric_config(gas_limit, config, temp_config):
-    eth_config = _rinkeby_with_gas_limit(gas_limit)
+    eth_config = _goerli_with_gas_limit(gas_limit)
 
     with temp_config(eth_config):
         actual = config.get_config("ethereum")
 
-        assert actual.rinkeby.gas_limit == 1234
+        assert actual.goerli.gas_limit == 1234
 
         # Local configuration is unaffected
         assert actual.local.gas_limit == "auto"
@@ -104,7 +104,7 @@ def test_network_gas_limit_invalid_numeric_string(config, temp_config):
     Test that using hex strings for a network's gas_limit config must be
     prefixed with '0x'
     """
-    eth_config = _rinkeby_with_gas_limit("4D2")
+    eth_config = _goerli_with_gas_limit("4D2")
 
     with pytest.raises(ValueError, match="Invalid gas_limit, must be 'auto', 'max', or a number"):
         with temp_config(eth_config):

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -128,8 +128,8 @@ def test_repr_on_local_network_and_disconnected(networks):
 
 
 def test_repr_on_live_network_and_disconnected(networks):
-    geth = networks.get_provider_from_choice("ethereum:rinkeby:geth")
-    assert repr(geth) == "<geth chain_id=4>"
+    geth = networks.get_provider_from_choice("ethereum:goerli:geth")
+    assert repr(geth) == "<geth chain_id=5>"
 
 
 def test_repr_connected(mock_web3, geth_provider):
@@ -150,8 +150,8 @@ def test_chain_id_when_connected(eth_tester_provider_geth):
 
 
 def test_chain_id_live_network_not_connected(networks):
-    geth = networks.get_provider_from_choice("ethereum:rinkeby:geth")
-    assert geth.chain_id == 4
+    geth = networks.get_provider_from_choice("ethereum:goerli:geth")
+    assert geth.chain_id == 5
 
 
 def test_chain_id_live_network_connected_uses_web3_chain_id(mocker, eth_tester_provider_geth):
@@ -166,7 +166,7 @@ def test_chain_id_live_network_connected_uses_web3_chain_id(mocker, eth_tester_p
 
 
 def test_connect_wrong_chain_id(mocker, ethereum, eth_tester_provider_geth):
-    eth_tester_provider_geth.network = ethereum.get_network("kovan")
+    eth_tester_provider_geth.network = ethereum.get_network("goerli")
 
     # Ensure when reconnecting, it does not use HTTP
     factory = mocker.patch("ape_geth.provider._create_web3")
@@ -174,8 +174,8 @@ def test_connect_wrong_chain_id(mocker, ethereum, eth_tester_provider_geth):
 
     expected_error_message = (
         "Provider connected to chain ID '131277322940537', "
-        "which does not match network chain ID '42'. "
-        "Are you connected to 'kovan'?"
+        "which does not match network chain ID '5'. "
+        "Are you connected to 'goerli'?"
     )
     with pytest.raises(NetworkMismatchError, match=expected_error_message):
         eth_tester_provider_geth.connect()

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -39,7 +39,7 @@ def get_context(networks_connected_to_tester):
 
 @pytest.fixture
 def network_with_no_providers(ethereum):
-    network = ethereum.get_network("rinkeby-fork")
+    network = ethereum.get_network("goerli-fork")
     default_provider = network.default_provider
     providers = network.__dict__["providers"]
 
@@ -62,29 +62,17 @@ def test_get_network_choices_filter_ecosystem(networks):
         "::test",
         ":goerli",
         ":goerli:geth",
-        ":kovan",
-        ":kovan:geth",
         ":local",
         ":mainnet",
         ":mainnet:geth",
-        ":rinkeby",
-        ":rinkeby:geth",
-        ":ropsten",
-        ":ropsten:geth",
         "ethereum",
         "ethereum:goerli",
         "ethereum:goerli:geth",
-        "ethereum:kovan",
-        "ethereum:kovan:geth",
         "ethereum:local",
         "ethereum:local:geth",
         "ethereum:local:test",
         "ethereum:mainnet",
         "ethereum:mainnet:geth",
-        "ethereum:rinkeby",
-        "ethereum:rinkeby:geth",
-        "ethereum:ropsten",
-        "ethereum:ropsten:geth",
     }
     assert all_choices.issubset(actual)
 
@@ -109,7 +97,7 @@ def test_get_network_choices_filter_provider(networks):
 
 def test_get_provider_when_no_default(network_with_no_providers):
     with pytest.raises(NetworkError) as err:
-        # Not provider installed out-of-the-box for rinkeby-fork network
+        # Not provider installed out-of-the-box for goerli-fork network
         provider = network_with_no_providers.get_provider()
         assert not provider, f"Provider should be None but got '{provider.name}'"
 
@@ -118,11 +106,11 @@ def test_get_provider_when_no_default(network_with_no_providers):
 
 def test_get_provider_when_not_found(networks):
     ethereum = networks.get_ecosystem("ethereum")
-    network = ethereum.get_network("rinkeby-fork")
+    network = ethereum.get_network("goerli-fork")
     with pytest.raises(NetworkError) as err:
         network.get_provider("test")
 
-    assert "'test' is not a valid provider for network 'rinkeby-fork'" in str(err.value)
+    assert "'test' is not a valid provider for network 'goerli-fork'" in str(err.value)
 
 
 def test_repr_connected_to_local(networks_connected_to_tester):
@@ -140,7 +128,7 @@ def test_repr_disconnected(networks_disconnected):
     assert repr(networks_disconnected) == "<NetworkManager>"
     assert repr(networks_disconnected.ethereum) == "<ethereum>"
     assert repr(networks_disconnected.ethereum.local) == "<ethereum:local>"
-    assert repr(networks_disconnected.ethereum.rinkeby) == "<ethereum:rinkeby chain_id=4>"
+    assert repr(networks_disconnected.ethereum.goerli) == "<ethereum:goerli chain_id=5>"
 
 
 def test_get_provider_from_choice_adhoc_provider(networks_connected_to_tester):
@@ -208,7 +196,7 @@ def test_parse_network_choice_multiple_contexts(get_provider_with_unused_chain_i
 
 
 def test_block_times(ethereum):
-    assert ethereum.rinkeby.block_time == 15
+    assert ethereum.goerli.block_time == 15
 
 
 def test_ecosystems_when_default_network_not_exists(temp_config, caplog, networks):
@@ -226,14 +214,14 @@ def test_ecosystems_when_default_network_not_exists(temp_config, caplog, network
 
 def test_ecosystems_when_default_provider_not_exists(temp_config, caplog, networks):
     bad_provider = "NOT_EXISTS"
-    config = {"ethereum": {"kovan": {"default_provider": bad_provider}}}
+    config = {"ethereum": {"goerli": {"default_provider": bad_provider}}}
     with temp_config(config):
         assert networks.ecosystems
 
     err = caplog.records[-1].message
     assert err == (
         f"Failed setting default provider: "
-        f"Provider '{bad_provider}' not found in network 'kovan'."
+        f"Provider '{bad_provider}' not found in network 'goerli'."
     )
 
 
@@ -241,5 +229,5 @@ def test_gas_limits(ethereum):
     """
     Test the default gas limit configurations for local and live networks.
     """
-    assert ethereum.rinkeby.gas_limit == "auto"
+    assert ethereum.goerli.gas_limit == "auto"
     assert ethereum.local.gas_limit == "auto"

--- a/tests/integration/cli/test_cache.py
+++ b/tests/integration/cli/test_cache.py
@@ -1,5 +1,5 @@
 def test_cache_init_purge(ape_cli, runner):
-    result = runner.invoke(ape_cli, ["cache", "init", "--network", "ethereum:rinkeby"])
-    assert result.output == "SUCCESS: Caching database initialized for ethereum:rinkeby.\n"
-    result = runner.invoke(ape_cli, ["cache", "purge", "--network", "ethereum:rinkeby"])
-    assert result.output == "SUCCESS: Caching database purged for ethereum:rinkeby.\n"
+    result = runner.invoke(ape_cli, ["cache", "init", "--network", "ethereum:goerli"])
+    assert result.output == "SUCCESS: Caching database initialized for ethereum:goerli.\n"
+    result = runner.invoke(ape_cli, ["cache", "purge", "--network", "ethereum:goerli"])
+    assert result.output == "SUCCESS: Caching database purged for ethereum:goerli.\n"

--- a/tests/integration/cli/test_networks.py
+++ b/tests/integration/cli/test_networks.py
@@ -7,12 +7,6 @@ _DEFAULT_NETWORKS_TREE = """
 ethereum  (default)
 ├── mainnet
 │   └── geth  (default)
-├── ropsten
-│   └── geth  (default)
-├── kovan
-│   └── geth  (default)
-├── rinkeby
-│   └── geth  (default)
 ├── goerli
 │   └── geth  (default)
 └── local  (default)
@@ -29,24 +23,6 @@ ecosystems:
     - name: geth
       isDefault: true
   - name: mainnet-fork
-    providers: []
-  - name: ropsten
-    providers:
-    - name: geth
-      isDefault: true
-  - name: ropsten-fork
-    providers: []
-  - name: kovan
-    providers:
-    - name: geth
-      isDefault: true
-  - name: kovan-fork
-    providers: []
-  - name: rinkeby
-    providers:
-    - name: geth
-      isDefault: true
-  - name: rinkeby-fork
     providers: []
   - name: goerli
     providers:
@@ -65,12 +41,6 @@ _GETH_NETWORKS_TREE = """
 ethereum  (default)
 ├── mainnet
 │   └── geth  (default)
-├── ropsten
-│   └── geth  (default)
-├── kovan
-│   └── geth  (default)
-├── rinkeby
-│   └── geth  (default)
 ├── goerli
 │   └── geth  (default)
 └── local  (default)
@@ -82,9 +52,9 @@ ethereum  (default)
 └── local  (default)
     └── test  (default)
 """
-_RINKEBY_NETWORK_TREE_OUTPUT = """
+_GOERLI_NETWORK_TREE_OUTPUT = """
 ethereum  (default)
-└── rinkeby
+└── goerli
     └── geth  (default)
 """
 
@@ -142,8 +112,8 @@ def test_geth(ape_cli, runner, networks):
 
 @run_once
 def test_filter_networks(ape_cli, runner, networks):
-    result = runner.invoke(ape_cli, ["networks", "list", "--network", "rinkeby"])
-    assert_rich_text(result.output, _RINKEBY_NETWORK_TREE_OUTPUT)
+    result = runner.invoke(ape_cli, ["networks", "list", "--network", "goerli"])
+    assert_rich_text(result.output, _GOERLI_NETWORK_TREE_OUTPUT)
 
 
 @run_once


### PR DESCRIPTION
### What I did

Ropsten, Kovan, and Rinkeby are all done. This PR removes their existence.
Hello Goerli, my new best friend!

Also changes the required confs in mainnet to be `2` instead of `13`, because of PoS.

Also no longer added PoA middleware to Goerli since it is now PoS

### How I did it

A big flamethrower and I burnt it all.
What could be salvaged was handed to Goerli.

### How to verify it

It doesn't seem like this breaks any of the plugins, which is what I was curious about.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
