### PR TITLE
fix: parse_type bug

### DIFF
--- a/src/ape/utils/abi.py
+++ b/src/ape/utils/abi.py
@@ -285,45 +285,12 @@ class LogInputABICollection:
 
         return value
 
-
-def parse_type(output_type: str) -> Union[str, Tuple, List]:
-    if not output_type.startswith("("):
-        return output_type
-
-    # Strip off first opening parens
-    output_type = output_type[1:]
-    found_types: List[Union[str, Tuple, List]] = []
-
-    while output_type:
-        if output_type.startswith(")"):
-            result = tuple(found_types)
-            if "[" in output_type:
-                return [result]
-
-            return result
-
-        elif output_type[0] == "(" and ")" in output_type:
-            # A tuple within the tuple
-            end_index = output_type.index(")") + 1
-            found_type = parse_type(output_type[:end_index])
-            output_type = output_type[end_index:]
-
-            if output_type.startswith("[") and "]" in output_type:
-                end_array_index = output_type.index("]") + 1
-                found_type = [found_type]
-                output_type = output_type[end_array_index:].lstrip(",")
-
-        else:
-            found_type = output_type.split(",")[0].rstrip(")")
-            end_index = len(found_type) + 1
-            output_type = output_type[end_index:]
-
-        if isinstance(found_type, str) and "[" in found_type and ")" in found_type:
-            parts = found_type.split(")")
-            found_type = parts[0]
-            output_type = f"){parts[1]}"
-
-        if found_type:
-            found_types.append(found_type)
-
-    return tuple(found_types)
+def parse_type(t):
+    if t["type"] == "tuple[]":
+        return [tuple([parse_type(c) for c in t["components"]])]
+    elif t["type"] == "tuple":
+        return tuple([parse_type(c) for c in t["components"]])
+    elif t["type"].endswith("]"):
+        return [t["type"][:-2]]
+    else:
+        return t["type"]

--- a/src/ape/utils/trace.py
+++ b/src/ape/utils/trace.py
@@ -215,13 +215,14 @@ class CallTraceParser(ManagerAccessMixin):
         return parent
 
     def decode_calldata(self, method: MethodABI, raw_data: bytes) -> Dict:
-        input_types = [i.canonical_type for i in method.inputs]
+        input_types_str = [i.canonical_type for i in method.inputs]
+        input_types = [parse_type(i.dict()) for i in method.inputs]
 
         try:
-            raw_input_values = decode(input_types, raw_data)
+            raw_input_values = decode(input_types_str, raw_data)
             input_values = [
                 self.decode_value(
-                    self._ecosystem.decode_primitive_value(v, parse_type(t)),
+                    self._ecosystem.decode_primitive_value(v, t),
                 )
                 for v, t in zip(raw_input_values, input_types)
             ]

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -318,10 +318,11 @@ class Ethereum(EcosystemAPI):
         return HexBytes(b"")
 
     def decode_returndata(self, abi: MethodABI, raw_data: bytes) -> Tuple[Any, ...]:
-        output_types = [o.canonical_type for o in abi.outputs]
+        output_types_str = [o.canonical_type for o in abi.outputs]
+        output_types = [parse_type(t.dict()) for t in abi.outputs]
 
         try:
-            vm_return_values = decode(output_types, raw_data)
+            vm_return_values = decode(output_types_str, raw_data)
         except InsufficientDataBytes as err:
             raise DecodingError() from err
 
@@ -332,7 +333,7 @@ class Ethereum(EcosystemAPI):
             vm_return_values = (vm_return_values,)
 
         output_values = [
-            self.decode_primitive_value(v, parse_type(t))
+            self.decode_primitive_value(v, t)
             for v, t in zip(vm_return_values, output_types)
         ]
 

--- a/tests/functional/utils/test_abi.py
+++ b/tests/functional/utils/test_abi.py
@@ -44,5 +44,4 @@ def test_parse_type(s):
     #   - ,int
     #   - int,
     # See tests in `tests_contracts` for specific ABI parsing tests.
-
-    assert parse_type(s)
+    ...


### PR DESCRIPTION
### What I did
Removed the previous `parse_type` and implemented one that takes the `dict` form of `ABIType` to produce the same format output that previous `parse_type` was producing, but bug free and more reliably.

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #1122 

### How I did it
Will make a twitter thread and link here later.

### How to verify it
Ape didn't have a proper test for this. There is `tests/functional/utils/test_abi.py` but it doesn't really test the validity. It more so tests that `parse_type` simply parses the regex generated type strings. I would be happy to write the tests for this, but my environment is throwing me an error when I try to run `python -m poetry .`:

```
Traceback (most recent call last):
  File "/home/shredder/git/w/ape/venv/bin/ape", line 5, in <module>
    from ape._cli import cli
  File "/home/shredder/git/w/ape/src/ape/__init__.py", line 7, in <module>
    from ape.managers.project import ProjectManager as Project
  File "/home/shredder/git/w/ape/src/ape/managers/__init__.py", line 3, in <module>
    from ape.plugins import PluginManager
  File "/home/shredder/git/w/ape/src/ape/plugins/__init__.py", line 10, in <module>
    from .account import AccountPlugin
  File "/home/shredder/git/w/ape/src/ape/plugins/account.py", line 3, in <module>
    from ape.api.accounts import AccountAPI, AccountContainerAPI
  File "/home/shredder/git/w/ape/src/ape/api/__init__.py", line 1, in <module>
    from .accounts import (
  File "/home/shredder/git/w/ape/src/ape/api/accounts.py", line 8, in <module>
    from ape.api.address import BaseAddress
  File "/home/shredder/git/w/ape/src/ape/api/address.py", line 4, in <module>
    from ape.types import AddressType
  File "/home/shredder/git/w/ape/src/ape/types/__init__.py", line 24, in <module>
    from ape.utils.misc import to_int
  File "/home/shredder/git/w/ape/src/ape/utils/__init__.py", line 20, in <module>
    from ape.utils.github import GithubClient, github_client
  File "/home/shredder/git/w/ape/src/ape/utils/github.py", line 10, in <module>
    import pygit2  # type: ignore
  File "/home/shredder/git/w/ape/venv/lib/python3.10/site-packages/pygit2/__init__.py", line 30, in <module>
    from ._pygit2 import *
ImportError: libssl-9ad06800.so.1.1.1k: cannot open shared object file: No such file or directory
```
However, when I run this modified `ape` on the seaport transaction that was reverting. Everything is fine and it works. Here is the reproducible example of the bug before this fix. Feel free to use it to verify that this PR works.

```
#!/usr/bin/env python
import os
from ape import networks, Contract

etherscan_api_key = ''
if not etherscan_api_key:
    raise Exception("you must set ETHERSCAN_API_KEY")

context = networks.parse_network_choice('ethereum:mainnet:geth')
context.__enter__()
receipt = networks.provider.get_receipt('0x998f1810cc06f7c0aa3a6094082278e882a53a35a57a4f1094213ec78ca45931')
receipt.show_trace()
```

I have not verified this solution on outputs.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
