### PR TITLE
feat: improve error when contract type collision

### DIFF
--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Set
 from ethpm_types import ContractType
 
 from ape.api import CompilerAPI
+from ape.logging import logger
 from ape.utils import get_relative_path
 
 
@@ -21,25 +22,27 @@ class InterfaceCompiler(CompilerAPI):
     def compile(
         self, filepaths: List[Path], base_path: Optional[Path] = None
     ) -> List[ContractType]:
+        filepaths.sort()  # Sort to assist in reproducing consistent results.
         contract_types: List[ContractType] = []
         for path in filepaths:
             data = json.loads(path.read_text())
-
-            source_id = (
-                str(get_relative_path(path, base_path))
-                if base_path and path.is_absolute()
-                else str(path)
+            source_path = (
+                get_relative_path(path, base_path) if base_path and path.is_absolute() else path
             )
+            source_id = str(source_path)
             if isinstance(data, list):
                 # ABI JSON list
                 contract_type_data = {"contractName": path.stem, "abi": data, "sourceId": source_id}
 
-            elif isinstance(data, dict):
+            elif isinstance(data, dict) and (
+                "contractName" in data or "abi" in data or "sourceId" in data
+            ):
                 # Raw contract type JSON
                 contract_type_data = data
 
             else:
-                raise TypeError(f"Unable to parse contract type '{data}'.")
+                logger.warning(f"Unable to parse {ContractType.__name__} from '{source_id}'.")
+                continue
 
             contract_type = ContractType(**contract_type_data)
             contract_types.append(contract_type)


### PR DESCRIPTION
### What I did

Currently, when you have a contract type collision, it looks like this:

```
ERROR: (CompilerError) ContractType collision across compiler plugins with contract: abi/v0.6/Ownable.json
```

but now with these changes, it looks like this:

```
ERROR: (CompilerError) ContractType collision between sources 'abi/v0.6/ENSInterface.json' and 'abi/v0.7/ENSInterface.json'.
```

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
