### PR TITLE
feat!: `encode_calldata()` helper method and API method

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -359,6 +359,19 @@ class EcosystemAPI(BaseInterfaceModel):
         """
 
     @abstractmethod
+    def encode_calldata(self, abi: Union[ConstructorABI, MethodABI], *args) -> bytes:
+        """
+        Encode the calldata for the given ABI.
+
+        Args:
+            abi (Union[ConstructorABI, MethodABI]): The ABI to use to encode the data.
+            *args: The calldata itself.
+
+        Returns:
+            bytes: Encoded calldata ready for a transaction.
+        """
+
+    @abstractmethod
     def decode_returndata(self, abi: MethodABI, raw_data: bytes) -> Any:
         """
         Get the result of a contract call.

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -48,6 +48,10 @@ class ContractConstructor(ManagerAccessMixin):
     def __repr__(self) -> str:
         return self.abi.signature if self.abi else "constructor()"
 
+    def encode_calldata(self, *args):
+        arguments = self.conversion_manager.convert(args, tuple)
+        return self.provider.network.ecosystem.encode_calldata(self.abi, *arguments)
+
     def serialize_transaction(self, *args, **kwargs) -> TransactionAPI:
         args = self.conversion_manager.convert(args, tuple)
         kwargs = _convert_kwargs(kwargs, self.conversion_manager.convert)
@@ -112,6 +116,11 @@ class ContractCallHandler(ManagerAccessMixin):
     def __repr__(self) -> str:
         abis = sorted(self.abis, key=lambda abi: len(abi.inputs or []))
         return abis[-1].signature
+
+    def encode_calldata(self, *args):
+        arguments = self.conversion_manager.convert(args, tuple)
+        selected_abi = _select_method_abi(self.abis, arguments)
+        return self.provider.network.ecosystem.encode_calldata(selected_abi, *arguments)
 
     def _convert_tuple(self, v: tuple) -> tuple:
         return self.conversion_manager.convert(v, tuple)
@@ -226,6 +235,11 @@ class ContractTransactionHandler(ManagerAccessMixin):
     def __repr__(self) -> str:
         abis = sorted(self.abis, key=lambda abi: len(abi.inputs or []))
         return abis[-1].signature
+
+    def encode_calldata(self, *args):
+        arguments = self.conversion_manager.convert(args, tuple)
+        selected_abi = _select_method_abi(self.abis, arguments)
+        return self.provider.network.ecosystem.encode_calldata(selected_abi, *arguments)
 
     def as_transaction(self, *args, **kwargs) -> TransactionAPI:
         """

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -73,7 +73,6 @@ def test_source_path_in_project(project_with_contract):
         project_with_contract.contracts_folder
         / project_with_contract.contracts["Contract"].source_id
     )
-    assert path
     assert project_with_contract.get_contract("Contract").source_path == path
 
 

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -341,3 +341,21 @@ def test_from_receipt_when_receipt_not_deploy(contract_instance, owner):
     )
     with pytest.raises(ContractError, match=expected_err):
         ContractInstance.from_receipt(receipt, contract_instance.contract_type)
+
+
+def test_encode_call_data_for_mutable_transaction(vyper_contract_instance):
+    actual = vyper_contract_instance.setNumber.encode_calldata(4)
+    expected = (
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04"
+    )
+    assert actual == expected
+
+
+def test_encode_call_data_for_view_call(vyper_contract_instance, owner):
+    actual = vyper_contract_instance.balances.encode_calldata(owner)
+    expected = (
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x001\x8bF\x9b\xba9j\xec,`4/"
+        b"\x94A\xbe6\xa1\x94Qt"
+    )
+    assert actual == expected


### PR DESCRIPTION
### What I did

* Adds `encode_calldata()` as  API method to Ecosystem API
* Adds `encode_calldata()` helper methods to transaction and call handlers

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
