### PR TITLE
fix: include memory when using geth to get geth-style traces

### DIFF
--- a/src/ape/utils/trace.py
+++ b/src/ape/utils/trace.py
@@ -372,7 +372,7 @@ class CallTraceParser(ManagerAccessMixin):
             # NOTE: Use contract name when possible to distinguish between sources with the same
             #  symbol. Also, ape projects don't permit multiple contract types with the same name.
             method_abi = _get_method_abi(selector, contract_type)
-            method_id = selector.hex() if not method_abi else method_abi.name
+            method_id = method_abi.name if method_abi else selector.hex()
 
             for exclusion in exclusions:
                 if not exclusion.method_name:

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -277,7 +277,9 @@ class GethProvider(Web3Provider, UpstreamProvider):
             del results[:]
 
     def get_transaction_trace(self, txn_hash: str) -> Iterator[TraceFrame]:
-        frames = self.stream_request("debug_traceTransaction", [txn_hash], "result.structLogs.item")
+        frames = self.stream_request(
+            "debug_traceTransaction", [txn_hash, {"enableMemory": True}], "result.structLogs.item"
+        )
         for frame in frames:
             yield TraceFrame(**frame)
 

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -263,7 +263,7 @@ class GethProvider(Web3Provider, UpstreamProvider):
         self._web3 = None
         self._client_version = None
 
-    def stream_request(self, method, params, iter_path="result.item"):
+    def stream_request(self, method: str, params: List, iter_path="result.item"):
         payload = {"jsonrpc": "2.0", "id": 1, "method": method, "params": params}
         results = ijson.sendable_list()
         coro = ijson.items_coro(results, iter_path)

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -176,6 +176,18 @@ def test_get_call_tree(mocker, mock_web3, geth_provider):
     expected = f"CALL: {RECEIPT_DATA['to']} [999 gas]"
     assert expected in actual
 
+    # Ensure we enabled memory correctly.
+    expected_params = [TRANSACTION_HASH, {"enableMemory": True}]
+    expected_payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "debug_traceTransaction",
+        "params": expected_params,
+    }
+    streamer.post.assert_called_once_with(
+        "http://localhost:8545", json=expected_payload, stream=True
+    )
+
 
 def test_get_call_tree_erigon(mock_web3, geth_provider, trace_response):
     mock_web3.client_version = "erigon_MOCK"


### PR DESCRIPTION
### What I did

OK, so I figured out why memory was missing on all my geth trace subcalls. It needs to be enabled.
This PR does that!

### How I did it

Enabled memory using RPC params

### How to verify it

* Take care to have `geth` installed
* Launch your favorite project to test gas reporting in (e.g. https://github.com/fubuloubu/ERC4626)
* Run `ape test --network :local:geth --gas --show-capture=no`
* Notice the magic!

Try again without this PR and you will see why it is needed. None of the subcalls are recognized otherwise.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
