### PR TITLE
refactor: replace pygit2 with subprocess calls to `git`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,6 @@ setup(
         "pandas>=1.3.0,<2",
         "pluggy>=1.0.0,<2",
         "pydantic>=1.9.2,<2",
-        "pygit2>=1.7.2,<2",
         "PyGithub>=1.54,<2",
         "pytest>=6.0,<8.0",
         "python-dateutil>=2.8.2,<3",


### PR DESCRIPTION
### What I did

Curently, we use `pygit2` when dependencies are specified via branch names instead of release versions because the GitHub release API does not support branches as arguments for obtaining releases; only release version IDs.

There are several reasons to not use `pygit2` as a core dependency for ape though:

* Installation issues on some operating systems
* It is not used in branch; just in a single use-case.

And more that I won't get into right now.

### How I did it

Replace usage of `pygit2` with `subprocess.run()` calls. Now, the expectation of certain git environments are not enforced. Users can avoid branch-based dependencies (as they should anyway) when they don't have the ability to use `git`, and it does not affect the core ape installation.

### How to verify it

Use github dependencies that are branch based:

```
dependencies:
  - name: ds-test
    github: dapphub/ds-test
    branch: master
```

^ Pick a different one than me though.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
