### PR TITLE
fix: use sourceId rather than contractType name for error message

### DIFF
--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -103,7 +103,7 @@ class CompilerManager(BaseManager):
                 if contract_type.name in contract_types_dict:
                     raise CompilerError(
                         "ContractType collision across compiler plugins "
-                        f"with contract name: {contract_type.name}"
+                        f"with contract: {contract_type.source_id}"
                     )
 
                 contract_types_dict[contract_type.name] = contract_type


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->
Using this PR to open up a discussion on creating a clearer compiler message.

Slightly edited the compiler message to be clearer about what is causing the contract type clash. I was having an issue where ape compile would fail if there was a JSON file that had the same name as a contract and I was confused until @fubuloubu pointed out that JSON files (ABIs) are treated as contract types. 
<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #

### How I did it
<!-- Discuss the thought process behind the change -->
Edited the compiler error message
### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
