### PR TITLE
fix: issue preventing use of geth with non parity traces

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.1.4,<0.2",
         "ethpm-types>=0.3.7,<0.4",
-        "evm-trace==0.1.0a10",
+        "evm-trace>=0.1.0a10",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -305,10 +305,11 @@ class ProviderAPI(BaseInterfaceModel):
     def send_call(self, txn: TransactionAPI) -> bytes:  # Return value of function
         """
         Execute a new transaction call immediately without creating a
-        transaction on the block chain.
+        transaction on the blockchain.
 
         Args:
-            txn: :class:`~ape.api.transactions.TransactionAPI`
+            txn (:class:`~ape.api.transactions.TransactionAPI`): The transaction
+              to send as a call.
 
         Returns:
             str: The result of the transaction call.
@@ -855,9 +856,9 @@ class Web3Provider(ProviderAPI, ABC):
         Args:
             txn_hash (str): The hash of the transaction to retrieve.
             required_confirmations (int): The amount of block confirmations
-              to wait before returning the receipt.
+              to wait before returning the receipt. Defaults to ``0``.
             timeout (Optional[int]): The amount of time to wait for a receipt
-              before timing out.
+              before timing out. Defaults ``None``.
 
         Raises:
             :class:`~ape.exceptions.TransactionNotFoundError`: Likely the exception raised
@@ -882,7 +883,7 @@ class Web3Provider(ProviderAPI, ABC):
         except TimeExhausted as err:
             raise TransactionNotFoundError(txn_hash) from err
 
-        txn = dict(self.web3.eth.get_transaction(txn_hash))  # type: ignore
+        txn = dict(self.web3.eth.get_transaction(HexStr(txn_hash)))
         receipt = self.network.ecosystem.decode_receipt(
             {
                 "provider": self,

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -269,11 +269,12 @@ class Ethereum(EcosystemAPI):
         if txn_hash:
             txn_hash = txn_hash.hex() if isinstance(txn_hash, HexBytes) else txn_hash
 
-        if data.get("data") and isinstance(data.get("data"), str):
-            data["data"] = HexBytes(data.get("data"))
+        data_bytes = data.get("data", b"")
+        if data_bytes and isinstance(data_bytes, str):
+            data["data"] = HexBytes(data_bytes)
 
-        elif data.get("input", b"") and isinstance(data.get("input", b""), str):
-            data["input"] = HexBytes(data.get("input", b""))
+        elif "input" in data and isinstance(data["input"], str):
+            data["input"] = HexBytes(data["input"])
 
         receipt = Receipt(
             block_number=data.get("block_number") or data.get("blockNumber"),

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -264,21 +264,21 @@ class Ethereum(EcosystemAPI):
 
             status = TransactionStatusEnum(status)
 
-        txn_hash = data.get("hash")
+        txn_hash = data.get("hash") or data.get("txn_hash") or data.get("transaction_hash")
 
         if txn_hash:
-            txn_hash = data["hash"].hex() if isinstance(data["hash"], HexBytes) else data["hash"]
+            txn_hash = txn_hash.hex() if isinstance(txn_hash, HexBytes) else txn_hash
 
         if data.get("data") and isinstance(data.get("data"), str):
-            data["data"] = bytes(HexBytes(data.get("data")))  # type: ignore
+            data["data"] = HexBytes(data.get("data"))
 
         elif data.get("input", b"") and isinstance(data.get("input", b""), str):
-            data["input"] = bytes(HexBytes(data.get("input", b"")))
+            data["input"] = HexBytes(data.get("input", b""))
 
         receipt = Receipt(
             block_number=data.get("block_number") or data.get("blockNumber"),
-            contract_address=data.get("contractAddress"),
-            gas_limit=data.get("gas") or data.get("gasLimit"),
+            contract_address=data.get("contract_address") or data.get("contractAddress"),
+            gas_limit=data.get("gas") or data.get("gas_limit") or data.get("gasLimit"),
             gas_price=data.get("gas_price") or data.get("gasPrice"),
             gas_used=data.get("gas_used") or data.get("gasUsed"),
             logs=data.get("logs", []),

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -4,8 +4,7 @@ from typing import Any, Dict, Iterator, List, Optional, Union
 
 import ijson  # type: ignore
 import requests
-from eth_typing import HexStr
-from eth_utils import add_0x_prefix, to_hex, to_wei
+from eth_utils import to_wei
 from evm_trace import (
     CallTreeNode,
     CallType,
@@ -19,7 +18,6 @@ from geth.accounts import ensure_account_exists  # type: ignore
 from geth.chain import initialize_chain  # type: ignore
 from geth.process import BaseGethProcess  # type: ignore
 from geth.wrapper import construct_test_chain_kwargs  # type: ignore
-from hexbytes import HexBytes
 from pydantic import Extra, PositiveInt
 from requests.exceptions import ConnectionError
 from web3 import HTTPProvider, Web3
@@ -29,7 +27,7 @@ from web3.middleware import geth_poa_middleware
 from web3.middleware.validation import MAX_EXTRADATA_LENGTH
 from yarl import URL
 
-from ape.api import PluginConfig, TransactionAPI, UpstreamProvider, Web3Provider
+from ape.api import PluginConfig, UpstreamProvider, Web3Provider
 from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.exceptions import APINotImplementedError, ProviderError
 from ape.logging import logger
@@ -317,26 +315,6 @@ class GethProvider(Web3Provider, UpstreamProvider):
 
             frames = self.get_transaction_trace(txn_hash)
             return get_calltree_from_geth_trace(frames, **root_node_kwargs)
-
-    def trace_call(self, txn: TransactionAPI, block_number: Optional[str] = None, **kwargs) -> Any:
-        block_number = block_number or "latest"
-        txn_dict = txn.dict()
-        data = txn_dict.get("data")
-        chain_id = txn_dict.get("chainId")
-        value = txn_dict.get("value")
-
-        if isinstance(data, bytes):
-            txn_dict["data"] = add_0x_prefix(HexStr(data.hex()))
-        if isinstance(chain_id, int):
-            txn_dict["chainId"] = to_hex(chain_id)
-        if isinstance(value, int):
-            txn_dict["value"] = to_hex(value)
-
-        result = self._make_request("debug_traceCall", [txn_dict, block_number, kwargs])
-        return_value = result["returnValue"]
-
-        # Returns `bytes` so an be used like `send_call()`.
-        return HexBytes(return_value)
 
     def _log_connection(self, client_name: str):
         logger.info(f"Connecting to existing {client_name} node at '{self._clean_uri}'.")

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -1,12 +1,14 @@
 import shutil
 from pathlib import Path
-from typing import Dict, Iterator, Optional, Union
+from typing import Any, Dict, Iterator, List, Optional, Union
 
 import ijson  # type: ignore
 import requests
-from eth_utils import to_wei
+from eth_typing import HexStr
+from eth_utils import add_0x_prefix, to_hex, to_wei
 from evm_trace import (
     CallTreeNode,
+    CallType,
     ParityTraceList,
     TraceFrame,
     get_calltree_from_geth_trace,
@@ -17,6 +19,7 @@ from geth.accounts import ensure_account_exists  # type: ignore
 from geth.chain import initialize_chain  # type: ignore
 from geth.process import BaseGethProcess  # type: ignore
 from geth.wrapper import construct_test_chain_kwargs  # type: ignore
+from hexbytes import HexBytes
 from pydantic import Extra, PositiveInt
 from requests.exceptions import ConnectionError
 from web3 import HTTPProvider, Web3
@@ -26,9 +29,9 @@ from web3.middleware import geth_poa_middleware
 from web3.middleware.validation import MAX_EXTRADATA_LENGTH
 from yarl import URL
 
-from ape.api import PluginConfig, UpstreamProvider, Web3Provider
+from ape.api import PluginConfig, TransactionAPI, UpstreamProvider, Web3Provider
 from ape.api.networks import LOCAL_NETWORK_NAME
-from ape.exceptions import ProviderError
+from ape.exceptions import APINotImplementedError, ProviderError
 from ape.logging import logger
 from ape.utils import generate_dev_accounts
 
@@ -295,12 +298,59 @@ class GethProvider(Web3Provider, UpstreamProvider):
         try:
             # Try the Parity traces first just in case
             return _get_call_tree_from_parity()
-        except ValueError:
+        except (ValueError, APINotImplementedError, ProviderError):
+            if not root_node_kwargs:
+                receipt = self.get_receipt(txn_hash)
+
+                if not receipt.receiver:
+                    raise ProviderError("Receipt missing receiver.")
+
+                root_node_kwargs = {
+                    "gas_cost": receipt.gas_used,
+                    "gas_limit": receipt.gas_limit,
+                    "address": receipt.receiver,
+                    "calldata": receipt.data,
+                    "value": receipt.value,
+                    "call_type": CallType.CALL,
+                    "failed": receipt.failed,
+                }
+
             frames = self.get_transaction_trace(txn_hash)
             return get_calltree_from_geth_trace(frames, **root_node_kwargs)
 
+    def trace_call(self, txn: TransactionAPI, block_number: Optional[str] = None, **kwargs) -> Any:
+        block_number = block_number or "latest"
+        txn_dict = txn.dict()
+        data = txn_dict.get("data")
+        chain_id = txn_dict.get("chainId")
+        value = txn_dict.get("value")
+
+        if isinstance(data, bytes):
+            txn_dict["data"] = add_0x_prefix(HexStr(data.hex()))
+        if isinstance(chain_id, int):
+            txn_dict["chainId"] = to_hex(chain_id)
+        if isinstance(value, int):
+            txn_dict["value"] = to_hex(value)
+
+        result = self._make_request("debug_traceCall", [txn_dict, block_number, kwargs])
+        return_value = result["returnValue"]
+
+        # Returns `bytes` so an be used like `send_call()`.
+        return HexBytes(return_value)
+
     def _log_connection(self, client_name: str):
         logger.info(f"Connecting to existing {client_name} node at '{self._clean_uri}'.")
+
+    def _make_request(self, endpoint: str, parameters: List) -> Any:
+        try:
+            return super()._make_request(endpoint, parameters)
+        except ProviderError as err:
+            if "does not exist/is not available" in str(err):
+                raise APINotImplementedError(
+                    f"RPC method '{endpoint}' is not implemented by this node instance."
+                ) from err
+
+            raise  # Original error
 
 
 def _create_web3(uri: str):

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -294,7 +294,7 @@ class GethProvider(Web3Provider, UpstreamProvider):
             return _get_call_tree_from_parity()
 
         try:
-            # Try the Parity traces first just in case
+            # Try the Parity traces first, in case node client supports it.
             return _get_call_tree_from_parity()
         except (ValueError, APINotImplementedError, ProviderError):
             if not root_node_kwargs:

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -3,6 +3,7 @@ from typing import cast
 
 import pytest
 from eth_typing import HexStr
+from evm_trace import CallType
 from web3.exceptions import ContractLogicError as Web3ContractLogicError
 
 from ape.api.networks import LOCAL_NETWORK_NAME
@@ -14,10 +15,45 @@ from ape.exceptions import (
     TransactionNotFoundError,
 )
 from ape_ethereum.ecosystem import Block
+from ape_ethereum.transactions import TransactionStatusEnum
 from ape_geth import GethProvider
 from tests.functional.data.python import TRACE_RESPONSE
 
 TEST_REVERT_REASON = "TEST REVERT REASON."
+TRACE_FRAME_DATA = [
+    {
+        "pc": 1564,
+        "op": "RETURN",
+        "gas": 0,
+        "gasCost": 0,
+        "depth": 1,
+        "callType": CallType.CALL.value,
+        "stack": [
+            "0000000000000000000000000000000000000000000000000000000040c10f19",
+            "0000000000000000000000000000000000000000000000000000000000000020",
+            "0000000000000000000000000000000000000000000000000000000000000140",
+        ],
+        "memory": [
+            "0000000000000000000000001e59ce931b4cfea3fe4b875411e280e173cb7a9c",
+            "0000000000000000000000000000000000000000000000000000000000000001",
+        ],
+        "storage": {
+            "0000000000000000000000000000000000000000000000000000000000000004": "0000000000000000000000001e59ce931b4cfea3fe4b875411e280e173cb7a9c",  # noqa: E501
+            "ad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5": "0000000000000000000000001e59ce931b4cfea3fe4b875411e280e173cb7a9c",  # noqa: E501
+            "aadb61a4b4c5d48b7a5669391b7c73852a3ab7795f24721b9a439220b54b591b": "0000000000000000000000000000000000000000000000000000000000000001",  # noqa: E501
+        },
+    }
+]
+TRANSACTION_HASH = "0x053cba5c12172654d894f66d5670bab6215517a94189a9ffc09bc40a589ec04d"
+RECEIPT_DATA = {
+    "hash": TRANSACTION_HASH,
+    "status": TransactionStatusEnum.NO_ERROR.value,
+    "gas_limit": 100,
+    "gas_price": 10,
+    "block_number": 123,
+    "gas_used": 999,
+    "to": "0x1230000000000000000000000000000000000123",
+}
 
 
 @pytest.fixture
@@ -115,15 +151,29 @@ def test_uri_uses_value_from_settings(mock_network, mock_web3, temp_config):
         assert provider.uri == "value/from/settings"
 
 
+def test_get_call_tree(mock_web3, geth_provider):
+    def side_effects(method_name: str, *args, **kwargs):
+        if method_name == "trace_transaction":
+            return {"error": "Method 'trace_transaction' does not exist/is not available"}
+        elif method_name == "debug_traceTransaction":
+            return TRACE_FRAME_DATA
+
+    mock_web3.clientVersion = "geth_MOCK"
+    mock_web3.provider.make_request.side_effects = side_effects
+    mock_web3.eth.get_transaction.return_value = RECEIPT_DATA
+    result = geth_provider.get_call_tree(TRANSACTION_HASH)
+    actual = repr(result)
+    expected = f"CALL: {RECEIPT_DATA['to']} [999 gas]"
+    assert expected in actual
+
+
 def test_get_call_tree_erigon(mock_web3, geth_provider, trace_response):
     mock_web3.clientVersion = "erigon_MOCK"
     mock_web3.provider.make_request.return_value = trace_response
-    result = geth_provider.get_call_tree(
-        "0x053cba5c12172654d894f66d5670bab6215517a94189a9ffc09bc40a589ec04d"
-    )
-    assert "CALL: 0xC17f2C69aE2E66FD87367E3260412EEfF637F70E.<0x96d373e5> [1401584 gas]" in repr(
-        result
-    )
+    result = geth_provider.get_call_tree(TRANSACTION_HASH)
+    actual = repr(result)
+    expected = "CALL: 0xC17f2C69aE2E66FD87367E3260412EEfF637F70E.<0x96d373e5> [1401584 gas]"
+    assert expected in actual
 
 
 def test_repr_on_local_network_and_disconnected(networks):
@@ -207,7 +257,7 @@ def test_get_block_not_found(eth_tester_provider_geth):
 
 
 def test_get_receipt_not_exists_with_timeout(eth_tester_provider_geth):
-    unknown_txn = "0x053cba5c12172654d894f66d5670bab6215517a94189a9ffc09bc40a589ec04d"
+    unknown_txn = TRANSACTION_HASH
     with pytest.raises(TransactionNotFoundError, match=f"Transaction '{unknown_txn}' not found"):
         eth_tester_provider_geth.get_receipt(unknown_txn, timeout=0)
 


### PR DESCRIPTION
### What I did

Issue preventing the use of local geth (like `geth --dev`) from working with traces.
Parity traces have been tested to death but regular geth hadn't.
This makes it so you can run tests using `etheruem:local:geth` and get tracing support.

**We have tracing support within core ape. We have really had it this whole time! Let's use it more.**

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
