### PR TITLE
fix: issue with `AddressAPI.__dir__()` implementation and its base-classes

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -5,14 +5,13 @@ import click
 from eip712.messages import SignableMessage as EIP712SignableMessage
 from eth_account import Account
 
+from ape.api.address import BaseAddress
+from ape.api.transactions import ReceiptAPI, TransactionAPI
 from ape.exceptions import AccountsError, AliasAlreadyInUseError, SignatureError, TransactionError
 from ape.logging import logger
 from ape.types import AddressType, MessageSignature, SignableMessage, TransactionSignature
 from ape.types.signatures import _Signature
 from ape.utils import BaseInterfaceModel, abstractmethod
-
-from .address import BaseAddress
-from .transactions import ReceiptAPI, TransactionAPI
 
 if TYPE_CHECKING:
     from ape.contracts import ContractContainer, ContractInstance
@@ -30,13 +29,16 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         Returns:
             List[str]: Method names that IPython uses for tab completion.
         """
-        return list(super(BaseAddress, self).__dir__()) + [
-            "alias",
-            "sign_message",
-            "sign_transaction",
-            "call",
-            "transfer",
-            "deploy",
+        base_value_excludes = ("code", "codesize", "is_contract")  # Not needed for accounts
+        base_values = [v for v in self._base_dir_values if v not in base_value_excludes]
+        return base_values + [
+            self.__class__.alias.fget.__name__,  # type: ignore[attr-defined]
+            self.__class__.call.__name__,
+            self.__class__.deploy.__name__,
+            self.__class__.prepare_transaction.__name__,
+            self.__class__.sign_message.__name__,
+            self.__class__.sign_transaction.__name__,
+            self.__class__.transfer.__name__,
         ]
 
     @property

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -18,7 +18,7 @@ class BaseAddress(BaseInterface):
         ``IPython`` ``__dir__`` values.
         """
 
