### PR TITLE
fix: issue where directories with compiler extension in name would cause issues

### DIFF
--- a/docs/methoddocs/managers.md
+++ b/docs/methoddocs/managers.md
@@ -86,7 +86,21 @@
 ```
 
 ```{eval-rst}
-.. automodule:: ape.managers.project.types
+.. autoclass:: ape.managers.project.types.BaseProject
+    :members:
+    :special-members:
+    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
+```
+
+```{eval-rst}
+.. autoclass:: ape.managers.project.types.ApeProject
+    :members:
+    :special-members:
+    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
+```
+
+```{eval-rst}
+.. autoclass:: ape.managers.project.types.BrownieProject
     :members:
     :special-members:
     :exclude-members: __repr__, __weakref__, __metaclass__, __init__

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -57,7 +57,7 @@ class ProjectAPI(BaseInterfaceModel):
         Create a manifest from the project.
 
         Args:
-            file_paths (Optional[List]): An optional list of paths to compile
+            file_paths (Optional[List[Path]]): An optional list of paths to compile
               from this project.
             use_cache (bool): Set to ``False`` to clear caches and force a re-compile.
 

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -96,7 +96,8 @@ class CompilerManager(BaseManager):
             paths_to_compile = [
                 path
                 for path in contract_filepaths
-                if path not in paths_to_ignore
+                if path.is_file()
+                and path not in paths_to_ignore
                 and path.suffix == extension
                 and ".cache" not in [p.name for p in path.parents]
             ]

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -147,7 +147,7 @@ class ProjectManager(BaseManager):
         compiler_list: List[Compiler] = []
         contracts_folder = self.config_manager.contracts_folder
         for ext, compiler in self.compiler_manager.registered_compilers.items():
-            sources = [x for x in self.source_paths if x.suffix == ext]
+            sources = [x for x in self.source_paths if x.is_file() and x.suffix == ext]
             if not sources:
                 continue
 

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -1,6 +1,6 @@
 import shutil
 from pathlib import Path
-from typing import Dict, List, Optional, Type, Union
+from typing import Dict, Iterable, List, Optional, Type, Union
 
 from ethpm_types import Compiler
 from ethpm_types import ContractInstance as EthPMContractInstance
