### PR TITLE
fix: issue where contract cache allowed non-checksum addresses

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -528,10 +528,36 @@ class ContractCache(BaseManager):
             contract_type (ContractType): The contract's type.
         """
 
+        if self.network_manager.active_provider:
+            address = self.provider.network.ecosystem.decode_address(int(address, 16))
+        else:
+            logger.warning("Not connected to a provider. Assuming Ethereum-style checksums.")
+            ethereum = self.network_manager.ethereum
+            address = ethereum.decode_address(int(address, 16))
+
         self._cache_contract_type(address, contract_type)
 
         # NOTE: The txn_hash is not included when caching this way.
         self._cache_deployment(address, contract_type)
+
+    def __delitem__(self, address: AddressType):
+        """
+        Delete a cached contract.
+        If using a live network, it will also delete the file-cache for the contract.
+
+        Args:
+            address (AddressType): The address to remove from the cache.
+        """
+
+        if address in self._local_contract_types:
+            del self._local_contract_types[address]
+
+        if self._is_live_network:
+            if not self._contract_types_cache.is_dir():
+                return
+
+            address_file = self._contract_types_cache / f"{address}.json"
+            address_file.unlink(missing_ok=True)
 
     def __contains__(self, address: AddressType) -> bool:
         return self.get(address) is not None

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -543,3 +543,16 @@ def test_contracts_get_non_contract_address(chain, owner):
 def test_contracts_get_attempts_to_convert(chain):
     with pytest.raises(ConversionError):
         chain.contracts.get("test.eth")
+
+
+def test_cache_non_checksum_address(chain, vyper_contract_instance):
+    """
+    When caching a non-checksum address, it should use its checksum
+    form automatically.
+    """
+    if vyper_contract_instance.address in chain.contracts:
+        del chain.contracts[vyper_contract_instance.address]
+
+    lowered_address = vyper_contract_instance.address.lower()
+    chain.contracts[lowered_address] = vyper_contract_instance.contract_type
+    assert chain.contracts[vyper_contract_instance.address] == vyper_contract_instance.contract_type


### PR DESCRIPTION
### What I did

When users use hardcoded addresses, there is the risk that they are not checksummed and they get cached with non-checksum keys. This PR makes it so it will always use the checksum version of the address in the contract  cache.

### How I did it

First check if connected and use the connected ecosystem.
Else, assume Ethereum-style checksums (with a warning).
Either way, fix the key before using it.

### How to verify it

See test!

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
