### PR TITLE
fix: correct method name shown in error multi-event error message

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -859,7 +859,7 @@ class ContractInstance(BaseAddress):
             if len(handler_options) > 1:
                 raise AttributeError(
                     f"Multiple events named '{attr_name}' in '{self.contract_type.name}'.\n"
-                    f"Use 'events_by_signature' look-up."
+                    f"Use '{self.get_event_by_signature.__name__}' look-up."
                 )
             handler = handler_options[0]
 

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -259,11 +259,12 @@ def test_contract_two_events_with_same_name(owner, chain, networks_connected_to_
     impl_container = chain.contracts.get_container(impl_contract_type)
     impl_instance = owner.deploy(impl_container)
 
-    with pytest.raises(AttributeError) as err:
+    expected_err = (
+        f"Multiple events named '{event_name}' in '{impl_contract_type.name}'.\n"
+        f"Use 'get_event_by_signature' look-up."
+    )
+    with pytest.raises(AttributeError, match=expected_err):
         _ = impl_instance.FooEvent
-
-    expected_err_prefix = f"Multiple events named '{event_name}'"
-    assert expected_err_prefix in str(err.value)
 
     expected_sig_from_impl = "FooEvent(uint256 bar, uint256 baz)"
     expected_sig_from_interface = "FooEvent(uint256 bar)"


### PR DESCRIPTION
### What I did

Noticed error message contained wrong method name. Fixed it and adjusted test.

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
