### PR TITLE
fix: add BaseTransacrtion.txn_hash type hint

### DIFF
--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -68,7 +68,7 @@ class BaseTransaction(TransactionAPI):
         return signed_txn
 
     @property
-    def txn_hash(self):
+    def txn_hash(self) -> HexBytes:
         txn_bytes = self.serialize_transaction()
         return HexBytes(keccak(txn_bytes))
 


### PR DESCRIPTION
Noticed a missing type hint here and wanted to make sure it was accounted for
