### PR TITLE
fix: regression

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -96,6 +96,9 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         max_fee = txn.max_fee
         gas_limit = txn.gas_limit
 
+        if not isinstance(gas_limit, int):
+            raise TransactionError(message="Transaction not prepared.")
+
         # The conditions below should never reached but are here for mypy's sake.
         # The `max_fee` was either set manaully or from `prepare_transaction()`.
         # The `gas_limit` was either set manually or from `prepare_transaction()`.

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -32,7 +32,6 @@ from ape.api.transactions import ReceiptAPI, TransactionAPI
 from ape.exceptions import (
     APINotImplementedError,
     BlockNotFoundError,
-    ConfigError,
     ContractLogicError,
     ProviderError,
     ProviderNotConnectedError,

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -504,18 +504,15 @@ class ProviderAPI(BaseInterfaceModel):
                 txn.max_fee = self.base_fee + txn.max_priority_fee
             # else: Assume user specified the correct amount or txn will fail and waste gas
 
-        if txn.gas_limit is None:
-            if isinstance(self.network.gas_limit, int):
-                txn.gas_limit = self.network.gas_limit
+        gas_limit = txn.gas_limit or self.network.gas_limit
+        if isinstance(gas_limit, int):
+            txn.gas_limit = self.network.gas_limit
 
-            elif self.network.gas_limit == "max":
-                txn.gas_limit = self.max_gas
+        elif gas_limit == "max":
+            txn.gas_limit = self.max_gas
 
-            elif self.network.gas_limit in ("auto", None):
-                txn.gas_limit = self.estimate_gas_cost(txn)
-
-            else:
-                raise ConfigError(f"Unknown gas limit value '{self.network.gas_limit}'")
+        elif gas_limit in ("auto", None):
+            txn.gas_limit = self.estimate_gas_cost(txn)
 
         # else: Assume user specified the correct amount or txn will fail and waste gas
 

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -12,7 +12,7 @@ from tqdm import tqdm  # type: ignore
 from ape.api.explorers import ExplorerAPI
 from ape.exceptions import ContractError, TransactionError
 from ape.logging import logger
-from ape.types import AddressType, ContractLog, TransactionSignature
+from ape.types import AddressType, ContractLog, GasLimit, TransactionSignature
 from ape.utils import BaseInterfaceModel, abstractmethod, raises_not_implemented
 
 if TYPE_CHECKING:
@@ -30,7 +30,7 @@ class TransactionAPI(BaseInterfaceModel):
     chain_id: int = Field(0, alias="chainId")
     receiver: Optional[AddressType] = Field(None, alias="to")
     sender: Optional[AddressType] = Field(None, alias="from")
-    gas_limit: Optional[int] = Field(None, alias="gas")
+    gas_limit: Optional[GasLimit] = Field(None, alias="gas")
     nonce: Optional[int] = None  # NOTE: `Optional` only to denote using default behavior
     value: int = 0
     data: bytes = b""

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -9,7 +9,7 @@ from hexbytes import HexBytes
 from ape.api import ConverterAPI
 from ape.api.address import BaseAddress
 from ape.exceptions import ConversionError
-from ape.types import AddressType
+from ape.types import AddressType, GasLimit
 from ape.utils import cached_property
 
 from .base import BaseManager
@@ -248,11 +248,14 @@ class ConversionManager(BaseManager):
             any: The same given value but with the new given type.
         """
 
-        if type not in self._converters:
+        if type == GasLimit:
+            type = int
+
+        elif type not in self._converters:
             options = ", ".join([t.__name__ for t in self._converters])
             raise ConversionError(f"Type '{type}' must be one of [{options}].")
 
-        if self.is_type(value, type) and not isinstance(value, (list, tuple)):
+        elif self.is_type(value, type) and not isinstance(value, (list, tuple)):
             # NOTE: Always process lists and tuples
             return value
 

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -9,7 +9,7 @@ from hexbytes import HexBytes
 from ape.api import ConverterAPI
 from ape.api.address import BaseAddress
 from ape.exceptions import ConversionError
-from ape.types import AddressType, GasLimit
+from ape.types import AddressType
 from ape.utils import cached_property
 
 from .base import BaseManager
@@ -248,10 +248,7 @@ class ConversionManager(BaseManager):
             any: The same given value but with the new given type.
         """
 
-        if type == GasLimit:
-            type = int
-
-        elif type not in self._converters:
+        if type not in self._converters:
             options = ", ".join([t.__name__ for t in self._converters])
             raise ConversionError(f"Type '{type}' must be one of [{options}].")
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -469,19 +469,7 @@ class Ethereum(EcosystemAPI):
         if "max_fee_per_gas" in kwargs:
             kwargs["max_fee"] = kwargs.pop("max_fee_per_gas")
 
-        do_estimate_gas = False
-        if kwargs.get("gas") == "auto":
-            kwargs.pop("gas")
-            do_estimate_gas = True
-        elif kwargs.get("gas") == "max":
-            kwargs["gas"] = self.provider.max_gas
-
-        txn = txn_class(**kwargs)
-
-        if do_estimate_gas:
-            txn.gas_limit = self.provider.estimate_gas_cost(txn)
-
-        return txn
+        return txn_class(**kwargs)
 
     def decode_logs(self, logs: List[Dict], *events: EventABI) -> Iterator["ContractLog"]:
         abi_inputs = {

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -53,9 +53,10 @@ def test_revert_no_message(owner, contract_instance):
         contract_instance.setNumber(5, sender=owner)
 
 
-def test_revert_specify_gas(sender, contract_instance):
+@pytest.mark.parametrize("gas", ("200000", 200000, "max", "auto", "0x235426"))
+def test_revert_specify_gas(sender, contract_instance, gas):
     with pytest.raises(ContractLogicError, match="!authorized"):
-        contract_instance.setNumber(5, sender=sender, gas="200000")
+        contract_instance.setNumber(5, sender=sender, gas=gas)
 
 
 def test_call_using_block_identifier(

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -120,9 +120,7 @@ def test_decode_logs_unspecified_abi_gets_all_logs(owner, contract_instance):
 
 def test_get_failed_receipt(owner, vyper_contract_instance, eth_tester_provider):
     # Setting to '5' always fails.
-    transaction = vyper_contract_instance.setNumber.as_transaction(
-        5, sender=owner, gas_limit=100000
-    )
+    transaction = vyper_contract_instance.setNumber.as_transaction(5, sender=owner, gas=100000)
 
     # Publish failing txn
     try:


### PR DESCRIPTION
### What I did

exclude from CHANGELOG, as is unreleased fix

regression from https://github.com/ApeWorX/ape/pull/1097 where we estimate gas too early in txn life cycle.

### How I did it

Pass along `max` or `auto` values when set until they reach `prepare_transaction()` so less chance of missing appropriate base fee.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
