### PR TITLE
feat: configure gas report, including skip files

### DIFF
--- a/docs/userguides/testing.md
+++ b/docs/userguides/testing.md
@@ -307,10 +307,10 @@ The following demonstrates how to use the `ape-config.yaml` file to exclude cont
 test:
   gas:
     exclude:
-      - method: DEBUG_*         # Exclude all methods starting with `DEBUG_`.
-      - contract: MockToken     # Exclude all methods in contract named `MockToken`.
-      - contract: PoolContract  # Exclude methods starting with `reset_` in `PoolContract`.
-        method: reset_*
+      - method_name: DEBUG_*         # Exclude all methods starting with `DEBUG_`.
+      - contract_name: MockToken     # Exclude all methods in contract named `MockToken`.
+      - contract_name: PoolContract  # Exclude methods starting with `reset_` in `PoolContract`.
+        method_name: reset_*
 ```
 
 Similarly, you can exclude sources via the CLI option `--gas-exclude`.

--- a/docs/userguides/testing.md
+++ b/docs/userguides/testing.md
@@ -314,7 +314,7 @@ test:
 ```
 
 Similarly, you can exclude sources via the CLI option `--gas-exclude`.
-The value `--gas-exclude` takes a comma-separated list of colon-separated values representing the structure similar as above, except you must explicitly use `*` where meaning "all".
+The value `--gas-exclude` takes is a comma-separated list of colon-separated values representing the structure similar as above, except you must explicitly use `*` where meaning "all".
 For example to exclude all methods starting with `DEBUG_`, you would do:
 
 ```bash

--- a/docs/userguides/testing.md
+++ b/docs/userguides/testing.md
@@ -279,7 +279,7 @@ ape test --network ethereum:local:hardhat --gas
 At the end of test suite, you will see tables such as:
 
 ```sh
-                            FundMe.vy Gas
+                            FundMe Gas
 
   Method           Times called    Min.    Max.    Mean   Median
  ────────────────────────────────────────────────────────────────
@@ -294,9 +294,41 @@ At the end of test suite, you will see tables such as:
  ───────────────────────────────────────────────────────
   to:test0              2   2400   9100   5750     5750
 
-                     TestContract.vy Gas
+                     TestContract Gas
 
   Method      Times called    Min.    Max.    Mean   Median
  ───────────────────────────────────────────────────────────
   setNumber              1   51021   51021   51021    51021
