### PR TITLE
fix: convert `block_identifier` to hex

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -926,10 +926,9 @@ class Web3Provider(ProviderAPI, ABC):
             if value is not None and not isinstance(value, str):
                 txn_dict[field] = to_hex(value)
 
-        if "block_identifier" in kwargs:
-            block_identifier = hex(kwargs["block_identifier"])
-        else:
-            block_identifier = "latest"
+        block_identifier = kwargs.pop("block_identifier", "latest")
+        if isinstance(block_identifier, int):
+            block_identifier = to_hex(block_identifier)
         arguments = [txn_dict, block_identifier]
         if "state_override" in kwargs:
             arguments.append(kwargs["state_override"])

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -926,7 +926,10 @@ class Web3Provider(ProviderAPI, ABC):
             if value is not None and not isinstance(value, str):
                 txn_dict[field] = to_hex(value)
 
-        block_identifier = kwargs.pop("block_identifier", "latest")
+        if "block_identifier" in kwargs:
+            block_identifier = hex(kwargs["block_identifier"])
+        else:
+            block_identifier = "latest"
         arguments = [txn_dict, block_identifier]
         if "state_override" in kwargs:
             arguments.append(kwargs["state_override"])

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -1,7 +1,7 @@
 import re
 
 import pytest
-from eth_utils import is_checksum_address
+from eth_utils import is_checksum_address, to_hex
 from hexbytes import HexBytes
 
 from ape import Contract
@@ -58,6 +58,24 @@ def test_call_view_method(owner, contract_instance):
     contract_instance.call_view_method("setNumber", 3, sender=owner)
     # myNumber should still equal 2 because the above line is call
     assert contract_instance.myNumber() == 2
+
+
+def test_call_use_block_identifier(contract_instance, owner, chain):
+    expected = 2
+    contract_instance.setNumber(expected, sender=owner)
+    block_id = chain.blocks.height  # int
+    contract_instance.setNumber(3, sender=owner)  # latest
+    actual = contract_instance.myNumber(block_identifier=block_id)
+    assert actual == expected
+
+    # Ensure works with hex
+    block_id = to_hex(block_id)
+    actual = contract_instance.myNumber(block_identifier=block_id)
+    assert actual == expected
+
+    # Ensure works keywords like "latest"
+    actual = contract_instance.myNumber(block_identifier="latest")
+    assert actual == 3
 
 
 def test_revert(sender, contract_instance):


### PR DESCRIPTION
### What I did
fixes: #1145

### How I did it
this might be a bit of naive approach, a more thorough solution might lay in understanding why `web3.provider.make_request` does not properly handle `block_identifier` as an int (it should convert to hex for the final raw rpc call).

### How to verify it
see #1145 for a example call to run

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [ ] Documentation has been updated
