### PR TITLE
feat: ability to interact with contracts by method string name

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -686,9 +686,11 @@ class ContractInstance(BaseAddress):
 
         Args:
             method_name (str): The contract method name to be called
+            *args: Contract method arguments.
+            **kwargs: Transaction values, such as ``value`` or ``sender``
 
         Returns:
-            Output of smart contract interaction
+            Any: Output of smart contract view call.
 
         """
 
@@ -719,9 +721,11 @@ class ContractInstance(BaseAddress):
 
         Args:
             method_name (str): The contract method name to be called
+            *args: Contract method arguments.
+            **kwargs: Transaction values, such as ``value`` or ``sender``
 
         Returns:
-            Output of smart contract interaction
+            ReceiptAPI: Output of smart contract interaction.
 
         """
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -677,6 +677,36 @@ class ContractInstance(BaseAddress):
             # NOTE: Must raise AttributeError for __attr__ method or will seg fault
             raise AttributeError(str(err)) from err
 
+    def method_call(self, method_name: str, *args, **kwargs) -> Any:
+        """
+        Call a contract function directly using the method_name.
+        This is helpful in the scenario where the contract has a
+        method name matching an attribute of the BaseAddress class,
+        such as 'nonce' or 'balance'
+
+        Args:
+            method_name (str): The contract method name to be called
+
+        Returns:
+            Output of smart contract interaction
+
+        """
+        if method_name not in {*self._view_methods_, *self._mutable_methods_}:
+            # Didn't find anything that matches
+            # NOTE: `__getattr__` *must* raise `AttributeError`
+            name = self.contract_type.name or self.__class__.__name__
+            raise AttributeError(f"'{name}' has no attribute '{method_name}'.")
+
+        if method_name in self._view_methods_:
+            view_handler = self._view_methods_[method_name]
+            output = view_handler(*args, **kwargs)
+            return output
+
+        elif method_name in self._mutable_methods_:
+            mutable_handler = self._mutable_methods_[method_name]
+            output = mutable_handler(*args, **kwargs)
+            return output
+
     def get_event_by_signature(self, signature: str) -> ContractEvent:
         """
         Get an event by its signature. Most often, you can use the

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -681,8 +681,9 @@ class ContractInstance(BaseAddress):
         """
         Call a contract's view function directly using the method_name.
         This is helpful in the scenario where the contract has a
-        method name matching an attribute of the BaseAddress class,
-        such as 'nonce' or 'balance'
+        method name matching an attribute of the
+        :class:`~ape.api.address.BaseAddress` class, such as ``nonce``
+        or ``balance``
 
         Args:
             method_name (str): The contract method name to be called
@@ -700,13 +701,12 @@ class ContractInstance(BaseAddress):
             return output
 
         elif method_name in self._mutable_methods_:
-            mutable_handler = self._mutable_methods_[method_name]
-            output = mutable_handler(*args, **kwargs)
+            handler = self._mutable_methods_[method_name].call
+            output = handler(*args, **kwargs)
             return output
 
         else:
             # Didn't find anything that matches
-            # NOTE: `__getattr__` *must* raise `AttributeError`
             name = self.contract_type.name or self.__class__.__name__
             raise AttributeError(f"'{name}' has no attribute '{method_name}'.")
 
@@ -716,8 +716,9 @@ class ContractInstance(BaseAddress):
         This function is for non-view function's which may change
         contract state and will execute a transaction.
         This is helpful in the scenario where the contract has a
-        method name matching an attribute of the BaseAddress class,
-        such as 'nonce' or 'balance'
+        method name matching an attribute of the
+        :class:`~ape.api.address.BaseAddress` class, such as ``nonce``
+        or ``balance``
 
         Args:
             method_name (str): The contract method name to be called
@@ -725,23 +726,22 @@ class ContractInstance(BaseAddress):
             **kwargs: Transaction values, such as ``value`` or ``sender``
 
         Returns:
-            ReceiptAPI: Output of smart contract interaction.
+            :class:`~ape.api.transactions.ReceiptAPI`: Output of smart contract interaction.
 
         """
 
         if method_name in self._view_methods_:
-            view_handler = self._view_methods_[method_name]
+            view_handler = self._view_methods_[method_name].transact
             output = view_handler(*args, **kwargs)
             return output
 
         elif method_name in self._mutable_methods_:
-            mutable_handler = self._mutable_methods_[method_name]
-            output = mutable_handler(*args, **kwargs)
+            handler = self._mutable_methods_[method_name]
+            output = handler(*args, **kwargs)
             return output
 
         else:
             # Didn't find anything that matches
-            # NOTE: `__getattr__` *must* raise `AttributeError`
             name = self.contract_type.name or self.__class__.__name__
             raise AttributeError(f"'{name}' has no attribute '{method_name}'.")
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -691,11 +691,6 @@ class ContractInstance(BaseAddress):
             Output of smart contract interaction
 
         """
-        if method_name not in {*self._view_methods_, *self._mutable_methods_}:
-            # Didn't find anything that matches
-            # NOTE: `__getattr__` *must* raise `AttributeError`
-            name = self.contract_type.name or self.__class__.__name__
-            raise AttributeError(f"'{name}' has no attribute '{method_name}'.")
 
         if method_name in self._view_methods_:
             view_handler = self._view_methods_[method_name]
