### PR TITLE
test: replace reverts mocks with geth provider

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -184,8 +184,9 @@ def reverts_contract_container(reverts_contract_type) -> ContractContainer:
 
 @pytest.fixture
 def reverts_contract_instance(
-    owner, reverts_contract_container, networks_connected_to_tester
+    owner, reverts_contract_container, networks_connected_to_tester, geth_provider
 ) -> ContractInstance:
+    _ = geth_provider  # Must use geth, as it supports traces
     return owner.deploy(reverts_contract_container, required_confirmations=0)
 
 

--- a/tests/functional/test_revert_context_manager.py
+++ b/tests/functional/test_revert_context_manager.py
@@ -1,56 +1,7 @@
-from typing import List
-from unittest.mock import MagicMock
-
 import pytest
-from evm_trace import TraceFrame
 
-from ape.contracts.base import ContractInstance
 from ape.pytest.contextmanagers import RevertsContextManager as reverts
-
-
-def make_mock_trace(contract: ContractInstance, expected_dev_message: str) -> List[TraceFrame]:
-    """
-    Create a mock REVERT frame whose PC location aligns with the line for the given
-    ``expected_dev_message``.
-
-    Only the ``TraceFrame.pc`` value will be used by RevertsContextManager.
-    """
-    if contract.contract_type.pcmap is None:
-        raise AssertionError("Contract is missing pcmap")
-
-    pcmap = contract.contract_type.pcmap.parse()
-    dev_messages = contract.contract_type.dev_messages or {}
-
-    expected_line = None
-    for line, message in dev_messages.items():
-        if message == expected_dev_message:
-            expected_line = line
-            break
-
-    if expected_line is not None:
-        for pc, line_info in pcmap.items():
-            if line_info.line_start == expected_line:
-                return [
-                    TraceFrame(
-                        pc=pc,
-                        op="REVERT",
-                        gas=0,
-                        gasCost=0,
-                        depth=0,
-                        stack=[],
-                        memory=[],
-                    )
-                ]
-
-    raise AssertionError("Could not resolve PC location for expected dev message")
-
-
-@pytest.fixture(scope="function")
-def mock_trace(mocker):
-    """
-    Allows tests to patch in a mock stack trace to facilitate RevertsContextManager testing.
-    """
-    return mocker.patch("ape.api.providers.ProviderAPI.get_transaction_trace", MagicMock())
+from tests.conftest import geth_process_test
 
 
 def test_no_args(owner, reverts_contract_instance):
@@ -89,35 +40,35 @@ def test_revert_msg_raises_partial(owner, reverts_contract_instance):
             reverts_contract_instance.revertStrings(0, sender=owner)
 
 
-def test_dev_revert(owner, reverts_contract_instance, mock_trace):
+@geth_process_test
+def test_dev_revert(owner, reverts_contract_instance, geth_provider):
     """
     Test catching transaction reverts and asserting on a dev message written in the contract source
     code.
     """
-    mock_trace.return_value = make_mock_trace(reverts_contract_instance, "dev: error")
 
     with reverts(dev_message="dev: error"):
         reverts_contract_instance.revertStrings(2, sender=owner)
 
 
-def test_dev_revert_fails(owner, reverts_contract_instance, mock_trace):
+@geth_process_test
+def test_dev_revert_fails(owner, reverts_contract_instance, geth_provider):
     """
     Test that ``AssertionError`` is raised if the supplied dev message does not match the actual
     dev message found in the contract at the source of the revert.
     """
-    mock_trace.return_value = make_mock_trace(reverts_contract_instance, "dev: error")
 
     with pytest.raises(AssertionError):
         with reverts(dev_message="dev: foo"):
             reverts_contract_instance.revertStrings(2, sender=owner)
 
 
-def test_both(owner, reverts_contract_instance, mock_trace):
+@geth_process_test
+def test_both(owner, reverts_contract_instance, geth_provider):
     """
     Test catching transaction reverts and asserting on the revert reason as well as a dev message
     written in the contract source code.
     """
-    mock_trace.return_value = make_mock_trace(reverts_contract_instance, "dev: error")
 
     with reverts(expected_message="two", dev_message="dev: error"):
         reverts_contract_instance.revertStrings(2, sender=owner)


### PR DESCRIPTION
### What I did

The revert context manager test are causing issues for me locally.
I figured out we can use the geth provider and don't need to patch `ProviderAPI`.

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
