### PR TITLE
feat: add `snapshot()` and `revert()` implementations to `ape-geth` local provider

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,7 +74,7 @@ jobs:
           uses: actions/cache@v3
           with:
             path: $HOME/.local/bin
-            key: ${{ runner.os }}-geth-$GETH_VERSION
+            key: ${{ runner.os }}-geth-${{ env.GETH_VERSION }}
 
         - name: Install Geth
           if: steps.cache-geth.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,6 +57,7 @@ jobs:
 
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GETH_VERSION: 1.10.26
 
         steps:
         - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,7 @@ jobs:
             tar -zxvf geth.tar.gz
             cd go-ethereum-$GETH_VERSION
             make geth
-            cp ./build/bin/geth $HOME/.local/bin
+            cp ./build/bin/geth /usr/local/bin
             geth version
 
         - name: Install Dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,7 +94,7 @@ jobs:
             pip install .[test]
 
         - name: Run Tests
-          run: pytest -m "not fuzzing" -s --cov=src -n auto
+          run: pytest -m "not fuzzing" -s --cov=src -n auto --dist loadscope
 
     fuzzing:
         runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,6 +85,7 @@ jobs:
             cd go-ethereum-$GETH_VERSION
             make geth
             cp ./build/bin/geth $HOME/.local/bin
+            geth version
 
         - name: Install Dependencies
           run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,6 +68,9 @@ jobs:
           with:
               python-version: ${{ matrix.python-version }}
 
+        - name: Install Geth
+          uses: gacts/install-geth-tools@v1.0.1
+
         - name: Install Dependencies
           run: |
             python -m pip install --upgrade pip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,8 +68,22 @@ jobs:
           with:
               python-version: ${{ matrix.python-version }}
 
+        - name: Cache Geth
+          id: cache-geth
+          uses: actions/cache@v3
+          with:
+            path: $HOME/.local/bin
+            key: ${{ runner.os }}-geth-$GETH_VERSION
+
         - name: Install Geth
-          uses: gacts/install-geth-tools@v1.0.1
+          if: steps.cache-geth.outputs.cache-hit != 'true'
+          run: |
+            mkdir -p $HOME/.local/bin
+            wget -O geth.tar.gz "https://github.com/ethereum/go-ethereum/archive/v$GETH_VERSION.tar.gz"
+            tar -zxvf geth.tar.gz
+            cd go-ethereum-$GETH_VERSION
+            make geth
+            cp ./build/bin/geth $HOME/.local/bin
 
         - name: Install Dependencies
           run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
 
 [tool.mypy]
-exclude = ["build/", "dist/", "docs/"]
+exclude = ["build/", "dist/", "docs/", "tests/integration/cli/projects/"]
 
 [tool.setuptools_scm]
 write_to = "src/ape/version.py"

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require = {
     ],
     "lint": [
         "black>=22.10.0,<23",  # auto-formatter and linter
-        "mypy>=0.982,<1",  # Static type analyzer
+        "mypy==0.982",  # Static type analyzer
         "types-PyYAML",  # NOTE: Needed due to mypy typeshed
         "types-requests",  # NOTE: Needed due to mypy typeshed
         "types-pkg-resources",  # NOTE: Needed due to mypy typeshed

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -738,12 +738,14 @@ class NetworkAPI(BaseInterfaceModel):
 
         provider_name = provider_name or self.default_provider
         if not provider_name:
+            from ape.managers.config import CONFIG_FILE_NAME
+
             raise NetworkError(
                 f"No default provider for network '{self.name}'. "
-                f"Set one in your ape-config.yaml:\n"
+                f"Set one in your {CONFIG_FILE_NAME}:\n"
                 f"\n{self.ecosystem.name}:"
                 f"\n  {self.name}:"
-                f"\n    default_provider: <DEFAULT_PROVIDER>"
+                "\n    default_provider: <DEFAULT_PROVIDER>"
             )
 
         provider_settings = provider_settings or {}

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -953,7 +953,16 @@ class Web3Provider(ProviderAPI, ABC):
         )
 
         receipt = self.get_receipt(txn_hash.hex(), required_confirmations=required_confirmations)
-        receipt.raise_for_status()
+        if receipt.failed:
+            txn_dict = receipt.transaction.dict()
+            txn_params = cast(TxParams, txn_dict)
+
+            # Replay txn to get revert reason
+            try:
+                self.web3.eth.call(txn_params)
+            except Exception as err:
+                raise self.get_virtual_machine_error(err) from err
+
         logger.info(f"Confirmed {receipt.txn_hash} (total fees paid = {receipt.total_fees_paid})")
         self.chain_manager.account_history.append(receipt)
         return receipt

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -720,7 +720,7 @@ class ContractCache(BaseManager):
 
             if proxy_info:
                 self._local_proxies[address_key] = proxy_info
-                return self.get(proxy_info.target)
+                return self.get(proxy_info.target, default=default)
 
             if not self.provider.get_code(address_key):
                 if default:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1090,6 +1090,7 @@ class ChainManager(BaseManager):
             self.pending_timestamp = timestamp
         elif deltatime:
             self.pending_timestamp += deltatime
+
         self.provider.mine(num_blocks)
 
     def set_balance(self, account: Union[BaseAddress, AddressType], amount: Union[int, str]):

--- a/src/ape_geth/__init__.py
+++ b/src/ape_geth/__init__.py
@@ -1,8 +1,8 @@
 from ape import plugins
 from ape.api.networks import LOCAL_NETWORK_NAME
 
-from .provider import GethNetworkConfig, GethDev, NetworkConfig
 from .provider import Geth as GethProvider  # TODO: Export as Geth on 0.6
+from .provider import GethDev, GethNetworkConfig, NetworkConfig
 
 
 @plugins.register(plugins.Config)

--- a/src/ape_geth/__init__.py
+++ b/src/ape_geth/__init__.py
@@ -1,6 +1,8 @@
 from ape import plugins
+from ape.api.networks import LOCAL_NETWORK_NAME
 
-from .provider import GethNetworkConfig, GethProvider, NetworkConfig
+from .provider import GethNetworkConfig, GethDev, NetworkConfig
+from .provider import Geth as GethProvider  # TODO: Export as Geth on 0.6
 
 
 @plugins.register(plugins.Config)
@@ -10,5 +12,9 @@ def config_class():
 
 @plugins.register(plugins.ProviderPlugin)
 def providers():
-    for network_name in GethNetworkConfig().dict():
+    networks_dict = GethNetworkConfig().dict()
+    networks_dict.pop(LOCAL_NETWORK_NAME)
+    for network_name in networks_dict:
         yield "ethereum", network_name, GethProvider
+
+    yield "ethereum", LOCAL_NETWORK_NAME, GethDev

--- a/src/ape_geth/__init__.py
+++ b/src/ape_geth/__init__.py
@@ -1,7 +1,7 @@
 from ape import plugins
 from ape.api.networks import LOCAL_NETWORK_NAME
 
-from .provider import Geth as GethProvider  # TODO: Export as Geth on 0.6
+from .provider import Geth as GethProvider
 from .provider import GethDev, GethNetworkConfig, NetworkConfig
 
 

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -349,8 +349,6 @@ class GethDev(TestProviderAPI, BaseGethProvider):
 
         super().disconnect()
 
-        super().disconnect()
-
     def revert(self, snapshot_id: SnapshotID):
         if isinstance(snapshot_id, int):
             block_number = to_hex(snapshot_id)

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -37,7 +37,7 @@ from ape.utils import generate_dev_accounts, raises_not_implemented
 DEFAULT_SETTINGS = {"uri": "http://localhost:8545"}
 
 
-class EphemeralGeth(LoggingMixin, BaseGethProcess):
+class GethDevProcess(LoggingMixin, BaseGethProcess):
     """
     A developer-configured geth that only exists until disconnected.
     """
@@ -294,7 +294,7 @@ class BaseGethProvider(Web3Provider):
 
 
 class GethDev(TestProviderAPI, BaseGethProvider):
-    _geth: Optional[EphemeralGeth] = None
+    _geth: Optional[GethDevProcess] = None
     name: str = "geth"
 
     def connect(self):
@@ -319,7 +319,7 @@ class GethDev(TestProviderAPI, BaseGethProvider):
         mnemonic = test_config["mnemonic"]
         num_of_accounts = test_config["number_of_accounts"]
 
