### PR TITLE
feat: local geth provider `snapshot()` and `revert()` implementations

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,7 +94,7 @@ jobs:
             pip install .[test]
 
         - name: Run Tests
-          run: pytest -m "not fuzzing" -s --cov=src -n auto
+          run: pytest -m "not fuzzing" -s --cov=src -n auto --dest loadscope
 
     fuzzing:
         runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,7 +94,7 @@ jobs:
             pip install .[test]
 
         - name: Run Tests
-          run: pytest -m "not fuzzing" -s --cov=src -n auto --dest loadscope
+          run: pytest -m "not fuzzing" -s --cov=src -n auto --dist loadscope
 
     fuzzing:
         runs-on: ubuntu-latest

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -5,7 +5,8 @@ from typing import Any, Dict, Iterator, List, Optional, Union
 
 import ijson  # type: ignore
 import requests
-from eth_utils import to_wei
+from eth_typing import HexStr
+from eth_utils import add_0x_prefix, to_hex, to_wei
 from evm_trace import (
     CallTreeNode,
     CallType,
@@ -348,13 +349,18 @@ class GethDev(TestProviderAPI, BaseGethProvider):
 
         super().disconnect()
 
-    @raises_not_implemented
     def revert(self, snapshot_id: SnapshotID):
-        pass
+        if isinstance(snapshot_id, int):
+            block_number = to_hex(snapshot_id)
+        elif isinstance(snapshot_id, bytes):
+            block_number = add_0x_prefix(HexStr(snapshot_id.hex()))
+        else:
+            block_number = str(snapshot_id)
 
-    @raises_not_implemented
+        self._make_request("debug_setHead", [block_number])
+
     def snapshot(self) -> SnapshotID:
-        pass
+        return self.get_block("latest").number or 0
 
     @raises_not_implemented
     def set_timestamp(self, new_timestamp: int):

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -351,9 +351,9 @@ class GethDev(TestProviderAPI, BaseGethProvider):
 
     def revert(self, snapshot_id: SnapshotID):
         if isinstance(snapshot_id, int):
-            block_number = to_hex(snapshot_id)
+            block_number = str(to_hex(snapshot_id))
         elif isinstance(snapshot_id, bytes):
-            block_number = add_0x_prefix(HexStr(snapshot_id.hex()))
+            block_number = str(add_0x_prefix(HexStr(snapshot_id.hex())))
         else:
             block_number = str(snapshot_id)
 

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -220,3 +220,28 @@ def test_get_receipt(accounts, geth_contract, geth):
     assert receipt.txn_hash == actual.txn_hash
     assert actual.receiver == contract.address
     assert actual.sender == receipt.sender
+
+
+@geth_process_test
+def test_snapshot_and_revert(geth, accounts, geth_contract):
+    owner = accounts.test_accounts[-6]
+    contract = owner.deploy(geth_contract)
+
+    snapshot = geth.snapshot()
+    start_nonce = owner.nonce
+    contract.setNumber(211112, sender=owner)  # Advance a block
+    actual_block_number = geth.get_block("latest").number
+    expected_block_number = snapshot + 1
+    actual_nonce = owner.nonce
+    expected_nonce = start_nonce + 1
+    assert actual_block_number == expected_block_number
+    assert actual_nonce == expected_nonce
+
+    geth.revert(snapshot)
+
+    actual_block_number = geth.get_block("latest").number
+    expected_block_number = snapshot
+    actual_nonce = owner.nonce
+    expected_nonce = start_nonce
+    assert actual_block_number == expected_block_number
+    assert actual_nonce == expected_nonce


### PR DESCRIPTION
### What I did

Implement `snapshot()` and `revert()` APIs from `TestProviderAPI` that the local Geth provider now subscribes too.

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #

### How I did it

RPC `debug_setHead` to revert to an old block number.
And for the snapshot, use the latest block number.
Not perfect but it works in most use-cases.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
