### PR TITLE
fix: Improve error log when no tracing support during gas profile display in tests

### DIFF
--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -163,12 +163,24 @@ class PytestApeRunner(ManagerAccessMixin):
         """
         if self.pytest_config.getoption("--gas"):
             terminalreporter.section("Gas Profile")
+
+            if not self.provider.supports_tracing:
+                terminalreporter.write_line(
+                    f"{LogLevel.ERROR.name}: Provider '{self.provider.name}' does not support "
+                    f"transaction tracing and is unable to display a gas profile.",
+                    red=True,
+                )
+                return
+
             gas_report = self.receipt_capture.gas_report
             if gas_report:
                 tables = parse_gas_table(gas_report)
                 rich_print(*tables)
             else:
-                terminalreporter.write_line(f"{LogLevel.WARNING.name}: No gas usage data found.")
+
+                terminalreporter.write_line(
+                    f"{LogLevel.WARNING.name}: No gas usage data found.", yellow=True
+                )
 
     def pytest_unconfigure(self):
         if self._provider_is_connected:

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -49,5 +49,8 @@ def test_fixture_docs(ape_test_runner, project):
 @skip_projects_except(["test"])
 def test_gas_flag(ape_test_runner, project):
     # NOTE: See `ape-hardhat` for better gas reporting tests.
-    result = ape_test_runner.invoke(["--help"])
-    assert "--gas" in result.output
+    result = ape_test_runner.invoke(["--gas"])
+    assert (
+        "Provider 'test' does not support transaction "
+        "tracing and is unable to display a gas profile"
+    ) in result.output


### PR DESCRIPTION
### What I did

Addressing feedback from @fubuloubu regarding the error log during no tracing support. Now, this is what it looks like:

<img width="1140" alt="Screen Shot 2022-10-07 at 09 34 47" src="https://user-images.githubusercontent.com/19540978/194578983-27062868-1f73-45ea-96c6-2964cbe6a91b.png">

### How I did it

* Check `supports_tracing()`.
* Use terminalwriter markup.

### How to verify it

* Run tests with `--gas` and not using provider with tracing support (such as the native test provider)
* Run tests that use no contracts and use `--gas`, You will get the original warning as before where there was no gas usage found. This time though it will be yellow.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