+```
+
+The following demonstrates how to use the `ape-config.yaml` file to exclude contracts and / or methods from the gas report:
+
+```yaml
+test:
+  gas:
+    exclude:
+      - method: DEBUG_*         # Exclude all methods starting with `DEBUG_`.
+      - contract: MockToken     # Exclude all methods in contract named `MockToken`.
+      - contract: PoolContract  # Exclude methods starting with `reset_` in `PoolContract`.
+        method: reset_*
+```
+
+Similarly, you can exclude sources via the CLI option `--gas-exclude`.
+The value `--gas-exclude` takes a comma-separated list of colon-separated values representing the structure similar as above, except you must explicitly use `*` where meaning "all".
+For example to exclude all methods starting with `DEBUG_`, you would do:
+
+```bash
+ape test --gas --gas-exclude "*:DEBUG_*".
+```
+
+To exclude all methods in the `MockToken` contract, do:
+
+```bash
+ape test --gas --gas-exclude MockToken
+```
+
+And finally, to exclude all methods starting with `reset_` in `PoolContract`, do:
+
+```bash
+ape test --gas --gas-exclude "PoolContract:reset_*"
 ```

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -316,6 +316,12 @@ class ReceiptAPI(BaseInterfaceModel):
 
     @property
     def method_called(self) -> Optional[MethodABI]:
+        """
+        The method ABI of the method called to produce this receipt.
+        Requires both that the user is using a provider that supports traces
+        as well as for this to have been a contract invocation.
+        """
+
         call_tree = self.call_tree
         if not call_tree:
             return None

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -3,7 +3,7 @@ import time
 from typing import IO, TYPE_CHECKING, Any, Iterator, List, Optional, Union
 
 from ethpm_types import HexBytes
-from ethpm_types.abi import EventABI
+from ethpm_types.abi import EventABI, MethodABI
 from evm_trace import TraceFrame
 from pydantic import validator
 from pydantic.fields import Field
@@ -315,12 +315,10 @@ class ReceiptAPI(BaseInterfaceModel):
         return self
 
     @property
-    def return_value(self) -> Any:
-        """
-        Obtain the final return value of the call. Requires tracing to function,
-        since this is not available from the receipt object.
-        """
-        call_tree = self.provider.get_call_tree(self.txn_hash)
+    def method_called(self) -> Optional[MethodABI]:
+        call_tree = self.call_tree
+        if not call_tree:
+            return None
 
         contract_type = self.chain_manager.contracts.get(call_tree.address)
         if not contract_type:
@@ -328,13 +326,25 @@ class ReceiptAPI(BaseInterfaceModel):
 
         selector = call_tree.calldata
         if selector in contract_type.mutable_methods:
-            method_abi = contract_type.mutable_methods[selector]
+            return contract_type.mutable_methods[selector]
         elif selector in contract_type.view_methods:
-            method_abi = contract_type.view_methods[selector]
-        else:
-            raise ContractError(f"Selector '{selector}' not found in {contract_type.name}")
+            return contract_type.view_methods[selector]
 
-        output = self.provider.network.ecosystem.decode_returndata(method_abi, call_tree.returndata)
+        raise ContractError(f"Selector '{selector}' not found in {contract_type.name}")
+
+    @property
+    def return_value(self) -> Any:
+        """
+        Obtain the final return value of the call. Requires tracing to function,
+        since this is not available from the receipt object.
+        """
+        call_tree = self.call_tree
+        if not call_tree:
+            return None
+
+        output = self.provider.network.ecosystem.decode_returndata(
+            self.method_called, call_tree.returndata
+        )
         if isinstance(output, tuple) and len(output) < 2:
             # NOTE: Two special cases
             output = output[0] if len(output) == 1 else None

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -342,9 +342,11 @@ class ReceiptAPI(BaseInterfaceModel):
         if not call_tree:
             return None
 
-        output = self.provider.network.ecosystem.decode_returndata(
-            self.method_called, call_tree.returndata
-        )
+        method_abi = self.method_called
+        if not method_abi:
+            return None
+
+        output = self.provider.network.ecosystem.decode_returndata(method_abi, call_tree.returndata)
         if isinstance(output, tuple) and len(output) < 2:
             # NOTE: Two special cases
             output = output[0] if len(output) == 1 else None

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -533,6 +533,9 @@ class ContractCache(BaseManager):
         # NOTE: The txn_hash is not included when caching this way.
         self._cache_deployment(address, contract_type)
 
+    def __contains__(self, address: AddressType) -> bool:
+        return self.get(address) is not None
+
     def cache_deployment(self, contract_instance: ContractInstance):
         """
         Cache the given contract instance's type and deployment information.

--- a/src/ape/pytest/config.py
+++ b/src/ape/pytest/config.py
@@ -60,7 +60,7 @@ class ConfigWrapper(ManagerAccessMixin):
 
         config_value = self.ape_test_config.gas.exclude
         paths = [
-            ContractFunctionPath(contract_id=x.contract_name, method_id=x.method_name)
+            ContractFunctionPath(contract_name=x.contract_name, method_name=x.method_name)
             for x in config_value
         ]
         exclusions.extend(paths)

--- a/src/ape/pytest/config.py
+++ b/src/ape/pytest/config.py
@@ -1,0 +1,72 @@
+from typing import Any, Dict, List
+
+from _pytest.config import Config as PytestConfig
+
+from ape.utils import ManagerAccessMixin, cached_property
+
+
+class ConfigWrapper(ManagerAccessMixin):
+    """
+    A class aggregating settings choices from both the pytest command line
+    as well as the `ape-config.yaml` file. Also serves as a wrapper around the
+    Pytest config object for ease-of-use and code-sharing.
+    """
+
+    def __init__(self, pytest_config: PytestConfig):
+        self.pytest_config = pytest_config
+
+    @cached_property
+    def interactive(self) -> bool:
+        return self.pytest_config.getoption("interactive")
+
+    @cached_property
+    def network(self) -> str:
+        return self.pytest_config.getoption("network")
+
+    @cached_property
+    def isolation(self) -> bool:
+        return not self.pytest_config.getoption("disable_isolation")
+
+    @cached_property
+    def disable_warnings(self) -> bool:
+        return self.pytest_config.getoption("--disable-warnings")
+
+    @cached_property
+    def ape_test_config(self):
+        return self.config_manager.get_config("test")
+
+    @cached_property
+    def track_gas(self) -> bool:
+        return self.pytest_config.getoption("--gas") or self.ape_test_config.gas.show
+
+    @cached_property
+    def gas_exclusions(self) -> List[Dict]:
+        """
+        The combination of both CLI values and config values.
+        """
+
+        cli_value = self.pytest_config.getoption("--gas-exclude")
+        exclusions = []
+        if cli_value:
+            items = cli_value.split(",")
+            for item in items:
+                if ":" in item:
+                    contract_name, method_name = item.split(":")
+                    exclusion = {"contract": contract_name, "method": method_name}
+                else:
+                    exclusion = {"contract": item}
+
+                exclusions.append(exclusion)
+
+        config_value = self.ape_test_config.gas.exclude
+        exclusions.extend([x.dict() for x in config_value])
+
+        filtered_exclusions = []
+        for exclusion in exclusions:
+            if exclusion not in filtered_exclusions:
+                filtered_exclusions.append(exclusion)
+
+        return filtered_exclusions
+
+    def get_pytest_plugin(self, name: str) -> Any:
+        return self.pytest_config.pluginmanager.get_plugin(name)

--- a/src/ape/pytest/config.py
+++ b/src/ape/pytest/config.py
@@ -33,6 +33,10 @@ class ConfigWrapper(ManagerAccessMixin):
         return self.pytest_config.getoption("--disable-warnings")
 
     @cached_property
+    def disconnect_providers_after(self) -> bool:
+        return self.ape_test_config.disconnect_providers_after
+
+    @cached_property
     def ape_test_config(self):
         return self.config_manager.get_config("test")
 

--- a/src/ape/pytest/config.py
+++ b/src/ape/pytest/config.py
@@ -51,23 +51,12 @@ class ConfigWrapper(ManagerAccessMixin):
         if cli_value:
             items = cli_value.split(",")
             for item in items:
-                if ":" in item:
-                    contract_name, method_name = item.split(":")
-                    exclusion = ContractFunctionPath(contract=contract_name, method=method_name)
-                else:
-                    exclusion = ContractFunctionPath(contract=item)
-
+                exclusion = ContractFunctionPath.from_str(item)
                 exclusions.append(exclusion)
 
         config_value = self.ape_test_config.gas.exclude
-        exclusions.extend([x.dict() for x in config_value])
-
-        filtered_exclusions = []
-        for exclusion in exclusions:
-            if exclusion not in filtered_exclusions:
-                filtered_exclusions.append(exclusion)
-
-        return filtered_exclusions
+        exclusions.extend(config_value)
+        return exclusions
 
     def get_pytest_plugin(self, name: str) -> Any:
         return self.pytest_config.pluginmanager.get_plugin(name)

--- a/src/ape/pytest/config.py
+++ b/src/ape/pytest/config.py
@@ -9,7 +9,7 @@ from ape.utils import ManagerAccessMixin, cached_property
 class ConfigWrapper(ManagerAccessMixin):
     """
     A class aggregating settings choices from both the pytest command line
-    as well as the `ape-config.yaml` file. Also serves as a wrapper around the
+    as well as the ``ape-config.yaml`` file. Also serves as a wrapper around the
     Pytest config object for ease-of-use and code-sharing.
     """
 

--- a/src/ape/pytest/config.py
+++ b/src/ape/pytest/config.py
@@ -1,7 +1,8 @@
-from typing import Any, Dict, List
+from typing import Any, List
 
 from _pytest.config import Config as PytestConfig
 
+from ape.types import ContractFunctionPath
 from ape.utils import ManagerAccessMixin, cached_property
 
 
@@ -40,21 +41,21 @@ class ConfigWrapper(ManagerAccessMixin):
         return self.pytest_config.getoption("--gas") or self.ape_test_config.gas.show
 
     @cached_property
-    def gas_exclusions(self) -> List[Dict]:
+    def gas_exclusions(self) -> List[ContractFunctionPath]:
         """
         The combination of both CLI values and config values.
         """
 
         cli_value = self.pytest_config.getoption("--gas-exclude")
-        exclusions = []
+        exclusions: List[ContractFunctionPath] = []
         if cli_value:
             items = cli_value.split(",")
             for item in items:
                 if ":" in item:
                     contract_name, method_name = item.split(":")
-                    exclusion = {"contract": contract_name, "method": method_name}
+                    exclusion = ContractFunctionPath(contract=contract_name, method=method_name)
                 else:
-                    exclusion = {"contract": item}
+                    exclusion = ContractFunctionPath(contract=item)
 
                 exclusions.append(exclusion)
 

--- a/src/ape/pytest/config.py
+++ b/src/ape/pytest/config.py
@@ -59,7 +59,11 @@ class ConfigWrapper(ManagerAccessMixin):
                 exclusions.append(exclusion)
 
         config_value = self.ape_test_config.gas.exclude
-        exclusions.extend(config_value)
+        paths = [
+            ContractFunctionPath(contract_id=x.contract_name, method_id=x.method_name)
+            for x in config_value
+        ]
+        exclusions.extend(paths)
         return exclusions
 
     def get_pytest_plugin(self, name: str) -> Any:

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -160,7 +160,11 @@ class ReceiptCapture(ManagerAccessMixin):
             # TODO: Handle deploy receipts once trace supports it
             return
 
-        contract_type = self.chain_manager.contracts[contract_address]
+        contract_type = self.chain_manager.contracts.get(contract_address)
+        if not contract_type:
+            # Not an invoke-transaction or a known address
+            return
+
         source_id = contract_type.source_id or None
         if not source_id:
             # Not a local or known contract type.
@@ -169,7 +173,7 @@ class ReceiptCapture(ManagerAccessMixin):
         elif source_id not in self.receipt_map:
             self.receipt_map[source_id] = {}
 
-        elif transaction_hash in self.receipt_map[source_id]:
+        if transaction_hash in self.receipt_map[source_id]:
             # Transaction already known.
             return
 

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -219,11 +219,11 @@ class ReceiptCapture(ManagerAccessMixin):
 
         for exclusion in self.config_wrapper.gas_exclusions:
             # Default to looking at all contracts
-            contract_pattern = exclusion.contract_id
+            contract_pattern = exclusion.contract_name
             if not fnmatch(contract_name, contract_pattern) or not method_name:
                 continue
 
-            method_pattern = exclusion.method_id
+            method_pattern = exclusion.method_name
             if not method_pattern or fnmatch(method_name, method_pattern):
                 return True
 

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -1,7 +1,7 @@
+from fnmatch import fnmatch
 from typing import Dict, Iterator, List, Optional
 
 import pytest
-from _pytest.config import Config as PytestConfig
 from evm_trace.gas import merge_reports
 
 from ape.api import ReceiptAPI, TestAccountAPI
@@ -9,6 +9,7 @@ from ape.logging import logger
 from ape.managers.chain import ChainManager
 from ape.managers.networks import NetworkManager
 from ape.managers.project import ProjectManager
+from ape.pytest.config import ConfigWrapper
 from ape.types import GasReport, SnapshotID
 from ape.utils import CallTraceParser, ManagerAccessMixin, allow_disconnected, cached_property
 
@@ -19,11 +20,10 @@ class PytestApeFixtures(ManagerAccessMixin):
     # `ape test -q --fixture` (`pytest -q --fixture`).
 
     _warned_for_unimplemented_snapshot = False
-    pytest_config: PytestConfig
     receipt_capture: "ReceiptCapture"
 
-    def __init__(self, pytest_config, receipt_capture: "ReceiptCapture"):
-        self.pytest_config = pytest_config
+    def __init__(self, config_wrapper: ConfigWrapper, receipt_capture: "ReceiptCapture"):
+        self.config_wrapper = config_wrapper
         self.receipt_capture = receipt_capture
 
     @cached_property
@@ -113,13 +113,13 @@ class PytestApeFixtures(ManagerAccessMixin):
 
 
 class ReceiptCapture(ManagerAccessMixin):
-    pytest_config: PytestConfig
+    config_wrapper: ConfigWrapper
     gas_report: Optional[GasReport] = None
-    receipt_map: Dict[str, ReceiptAPI] = {}
+    receipt_map: Dict[str, Dict[str, ReceiptAPI]] = {}
     enter_blocks: List[int] = []
 
-    def __init__(self, pytest_config):
-        self.pytest_config = pytest_config
+    def __init__(self, config_wrapper: ConfigWrapper):
+        self.config_wrapper = config_wrapper
 
     def __enter__(self):
         block_number = self._get_block_number()
@@ -137,10 +137,6 @@ class ReceiptCapture(ManagerAccessMixin):
 
         self.capture_range(start_block, stop_block)
 
-    @cached_property
-    def _track_gas(self) -> bool:
-        return self.pytest_config.getoption("--gas")
-
     def capture_range(self, start_block: int, stop_block: int):
         blocks = self.chain_manager.blocks.range(start_block, stop_block + 1)
         transactions = [
@@ -154,23 +150,55 @@ class ReceiptCapture(ManagerAccessMixin):
             self.capture(txn.txn_hash.hex())
 
     def capture(self, transaction_hash: str, track_gas: Optional[bool] = None):
-        if transaction_hash in self.receipt_map:
-            return
-
         receipt = self.chain_manager.account_history.get_receipt(transaction_hash)
-        self.receipt_map[transaction_hash] = receipt
         if not receipt:
             return
 
-        if not receipt.receiver:
+        contract_address = receipt.receiver
+        if not contract_address:
             # TODO: Handle deploy receipts once trace supports it
             return
 
-        # Merge-in the receipt's gas report with everything so far.
+        contract_type = self.chain_manager.contracts[contract_address]
+        source_id = contract_type.source_id or None
+        if not source_id:
+            # Not a local or known contract type.
+            return
+
+        elif source_id not in self.receipt_map:
+            self.receipt_map[source_id] = {}
+
+        elif transaction_hash in self.receipt_map[source_id]:
+            # Transaction already known.
+            return
+
+        self.receipt_map[source_id][transaction_hash] = receipt
+
+        # Merge-in the receipt's gas rdeport with everything so far.
         call_tree = receipt.call_tree
-        do_track_gas = track_gas if track_gas is not None else self._track_gas
+        do_track_gas = self.config_wrapper.track_gas if track_gas is None else track_gas
+        exclusions = self.config_wrapper.gas_exclusions
+        if exclusions:
+            contract_address = receipt.receiver
+            contract_type = self.chain_manager.contracts[contract_address]
+            contract_name = contract_type.name
+            method_called = receipt.method_called
+            method_name = method_called.name if method_called else None
+
         if do_track_gas and call_tree:
             parser = CallTraceParser(receipt)
+            for exclusion in exclusions:
+                # Default to looking at all contracts
+                contract_pattern = exclusion.get("contract") or "*"
+                if not fnmatch(contract_name, contract_pattern):
+                    continue
+
+                method_pattern = exclusion.get("method")
+                if not method_pattern or fnmatch(method_name, method_pattern):
+                    # Only contract was specified. It's a match.
+                    return
+
+            # Update the gas report using this receipt
             gas_report = parser._get_rich_gas_report(call_tree)
             if self.gas_report:
                 self.gas_report = merge_reports(self.gas_report, gas_report)

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -219,11 +219,11 @@ class ReceiptCapture(ManagerAccessMixin):
 
         for exclusion in self.config_wrapper.gas_exclusions:
             # Default to looking at all contracts
-            contract_pattern = exclusion.contract
+            contract_pattern = exclusion.contract_id
             if not fnmatch(contract_name, contract_pattern) or not method_name:
                 continue
 
-            method_pattern = exclusion.method
+            method_pattern = exclusion.method_id
             if not method_pattern or fnmatch(method_name, method_pattern):
                 return True
 

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -175,7 +175,7 @@ class ReceiptCapture(ManagerAccessMixin):
 
         self.receipt_map[source_id][transaction_hash] = receipt
 
-        # Merge-in the receipt's gas rdeport with everything so far.
+        # Merge-in the receipt's gas report with everything so far.
         call_tree = receipt.call_tree
         do_track_gas = self.config_wrapper.track_gas if track_gas is None else track_gas
         exclusions = self.config_wrapper.gas_exclusions

--- a/src/ape/pytest/plugin.py
+++ b/src/ape/pytest/plugin.py
@@ -39,7 +39,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--gas-exclude",
         action="store",
-        help="A comma-separated list of contract:method-name patterns to ignore.",
+        help="A comma-separated list of contract:method-name glob-patterns to ignore.",
     )
 
     # NOTE: Other pytest plugins, such as hypothesis, should integrate with pytest separately

--- a/src/ape/pytest/plugin.py
+++ b/src/ape/pytest/plugin.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from ape import networks, project
+from ape.pytest.config import ConfigWrapper
 from ape.pytest.fixtures import PytestApeFixtures, ReceiptCapture
 from ape.pytest.runners import PytestApeRunner
 
@@ -35,6 +36,11 @@ def pytest_addoption(parser):
         action="store_true",
         help="Show a transaction gas report at the end of the test session.",
     )
+    parser.addoption(
+        "--gas-exclude",
+        action="store",
+        help="A comma-separated list of contract:method-name patterns to ignore.",
+    )
 
     # NOTE: Other pytest plugins, such as hypothesis, should integrate with pytest separately
 
@@ -51,13 +57,14 @@ def pytest_configure(config):
         for module in modules:
             module.__tracebackhide__ = True
 
-    receipt_capture = ReceiptCapture(config)
+    config_wrapper = ConfigWrapper(config)
+    receipt_capture = ReceiptCapture(config_wrapper)
 
     # Enable verbose output if stdout capture is disabled
     config.option.verbose = config.getoption("capture") == "no"
 
     # Register the custom Ape test runner
-    session = PytestApeRunner(config, receipt_capture)
+    session = PytestApeRunner(config_wrapper, receipt_capture)
     config.pluginmanager.register(session, "ape-test")
 
     # Include custom fixtures for project, accounts etc.

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -178,6 +178,6 @@ class PytestApeRunner(ManagerAccessMixin):
                 )
 
     def pytest_unconfigure(self):
-        if self._provider_is_connected:
+        if self._provider_is_connected and self.config_wrapper.disconnect_providers_after:
             self._provider_context.disconnect_all()
             self._provider_is_connected = False

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -2,12 +2,12 @@ from pathlib import Path
 
 import click
 import pytest
-from _pytest.config import Config as PytestConfig
 from rich import print as rich_print
 
 import ape
 from ape.api import ProviderContextManager
 from ape.logging import LogLevel, logger
+from ape.pytest.config import ConfigWrapper
 from ape.pytest.contextmanagers import RevertsContextManager
 from ape.pytest.fixtures import ReceiptCapture
 from ape.utils import ManagerAccessMixin, parse_gas_table
@@ -17,22 +17,17 @@ from ape_console._cli import console
 class PytestApeRunner(ManagerAccessMixin):
     def __init__(
         self,
-        pytest_config: PytestConfig,
+        config_wrapper: ConfigWrapper,
         receipt_capture: ReceiptCapture,
     ):
-        self.pytest_config = pytest_config
+        self.config_wrapper = config_wrapper
         self.receipt_capture = receipt_capture
         self._provider_is_connected = False
         ape.reverts = RevertsContextManager  # type: ignore
 
     @property
-    def _network_choice(self) -> str:
-        # The option the user providers via --network (or the default).
-        return self.pytest_config.getoption("network")
-
-    @property
     def _provider_context(self) -> ProviderContextManager:
-        return self.network_manager.parse_network_choice(self._network_choice)
+        return self.network_manager.parse_network_choice(self.config_wrapper.network)
 
     def pytest_exception_interact(self, report, call):
         """
@@ -41,8 +36,8 @@ class PytestApeRunner(ManagerAccessMixin):
         same console as the ``ape console`` command.
         """
 
-        if self.pytest_config.getoption("interactive") and report.failed:
-            capman = self.pytest_config.pluginmanager.get_plugin("capturemanager")
+        if self.config_wrapper.interactive and report.failed:
+            capman = self.config_wrapper.get_pytest_plugin("capturemanager")
             if capman:
                 capman.suspend_global_capture(in_=True)
 
@@ -96,7 +91,7 @@ class PytestApeRunner(ManagerAccessMixin):
         https://docs.pytest.org/en/6.2.x/reference.html#pytest.hookspec.pytest_runtest_setup
         """
         if (
-            self.pytest_config.getoption("disable_isolation") is True
+            self.config_wrapper.isolation is False
             or "_function_isolation" in item.fixturenames  # prevent double injection
         ):
             # isolation is disabled via cmdline option
@@ -138,10 +133,10 @@ class PytestApeRunner(ManagerAccessMixin):
         so related assertions cannot be rewritten". The warning is not relevant
         for end users who are performing tests with ape.
         """
-        reporter = self.pytest_config.pluginmanager.get_plugin("terminalreporter")
+        reporter = self.config_wrapper.get_pytest_plugin("terminalreporter")
         warnings = reporter.stats.pop("warnings", [])
         warnings = [i for i in warnings if "PytestAssertRewriteWarning" not in i.message]
-        if warnings and not self.pytest_config.getoption("--disable-warnings"):
+        if warnings and not self.config_wrapper.disable_warnings:
             reporter.stats["warnings"] = warnings
 
     @pytest.hookimpl(trylast=True, hookwrapper=True)
@@ -161,7 +156,7 @@ class PytestApeRunner(ManagerAccessMixin):
         Add a section to terminal summary reporting.
         When ``--gas`` is active, outputs the gas profile report.
         """
-        if self.pytest_config.getoption("--gas"):
+        if self.config_wrapper.track_gas:
             terminalreporter.section("Gas Profile")
 
             if not self.provider.supports_tracing:

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -71,19 +71,19 @@ class ContractFunctionPath:
     Useful for identifying a method in a contract.
     """
 
-    contract: str
-    method: Optional[str] = None
+    contract_id: str
+    method_id: Optional[str] = None
 
     @classmethod
     def from_str(cls, value: str) -> "ContractFunctionPath":
         if ":" in value:
             contract_name, method_name = value.split(":")
-            return cls(contract=contract_name, method=method_name)
+            return cls(contract_id=contract_name, method_id=method_name)
 
-        return cls(contract=value)
+        return cls(contract_id=value)
 
     def __str__(self) -> str:
-        return f"{self.contract}:{self.method}"
+        return f"{self.contract_id}:{self.method_id}"
 
     def __repr__(self) -> str:
         return f"<{self}>"

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -74,6 +74,20 @@ class ContractFunctionPath:
     contract: str
     method: Optional[str] = None
 
+    @classmethod
+    def from_str(cls, value: str) -> "ContractFunctionPath":
+        if ":" in value:
+            contract_name, method_name = value.split(":")
+            return cls(contract=contract_name, method=method_name)
+
+        return cls(contract=value)
+
+    def __str__(self) -> str:
+        return f"{self.contract}:{self.method}"
+
+    def __repr__(self) -> str:
+        return f"<{self}>"
+
 
 class LogFilter(BaseModel):
     addresses: List[AddressType] = []

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -71,19 +71,19 @@ class ContractFunctionPath:
     Useful for identifying a method in a contract.
     """
 
-    contract_id: str
-    method_id: Optional[str] = None
+    contract_name: str
+    method_name: Optional[str] = None
 
     @classmethod
     def from_str(cls, value: str) -> "ContractFunctionPath":
         if ":" in value:
             contract_name, method_name = value.split(":")
-            return cls(contract_id=contract_name, method_id=method_name)
+            return cls(contract_name=contract_name, method_name=method_name)
 
-        return cls(contract_id=value)
+        return cls(contract_name=value)
 
     def __str__(self) -> str:
-        return f"{self.contract_id}:{self.method_id}"
+        return f"{self.contract_name}:{self.method_name}"
 
     def __repr__(self) -> str:
         return f"<{self}>"

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from eth_abi.abi import encode
@@ -62,6 +63,16 @@ A gas report in Ape.
 
 
 TopicFilter = List[Union[Optional[HexStr], List[Optional[HexStr]]]]
+
+
+@dataclass
+class ContractFunctionPath:
+    """
+    Useful for identifying a method in a contract.
+    """
+
+    contract: str
+    method: Optional[str] = None
 
 
 class LogFilter(BaseModel):

--- a/src/ape/utils/trace.py
+++ b/src/ape/utils/trace.py
@@ -347,11 +347,11 @@ class CallTraceParser(ManagerAccessMixin):
         contract_id = self._get_contract_id(address, contract_type=contract_type, use_symbol=False)
 
         for exclusion in exclusions:
-            if exclusion.method is not None:
+            if exclusion.method_id is not None:
                 # Method-related excludes are handled below, even when contract also specified.
                 continue
 
-            if fnmatch.fnmatch(contract_id, exclusion.contract):
+            if fnmatch.fnmatch(contract_id, exclusion.contract_id):
                 # Skip this whole contract
                 reports = [x for x in map(this_method, sub_calls, exclude_arg)]
                 if len(reports) == 1:
@@ -375,15 +375,15 @@ class CallTraceParser(ManagerAccessMixin):
             method_id = selector.hex() if not method_abi else method_abi.name
 
             for exclusion in exclusions:
-                if not exclusion.method:
+                if not exclusion.method_id:
                     # Full contract skips handled above.
                     continue
 
-                elif not fnmatch.fnmatch(contract_id, exclusion.contract):
+                elif not fnmatch.fnmatch(contract_id, exclusion.contract_id):
                     # Method may match, but contract does not match, so continue.
                     continue
 
-                elif fnmatch.fnmatch(method_id, exclusion.method):
+                elif fnmatch.fnmatch(method_id, exclusion.method_id):
                     # Skip this report
                     reports = [r for r in map(this_method, sub_calls, exclude_arg)]
                     if len(reports) == 1:

--- a/src/ape/utils/trace.py
+++ b/src/ape/utils/trace.py
@@ -347,11 +347,11 @@ class CallTraceParser(ManagerAccessMixin):
         contract_id = self._get_contract_id(address, contract_type=contract_type, use_symbol=False)
 
         for exclusion in exclusions:
-            if exclusion.method_id is not None:
+            if exclusion.method_name is not None:
                 # Method-related excludes are handled below, even when contract also specified.
                 continue
 
-            if fnmatch.fnmatch(contract_id, exclusion.contract_id):
+            if fnmatch.fnmatch(contract_id, exclusion.contract_name):
                 # Skip this whole contract
                 reports = [x for x in map(this_method, sub_calls, exclude_arg)]
                 if len(reports) == 1:
@@ -375,15 +375,15 @@ class CallTraceParser(ManagerAccessMixin):
             method_id = selector.hex() if not method_abi else method_abi.name
 
             for exclusion in exclusions:
-                if not exclusion.method_id:
+                if not exclusion.method_name:
                     # Full contract skips handled above.
                     continue
 
-                elif not fnmatch.fnmatch(contract_id, exclusion.contract_id):
+                elif not fnmatch.fnmatch(contract_id, exclusion.contract_name):
                     # Method may match, but contract does not match, so continue.
                     continue
 
-                elif fnmatch.fnmatch(method_id, exclusion.method_id):
+                elif fnmatch.fnmatch(method_id, exclusion.method_name):
                     # Skip this report
                     reports = [r for r in map(this_method, sub_calls, exclude_arg)]
                     if len(reports) == 1:

--- a/src/ape_test/__init__.py
+++ b/src/ape_test/__init__.py
@@ -12,8 +12,8 @@ from .provider import LocalProvider
 
 
 class GasExclusion(PluginConfig):
-    contract: str = "*"  # If only given method, searches across all contracts.
-    method: Optional[str] = None
+    contract_name: str = "*"  # If only given method, searches across all contracts.
+    method_name: Optional[str] = None  # By default, match all methods in a contract
 
 
 class GasConfig(PluginConfig):

--- a/src/ape_test/__init__.py
+++ b/src/ape_test/__init__.py
@@ -38,8 +38,24 @@ class GasConfig(PluginConfig):
 
 class Config(PluginConfig):
     mnemonic: str = DEFAULT_TEST_MNEMONIC
+    """
+    The mnemonic to use when generating the test accounts.
+    """
+
     number_of_accounts: PositiveInt = DEFAULT_NUMBER_OF_TEST_ACCOUNTS
+    """
+    The number of test accounts to generate in the provider.
+    """
+
     gas: GasConfig = GasConfig()
+    """
+    Configuration related to gas reporting.
+    """
+
+    disconnect_providers_after: bool = True
+    """
+    Set to ``False`` to keep providers connected at the end of the test run.
+    """
 
 
 @plugins.register(plugins.Config)

--- a/src/ape_test/__init__.py
+++ b/src/ape_test/__init__.py
@@ -28,9 +28,9 @@ class GasConfig(PluginConfig):
 
     exclude: List[GasExclusion] = []
     """
-    Contract methods patterns to skip. Specify ``contract:`` and not
-    ``method:`` to skip all methods in the contract. Only specify
-    ``method:`` to skip all methods across all contracts. Specify
+    Contract methods patterns to skip. Specify ``contract_name:`` and not
+    ``method_name:`` to skip all methods in the contract. Only specify
+    ``method_name:`` to skip all methods across all contracts. Specify
     both to skip methods in a certain contracts. Entries use glob-rules;
     use ``prefix_*`` to skip all items with a certain prefix.
     """

--- a/src/ape_test/__init__.py
+++ b/src/ape_test/__init__.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from pydantic import PositiveInt
 
 from ape import plugins
@@ -9,9 +11,35 @@ from .accounts import TestAccount, TestAccountContainer
 from .provider import LocalProvider
 
 
+class GasExclusion(PluginConfig):
+    contract: Optional[str] = None
+    method: Optional[str] = None
+
+
+class GasConfig(PluginConfig):
+    """
+    Configuration related to test gas reports.
+    """
+
+    show: bool = False
+    """
+    Set to ``True`` to always show gas.
+    """
+
+    exclude: List[GasExclusion] = []
+    """
+    Contract methods patterns to skip.
+    Skip all methods in a contract by including the contract name.
+    Skip a particular method in a contract by including a value like
+    ``<contract-name>:<method-name>``. Skip all methods starting with a
+    prefix by doing ``*:<prefix>*``
+    """
+
+
 class Config(PluginConfig):
     mnemonic: str = DEFAULT_TEST_MNEMONIC
     number_of_accounts: PositiveInt = DEFAULT_NUMBER_OF_TEST_ACCOUNTS
+    gas: GasConfig = GasConfig()
 
 
 @plugins.register(plugins.Config)

--- a/src/ape_test/__init__.py
+++ b/src/ape_test/__init__.py
@@ -28,11 +28,11 @@ class GasConfig(PluginConfig):
 
     exclude: List[GasExclusion] = []
     """
-    Contract methods patterns to skip.
-    Skip all methods in a contract by including the contract name.
-    Skip a particular method in a contract by including a value like
-    ``<contract-name>:<method-name>``. Skip all methods starting with a
-    prefix by doing ``*:<prefix>*``
+    Contract methods patterns to skip. Specify ``contract:`` and not
+    ``method:`` to skip all methods in the contract. Only specify
+    ``method:`` to skip all methods across all contracts. Specify
+    both to skip methods in a certain contracts. Entries use glob-rules;
+    use ``prefix_*`` to skip all items with a certain prefix.
     """
 
 

--- a/src/ape_test/__init__.py
+++ b/src/ape_test/__init__.py
@@ -12,7 +12,7 @@ from .provider import LocalProvider
 
 
 class GasExclusion(PluginConfig):
-    contract: Optional[str] = None
+    contract: str = "*"  # If only given method, searches across all contracts.
     method: Optional[str] = None
 
 

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+from contextlib import contextmanager
 from distutils.dir_util import copy_tree
 from importlib import import_module
 from pathlib import Path
@@ -167,3 +168,31 @@ def subprocess_runner_cls():
 @pytest.fixture(scope="session")
 def subprocess_runner(subprocess_runner_cls):
     return subprocess_runner_cls()
+
+
+@pytest.fixture
+def switch_config(config):
+    def replace_config(config_file, new_content: str):
+        if config_file.is_file():
+            config_file.unlink()
+
+        config_file.touch()
+        config_file.write_text(new_content)
+
+    @contextmanager
+    def switch(project, new_content: str):
+        config_file = project.path / "ape-config.yaml"
+        original = config_file.read_text() if config_file.is_file() else None
+
+        try:
+            replace_config(config_file, new_content)
+            config.load(force_reload=True)
+            yield
+        finally:
+            if original:
+                replace_config(config_file, original)
+            elif config_file.is_file():
+                # Delete created config.
+                config_file.unlink()
+
+    return switch

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -172,6 +172,13 @@ def subprocess_runner(subprocess_runner_cls):
 
 @pytest.fixture
 def switch_config(config):
+    """
+    A config-context switcher for Integration tests.
+    It will change the contents of the active project's config file,
+    reload it, yield, and change it back. Useful for testing different
+    config scenarios without having to create entire new projects.
+    """
+
     def replace_config(config_file, new_content: str):
         if config_file.is_file():
             config_file.unlink()

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -54,3 +54,19 @@ def test_gas_flag(ape_test_runner, project):
         "Provider 'test' does not support transaction "
         "tracing and is unable to display a gas profile"
     ) in result.output
+
+
+@skip_projects_except(["test"])
+def test_gas_flag_set_in_config(ape_test_runner, project, switch_config):
+    gas_config = r"""
+    test:
+      gas:
+        show: true
+    """
+    with switch_config(project, gas_config):
+        assert project.config_manager.get_config("test").gas.show
+        result = ape_test_runner.invoke()
+        assert (
+            "Provider 'test' does not support transaction "
+            "tracing and is unable to display a gas profile"
+        ) in result.output


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #1092 - Note uses glob instead of regex though, is that okay?

Additionally fixes bug where if two receipts had same transaction hash, the second one would not show in the gas report.

### How I did it

* Add config wrapper to handle both CLI args and `ape-config.yaml` as one and pass that as a dependency in the `pytest-plugin` code.
* Change `receipt_map` in `ReceiptCapture` to first use a key of the source ID so can trace transactions with same hash from different sources.

### How to verify it

https://github.com/fubuloubu/ERC4626/pull/18

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
