### PR TITLE
fix: change to http default in github clone for dependencies

### DIFF
--- a/src/ape/utils/github.py
+++ b/src/ape/utils/github.py
@@ -141,7 +141,7 @@ class GithubClient:
         repo_path: str,
         target_path: Path,
         branch: Optional[str] = None,
-        scheme: str = "ssh",
+        scheme: str = "http",
     ):
         """
         Clone a repository from Github.

--- a/tests/functional/utils/test_github.py
+++ b/tests/functional/utils/test_github.py
@@ -59,7 +59,7 @@ class TestGithubClient:
         cmd = git_patch.call_args[0][0]
         assert cmd[0].endswith("git")
         assert cmd[1] == "clone"
-        assert cmd[2] == "git@github.com:dapphub/ds-test.git"
+        assert cmd[2] == "https://github.com/dapphub/ds-test.git"
         # cmd[3] is the temporary output path
         assert cmd[4] == "--branch"
         assert cmd[5] == "master"


### PR DESCRIPTION
### What I did

This works in CI better than SSH.

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