-        self._geth = EphemeralGeth(
+        self._geth = GethDevProcess(
             self.data_folder,
             parsed_uri.host,
             parsed_uri.port,

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -5,9 +5,7 @@ from typing import Any, Dict, Iterator, List, Optional, Union
 import ijson  # type: ignore
 import requests
 from eth_typing import HexStr
-from eth_utils import to_wei, to_hex, add_0x_prefix
-
-from ape.types import SnapshotID
+from eth_utils import add_0x_prefix, to_hex, to_wei
 from evm_trace import (
     CallTreeNode,
     CallType,
@@ -30,9 +28,10 @@ from web3.middleware import geth_poa_middleware
 from web3.middleware.validation import MAX_EXTRADATA_LENGTH
 from yarl import URL
 
-from ape.api import PluginConfig, UpstreamProvider, Web3Provider, TestProviderAPI
+from ape.api import PluginConfig, TestProviderAPI, UpstreamProvider, Web3Provider
 from ape.exceptions import APINotImplementedError, ProviderError
 from ape.logging import logger
+from ape.types import SnapshotID
 from ape.utils import generate_dev_accounts, raises_not_implemented
 
 DEFAULT_SETTINGS = {"uri": "http://localhost:8545"}
@@ -309,9 +308,9 @@ class GethDev(TestProviderAPI, BaseGethProvider):
         parsed_uri = URL(self.uri)
 
         if parsed_uri.host not in ("localhost", "127.0.0.1"):
-            raise ConnectionError(f"Unable to connect web3 to {parsed_uri.host}.")
+            raise ConnectionError(f"Unable to start Geth on non-local host {parsed_uri.host}.")
 
-        if not shutil.which("geth"):
+        elif not shutil.which("geth"):
             raise GethNotInstalledError()
 
         # Use mnemonic from test config
@@ -365,7 +364,6 @@ class GethDev(TestProviderAPI, BaseGethProvider):
 
 
 class Geth(BaseGethProvider, UpstreamProvider):
-
     @property
     def connection_str(self) -> str:
         return self.uri

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -1,4 +1,5 @@
 import shutil
+from abc import ABC
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Union
 
@@ -146,7 +147,7 @@ class GethNotInstalledError(ConnectionError):
         )
 
 
-class BaseGethProvider(Web3Provider):
+class BaseGethProvider(Web3Provider, ABC):
     _client_version: Optional[str] = None
 
     # optimal values for geth

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ ape.config.PROJECT_FOLDER = Path(mkdtemp()).resolve()
 
 # Needed to test tracing support in core `ape test` command.
 pytest_plugins = ["pytester"]
+geth_process_test = pytest.mark.xdist_group(name="geth-tests")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,15 @@ import yaml
 from click.testing import CliRunner
 
 import ape
-from ape.exceptions import UnknownSnapshotError
+from ape.exceptions import APINotImplementedError, UnknownSnapshotError
 from ape.managers.config import CONFIG_FILE_NAME
 
 # NOTE: Ensure that we don't use local paths for these
 ape.config.DATA_FOLDER = Path(mkdtemp()).resolve()
 ape.config.PROJECT_FOLDER = Path(mkdtemp()).resolve()
+
+# Needed to test tracing support in core `ape test` command.
+pytest_plugins = ["pytester"]
 
 
 @pytest.fixture(autouse=True)
@@ -151,7 +154,11 @@ def eth_tester_provider(networks_connected_to_tester):
 
 @pytest.fixture(autouse=True)
 def isolation(chain, eth_tester_provider):
-    snapshot = chain.snapshot()
+    try:
+        snapshot = chain.snapshot()
+    except APINotImplementedError:
+        snapshot = None
+
     yield
 
     if snapshot:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,7 @@ def isolation(chain, eth_tester_provider):
 
     yield
 
-    if snapshot:
+    if snapshot is not None:
         try:
             chain.restore(snapshot)
         except UnknownSnapshotError:

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -13,8 +13,9 @@ from ape_ethereum.transactions import Receipt, TransactionStatusEnum
 
 
 @pytest.fixture(scope="module", autouse=True)
-def connection(networks_connected_to_tester):
-    yield
+def connection(networks):
+    with networks.ethereum.local.use_provider("test"):
+        yield
 
 
 @pytest.fixture
@@ -244,7 +245,8 @@ def test_set_pending_timestamp_with_deltatime(chain):
     start_timestamp = chain.pending_timestamp
     chain.mine(deltatime=5)
     new_timestamp = chain.pending_timestamp
-    assert new_timestamp - start_timestamp - 5 <= 1
+    actual = new_timestamp - start_timestamp - 5
+    assert actual <= 1
 
 
 def test_set_pending_timestamp_failure(chain):

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -358,7 +358,7 @@ def test_receipt(contract_instance, owner):
 
 
 def test_from_receipt_when_receipt_not_deploy(contract_instance, owner):
-    receipt = contract_instance.setNumber(123, sender=owner)
+    receipt = contract_instance.setNumber(555, sender=owner)
     expected_err = (
         "Receipt missing 'contract_address' field. "
         "Was this from a deploy transaction (e.g. `project.MyContract.deploy()`)?"
@@ -372,12 +372,12 @@ def test_transact_specify_auto_gas(vyper_contract_instance, owner):
     Tests that we can specify "auto" gas even though "max" is the default for
     local networks.
     """
-    receipt = vyper_contract_instance.setNumber(123, sender=owner, gas="auto")
+    receipt = vyper_contract_instance.setNumber(111, sender=owner, gas="auto")
     assert not receipt.failed
 
 
 def test_transact_specify_max_gas(vyper_contract_instance, owner):
-    receipt = vyper_contract_instance.setNumber(123, sender=owner, gas="max")
+    receipt = vyper_contract_instance.setNumber(222, sender=owner, gas="max")
     assert not receipt.failed
 
 

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -55,12 +55,6 @@ def parity_trace_response():
 
 
 @geth_process_test
-def test_did_start_local_process(geth):
-    assert geth._process is not None
-    assert geth._process.is_running
-
-
-@geth_process_test
 def test_uri(geth):
     assert geth.uri == URI
 

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -15,6 +15,7 @@ from ape.exceptions import (
 )
 from ape_ethereum.ecosystem import Block
 from ape_geth.provider import Geth
+from tests.conftest import geth_process_test
 from tests.functional.conftest import RAW_VYPER_CONTRACT_TYPE
 from tests.functional.data.python import TRACE_RESPONSE
 
@@ -28,6 +29,7 @@ def geth(networks):
         yield provider
 
 
+@geth_process_test
 @pytest.fixture
 def mock_geth(geth, mock_web3):
     provider = Geth(
@@ -52,15 +54,18 @@ def parity_trace_response():
     return TRACE_RESPONSE
 
 
+@geth_process_test
 def test_did_start_local_process(geth):
     assert geth._process is not None
     assert geth._process.is_running
 
 
+@geth_process_test
 def test_uri(geth):
     assert geth.uri == URI
 
 
+@geth_process_test
 def test_uri_uses_value_from_config(geth, temp_config):
     settings = geth.provider_settings
     geth.provider_settings = {}
@@ -88,6 +93,7 @@ def test_revert_no_message(accounts, geth_contract):
         contract.setNumber(5, sender=owner)
 
 
+@geth_process_test
 def test_get_call_tree(geth, geth_contract, accounts):
     owner = accounts.test_accounts[-3]
     contract = owner.deploy(geth_contract)
@@ -107,6 +113,7 @@ def test_get_call_tree_erigon(mock_web3, mock_geth, parity_trace_response):
     assert re.match(expected, actual)
 
 
+@geth_process_test
 def test_repr_connected(geth):
     assert repr(geth) == "<geth chain_id=1337>"
 
@@ -121,6 +128,7 @@ def test_repr_on_live_network_and_disconnected(networks):
     assert repr(geth) == "<geth chain_id=5>"
 
 
+@geth_process_test
 def test_get_logs(geth, accounts, geth_contract):
     owner = accounts.test_accounts[-4]
     contract = owner.deploy(geth_contract)
@@ -131,6 +139,7 @@ def test_get_logs(geth, accounts, geth_contract):
     assert actual.event_arguments["newNum"] == 101010
 
 
+@geth_process_test
 def test_chain_id_when_connected(geth):
     assert geth.chain_id == 1337
 
@@ -140,6 +149,7 @@ def test_chain_id_live_network_not_connected(networks):
     assert geth.chain_id == 5
 
 
+@geth_process_test
 def test_chain_id_live_network_connected_uses_web3_chain_id(mocker, geth):
     mock_network = mocker.MagicMock()
     mock_network.chain_id = 999999999  # Shouldn't use hardcoded network
@@ -154,6 +164,7 @@ def test_chain_id_live_network_connected_uses_web3_chain_id(mocker, geth):
         geth.network = orig_network
 
 
+@geth_process_test
 def test_connect_wrong_chain_id(mocker, ethereum, geth):
     start_network = geth.network
 
@@ -175,10 +186,12 @@ def test_connect_wrong_chain_id(mocker, ethereum, geth):
         geth.network = start_network
 
 
+@geth_process_test
 def test_supports_tracing(geth):
     assert geth.supports_tracing
 
 
+@geth_process_test
 @pytest.mark.parametrize("block_id", (0, "0", "0x0", HexStr("0x0")))
 def test_get_block(geth, block_id):
     block = cast(Block, geth.get_block(block_id))
@@ -189,6 +202,7 @@ def test_get_block(geth, block_id):
     assert block.gas_used == 0
 
 
+@geth_process_test
 def test_get_block_not_found(geth):
     latest_block = geth.get_block("latest")
     block_id = latest_block.number + 1000
@@ -196,12 +210,14 @@ def test_get_block_not_found(geth):
         geth.get_block(block_id)
 
 
+@geth_process_test
 def test_get_receipt_not_exists_with_timeout(geth):
     unknown_txn = TRANSACTION_HASH
     with pytest.raises(TransactionNotFoundError, match=f"Transaction '{unknown_txn}' not found"):
         geth.get_receipt(unknown_txn, timeout=0)
 
 
+@geth_process_test
 def test_get_receipt(accounts, geth_contract, geth):
     owner = accounts.test_accounts[-5]
     contract = owner.deploy(geth_contract)

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -1,201 +1,117 @@
+import re
 from pathlib import Path
 from typing import cast
 
 import pytest
 from eth_typing import HexStr
-from evm_trace import CallType
-from web3.exceptions import ContractLogicError as Web3ContractLogicError
+from ethpm_types import ContractType
 
-from ape.api.networks import LOCAL_NETWORK_NAME
+from ape.contracts import ContractContainer
 from ape.exceptions import (
     BlockNotFoundError,
     ContractLogicError,
     NetworkMismatchError,
-    TransactionError,
     TransactionNotFoundError,
 )
 from ape_ethereum.ecosystem import Block
-from ape_ethereum.transactions import TransactionStatusEnum
-from ape_geth import GethProvider
+from ape_geth.provider import Geth
+from tests.functional.conftest import RAW_VYPER_CONTRACT_TYPE
 from tests.functional.data.python import TRACE_RESPONSE
 
-TEST_REVERT_REASON = "TEST REVERT REASON."
-TRACE_FRAME_DATA = [
-    {
-        "pc": 1564,
-        "op": "RETURN",
-        "gas": 0,
-        "gasCost": 0,
-        "depth": 1,
-        "callType": CallType.CALL.value,
-        "stack": [
-            "0000000000000000000000000000000000000000000000000000000040c10f19",
-            "0000000000000000000000000000000000000000000000000000000000000020",
-            "0000000000000000000000000000000000000000000000000000000000000140",
-        ],
-        "memory": [
-            "0000000000000000000000001e59ce931b4cfea3fe4b875411e280e173cb7a9c",
-            "0000000000000000000000000000000000000000000000000000000000000001",
-        ],
-        "storage": {
-            "0000000000000000000000000000000000000000000000000000000000000004": "0000000000000000000000001e59ce931b4cfea3fe4b875411e280e173cb7a9c",  # noqa: E501
-            "ad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5": "0000000000000000000000001e59ce931b4cfea3fe4b875411e280e173cb7a9c",  # noqa: E501
-            "aadb61a4b4c5d48b7a5669391b7c73852a3ab7795f24721b9a439220b54b591b": "0000000000000000000000000000000000000000000000000000000000000001",  # noqa: E501
-        },
-    }
-]
 TRANSACTION_HASH = "0x053cba5c12172654d894f66d5670bab6215517a94189a9ffc09bc40a589ec04d"
-RECEIPT_DATA = {
-    "hash": TRANSACTION_HASH,
-    "status": TransactionStatusEnum.NO_ERROR.value,
-    "gas_limit": 100,
-    "gas_price": 10,
-    "block_number": 123,
-    "gas_used": 999,
-    "to": "0x1230000000000000000000000000000000000123",
-}
+
+
+@pytest.fixture(scope="module", autouse=True)
+def geth(networks):
+    with networks.ethereum.local.use_provider("geth") as provider:
+        yield provider
 
 
 @pytest.fixture
-def trace_response():
-    return TRACE_RESPONSE
-
-
-@pytest.fixture
-def mock_network(mock_network_api, ethereum):
-    mock_network_api.name = LOCAL_NETWORK_NAME
-    mock_network_api.ecosystem = ethereum
-    return mock_network_api
-
-
-@pytest.fixture
-def geth_provider(mock_network, mock_web3):
-    return create_geth(mock_network, mock_web3)
-
-
-def create_geth(network, web3):
-    provider = GethProvider(
+def mock_geth(geth, mock_web3):
+    provider = Geth(
         name="geth",
-        network=network,
+        network=geth.network,
         provider_settings={},
         data_folder=Path("."),
         request_header="",
     )
-    provider._web3 = web3
+    provider._web3 = mock_web3
     return provider
 
 
+@pytest.fixture(scope="module")
+def geth_contract():
+    contract_type = ContractType.parse_raw(RAW_VYPER_CONTRACT_TYPE)
+    return ContractContainer(contract_type=contract_type)
+
+
 @pytest.fixture
-def eth_tester_provider_geth(eth_tester_provider, networks):
-    """Geth using eth-tester provider"""
-    provider = create_geth(eth_tester_provider.network, eth_tester_provider.web3)
-    init_provider = networks.active_provider
-    networks.active_provider = provider
-    yield provider
-    networks.active_provider = init_provider
+def parity_trace_response():
+    return TRACE_RESPONSE
 
 
-def test_send_when_web3_error_raises_transaction_error(geth_provider, mock_web3, mock_transaction):
-    web3_error_data = {
-        "code": -32000,
-        "message": "Test Error Message",
-    }
-    mock_web3.eth.send_raw_transaction.side_effect = ValueError(web3_error_data)
-    with pytest.raises(TransactionError, match=web3_error_data["message"]):
-        geth_provider.send_transaction(mock_transaction)
+def test_did_start_local_process(geth):
+    assert geth._process is not None
+    assert geth._process.is_running
 
 
-def test_send_transaction_reverts_from_contract_logic(geth_provider, mock_web3, mock_transaction):
-    test_err = Web3ContractLogicError(f"execution reverted: {TEST_REVERT_REASON}")
-    mock_web3.eth.send_raw_transaction.side_effect = test_err
-
-    with pytest.raises(ContractLogicError, match=TEST_REVERT_REASON):
-        geth_provider.send_transaction(mock_transaction)
+def test_uri(geth):
+    assert geth.uri == "http://localhost:8545"
 
 
-def test_send_transaction_when_specify_gas_reverts_from_contract_logic(
-    geth_provider, mock_web3, mock_transaction
-):
-    test_err = Web3ContractLogicError(f"execution reverted: {TEST_REVERT_REASON}")
-    mock_web3.eth.send_raw_transaction.side_effect = test_err
-
-    with pytest.raises(ContractLogicError, match=TEST_REVERT_REASON):
-        geth_provider.send_transaction(mock_transaction)
-
-
-def test_send_transaction_no_revert_message(mock_web3, geth_provider, mock_transaction):
-    test_err = Web3ContractLogicError("execution reverted")
-    mock_web3.eth.send_raw_transaction.side_effect = test_err
-
-    with pytest.raises(ContractLogicError, match=TransactionError.DEFAULT_MESSAGE):
-        geth_provider.send_transaction(mock_transaction)
-
-
-def test_uri_default_value(geth_provider):
-    assert geth_provider.uri == "http://localhost:8545"
-
-
-def test_uri_uses_value_from_config(mock_network, mock_web3, temp_config):
+def test_uri_uses_value_from_config(geth, temp_config):
     config = {"geth": {"ethereum": {"local": {"uri": "value/from/config"}}}}
     with temp_config(config):
-        provider = create_geth(mock_network, mock_web3)
-        assert provider.uri == "value/from/config"
+        assert geth.uri == "value/from/config"
 
 
-def test_uri_uses_value_from_settings(mock_network, mock_web3, temp_config):
+def test_uri_uses_value_from_settings(geth, temp_config):
     # The value from the adhoc-settings is valued over the value from the config file.
     config = {"geth": {"ethereum": {"local": {"uri": "value/from/config"}}}}
     with temp_config(config):
-        provider = create_geth(mock_network, mock_web3)
-        provider.provider_settings["uri"] = "value/from/settings"
-        assert provider.uri == "value/from/settings"
+        geth.provider_settings["uri"] = "value/from/settings"
+        assert geth.uri == "value/from/settings"
+        del geth.provider_settings["uri"]
 
 
-def test_get_call_tree(mocker, mock_web3, geth_provider):
-    # If trying Parity style traces, it will raise not-implemented,
-    #  which should trigger attempting the geth-style traces.
-    mock_web3.client_version = "geth_MOCK"
-    mock_web3.provider.make_request.return_value = {
-        "error": "Method 'trace_transaction' does not exist/is not available"
-    }
-    mock_web3.eth.get_transaction.return_value = RECEIPT_DATA
+def test_tx_revert(accounts, sender, geth_contract):
+    # 'sender' is not the owner so it will revert (with a message)
+    contract = accounts.test_accounts[-1].deploy(geth_contract)
+    with pytest.raises(ContractLogicError, match="!authorized"):
+        contract.setNumber(5, sender=sender)
 
-    # Prevent actual `post()` request from being made during
-    #  streaming the trace's structLogs.
-    streamer = mocker.patch("ape_geth.provider.requests")
-    mock_response = mocker.MagicMock()
-    mock_response.iter_content.return_value = (x for x in [])
-    streamer.post.return_value = mock_response
 
-    # Inject mock trace data so the geth traces works.
-    mock_response_collector = mocker.patch("ape_geth.provider.ijson")
-    mock_response_collector.sendable_list.return_value = TRACE_RESPONSE
+def test_revert_no_message(accounts, geth_contract):
+    # The Contract raises empty revert when setting number to 5.
+    expected = "Transaction failed."  # Default message
+    owner = accounts.test_accounts[-2]
+    contract = owner.deploy(geth_contract)
+    with pytest.raises(ContractLogicError, match=expected):
+        contract.setNumber(5, sender=owner)
 
-    result = geth_provider.get_call_tree(TRANSACTION_HASH)
+
+def test_get_call_tree(geth, geth_contract, accounts):
+    owner = accounts.test_accounts[-3]
+    contract = owner.deploy(geth_contract)
+    receipt = contract.setNumber(10, sender=owner)
+    result = geth.get_call_tree(receipt.txn_hash)
+    expected = rf"CALL: {contract.address}.<0x3fb5c1cb> \[\d+ gas\]"
     actual = repr(result)
-    expected = f"CALL: {RECEIPT_DATA['to']} [999 gas]"
-    assert expected in actual
-
-    # Ensure we enabled memory correctly.
-    expected_params = [TRANSACTION_HASH, {"enableMemory": True}]
-    expected_payload = {
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "debug_traceTransaction",
-        "params": expected_params,
-    }
-    streamer.post.assert_called_once_with(
-        "http://localhost:8545", json=expected_payload, stream=True
-    )
+    assert re.match(expected, actual)
 
 
-def test_get_call_tree_erigon(mock_web3, geth_provider, trace_response):
+def test_get_call_tree_erigon(mock_web3, mock_geth, parity_trace_response):
     mock_web3.client_version = "erigon_MOCK"
-    mock_web3.provider.make_request.return_value = trace_response
-    result = geth_provider.get_call_tree(TRANSACTION_HASH)
+    mock_web3.provider.make_request.return_value = parity_trace_response
+    result = mock_geth.get_call_tree(TRANSACTION_HASH)
     actual = repr(result)
-    expected = "CALL: 0xC17f2C69aE2E66FD87367E3260412EEfF637F70E.<0x96d373e5> [1401584 gas]"
-    assert expected in actual
+    expected = r"CALL: 0xC17f2C69aE2E66FD87367E3260412EEfF637F70E.<0x96d373e5> \[\d+ gas\]"
+    assert re.match(expected, actual)
+
+
+def test_repr_connected(geth):
+    assert repr(geth) == "<geth chain_id=1337>"
 
 
 def test_repr_on_local_network_and_disconnected(networks):
@@ -208,21 +124,18 @@ def test_repr_on_live_network_and_disconnected(networks):
     assert repr(geth) == "<geth chain_id=5>"
 
 
-def test_repr_connected(mock_web3, geth_provider):
-    mock_web3.eth.chain_id = 123
-    assert repr(geth_provider) == "<geth chain_id=123>"
-
-
-def test_get_logs_when_connected_to_geth(vyper_contract_instance, eth_tester_provider_geth, owner):
-    vyper_contract_instance.setNumber(123, sender=owner)
-    actual = vyper_contract_instance.NumberChange[-1]
+def test_get_logs(geth, accounts, geth_contract):
+    owner = accounts.test_accounts[-4]
+    contract = owner.deploy(geth_contract)
+    contract.setNumber(101010, sender=owner)
+    actual = contract.NumberChange[-1]
     assert actual.event_name == "NumberChange"
-    assert actual.contract_address == vyper_contract_instance.address
-    assert actual.event_arguments["newNum"] == 123
+    assert actual.contract_address == contract.address
+    assert actual.event_arguments["newNum"] == 101010
 
 
-def test_chain_id_when_connected(eth_tester_provider_geth):
-    assert eth_tester_provider_geth.chain_id == 131277322940537
+def test_chain_id_when_connected(geth):
+    assert geth.chain_id == 1337
 
 
 def test_chain_id_live_network_not_connected(networks):
@@ -230,40 +143,48 @@ def test_chain_id_live_network_not_connected(networks):
     assert geth.chain_id == 5
 
 
-def test_chain_id_live_network_connected_uses_web3_chain_id(mocker, eth_tester_provider_geth):
+def test_chain_id_live_network_connected_uses_web3_chain_id(mocker, geth):
     mock_network = mocker.MagicMock()
     mock_network.chain_id = 999999999  # Shouldn't use hardcoded network
-    orig_network = eth_tester_provider_geth.network
-    eth_tester_provider_geth.network = mock_network
+    orig_network = geth.network
 
-    # Still use the connected chain ID instead network's
-    assert eth_tester_provider_geth.chain_id == 131277322940537
-    eth_tester_provider_geth.network = orig_network
+    try:
+        geth.network = mock_network
 
-
-def test_connect_wrong_chain_id(mocker, ethereum, eth_tester_provider_geth):
-    eth_tester_provider_geth.network = ethereum.get_network("goerli")
-
-    # Ensure when reconnecting, it does not use HTTP
-    factory = mocker.patch("ape_geth.provider._create_web3")
-    factory.return_value = eth_tester_provider_geth._web3
-
-    expected_error_message = (
-        "Provider connected to chain ID '131277322940537', "
-        "which does not match network chain ID '5'. "
-        "Are you connected to 'goerli'?"
-    )
-    with pytest.raises(NetworkMismatchError, match=expected_error_message):
-        eth_tester_provider_geth.connect()
+        # Still use the connected chain ID instead network's
+        assert geth.chain_id == 1337
+    finally:
+        geth.network = orig_network
 
 
-def test_supports_tracing(eth_tester_provider_geth):
-    assert eth_tester_provider_geth.supports_tracing
+def test_connect_wrong_chain_id(mocker, ethereum, geth):
+    start_network = geth.network
+
+    try:
+        geth.network = ethereum.get_network("goerli")
+
+        # Ensure when reconnecting, it does not use HTTP
+        factory = mocker.patch("ape_geth.provider._create_web3")
+        factory.return_value = geth._web3
+        expected_error_message = (
+            "Provider connected to chain ID '1337', "
+            "which does not match network chain ID '5'. "
+            "Are you connected to 'goerli'?"
+        )
+
+        with pytest.raises(NetworkMismatchError, match=expected_error_message):
+            geth.connect()
+    finally:
+        geth.network = start_network
+
+
+def test_supports_tracing(geth):
+    assert geth.supports_tracing
 
 
 @pytest.mark.parametrize("block_id", (0, "0", "0x0", HexStr("0x0")))
-def test_get_block(eth_tester_provider_geth, block_id):
-    block = cast(Block, eth_tester_provider_geth.get_block(block_id))
+def test_get_block(geth, block_id):
+    block = cast(Block, geth.get_block(block_id))
 
     # Each parameter is the same as requesting the first block.
     assert block.number == 0
@@ -271,22 +192,24 @@ def test_get_block(eth_tester_provider_geth, block_id):
     assert block.gas_used == 0
 
 
-def test_get_block_not_found(eth_tester_provider_geth):
-    latest_block = eth_tester_provider_geth.get_block("latest")
+def test_get_block_not_found(geth):
+    latest_block = geth.get_block("latest")
     block_id = latest_block.number + 1000
     with pytest.raises(BlockNotFoundError, match=f"Block with ID '{block_id}' not found."):
-        eth_tester_provider_geth.get_block(block_id)
+        geth.get_block(block_id)
 
 
-def test_get_receipt_not_exists_with_timeout(eth_tester_provider_geth):
+def test_get_receipt_not_exists_with_timeout(geth):
     unknown_txn = TRANSACTION_HASH
     with pytest.raises(TransactionNotFoundError, match=f"Transaction '{unknown_txn}' not found"):
-        eth_tester_provider_geth.get_receipt(unknown_txn, timeout=0)
+        geth.get_receipt(unknown_txn, timeout=0)
 
 
-def test_get_receipt(vyper_contract_instance, eth_tester_provider_geth, owner):
-    receipt = vyper_contract_instance.setNumber(123, sender=owner)
-    actual = eth_tester_provider_geth.get_receipt(receipt.txn_hash)
+def test_get_receipt(accounts, geth_contract, geth):
+    owner = accounts.test_accounts[-5]
+    contract = owner.deploy(geth_contract)
+    receipt = contract.setNumber(111111, sender=owner)
+    actual = geth.get_receipt(receipt.txn_hash)
     assert receipt.txn_hash == actual.txn_hash
-    assert actual.receiver == vyper_contract_instance.address
+    assert actual.receiver == contract.address
     assert actual.sender == receipt.sender

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -23,7 +23,8 @@ TRANSACTION_HASH = "0x053cba5c12172654d894f66d5670bab6215517a94189a9ffc09bc40a58
 
 @pytest.fixture(scope="module", autouse=True)
 def geth(networks):
-    with networks.ethereum.local.use_provider("geth") as provider:
+    config = {"geth": {"ethereum": {"local": {"uri": "http://127.0.0.1:5550"}}}}
+    with networks.ethereum.local.use_provider("geth", provider_settings=config) as provider:
         yield provider
 
 

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -220,3 +220,28 @@ def test_get_receipt(accounts, geth_contract, geth):
     assert receipt.txn_hash == actual.txn_hash
     assert actual.receiver == contract.address
     assert actual.sender == receipt.sender
+
+
+@geth_process_test
+def test_snapshot_and_revert(geth, accounts, geth_contract):
+    owner = accounts.test_accounts[-6]
+    contract = owner.deploy(geth_contract)
+
+    snapshot = geth.snapshot()
+    start_nonce = owner.nonce
+    contract.setNumber(211112, sender=owner)  # Advance a block
+    actual_block_number = geth.get_block("latest").number
+    expected_block_number = snapshot + 1
+    actual_nonce = owner.nonce
+    expected_nonce = start_nonce + 1
+    assert actual_block_number == expected_block_number
+    assert actual_nonce == expected_nonce
+
+    geth.revert(snapshot)
+
+    actual_block_number = geth.get_block("latest").number
+    expected_block_number = snapshot
+    actual_nonce = owner.nonce
+    expected_nonce = start_nonce
+    assert actual_block_number == expected_block_number
+    assert actual_nonce == expected_nonce

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -73,7 +73,7 @@ def test_get_receipt_not_exists_with_timeout(eth_tester_provider):
 
 
 def test_get_receipt_exists_with_timeout(eth_tester_provider, vyper_contract_instance, owner):
-    receipt_from_invoke = vyper_contract_instance.setNumber(123, sender=owner)
+    receipt_from_invoke = vyper_contract_instance.setNumber(888, sender=owner)
     receipt_from_provider = eth_tester_provider.get_receipt(receipt_from_invoke.txn_hash, timeout=0)
     assert receipt_from_provider.txn_hash == receipt_from_invoke.txn_hash
     assert receipt_from_provider.receiver == vyper_contract_instance.address

--- a/tests/integration/cli/projects/geth/ape-config.yaml
+++ b/tests/integration/cli/projects/geth/ape-config.yaml
@@ -8,4 +8,10 @@ ethereum:
 geth:
   ethereum:
     mainnet:
-      uri: localhost:5000
+      uri: http://localhost:5000
+    local:
+      uri: http://127.0.0.1:5001
+
+test:
+  # `false` because running pytest within pytest.
+  disconnect_providers_after: false

--- a/tests/integration/cli/projects/geth/tests/conftest.py
+++ b/tests/integration/cli/projects/geth/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+@pytest.fixture(scope="session")
+def owner(accounts):
+    return accounts[0]
+
+
+@pytest.fixture(scope="session")
+def contract(project, owner):
+    _contract = project.TestContractVy.deploy(sender=owner)
+
+    # Show that contract transactions in fixtures appear in gas report
+    _contract.setNumber(999, sender=owner)
+
+    return _contract

--- a/tests/integration/cli/projects/geth/tests/test_using_local_geth.py
+++ b/tests/integration/cli/projects/geth/tests/test_using_local_geth.py
@@ -1,0 +1,68 @@
+def test_provider(project, networks):
+    """
+    Tests that the network gets set from ape-config.yaml.
+    """
+    assert networks.provider.name == "geth"
+
+
+def test_contract_interaction(owner, contract):
+    """
+    Traditional ape-test style test.
+    """
+    contract.setNumber(999, sender=owner)
+    assert contract.myNumber() == 999
+
+
+def test_transfer(accounts):
+    """
+    Tests that the ReceiptCapture handles transfer transactions.
+    """
+    accounts[-1].transfer(accounts[-2], "100 gwei")
+
+
+def test_using_contract_with_same_type_and_method_call(accounts, project):
+    """
+    Deploy the same contract from the ``contract`` fixture and call a method
+    that gets called elsewhere in the test suite. This shows that we amass
+    results across all instances of contract types when making the gas report.
+    """
+
+    owner = accounts[7]
+    contract = project.TestContractVy.deploy(sender=owner)
+    contract.setNumber(777, sender=owner)
+    assert contract.myNumber() == 777
+
+
+def test_two_contracts_with_same_symbol(accounts, project):
+    """
+    Tests against scenario when using 2 tokens with same symbol.
+    There was almost a bug where the contract IDs clashed.
+    This is to help prevent future bugs related to this.
+    """
+    receiver = accounts[-1]
+    sender = accounts[-2]
+    token_a = project.TokenA.deploy(sender=sender)
+    token_b = project.TokenB.deploy(sender=sender)
+    token_a.transfer(receiver, 5, sender=sender)
+    token_b.transfer(receiver, 6, sender=sender)
+    assert token_a.balanceOf(receiver) == 5
+    assert token_b.balanceOf(receiver) == 6
+
+
+def test_call_method_excluded_from_cli_options(accounts, contract):
+    """
+    Call a method so that we can intentionally ignore it via command
+    line options and test that it does not show in the report.
+    """
+    receipt = contract.fooAndBar(sender=accounts[8])
+    assert not receipt.failed
+
+
+def test_call_method_excluded_from_config(accounts, contract):
+    """
+    Call a method excluded in the ``ape-config.yaml`` file
+    for asserting it does not show in gas report.
+    """
+    account = accounts[-4]
+    receipt = contract.setAddress(account.address, sender=account)
+    assert not receipt.failed

--- a/tests/integration/cli/projects/test/ape-config.yaml
+++ b/tests/integration/cli/projects/test/ape-config.yaml
@@ -1,0 +1,3 @@
+test:
+  # `false` because running pytest within pytest.
+  disconnect_providers_after: false

--- a/tests/integration/cli/projects/test/tests/test_fixture_isolation.py
+++ b/tests/integration/cli/projects/test/tests/test_fixture_isolation.py
@@ -13,17 +13,24 @@ def bob(accounts):
 
 @pytest.fixture(scope="module", autouse=True)
 def setup(alice, bob, chain):
-    assert chain.provider.get_block("latest").number == 0
+    start_number = chain.provider.get_block("latest").number
     alice.transfer(bob, 10**18)
-    assert chain.provider.get_block("latest").number == 1
+    actual = chain.provider.get_block("latest").number
+    expected = start_number + 1
+    assert actual == expected
 
 
-def test_isolation_first(alice, bob, chain):
-    assert chain.provider.get_block("latest").number == 1
+@pytest.fixture(scope="module")
+def start_block_number(chain):
+    return chain.blocks.height
+
+
+def test_isolation_first(alice, bob, chain, start_block_number):
+    assert chain.provider.get_block("latest").number == start_block_number
     assert bob.balance == 1_000_001 * 10**18
     alice.transfer(bob, "1 ether")
 
 
-def test_isolation_second(bob, chain):
-    assert chain.provider.get_block("latest").number == 1
+def test_isolation_second(bob, chain, start_block_number):
+    assert chain.provider.get_block("latest").number == start_block_number
     assert bob.balance == 1_000_001 * 10**18

--- a/tests/integration/cli/projects/with-contracts/ape-config.yaml
+++ b/tests/integration/cli/projects/with-contracts/ape-config.yaml
@@ -1,1 +1,5 @@
 name: withcontracts
+
+test:
+  # `false` because running pytest within pytest.
+  disconnect_providers_after: false

--- a/tests/integration/cli/projects/with-contracts/tests/test_contract.py
+++ b/tests/integration/cli/projects/with-contracts/tests/test_contract.py
@@ -1,8 +1,8 @@
 def test_contract_interaction_in_tests(project, contract_from_fixture, owner):
     contract_in_test = owner.deploy(project.Contract)
-    contract_in_test.setNumber(123, sender=owner)
+    contract_in_test.setNumber(333, sender=owner)
     actual = contract_in_test.myNumber()
-    assert actual == 123
+    assert actual == 333
 
     contract_from_fixture.setNumber(456, sender=owner)
     actual = contract_from_fixture.myNumber()

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -20,7 +20,7 @@ skip_non_compilable_projects = skip_projects(
 
 
 @skip_projects(
-    [
+    (
         "geth",
         "multiple-interfaces",
         "only-dependencies",
@@ -28,7 +28,7 @@ skip_non_compilable_projects = skip_projects(
         "unregistered-contracts",
         "with-dependencies",
         "with-contracts",
-    ]
+    )
 )
 def test_compile_missing_contracts_dir(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["compile"])
@@ -37,7 +37,7 @@ def test_compile_missing_contracts_dir(ape_cli, runner, project):
     assert "Nothing to compile" in result.output
 
 
-@skip_projects_except(["unregistered-contracts"])
+@skip_projects_except("unregistered-contracts")
 def test_missing_extensions(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["compile", "--force"])
     assert result.exit_code == 0, result.output
@@ -46,7 +46,7 @@ def test_missing_extensions(ape_cli, runner, project):
     assert ".foobar" in result.output
 
 
-@skip_projects_except(["unregistered-contracts"])
+@skip_projects_except("unregistered-contracts")
 def test_no_compiler_for_extension(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["compile", "contracts/Contract.test"])
     assert result.exit_code == 0, result.output
@@ -78,7 +78,7 @@ def test_compile(ape_cli, runner, project, clean_cache):
         assert file.stem not in result.output
 
 
-@skip_projects_except(["multiple-interfaces"])
+@skip_projects_except("multiple-interfaces")
 def test_compile_when_sources_change(ape_cli, runner, project, clean_cache):
     result = runner.invoke(ape_cli, ["compile"], catch_exceptions=False)
     assert result.exit_code == 0, result.output
@@ -101,7 +101,7 @@ def test_compile_when_sources_change(ape_cli, runner, project, clean_cache):
     assert "Compiling 'Interface.json'" not in result.output
 
 
-@skip_projects_except(["multiple-interfaces"])
+@skip_projects_except("multiple-interfaces")
 def test_compile_when_source_contains_return_characters(ape_cli, runner, project, clean_cache):
     # NOTE: This tests a bugfix where a source file contained return-characters
     # and that triggered endless re-compiles because it technically contains extra
@@ -124,14 +124,14 @@ def test_compile_when_source_contains_return_characters(ape_cli, runner, project
     assert "Compiling 'Interface.json'" not in result.output
 
 
-@skip_projects_except(["multiple-interfaces"])
+@skip_projects_except("multiple-interfaces")
 def test_can_access_contracts(project, clean_cache):
     # This test does not use the CLI but still requires a project or run off of.
     assert project.Interface, "Unable to access contract when needing to compile"
     assert project.Interface, "Unable to access contract when not needing to compile"
 
 
-@skip_projects_except(["multiple-interfaces"])
+@skip_projects_except("multiple-interfaces")
 @pytest.mark.parametrize(
     "contract_path",
     ("Interface", "Interface.json", "contracts/Interface", "contracts/Interface.json"),
@@ -142,7 +142,7 @@ def test_compile_specified_contracts(ape_cli, runner, project, contract_path, cl
     assert "Compiling 'Interface.json'" in result.output
 
 
-@skip_projects_except(["multiple-interfaces"])
+@skip_projects_except("multiple-interfaces")
 def test_compile_unknown_extension_does_not_compile(ape_cli, runner, project, clean_cache):
     result = runner.invoke(
         ape_cli, ["compile", "Interface.js"], catch_exceptions=False
@@ -151,7 +151,7 @@ def test_compile_unknown_extension_does_not_compile(ape_cli, runner, project, cl
     assert "Error: Contract 'Interface.js' not found." in result.output
 
 
-@skip_projects_except([])
+@skip_projects_except()
 def test_compile_contracts(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["compile", "--size"], catch_exceptions=False)
     assert result.exit_code == 0, result.output
@@ -160,7 +160,7 @@ def test_compile_contracts(ape_cli, runner, project):
         assert file.stem in result.output
 
 
-@skip_projects_except(["with-dependencies"])
+@skip_projects_except("with-dependencies")
 @pytest.mark.parametrize(
     "contract_path",
     (None, "contracts/", "Project", "contracts/Project.json"),
@@ -184,21 +184,21 @@ def test_compile_with_dependency(ape_cli, runner, project, contract_path):
         assert type(project.dependencies[name]["local"]["name"]) == ContractContainer
 
 
-@skip_projects_except(["with-dependencies"])
+@skip_projects_except("with-dependencies")
 def test_compile_individual_contract_excludes_other_contract(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["compile", "Project", "--force"], catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert "Other" not in result.output
 
 
-@skip_projects_except(["with-dependencies"])
+@skip_projects_except("with-dependencies")
 def test_compile_non_ape_project_deletes_ape_config_file(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["compile", "Project", "--force"], catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert "ape-config.yaml" not in [f.name for f in (project.path / "default").iterdir()]
 
 
-@skip_projects_except(["only-dependencies"])
+@skip_projects_except("only-dependencies")
 def test_compile_only_dependency(ape_cli, runner, project, clean_cache):
     dependency_cache = project.path / "renamed_contracts_folder" / ".build"
     if dependency_cache.is_dir():

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -7,28 +7,24 @@ from ape.contracts import ContractContainer
 from .utils import skip_projects, skip_projects_except
 
 skip_non_compilable_projects = skip_projects(
-    [
-        "empty-config",
-        "no-config",
-        "script",
-        "only-dependencies",
-        "unregistered-contracts",
-        "test",
-        "geth",
-    ]
+    "empty-config",
+    "no-config",
+    "script",
+    "only-dependencies",
+    "unregistered-contracts",
+    "test",
+    "geth",
 )
 
 
 @skip_projects(
-    (
-        "geth",
-        "multiple-interfaces",
-        "only-dependencies",
-        "test",
-        "unregistered-contracts",
-        "with-dependencies",
-        "with-contracts",
-    )
+    "geth",
+    "multiple-interfaces",
+    "only-dependencies",
+    "test",
+    "unregistered-contracts",
+    "with-dependencies",
+    "with-contracts",
 )
 def test_compile_missing_contracts_dir(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["compile"])

--- a/tests/integration/cli/test_console.py
+++ b/tests/integration/cli/test_console.py
@@ -71,7 +71,7 @@ def clean_console_rc_write(project):
 
 
 # NOTE: We export `__all__` into the IPython session that the console runs in
-@skip_projects(["geth"])
+@skip_projects("geth")
 @pytest.mark.parametrize("item", __all__)
 def test_console(ape_cli, runner, item):
     result = runner.invoke(ape_cli, ["console"], input=f"{item}\nexit\n", catch_exceptions=False)
@@ -84,7 +84,7 @@ def test_console(ape_cli, runner, item):
     assert no_console_error(result), result.output
 
 
-@skip_projects(["geth"])
+@skip_projects("geth")
 @data_and_project_folders
 def test_console_extras(project, folder, ape_cli, runner):
     write_ape_console_extras(project, folder, EXTRAS_SCRIPT_1)
@@ -102,7 +102,7 @@ def test_console_extras(project, folder, ape_cli, runner):
     assert no_console_error(result), result.output
 
 
-@skip_projects(["geth"])
+@skip_projects("geth")
 @data_and_project_folders
 def test_console_init_extras(project, folder, ape_cli, runner):
     write_ape_console_extras(project, folder, EXTRAS_SCRIPT_2)
@@ -113,7 +113,7 @@ def test_console_init_extras(project, folder, ape_cli, runner):
     assert no_console_error(result), result.output
 
 
-@skip_projects(["geth"])
+@skip_projects("geth")
 @data_and_project_folders
 def test_console_init_extras_kwargs(project, folder, ape_cli, runner):
     write_ape_console_extras(project, folder, EXTRAS_SCRIPT_3)
@@ -123,7 +123,7 @@ def test_console_init_extras_kwargs(project, folder, ape_cli, runner):
     assert no_console_error(result), result.output
 
 
-@skip_projects(["geth"])
+@skip_projects("geth")
 @data_and_project_folders
 def test_console_init_extras_return(project, folder, ape_cli, runner):
     write_ape_console_extras(project, folder, EXTRAS_SCRIPT_4)
@@ -146,7 +146,7 @@ def test_console_init_extras_return(project, folder, ape_cli, runner):
     assert no_console_error(result), result.output
 
 
-@skip_projects_except(["only-dependencies"])
+@skip_projects_except("only-dependencies")
 def test_console_import_local_path(project, ape_cli, runner):
     result = runner.invoke(
         ape_cli,
@@ -157,7 +157,7 @@ def test_console_import_local_path(project, ape_cli, runner):
     assert no_console_error(result), result.output
 
 
-@skip_projects_except(["only-dependencies"])
+@skip_projects_except("only-dependencies")
 def test_console_import_local_path_in_extras_file(project, ape_cli, runner):
     write_ape_console_extras(project, "PROJECT_FOLDER", EXTRAS_SCRIPT_5)
 

--- a/tests/integration/cli/test_networks.py
+++ b/tests/integration/cli/test_networks.py
@@ -1,5 +1,4 @@
 from ape.api.networks import LOCAL_NETWORK_NAME
-from ape_geth.provider import DEFAULT_SETTINGS
 
 from .utils import run_once, skip_projects_except
 
@@ -99,7 +98,7 @@ def test_list_yaml(ape_cli, runner):
         assert expected_line in result.output
 
 
-@skip_projects_except(["geth"])
+@skip_projects_except("geth")
 def test_geth(ape_cli, runner, networks):
     result = runner.invoke(ape_cli, ["networks", "list"])
     assert_rich_text(result.output, _GETH_NETWORKS_TREE)
@@ -107,7 +106,9 @@ def test_geth(ape_cli, runner, networks):
     # Assert that URI still exists for local network
     # (was bug where one network's URI disappeared when setting different network's URI)
     geth_provider = networks.get_provider_from_choice(f"ethereum:{LOCAL_NETWORK_NAME}:geth")
-    assert geth_provider.uri == DEFAULT_SETTINGS["uri"]
+    actual = geth_provider.uri
+    expected = "http://127.0.0.1:5001"  # Exists in `ape-config.yaml` for geth project.
+    assert actual == expected
 
 
 @run_once

--- a/tests/integration/cli/test_project.py
+++ b/tests/integration/cli/test_project.py
@@ -1,14 +1,14 @@
 from .utils import skip_projects_except
 
 
-@skip_projects_except(["with-dependencies"])
+@skip_projects_except("with-dependencies")
 def test_get_project_without_contracts_path(project):
     project_path = project.path / "default"
     project = project.get_project(project_path)
     assert project.contracts_folder == project_path / "contracts"
 
 
-@skip_projects_except(["with-dependencies"])
+@skip_projects_except("with-dependencies")
 def test_get_project_with_contracts_path(project):
     project_path = project.path / "renamed_contracts_folder"
     project = project.get_project(project_path, project_path / "sources")

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -3,14 +3,14 @@ from .utils import skip_projects_except
 BAD_COMMAND = "not-a-name"
 
 
-@skip_projects_except(["script"])
+@skip_projects_except("script")
 def test_run_unknown_script(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["run", BAD_COMMAND])
     assert result.exit_code == 2
     assert f"No such command '{BAD_COMMAND}'." in result.output
 
 
-@skip_projects_except(["script"])
+@skip_projects_except("script")
 def test_run(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["run"])
     assert result.exit_code == 0, result.output
@@ -31,7 +31,7 @@ def test_run(ape_cli, runner, project):
             assert "Super secret script output" in result.output
 
 
-@skip_projects_except(["script"])
+@skip_projects_except("script")
 def test_run_when_script_errors(ape_cli, runner, project):
     scripts = [s for s in project.scripts_folder.glob("*.py") if s.name.startswith("error")]
     for script_file in scripts:
@@ -42,14 +42,14 @@ def test_run_when_script_errors(ape_cli, runner, project):
         assert str(result.exception) == "Expected exception"
 
 
-@skip_projects_except(["script"])
+@skip_projects_except("script")
 def test_run_interactive(ape_cli, runner, project):
     scripts = [s for s in project.scripts_folder.glob("*.py") if s.name.startswith("error")]
     result = runner.invoke(ape_cli, ["run", "--interactive", scripts[0].stem], input="exit\n")
     assert result.exit_code == 0, result.output
 
 
-@skip_projects_except(["script"])
+@skip_projects_except("script")
 def test_run_adhoc_provider(ape_cli, runner, project):
     result = runner.invoke(
         ape_cli, ["run", "deploy", "--network", "ethereum:mainnet:http://127.0.0.1:9545"]
@@ -60,7 +60,7 @@ def test_run_adhoc_provider(ape_cli, runner, project):
     assert "No node found on 'http://127.0.0.1:9545" in result.output
 
 
-@skip_projects_except(["script"])
+@skip_projects_except("script")
 def test_run_adhoc_network(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["run", "deploy", "--network", "http://127.0.0.1:9545"])
 

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -84,14 +84,14 @@ def run_gas_test(result, expected_number_passed: int, expected_report: str = EXP
         assert actual_line == expected_line
 
 
-@skip_projects_except(("test", "with-contracts"))
+@skip_projects_except("test", "with-contracts")
 def test_test(networks, setup_pytester, project, pytester):
     expected_test_passes = setup_pytester(project.path.name)
     result = pytester.runpytest()
     result.assert_outcomes(passed=expected_test_passes), "\n".join(result.outlines)
 
 
-@skip_projects_except(("test", "with-contracts"))
+@skip_projects_except("test", "with-contracts")
 def test_test_isolation_disabled(setup_pytester, project, pytester):
     # check the disable isolation option actually disables built-in isolation
     setup_pytester(project.path.name)
@@ -99,7 +99,7 @@ def test_test_isolation_disabled(setup_pytester, project, pytester):
     assert "F _function_isolation" not in "\n".join(result.outlines)
 
 
-@skip_projects_except(("test", "with-contracts"))
+@skip_projects_except("test", "with-contracts")
 def test_fixture_docs(setup_pytester, project, pytester):
     result = pytester.runpytest("-q", "--fixtures")
 

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -1,72 +1,193 @@
+from pathlib import Path
+
 import pytest
 
 from ape.pytest.fixtures import PytestApeFixtures
+from tests.integration.cli.utils import skip_projects_except
 
-from .utils import skip_projects_except
+BASE_PROJECTS_PATH = Path(__file__).parent / "projects"
+TOKEN_B_GAS_REPORT = """
+                         TokenB Gas
 
-projects_with_tests = skip_projects_except(["test", "with-contracts"])
+  Method     Times called    Min.    Max.    Mean   Median
+ ──────────────────────────────────────────────────────────
+  transfer              1   50911   50911   50911    50911
+"""
+EXPECTED_GAS_REPORT = rf"""
+                      TestContractVy Gas
+
+  Method       Times called    Min.    Max.    Mean   Median
+ ────────────────────────────────────────────────────────────
+  setNumber               3   51033   51033   51033    51033
+  fooAndBar               1   23430   23430   23430    23430
+  setAddress              1   44850   44850   44850    44850
+
+                         TokenA Gas
+
+  Method     Times called    Min.    Max.    Mean   Median
+ ──────────────────────────────────────────────────────────
+  transfer              1   50911   50911   50911    50911
+{TOKEN_B_GAS_REPORT}
+"""
+
+
+@pytest.fixture(autouse=True)
+def connection(networks):
+    with networks.ethereum.local.use_default_provider():
+        yield
 
 
 @pytest.fixture
-def ape_test_runner(subprocess_runner_cls):
-    return subprocess_runner_cls(["test"])
+def setup_pytester(pytester):
+    def setup(project_name: str):
+        tests_path = BASE_PROJECTS_PATH / project_name / "tests"
+
+        # Assume all tests should pass
+        number_of_tests = 0
+        test_files = {}
+        for file_path in tests_path.iterdir():
+            if file_path.name.startswith("test_") and file_path.suffix == ".py":
+                content = file_path.read_text()
+                test_files[file_path.name] = content
+                number_of_tests += len(
+                    [x for x in content.split("\n") if x.startswith("def test_")]
+                )
+
+        pytester.makepyfile(**test_files)
+
+        # Check for a conftest.py
+        conftest = tests_path / "conftest.py"
+        if conftest.is_file():
+            pytester.makeconftest(conftest.read_text())
+
+        # Returns expected number of passing tests.
+        return number_of_tests
+
+    return setup
 
 
-@pytest.fixture(autouse=True, scope="module")
-def reset_provider(eth_tester_provider):
-    eth_tester_provider.disconnect()
-    eth_tester_provider.connect()
+def run_gas_test(result, expected_number_passed: int, expected_report: str = EXPECTED_GAS_REPORT):
+    result.assert_outcomes(passed=expected_number_passed), "\n".join(result.outlines)
+
+    gas_header_line_index = None
+    for index, line in enumerate(result.outlines):
+        if "Gas Profile" in line:
+            gas_header_line_index = index
+
+    assert gas_header_line_index is not None, "'Gas Profile' not in output."
+    expected = expected_report.split("\n")[1:]
+    start_index = gas_header_line_index + 1
+    end_index = start_index + len(expected)
+    actual = [x.rstrip() for x in result.outlines[start_index:end_index]]
+    assert len(actual) == len(expected)
+    for actual_line, expected_line in zip(actual, expected):
+        assert actual_line == expected_line
 
 
-@projects_with_tests
-def test_test(ape_test_runner, project):
-    # test cases implicitly test built-in isolation
-    result = ape_test_runner.invoke()
-    assert result.exit_code == 0, result.output
+@skip_projects_except(("test", "with-contracts"))
+def test_test(networks, setup_pytester, project, pytester):
+    expected_test_passes = setup_pytester(project.path.name)
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=expected_test_passes), "\n".join(result.outlines)
 
 
-@projects_with_tests
-def test_test_isolation_disabled(ape_test_runner, project):
+@skip_projects_except(("test", "with-contracts"))
+def test_test_isolation_disabled(setup_pytester, project, pytester):
     # check the disable isolation option actually disables built-in isolation
-    result = ape_test_runner.invoke(["--disable-isolation", "--setup-show"])
-    assert result.exit_code == (1 if project.path.name == "test" else 0)
-    assert "F _function_isolation" not in result.output
+    setup_pytester(project.path.name)
+    result = pytester.runpytest("--disable-isolation", "--setup-show")
+    assert "F _function_isolation" not in "\n".join(result.outlines)
 
 
-@projects_with_tests
-def test_fixture_docs(ape_test_runner, project):
-    result = ape_test_runner.invoke(["-q", "--fixtures"])
+@skip_projects_except(("test", "with-contracts"))
+def test_fixture_docs(setup_pytester, project, pytester):
+    result = pytester.runpytest("-q", "--fixtures")
 
     # 'accounts', 'networks', 'chain', and 'project' (etc.)
     fixtures = [prop for n, prop in vars(PytestApeFixtures).items() if not n.startswith("_")]
     for fixture in fixtures:
-
         # The doc str of the fixture shows in the CLI output
         doc_str = fixture.__doc__.strip()
-        assert doc_str in result.output
+        assert doc_str in "\n".join(result.outlines)
 
 
-@skip_projects_except(["test"])
-def test_gas_flag(ape_test_runner, project):
-    # NOTE: See `ape-hardhat` for better gas reporting tests.
-    result = ape_test_runner.invoke(["--gas"])
-    assert (
-        "Provider 'test' does not support transaction "
-        "tracing and is unable to display a gas profile"
-    ) in result.output
+class ApeTestGethTests:
+    """
+    Tests using ``ape-geth`` provider. Geth supports more testing features,
+    such as tracing.
 
+    Tests are placed in class for ``pytest-xdist`` scoping reasons.
+    """
 
-@skip_projects_except(["test"])
-def test_gas_flag_set_in_config(ape_test_runner, project, switch_config):
-    gas_config = r"""
+    @skip_projects_except("geth")
+    def test_gas_flag_in_tests(self, networks, setup_pytester, project, pytester):
+        settings = {"geth": {"ethereum": {"local": {"uri": "http://127.0.0.1:5005"}}}}
+        expected_test_passes = setup_pytester(project.path.name)
+        with networks.ethereum.local.use_default_provider(provider_settings=settings):
+            result = pytester.runpytest("--gas")
+            run_gas_test(result, expected_test_passes)
+
+    @skip_projects_except("geth")
+    def test_gas_flag_set_in_config(self, setup_pytester, project, pytester, switch_config):
+        expected_test_passes = setup_pytester(project.path.name)
+        config_content = """
+geth:
+  ethereum:
+    local:
+      uri: http://127.0.0.1:5001
+
+test:
+  gas:
+    show: true
+    """
+
+        with switch_config(project, config_content):
+            result = pytester.runpytest()
+            run_gas_test(result, expected_test_passes)
+
+    @skip_projects_except("geth")
+    def test_gas_flag_exclude_method_using_cli_option(self, setup_pytester, project, pytester):
+        expected_test_passes = setup_pytester(project.path.name)
+        line = "\n  fooAndBar               1   23430   23430   23430    23430"
+        expected = EXPECTED_GAS_REPORT.replace(line, "")
+        result = pytester.runpytest("--gas", "--gas-exclude", "*:fooAndBar")
+        run_gas_test(result, expected_test_passes, expected_report=expected)
+
+    @skip_projects_except("geth")
+    def test_gas_flag_exclusions_set_in_config(
+        self, setup_pytester, project, pytester, switch_config
+    ):
+        expected_test_passes = setup_pytester(project.path.name)
+        line = "\n  fooAndBar               1   23430   23430   23430    23430"
+        expected = EXPECTED_GAS_REPORT.replace(line, "")
+        expected = expected.replace(TOKEN_B_GAS_REPORT, "")
+        config_content = r"""
+    geth:
+      ethereum:
+        local:
+          uri: http://127.0.0.1:5001
+
     test:
       gas:
-        show: true
+        exclude:
+          - method_name: fooAndBar
+          - contract_name: TokenB
     """
-    with switch_config(project, gas_config):
-        assert project.config_manager.get_config("test").gas.show
-        result = ape_test_runner.invoke()
+        with switch_config(project, config_content):
+            result = pytester.runpytest("--gas")
+            run_gas_test(result, expected_test_passes, expected_report=expected)
+
+    @skip_projects_except("geth")
+    def test_gas_flag_excluding_contracts(self, setup_pytester, project, pytester):
+        expected_test_passes = setup_pytester(project.path.name)
+        result = pytester.runpytest("--gas", "--gas-exclude", "TestContractVy,TokenA")
+        run_gas_test(result, expected_test_passes, expected_report=TOKEN_B_GAS_REPORT)
+
+    @skip_projects_except("test")
+    def test_gas_flag_when_not_supported(self, setup_pytester, project, pytester):
+        setup_pytester(project.path.name)
+        result = pytester.runpytest("--gas")
         assert (
             "Provider 'test' does not support transaction "
             "tracing and is unable to display a gas profile"
-        ) in result.output
+        ) in "\n".join(result.outlines)

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -3,8 +3,8 @@ from pathlib import Path
 import pytest
 
 from ape.pytest.fixtures import PytestApeFixtures
-from tests.integration.cli.utils import skip_projects_except
 from tests.conftest import geth_process_test
+from tests.integration.cli.utils import skip_projects_except
 
 BASE_PROJECTS_PATH = Path(__file__).parent / "projects"
 TOKEN_B_GAS_REPORT = """

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -116,7 +116,7 @@ class ApeTestGethTests:
     Tests using ``ape-geth`` provider. Geth supports more testing features,
     such as tracing.
 
-    Tests are placed in class for ``pytest-xdist`` scoping reasons.
+    **NOTE**: These tests are placed in a class for ``pytest-xdist`` scoping reasons.
     """
 
     @skip_projects_except("geth")

--- a/tests/integration/cli/utils.py
+++ b/tests/integration/cli/utils.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Callable, List
+from typing import Callable, Collection, List, Optional, Union
 
 import pytest
 
@@ -77,7 +77,7 @@ class ProjectSkipper:
 
             self.projects[project][node.module_name].add(node.name)
 
-    def skip_projects_except(self, method: Callable, projects: List[str]):
+    def skip_projects_except(self, method: Callable, projects: Collection[str]):
         """
         Call this method to record 'skip's for each project that is not
         in the given list. The ``skip_project_except`` decorator calls
@@ -96,11 +96,15 @@ class ProjectSkipper:
 project_skipper = ProjectSkipper()
 
 
-def skip_projects(names: List[str]):
+def skip_projects(names: Optional[Union[str, Collection[str]]] = None):
     """
     Use this decorator to cause a CLI integration test
     not to run for the given projects.
     """
+
+    names = names or []
+    if isinstance(names, str):
+        names = (names,)
 
     def decorator(f):
         project_skipper.skip_projects(f, names)
@@ -109,11 +113,15 @@ def skip_projects(names: List[str]):
     return decorator
 
 
-def skip_projects_except(names: List[str]):
+def skip_projects_except(names: Optional[Union[str, Collection[str]]] = None):
     """
     Use this decorator to cause a CLI integration test
     to only run for the given projects.
     """
+
+    names = names or []
+    if isinstance(names, str):
+        names = (names,)
 
     def decorator(f):
         project_skipper.skip_projects_except(f, names)
@@ -122,7 +130,7 @@ def skip_projects_except(names: List[str]):
     return decorator
 
 
-run_once = skip_projects_except(["test"])
+run_once = skip_projects_except("test")
 """
 For times when the CLI integration test is unlikely to be
 affected by project structure.

--- a/tests/integration/cli/utils.py
+++ b/tests/integration/cli/utils.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Callable, Collection, List, Optional, Union
+from typing import Callable
 
 import pytest
 
@@ -63,7 +63,7 @@ class ProjectSkipper:
                 f"Project '{project_name}' does not exist (test={node_id}."
             )
 
-    def skip_projects(self, method: Callable, projects: List[str]):
+    def skip_projects(self, method: Callable, *projects: str):
         """
         Call this method to record a 'skip'.
         The ``skip_project`` decorator calls this method
@@ -77,7 +77,7 @@ class ProjectSkipper:
 
             self.projects[project][node.module_name].add(node.name)
 
-    def skip_projects_except(self, method: Callable, projects: Collection[str]):
+    def skip_projects_except(self, method: Callable, *projects: str):
         """
         Call this method to record 'skip's for each project that is not
         in the given list. The ``skip_project_except`` decorator calls
@@ -89,42 +89,34 @@ class ProjectSkipper:
         for proj in projects:
             self._raise_if_not_exists(proj, node.node_id)
 
-        projects = [p for p in self.projects if p not in projects]
-        self.skip_projects(method, projects)
+        filtered_projects = [p for p in self.projects if p not in projects]
+        self.skip_projects(method, *filtered_projects)
 
 
 project_skipper = ProjectSkipper()
 
 
-def skip_projects(names: Optional[Union[str, Collection[str]]] = None):
+def skip_projects(*names: str):
     """
     Use this decorator to cause a CLI integration test
     not to run for the given projects.
     """
 
-    names = names or []
-    if isinstance(names, str):
-        names = (names,)
-
     def decorator(f):
-        project_skipper.skip_projects(f, names)
+        project_skipper.skip_projects(f, *names)
         return f
 
     return decorator
 
 
-def skip_projects_except(names: Optional[Union[str, Collection[str]]] = None):
+def skip_projects_except(*names: str):
     """
     Use this decorator to cause a CLI integration test
     to only run for the given projects.
     """
 
-    names = names or []
-    if isinstance(names, str):
-        names = (names,)
-
     def decorator(f):
-        project_skipper.skip_projects_except(f, names)
+        project_skipper.skip_projects_except(f, *names)
         return f
 
     return decorator


### PR DESCRIPTION
### What I did

While working on my trace call work, I realized I needed to separate the Geths in order to subscribe to `TestProviderAPI`.
While making the `GethDev` class, I noticed there were a couple Test APIs that  could easily be implemented, namely `snapshot()` and `revert()`.

### How I did it

Use `debug_setHead` to return to an older block.
For the `SnapshotID`, use the block number of the latest block.
Now, you have the same feature implemented in the Geth Dev provider we have.
This is 1 step closer to making GethDev great, because it has amazing tracing features so I want to encourage its use.

The work related to the refactor is needed for my trace work.

### How to verify it

**NOTE: Cannot add very interesting tests because the logic is rather simple and we don't have a `geth` installed on CI/CD yet to test on.**

Here is the test if I were to add one:

```python
def test_snapshot_and_revert(geth_dev, account_0, account_1):
    block_number = geth_dev.snapshot()
    # Increase blocks
    account_0.transfer(account_1, "1 ETH")
    assert geth_dev.get_block("latest") == block_number + 1
    geth_dev.revert(block_number)
    assert geth_dev.get_block("latest") == block_number
```

You can use or something like it to manually verify the feature.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