@@ -483,7 +483,7 @@ class ProjectManager(BaseManager):
         return find_in_dir(self.contracts_folder)
 
     def load_contracts(
-        self, file_paths: Optional[Union[List[Path], Path]] = None, use_cache: bool = True
+        self, file_paths: Optional[Union[Iterable[Path], Path]] = None, use_cache: bool = True
     ) -> Dict[str, ContractType]:
         """
         Compile and get the contract types in the project.
@@ -512,8 +512,14 @@ class ProjectManager(BaseManager):
         if not use_cache and in_source_cache.is_dir():
             shutil.rmtree(str(in_source_cache))
 
-        file_paths = [file_paths] if isinstance(file_paths, Path) else file_paths
-        manifest = self._project.create_manifest(file_paths, use_cache=use_cache)
+        if isinstance(file_paths, Path):
+            file_path_list = [file_paths]
+        elif file_paths is not None:
+            file_path_list = list(file_paths)
+        else:
+            file_path_list = None
+
+        manifest = self._project.create_manifest(file_paths=file_path_list, use_cache=use_cache)
         return manifest.contract_types or {}
 
     def _load_dependencies(self) -> Dict[str, Dict[str, DependencyAPI]]:

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -12,7 +12,7 @@ from ape.managers.config import CONFIG_FILE_NAME as APE_CONFIG_FILE_NAME
 from ape.utils import cached_property, get_all_files_in_directory, get_relative_path
 
 
-class ProjectSources:
+class _ProjectSources:
     # NOTE: This class is an implementation detail and excluded from the public API.
     # It helps with diff calculations between the project's cached manifest sources
     # and the current, active sources. It's used to determine what files to compile when
@@ -174,7 +174,7 @@ class BaseProject(ProjectAPI):
                     else self.source_paths
                 )
             )
-            project_sources = ProjectSources(manifest, source_paths, self.contracts_folder)
+            project_sources = _ProjectSources(manifest, source_paths, self.contracts_folder)
             contract_types = project_sources.contract_types
 
             # Set the context in case compiling a dependency (or anything outside the root project).

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -1,20 +1,96 @@
-import json
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
-from ethpm_types import PackageManifest
+from ethpm_types import ContractType, PackageManifest, Source
 from ethpm_types.utils import compute_checksum
 
 from ape.api import ProjectAPI
 from ape.logging import logger
 from ape.managers.config import CONFIG_FILE_NAME as APE_CONFIG_FILE_NAME
-from ape.utils import get_all_files_in_directory, get_relative_path
+from ape.utils import cached_property, get_all_files_in_directory, get_relative_path
+
+
+class ProjectSources:
+    # NOTE: This class is an implementation detail and excluded from the public API.
+    # It helps with diff calculations between the project's cached manifest sources
+    # and the current, active sources. It's used to determine what files to compile when
+    # running `ape compile`.
+
+    def __init__(
+        self, cached_manifest: PackageManifest, active_sources: List[Path], contracts_folder: Path
+    ):
+        self.cached_manifest = cached_manifest
+        self.active_sources = active_sources
+        self.contracts_folder = contracts_folder
+
+    @cached_property
+    def cached_sources(self) -> Dict[str, Source]:
+        return self.cached_manifest.sources or {}
+
+    @cached_property
+    def contract_types(self) -> Dict[str, ContractType]:
+        cached_contract_types = self.cached_manifest.contract_types or {}
+
+        # Filter out deleted sources.
+        deleted_source_ids = self.cached_sources.keys() - set(
+            map(str, [get_relative_path(p, self.contracts_folder) for p in self.active_sources])
+        )
+        return {
+            name: contract_type
+            for name, contract_type in cached_contract_types.items()
+            if contract_type.source_id not in deleted_source_ids
+        }
+
+    @cached_property
+    def sources_needing_compilation(self) -> List[Path]:
+        needs_compile = set(filter(self._check_needs_compiling, self.active_sources))
+
+        # NOTE: Add referring path imports for each source path
+        all_referenced_paths: List[Path] = []
+        sources_to_check_refs = needs_compile.copy()
+        while sources_to_check_refs:
+            source_id = str(get_relative_path(sources_to_check_refs.pop(), self.contracts_folder))
+            reference_paths = [
+                s for s in self._source_reference_paths.get(source_id, []) if s.is_file()
+            ]
+            all_referenced_paths.extend(reference_paths)
+            needs_compile.update(reference_paths)
+
+        needs_compile.update(all_referenced_paths)
+        return list(needs_compile)
+
+    @cached_property
+    def _source_reference_paths(self) -> Dict[str, List[Path]]:
+        return {
+            source_id: [self.contracts_folder.joinpath(Path(s)) for s in source.references or []]
+            for source_id, source in self.cached_sources.items()
+        }
+
+    def _check_needs_compiling(self, source_path: Path) -> bool:
+        source_id = str(get_relative_path(source_path, self.contracts_folder))
+
+        if source_id not in self.cached_sources:
+            return True  # New file added
+
+        cached_source = self.cached_sources[source_id]
+        cached_checksum = cached_source.calculate_checksum()
+
+        source_file = self.contracts_folder / source_path
+        checksum = compute_checksum(
+            source_file.read_text("utf8").encode("utf8"),
+            algorithm=cached_checksum.algorithm,
+        )
+
+        # NOTE: Filter by checksum to only update what's needed
+        return checksum != cached_checksum.hash  # Contents changed
+
+    def get_source_reference_paths(self, source_id: str) -> List[Path]:
+        return [s for s in self._source_reference_paths.get(source_id, []) if s.is_file()]
 
 
 class BaseProject(ProjectAPI):
-    created_temporary_config_file: bool = False
-
     @property
     def config_file(self) -> Path:
         return self.path / APE_CONFIG_FILE_NAME
@@ -53,11 +129,12 @@ class BaseProject(ProjectAPI):
 
         return files
 
-    def configure(self, **kwargs):
-        # Don't override existing config file.
+    def configure(self, **kwargs) -> bool:
         if self.config_file.is_file():
-            return
+            # Don't override existing config file.
+            return False
 
+        # Create a temporary config file that should be cleaned up after.
         config_data = {**kwargs}
         if self.name:
             config_data["name"] = self.name
@@ -68,106 +145,49 @@ class BaseProject(ProjectAPI):
             str(self.contracts_folder).replace(str(self.path), "").strip("/")
         )
         config_data["contracts_folder"] = contracts_folder_config_item
+
         with open(self.config_file, "w") as f:
             yaml.safe_dump(config_data, f)
+            return True
 
-            # Indicate that we need to clean up the file later.
-            self.created_temporary_config_file = True
+    @contextmanager
+    def _configured(self, **kwargs):
+        created_temporary_config_file = False
+        try:
+            created_temporary_config_file = self.configure(**kwargs)
+            yield
+        finally:
+            if created_temporary_config_file and self.config_file.is_file():
+                self.config_file.unlink()
 
     def create_manifest(
         self, file_paths: Optional[List[Path]] = None, use_cache: bool = True
     ) -> PackageManifest:
         # Create a config file if one doesn't exist to forward values from
         # the root project's 'ape-config.yaml' 'dependencies:' config.
-        try:
-            self.configure()
-
-            # Load a cached or clean manifest (to use for caching)
-            if self.cached_manifest and use_cache:
-                manifest = self.cached_manifest
-            else:
-                manifest = PackageManifest()
-
-                if self.manifest_cachefile.is_file():
-                    self.manifest_cachefile.unlink()
-
-            cached_sources = manifest.sources or {}
-            cached_contract_types = manifest.contract_types or {}
-            cached_source_reference_paths = {
-                source_id: [
-                    self.contracts_folder.joinpath(Path(s)) for s in source.references or []
-                ]
-                for source_id, source in cached_sources.items()
-            }
-            source_paths = (
-                {p for p in self.source_paths if p in file_paths}
-                if file_paths
-                else set(self.source_paths)
-            )
-
-            # Filter out deleted source_paths
-            deleted_source_ids = cached_sources.keys() - set(
-                map(str, [get_relative_path(p, self.contracts_folder) for p in source_paths])
-            )
-            contract_types = {
-                name: contract_type
-                for name, contract_type in cached_contract_types.items()
-                if contract_type.source_id not in deleted_source_ids
-            }
-
-            def does_need_compiling(source_path: Path) -> bool:
-                source_id = str(get_relative_path(source_path, self.contracts_folder))
-
-                if source_id not in cached_sources:
-                    return True  # New file added
-
-                cached_source = cached_sources[source_id]
-                cached_checksum = cached_source.calculate_checksum()
-
-                source_file = self.contracts_folder / source_path
-                checksum = compute_checksum(
-                    source_file.read_text("utf8").encode("utf8"),
-                    algorithm=cached_checksum.algorithm,
+        with self._configured():
+            manifest = self._get_base_manifest(use_cache=use_cache)
+            source_paths: List[Path] = list(
+                set(
+                    [p for p in self.source_paths if p in file_paths]
+                    if file_paths
+                    else self.source_paths
                 )
-
-                return checksum != cached_checksum.hash  # Contents changed
-
-            # NOTE: Filter by checksum to only update what's needed
-            needs_compiling = set(filter(does_need_compiling, source_paths))
-
-            # NOTE: Add referring path imports for each source path
-            referenced_paths: List[Path] = []
-
-            paths_to_compile = needs_compiling.copy()
-
-            # NOTE: Recompile all dependent sources for a changed source
-            while paths_to_compile:
-                source_id = str(get_relative_path(paths_to_compile.pop(), self.contracts_folder))
-                ref_paths = [
-                    s for s in cached_source_reference_paths.get(source_id, []) if s.is_file()
-                ]
-                referenced_paths.extend(ref_paths)
-                paths_to_compile.update(ref_paths)
-
-            needs_compiling.update(referenced_paths)
+            )
+            project_sources = ProjectSources(manifest, source_paths, self.contracts_folder)
+            contract_types = project_sources.contract_types
 
             # Set the context in case compiling a dependency (or anything outside the root project).
             with self.config_manager.using_project(
                 self.path, contracts_folder=self.contracts_folder
             ):
                 self.project_manager._load_dependencies()
-                compiled_contract_types = self.compiler_manager.compile(list(needs_compiling))
-                contract_types.update(compiled_contract_types)
-
-                # NOTE: Update contract types & re-calculate source code entries in manifest
-                source_paths = (
-                    {p for p in self.source_paths if p in file_paths}
-                    if file_paths
-                    else set(self.source_paths)
+                compiled_contract_types = self.compiler_manager.compile(
+                    project_sources.sources_needing_compilation
                 )
-
+                contract_types.update(compiled_contract_types)
                 manifest = self._create_manifest(
-                    list(source_paths),
+                    source_paths,
                     self.contracts_folder,
                     contract_types,
                     initial_manifest=manifest,
@@ -176,13 +196,18 @@ class BaseProject(ProjectAPI):
                 )
 
                 # Cache the updated manifest so `self.cached_manifest` reads it next time
-                self.manifest_cachefile.write_text(json.dumps(manifest.dict()))
+                self.manifest_cachefile.write_text(manifest.json())
                 return manifest
 
-        finally:
-            if self.created_temporary_config_file and self.config_file.is_file():
-                self.config_file.unlink()
-                self.created_temporary_config_file = False
+    def _get_base_manifest(self, use_cache: bool = True) -> PackageManifest:
+        if self.cached_manifest and use_cache:
+            return self.cached_manifest
+
+        manifest = PackageManifest()
+        if self.manifest_cachefile.is_file():
+            self.manifest_cachefile.unlink()
+
+        return manifest
 
 
 class ApeProject(BaseProject):

--- a/src/ape/utils/os.py
+++ b/src/ape/utils/os.py
@@ -81,18 +81,18 @@ def get_all_files_in_directory(
     if not path.exists():
         return []
 
-    if isinstance(pattern, str):
-        pattern = re.compile(pattern)
+    elif path.is_file():
+        return [path]
 
-    if path.is_dir():
-        all_files = [p for p in list(path.rglob("*.*")) if p.is_file()]
+    # is dir
+    all_files = [p for p in list(path.rglob("*.*")) if p.is_file()]
+    if pattern:
+        if isinstance(pattern, str):
+            pattern = re.compile(pattern)
 
-        if pattern:
-            return [f for f in all_files if pattern.match(f.name)]
+        return [f for f in all_files if pattern.match(f.name)]
 
-        return all_files
-
-    return [path]
+    return all_files
 
 
 def expand_environment_variables(contents: str) -> str:

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -1,4 +1,5 @@
-from typing import Dict
+from pathlib import Path
+from typing import Dict, Set
 
 import click
 from ethpm_types import ContractType
@@ -26,7 +27,7 @@ from ape.cli import ape_cli_context, contract_file_paths_argument
     help="Show deployment bytecode size for all contracts",
 )
 @ape_cli_context()
-def cli(cli_ctx, file_paths, use_cache, display_size):
+def cli(cli_ctx, file_paths: Set[Path], use_cache: bool, display_size: bool):
     """
     Compiles the manifest for this project and saves the results
     back to the manifest.

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -59,7 +59,15 @@ def test_compile(ape_cli, runner, project, clean_cache):
     # First time it compiles, it compiles the files with registered compilers successfully.
     # Files with multiple extensions are currently not supported.
     all_files = [f for f in project.path.glob("contracts/**/*")]
-    expected_files = [f for f in all_files if f.name.count(".") == 1]
+
+    # Don't expect directories that may happen to have `.json` in name
+    # as well as hidden files, such as `.gitkeep`. Both examples are present
+    # in the test project!
+    expected_files = [
+        f
+        for f in all_files
+        if f.name.count(".") == 1 and f.is_file() and not f.name.startswith(".")
+    ]
     unexpected_files = [f for f in all_files if f not in expected_files]
 
     manifest = project.extract_manifest()


### PR DESCRIPTION
### What I did

While poking around https://github.com/smartcontractkit/chainlink-brownie-contracts/tree/main/contracts/abi/%40openzeppelin/ and comparing ape and brownie, I noticed ape was failing to compile certain `.sol` "files"... Turns out, they are actually directories, such as this gem: https://github.com/smartcontractkit/chainlink-brownie-contracts/tree/main/contracts/abi/%40openzeppelin/contracts/proxy/Proxy.sol

I located the bug in core ape and fixed it (this PR).

### How I did it

Check for `is_file()` as well.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
