### PR TITLE
feat: don't compile dependencies

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -237,16 +237,8 @@ class DependencyAPI(BaseInterfaceModel):
 
         return None
 
-    def _extract_local_manifest(self, project_path: Path):
-        project_path = project_path.resolve()
-        contracts_folder = project_path / self.contracts_folder
-        project = self.project_manager.get_project(
-            project_path,
-            contracts_folder=contracts_folder,
-            name=self.name,
-            version=self.version,
-        )
-
+    def _extract_local_manifest(self, project_path: Path, compile: bool = False):
+        project = self._get_project(project_path)
         all_sources = get_all_files_in_directory(project.contracts_folder)
 
         excluded_files = set()
@@ -267,6 +259,16 @@ class DependencyAPI(BaseInterfaceModel):
         self._target_manifest_cache_file.write_text(project_manifest.json())
 
         return project_manifest
+
+    def _get_project(self, project_path: Path) -> ProjectAPI:
+        project_path = project_path.resolve()
+        contracts_folder = project_path / self.contracts_folder
+        return self.project_manager.get_project(
+            project_path,
+            contracts_folder=contracts_folder,
+            name=self.name,
+            version=self.version,
+        )
 
 
 def _load_manifest_from_file(file_path: Path) -> Optional[PackageManifest]:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -946,14 +946,14 @@ class ContractCache(BaseManager):
         if not address_file.is_file():
             return None
 
-        return ContractType.parse_raw(address_file.read_text())
+        return ContractType.parse_file(address_file)
 
     def _get_proxy_info_from_disk(self, address: AddressType) -> Optional[ProxyInfoAPI]:
         address_file = self._proxy_info_cache / f"{address}.json"
         if not address_file.is_file():
             return None
 
-        return ProxyInfoAPI.parse_raw(address_file.read_text())
+        return ProxyInfoAPI.parse_file(address_file)
 
     def _get_contract_type_from_explorer(self, address: AddressType) -> Optional[ContractType]:
         if not self._network.explorer:

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -208,7 +208,7 @@ class ProjectManager(BaseManager):
 
         for ecosystem_path in [x for x in self._package_deployments_folder.iterdir() if x.is_dir()]:
             for deployment_path in [x for x in ecosystem_path.iterdir() if x.suffix == ".json"]:
-                ethpm_instance = EthPMContractInstance.parse_raw(deployment_path.read_text())
+                ethpm_instance = EthPMContractInstance.parse_file(deployment_path)
                 if not ethpm_instance:
                     continue
 
@@ -526,17 +526,20 @@ class ProjectManager(BaseManager):
         if self.path.name in self._cached_dependencies:
             return self._cached_dependencies[self.path.name]
 
-        dependencies: Dict[str, Dict[str, DependencyAPI]] = {}
+        self._cached_dependencies[self.path.name] = {}
         for dependency_config in self.config_manager.dependencies:
             dependency_config.extract_manifest()
             version_id = dependency_config.version_id
-            if dependency_config.name in dependencies:
-                dependencies[dependency_config.name][version_id] = dependency_config
+            if dependency_config.name in self._cached_dependencies[self.path.name]:
+                self._cached_dependencies[self.path.name][dependency_config.name][
+                    version_id
+                ] = dependency_config
             else:
-                dependencies[dependency_config.name] = {version_id: dependency_config}
+                self._cached_dependencies[self.path.name][dependency_config.name] = {
+                    version_id: dependency_config
+                }
 
-        self._cached_dependencies[self.path.name] = dependencies
-        return dependencies
+        return self._cached_dependencies[self.path.name]
 
     def track_deployment(self, contract: ContractInstance):
         """

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -38,14 +38,11 @@ def test_two_dependencies_with_same_name(already_downloaded_dependencies, projec
     assert oz_442.name == name
 
 
-def test_dependency_with_longer_contracts_folder(
-    dependency_config, config, mocker, project_manager
-):
-    spy = mocker.patch("ape.managers.project.types.yaml")
-    _ = project_manager.dependencies
-    assert spy.safe_dump.call_args, "Config file never created"
-    call_config = spy.safe_dump.call_args[0][0]
-    assert call_config["contracts_folder"] == "source/v0.1"
+def test_dependency_with_longer_contracts_folder(dependency_config, config, project_manager):
+    dependency = project_manager.dependencies["testdependency"]["local"]
+    expected = "source/v0.1"
+    actual = dependency.contracts_folder
+    assert actual == expected
 
 
 def test_dependency_with_non_version_version_id(recwarn, dependency_manager):

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -238,4 +238,6 @@ def test_compile_only_dependency(ape_cli, runner, project, clean_cache):
 
     result = runner.invoke(ape_cli, ["compile", "--force"], catch_exceptions=False)
     assert result.exit_code == 0, result.output
-    assert "Compiling 'DependencyInProjectOnly.json'" in result.output
+
+    # Dependencies are not compiled automatically
+    assert "Compiling 'DependencyInProjectOnly.json'" not in result.output


### PR DESCRIPTION
### What I did
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #799 

Goes with https://github.com/ApeWorX/ape-solidity/pull/84

### How I did it

Dependency's no longer need to compile. Instead, we create a contract-type-less `PackageManifest` that contains the sources to be imported in a project. This makes compiling works a lot better and certain dependencies don't compile if they don't ever need to.

### How to verify it

Use dependencies.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