@@ -706,6 +701,12 @@ class ContractInstance(BaseAddress):
             mutable_handler = self._mutable_methods_[method_name]
             output = mutable_handler(*args, **kwargs)
             return output
+
+        else:
+            # Didn't find anything that matches
+            # NOTE: `__getattr__` *must* raise `AttributeError`
+            name = self.contract_type.name or self.__class__.__name__
+            raise AttributeError(f"'{name}' has no attribute '{method_name}'.")
 
     def get_event_by_signature(self, signature: str) -> ContractEvent:
         """

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -710,7 +710,7 @@ class ContractInstance(BaseAddress):
             name = self.contract_type.name or self.__class__.__name__
             raise AttributeError(f"'{name}' has no attribute '{method_name}'.")
 
-    def invoke_transaction(self, method_name: str, *args, **kwargs) -> Any:
+    def invoke_transaction(self, method_name: str, *args, **kwargs) -> ReceiptAPI:
         """
         Call a contract's function directly using the method_name.
         This function is for non-view function's which may change

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -710,7 +710,7 @@ class ContractInstance(BaseAddress):
             name = self.contract_type.name or self.__class__.__name__
             raise AttributeError(f"'{name}' has no attribute '{method_name}'.")
 
-    def invoke_transaction(self, method_name: str, *args, **kwargs) -> ReceiptAPI:
+    def invoke_transaction(self, method_name: str, *args, **kwargs) -> Any:
         """
         Call a contract's function directly using the method_name.
         This function is for non-view function's which may change

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -43,7 +43,6 @@ def test_contract_calls(owner, contract_instance):
 def test_invoke_transaction(owner, contract_instance):
     # Test mutable method call with invoke_transaction
     receipt = contract_instance.invoke_transaction("setNumber", 3, sender=owner)
-    print(receipt)
     assert contract_instance.myNumber() == 3
     assert not receipt.failed
     # Test view method can be called with invoke transaction and returns a receipt

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -38,12 +38,9 @@ def test_init_specify_contract_type(
 def test_contract_calls(owner, contract_instance):
     contract_instance.setNumber(2, sender=owner)
     assert contract_instance.myNumber() == 2
-
-
-def test_contract_mehtod_calls(owner, contract_instance):
-    contract_instance.method_call("setNumber", 3, sender=owner)
+    contract_instance.invoke_transaction("setNumber", 3, sender=owner)
     assert contract_instance.myNumber() == 3
-    assert contract_instance.method_call("myNumber", sender=owner) == 3
+    assert contract_instance.call_view_method("myNumber")
 
 
 def test_revert(sender, contract_instance):

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -40,6 +40,12 @@ def test_contract_calls(owner, contract_instance):
     assert contract_instance.myNumber() == 2
 
 
+def test_contract_mehtod_calls(owner, contract_instance):
+    contract_instance.method_call("setNumber", 3, sender=owner)
+    assert contract_instance.myNumber() == 3
+    assert contract_instance.method_call("myNumber", sender=owner) == 3
+
+
 def test_revert(sender, contract_instance):
     # 'sender' is not the owner so it will revert (with a message)
     with pytest.raises(ContractLogicError, match="!authorized"):

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -38,9 +38,27 @@ def test_init_specify_contract_type(
 def test_contract_calls(owner, contract_instance):
     contract_instance.setNumber(2, sender=owner)
     assert contract_instance.myNumber() == 2
-    contract_instance.invoke_transaction("setNumber", 3, sender=owner)
+
+
+def test_invoke_transaction(owner, contract_instance):
+    # Test mutable method call with invoke_transaction
+    receipt = contract_instance.invoke_transaction("setNumber", 3, sender=owner)
+    print(receipt)
     assert contract_instance.myNumber() == 3
-    assert contract_instance.call_view_method("myNumber")
+    assert not receipt.failed
+    # Test view method can be called with invoke transaction and returns a receipt
+    view_receipt = contract_instance.invoke_transaction("myNumber", sender=owner)
+    assert not view_receipt.failed
+
+
+def test_call_view_method(owner, contract_instance):
+    contract_instance.setNumber(2, sender=owner)
+    value = contract_instance.call_view_method("myNumber")
+    assert value == 2
+    # Test that a mutable method can be called and is treated as a call (a simulation)
+    contract_instance.call_view_method("setNumber", 3, sender=owner)
+    # myNumber should still equal 2 because the above line is call
+    assert contract_instance.myNumber() == 2
 
 
 def test_revert(sender, contract_instance):


### PR DESCRIPTION
### What I did
Added a function, `method_call(method_name: str, *args, **kwargs)`, to the `ContractInstance` class. This makes it possible to directly call a method of the contract using `<contract_name>.method_call('<method_name>', *args, **kwargs)`.

###  Fixes
fixes: #627 

### How I did it
Instead of relying on `__getattr__` to place the unknown attributes, the `method_call` function uses the `method_name` input to look up the `ContractCallHandler` object associated with that method name. It then executes the smart contract function by executing `ContractCallHandler` with `*args` & `**kwargs`. It then returns the output of the smart contract call.

### How to verify it
This is easily verifiable by calling any smart contract function using `<contract_name>.method_call('method_name', *args, *kwargs)`. For examples you can look at lines 26-35 of `test_contract_instance.py`

### Checklist

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