-        # NOTE: mypy is confused by abstract properties.
+        # NOTE: mypy is confused by properties.
         #  https://github.com/python/typing/issues/1112
         return [
             str(BaseAddress.address.fget.__name__),  # type: ignore[attr-defined]

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -11,6 +11,26 @@ class BaseAddress(BaseInterface):
     """
 
     @property
+    def _base_dir_values(self) -> List[str]:
+        """
+        This exists because when you call ``dir(BaseAddress)``, you get the type's return
+        value and not the instances. This allows base-classes to make use of shared
+        ``IPython`` ``__dir__`` values.
+        """
+
+        # NOTE: mypy is confused by abstract properties.
+        #  https://github.com/python/typing/issues/1112
+        return [
+            str(BaseAddress.address.fget.__name__),  # type: ignore[attr-defined]
+            str(BaseAddress.balance.fget.__name__),  # type: ignore[attr-defined]
+            str(BaseAddress.code.fget.__name__),  # type: ignore[attr-defined]
+            str(BaseAddress.codesize.fget.__name__),  # type: ignore[attr-defined]
+            str(BaseAddress.nonce.fget.__name__),  # type: ignore[attr-defined]
+            str(BaseAddress.is_contract.fget.__name__),  # type: ignore[attr-defined]
+            str(BaseAddress.provider.fget.__name__),  # type: ignore[attr-defined]
+        ]
+
+    @property
     @abstractmethod
     def address(self) -> AddressType:
         """
@@ -35,19 +55,12 @@ class BaseAddress(BaseInterface):
     def __dir__(self) -> List[str]:
         """
         Display methods to IPython on ``a.[TAB]`` tab completion.
+        Overridden to lessen amount of methods shown to only those that are useful.
 
         Returns:
             List[str]: Method names that IPython uses for tab completion.
         """
-        return [
-            "address",
-            "balance",
-            "code",
-            "codesize",
-            "nonce",
-            "is_contract",
-            "provider",
-        ]
+        return self._base_dir_values
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {self.address}>"

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -731,9 +731,17 @@ class ContractInstance(BaseAddress):
         Returns:
             List[str]
         """
+
+        # NOTE: Type ignores because of this issue: https://github.com/python/typing/issues/1112
+        #  They can be removed after next `mypy` release containing fix.
+        values = [
+            "contract_type",
+            "txn_hash",
+            ContractInstance.receipt.fget.__name__,  # type: ignore[attr-defined]
+        ]
         return list(
-            set(super(BaseAddress, self).__dir__()).union(
-                self._view_methods_, self._mutable_methods_, self._events_
+            set(self._base_dir_values).union(
+                self._view_methods_, self._mutable_methods_, self._events_, values
             )
         )
 

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -68,9 +68,13 @@ class LocalProvider(TestProviderAPI, Web3Provider):
 
         block_id = kwargs.pop("block_identifier", None)
         estimate_gas = self.web3.eth.estimate_gas
+        txn_dict = txn.dict()
+        if txn_dict.get("gas") == "auto":
+            # Remove from dict before estimating
+            txn_dict.pop("gas")
 
         try:
-            return estimate_gas(txn.dict(), block_identifier=block_id)  # type: ignore
+            return estimate_gas(txn_dict, block_identifier=block_id)  # type: ignore
         except (ValidationError, TransactionFailed) as err:
             ape_err = self.get_virtual_machine_error(err, sender=txn.sender)
             gas_match = self._INVALID_NONCE_PATTERN.match(str(ape_err))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,7 +139,7 @@ def networks_disconnected(networks):
     networks.active_provider = provider
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def ethereum(networks):
     return networks.ethereum
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -380,6 +380,4 @@ def test_dir(core_account):
         "sign_transaction",
         "transfer",
     ]
-    missing = [x for x in actual if x not in expected]
-    err_msg = f"Extra: {', '.join(missing)}" if missing else ""
-    assert actual == expected, err_msg
+    assert sorted(actual) == sorted(expected)

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -11,6 +11,9 @@ from ape_ethereum.ecosystem import ProxyType
 
 MISSING_VALUE_TRANSFER_ERR_MSG = "Must provide 'VALUE' or use 'send_everything=True"
 
+APE_TEST_PATH = "ape_test.accounts.TestAccount"
+APE_ACCOUNTS_PATH = "ape_accounts.accounts.KeyfileAccount"
+
 
 @pytest.fixture(autouse=True, scope="module")
 def connected(eth_tester_provider):
@@ -20,6 +23,15 @@ def connected(eth_tester_provider):
 @pytest.fixture
 def signer(test_accounts):
     return test_accounts[2]
+
+
+@pytest.fixture(params=(APE_TEST_PATH, APE_ACCOUNTS_PATH))
+def core_account(request, owner, keyfile_account):
+    if request.param == APE_TEST_PATH:
+        yield owner  # from ape_test plugin
+
+    elif request.param == APE_ACCOUNTS_PATH:
+        yield keyfile_account  # from ape_accounts plugin
 
 
 class Foo(EIP712Message):
@@ -329,7 +341,7 @@ def test_unlock_from_prompt_and_sign_transaction(runner, keyfile_account, receiv
         assert receipt.receiver == receiver
 
 
-def test_custom_num_of_test_accts_config(test_accounts, temp_config):
+def test_custom_num_of_test_accounts_config(test_accounts, temp_config):
     custom_number_of_test_accounts = 20
     test_config = {
         "test": {
@@ -348,6 +360,26 @@ def test_test_accounts_repr(test_accounts):
     assert all(a.address in actual for a in test_accounts)
 
 
-def test_account_comparison_to_non_account(receiver):
+def test_account_comparison_to_non_account(core_account):
     # Before, would get a ConversionError.
-    assert receiver != "foo"
+    assert core_account != "foo"
+
+
+def test_dir(core_account):
+    actual = dir(core_account)
+    expected = [
+        "address",
+        "alias",
+        "balance",
+        "call",
+        "deploy",
+        "nonce",
+        "prepare_transaction",
+        "provider",
+        "sign_message",
+        "sign_transaction",
+        "transfer",
+    ]
+    missing = [x for x in actual if x not in expected]
+    err_msg = f"Extra: {', '.join(missing)}" if missing else ""
+    assert actual == expected, err_msg

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -399,6 +399,4 @@ def test_dir(vyper_contract_instance):
         *vyper_contract_instance._mutable_methods_,
         *vyper_contract_instance._view_methods_,
     ]
-    missing = [x for x in actual if x not in expected]
-    err_msg = f"Extra: {', '.join(missing)}" if missing else ""
-    assert actual == expected, err_msg
+    assert sorted(actual) == sorted(expected)

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -379,3 +379,26 @@ def test_transact_specify_auto_gas(vyper_contract_instance, owner):
 def test_transact_specify_max_gas(vyper_contract_instance, owner):
     receipt = vyper_contract_instance.setNumber(123, sender=owner, gas="max")
     assert not receipt.failed
+
+
+def test_dir(vyper_contract_instance):
+    actual = dir(vyper_contract_instance)
+    expected = [
+        # From base class
+        "address",
+        "balance",
+        "code",
+        "contract_type",
+        "codesize",
+        "nonce",
+        "is_contract",
+        "provider",
+        "receipt",
+        "txn_hash",
+        *vyper_contract_instance._events_,
+        *vyper_contract_instance._mutable_methods_,
+        *vyper_contract_instance._view_methods_,
+    ]
+    missing = [x for x in actual if x not in expected]
+    err_msg = f"Extra: {', '.join(missing)}" if missing else ""
+    assert actual == expected, err_msg

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -225,9 +225,10 @@ def test_ecosystems_when_default_provider_not_exists(temp_config, caplog, networ
     )
 
 
-def test_gas_limits(ethereum):
+def test_gas_limits(networks, config, project_with_source_files_contract):
     """
     Test the default gas limit configurations for local and live networks.
     """
-    assert ethereum.goerli.gas_limit == "auto"
-    assert ethereum.local.gas_limit == "max"
+    _ = project_with_source_files_contract  # Ensure use of project with default config
+    assert networks.ethereum.goerli.gas_limit == "auto"
+    assert networks.ethereum.local.gas_limit == "max"

--- a/tests/functional/utils/test_github.py
+++ b/tests/functional/utils/test_github.py
@@ -2,6 +2,7 @@ import tempfile
 
 import pytest
 from github import UnknownObjectException
+from requests.exceptions import ConnectTimeout
 
 from ape.utils.github import GithubClient, GitRemoteCallbacks
 
@@ -48,7 +49,10 @@ class TestGithubClient:
         client = GithubClient()
         git_patch = mocker.patch("ape.utils.github.pygit2.clone_repository")
         with tempfile.TemporaryDirectory() as temp_dir:
-            client.clone_repo("dapphub/ds-test", temp_dir, branch="master")
+            try:
+                client.clone_repo("dapphub/ds-test", temp_dir, branch="master")
+            except ConnectTimeout:
+                pytest.skip("Internet required to run this test.")
 
         call_args = git_patch.call_args[0]
         call_kwargs = git_patch.call_args[1]

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -202,4 +202,7 @@ def switch_config(config):
                 # Delete created config.
                 config_file.unlink()
 
+        # Reload back
+        config.load(force_reload=True)
+
     return switch


### PR DESCRIPTION
### What I did

The implementation for `__dir__` in both `AccountAPI` and `ContractInstance` API was wrong.
It called `__dir__` on the an uninstantiated super-class type, which yields different results than `__dir__` on a class instance.
Thus, the results for auto-tab completion in `ape console` contained many unusual and unnecessary methods from Pydantic, differing from the intent of the `AddressAPI` implementation which returned a much more controlled list.

This PR:

* Use the controlled list in `AddressAPI` to achieve the original intent
* Removes contract-only related methods from the `AccountAPI.__dir__()` implementation
* Ensures quality constrained tab-completions via new tests.
* Uses programmatic approach to retrieving method and property names when possible.  **NOTE: Currently there is an annoying mypy bug here though, hence the type ignores. We should be able to delete those on the next mypy release.**
* Fixes other issues found from failing tests.

### How I did it

Was working on a separate ticket but was trying to use `__dir__` but it wasn't helping me.. Noticed this bug, now it can help me work on what I need.

To achieve it, uses a hardcodes list that can be called from base classes so no need to do anything with `super()`.

### How to verify it

Try out tab completion now and tell me about the experience!
It actual completes more often now and limits the results to only the really public stuff. :))))

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
