### PR TITLE
feat: set local networks to max gas_limit

### DIFF
--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -146,6 +146,8 @@ You may use one of:
 - `"max"` - the maximum block gas limit is used
 - A number or numeric string, base 10 or 16 (e.g. `1234`, `"1234"`, `0x1234`, `"0x1234"`)
 
+For the local network configuration, the default is `"max"`. Otherwise it is `"auto"`.
+
 ## Plugins
 
 Set which plugins you want to always use:

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -52,6 +52,8 @@ You may use one of:
 - `"max"` - the maximum block gas limit is used
 - A number or numeric string, base 10 or 16 (e.g. `1234`, `"1234"`, `0x1234`, `"0x1234"`)
 
+For the local network configuration, the default is `"max"`. Otherwise it is `"auto"`.
+
 ## Local Network
 
 The default network in Ape is the local network (keyword `"local"`).

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -469,7 +469,19 @@ class Ethereum(EcosystemAPI):
         if "max_fee_per_gas" in kwargs:
             kwargs["max_fee"] = kwargs.pop("max_fee_per_gas")
 
-        return txn_class(**kwargs)
+        do_estimate_gas = False
+        if kwargs.get("gas") == "auto":
+            kwargs.pop("gas")
+            do_estimate_gas = True
+        elif kwargs.get("gas") == "max":
+            kwargs["gas"] = self.provider.max_gas
+
+        txn = txn_class(**kwargs)
+
+        if do_estimate_gas:
+            txn.gas_limit = self.provider.estimate_gas_cost(txn)
+
+        return txn
 
     def decode_logs(self, logs: List[Dict], *events: EventABI) -> Iterator["ContractLog"]:
         abi_inputs = {

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -79,6 +79,8 @@ class NetworkConfig(PluginConfig):
     estimate gas limits based on the transaction. If set to ``"max"`` the gas limit
     will be set to the maximum block gas limit for the network. Otherwise an ``int``
     can be used to specify an explicit gas limit amount (either base 10 or 16).
+
+    The default for local networks is ``"max"``, otherwise ``"auto"``.
     """
 
     class Config:
@@ -108,6 +110,7 @@ def _create_local_config(default_provider: Optional[str] = None, **kwargs) -> Ne
         required_confirmations=0,
         default_provider=default_provider,
         transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
+        gas_limit="max",
         **kwargs,
     )
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -223,7 +223,7 @@ def test_send_transaction_with_bad_nonce(sender, receiver):
 
 
 def test_send_transaction_without_enough_funds(sender, receiver):
-    with pytest.raises(TransactionError, match="Sender does not have enough balance to cover"):
+    with pytest.raises(AccountsError, match="Transfer value meets or exceeds account balance"):
         sender.transfer(receiver, "10000000000000 ETH")
 
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -86,7 +86,7 @@ def test_transfer_without_value_send_everything_false(sender, receiver):
         sender.transfer(receiver, send_everything=False)
 
 
-def test_transfer_without_value_send_everything_true(sender, receiver):
+def test_transfer_without_value_send_everything_true_with_low_gas(sender, receiver):
     initial_receiver_balance = receiver.balance
     initial_sender_balance = sender.balance
 
@@ -105,7 +105,7 @@ def test_transfer_without_value_send_everything_true(sender, receiver):
         sender.transfer(receiver, send_everything=True)
 
 
-def test_transfer_without_value_send_everything_true_with_gas_specified(
+def test_transfer_without_value_send_everything_true_with_high_gas(
     sender, receiver, eth_tester_provider
 ):
     initial_receiver_balance = receiver.balance

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -4,13 +4,7 @@ from eth_account.messages import encode_defunct
 
 import ape
 from ape import convert
-from ape.exceptions import (
-    AccountsError,
-    NetworkError,
-    ProjectError,
-    SignatureError,
-    TransactionError,
-)
+from ape.exceptions import AccountsError, NetworkError, ProjectError, SignatureError
 from ape.types.signatures import recover_signer
 from ape.utils.testing import DEFAULT_NUMBER_OF_TEST_ACCOUNTS
 from ape_ethereum.ecosystem import ProxyType

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -90,8 +90,9 @@ def test_transfer_without_value_send_everything_true(sender, receiver):
     initial_receiver_balance = receiver.balance
     initial_sender_balance = sender.balance
 
-    # Clear balance of sender
-    receipt = sender.transfer(receiver, send_everything=True)
+    # Clear balance of sender.
+    # Use small gas so for sure runs out of money.
+    receipt = sender.transfer(receiver, send_everything=True, gas=21000)
 
     value_given = receipt.value
     total_spent = value_given + receipt.total_fees_paid
@@ -123,7 +124,8 @@ def test_transfer_without_value_send_everything_true_with_gas_specified(
 
     # The sender is able to transfer again because they have so much left over
     # from safely using such a high gas before.
-    sender.transfer(receiver, send_everything=True)
+    # Use smaller (more expected) amount of gas this time.
+    sender.transfer(receiver, send_everything=True, gas=21000)
 
 
 def test_transfer_with_value_send_everything_true(sender, receiver, isolation):

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -59,7 +59,7 @@ def test_network_gas_limit_default(config):
     eth_config = config.get_config("ethereum")
 
     assert eth_config.goerli.gas_limit == "auto"
-    assert eth_config.local.gas_limit == "auto"
+    assert eth_config.local.gas_limit == "max"
 
 
 def _goerli_with_gas_limit(gas_limit: GasLimit) -> dict:
@@ -83,7 +83,7 @@ def test_network_gas_limit_string_config(gas_limit, config, temp_config):
         assert actual.goerli.gas_limit == gas_limit
 
         # Local configuration is unaffected
-        assert actual.local.gas_limit == "auto"
+        assert actual.local.gas_limit == "max"
 
 
 @pytest.mark.parametrize("gas_limit", (1234, "1234", 0x4D2, "0x4D2"))
@@ -96,7 +96,7 @@ def test_network_gas_limit_numeric_config(gas_limit, config, temp_config):
         assert actual.goerli.gas_limit == 1234
 
         # Local configuration is unaffected
-        assert actual.local.gas_limit == "auto"
+        assert actual.local.gas_limit == "max"
 
 
 def test_network_gas_limit_invalid_numeric_string(config, temp_config):

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -364,3 +364,17 @@ def test_from_receipt_when_receipt_not_deploy(contract_instance, owner):
     )
     with pytest.raises(ContractError, match=expected_err):
         ContractInstance.from_receipt(receipt, contract_instance.contract_type)
+
+
+def test_transact_specify_auto_gas(vyper_contract_instance, owner):
+    """
+    Tests that we can specify "auto" gas even though "max" is the default for
+    local networks.
+    """
+    receipt = vyper_contract_instance.setNumber(123, sender=owner, gas="auto")
+    assert not receipt.failed
+
+
+def test_transact_specify_max_gas(vyper_contract_instance, owner):
+    receipt = vyper_contract_instance.setNumber(123, sender=owner, gas="max")
+    assert not receipt.failed

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -230,4 +230,4 @@ def test_gas_limits(ethereum):
     Test the default gas limit configurations for local and live networks.
     """
     assert ethereum.goerli.gas_limit == "auto"
-    assert ethereum.local.gas_limit == "auto"
+    assert ethereum.local.gas_limit == "max"


### PR DESCRIPTION
### What I did

Updated local config to use max gas limit

Also updated documentation to reflect the two defaults

### How I did it
Set `EthereumConfig.local` to `gas_limit="max"`

### How to verify it
Shown in tests that the local config uses "max" by default

### Checklist
- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
