### PR TITLE
fix: pass default contract type to proxy target

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -720,7 +720,7 @@ class ContractCache(BaseManager):
 
             if proxy_info:
                 self._local_proxies[address_key] = proxy_info
-                return self.get(proxy_info.target, default)
+                return self.get(proxy_info.target, default=default)
 
             if not self.provider.get_code(address_key):
                 if default:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -720,7 +720,7 @@ class ContractCache(BaseManager):
 
             if proxy_info:
                 self._local_proxies[address_key] = proxy_info
-                return self.get(proxy_info.target)
+                return self.get(proxy_info.target, default)
 
             if not self.provider.get_code(address_key):
                 if default:


### PR DESCRIPTION
### What I did
Getting a contract type for a proxy pointing to a non-verified contract as target fails and there is no way to specify the default contract type for the target. 

I changed the call to `get(proxy_info.target)` so that it passes the default argument that was specified when calling `get` for the proxy contract. Resulting in `get(proxy_info.target, default)`

### How I did it
the code now passes the optional argument

### Checklist

- [x] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
