### PR TITLE
feat: add default yaml config

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -1,0 +1,37 @@
+default_required_confirmations: &default_required_confirmations 2
+default_local_required_confirmations: &default_local_required_confirmations 0
+default_local_block_time: &default_local_block_time 0
+default_transaction_acceptance_timeout: &default_transaction_acceptance_timeout 120
+default_local_transaction_acceptance_timeout: &default_local_transaction_acceptance_timeout 20
+default_gas_limit: &default_gas_limit "auto"
+default_local_gas_limit: &default_local_gas_limit "max"
+ethereum:
+  mainnet:
+    required_confirmations: *default_required_confirmations
+    block_time: 13
+    transaction_acceptance_timeout: *default_transaction_acceptance_timeout
+    gas_limit: *default_gas_limit
+    # alchemy:
+    #   min_retry_delay: 1_000 # 1 second delay on fail
+    #   retry_backoff_factor: 2 # explonential backoff
+    #   max_retry_delay: 30_000 # 30 seconds
+    #   max_retries: 3
+    #   retry_jitter: 250 # 250 milliseconds
+  goerli:
+    required_confirmations: *default_required_confirmations
+    block_time: 15
+    transaction_acceptance_timeout: *default_transaction_acceptance_timeout
+    gas_limit: *default_gas_limit
+  local:
+    transaction_acceptance_timeout: *default_local_transaction_acceptance_timeout
+    gas_limit: *default_local_gas_limit
+    default_provider: "test"
+  mainnet_fork:
+    transaction_acceptance_timeout: *default_local_transaction_acceptance_timeout
+    gas_limit: *default_local_gas_limit
+    default_provider: 
+  goerli_fork:
+    transaction_acceptance_timeout: *default_local_transaction_acceptance_timeout
+    gas_limit: *default_local_gas_limit
+    default_provider: 
+dependencies:

--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -25,11 +25,13 @@ class PluginConfig(BaseSettings):
     @classmethod
     def from_overrides(cls, overrides: Dict) -> "PluginConfig":
         default_values = cls().dict()
-
         def update(root: Dict, value_map: Dict):
             for key, val in value_map.items():
                 if key in root and isinstance(val, dict):
+                    print(f" overriding {key}")
+                    print(f"  old root[key]: {root[key]}")
                     root[key] = update(root[key], val)
+                    print(f"  new root[key]: {root[key]}")
                 else:
                     root[key] = val
 

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -99,7 +99,9 @@ class NetworkManager(BaseManager):
                 data_folder=self.config_manager.DATA_FOLDER / plugin_name,
                 request_header=self.config_manager.REQUEST_HEADER,
             )
+            print(f"ecosystem config for {plugin_name}:")
             ecosystem_config = self.config_manager.get_config(plugin_name).dict()
+            print(f" {ecosystem_config}")
             default_network = ecosystem_config.get("default_network", LOCAL_NETWORK_NAME)
 
             try:

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -7,6 +7,7 @@ import pytest
 from ape.api import ReceiptAPI, TestAccountAPI
 from ape.logging import logger
 from ape.managers.chain import ChainManager
+from ape.managers.config import ConfigManager
 from ape.managers.networks import NetworkManager
 from ape.managers.project import ProjectManager
 from ape.pytest.config import ConfigWrapper
@@ -36,6 +37,20 @@ class PytestApeFixtures(ManagerAccessMixin):
             and self.config_wrapper.track_gas
         )
 
+    @pytest.fixture(scope="session")
+    def wrapped_config(self) -> ConfigWrapper:
+        """
+        A wrapper around the pytest config object.
+        """
+        return self.config_wrapper
+
+    @pytest.fixture(scope="session")
+    def cfg_manager(self) -> ConfigManager:
+        """
+        A wrapper around the pytest config object.
+        """
+        return self.config_manager
+    
     @pytest.fixture(scope="session")
     def accounts(self) -> List[TestAccountAPI]:
         """

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -36,20 +36,6 @@ class PytestApeFixtures(ManagerAccessMixin):
             # Has reason to use traces?
             and self.config_wrapper.track_gas
         )
-
-    @pytest.fixture(scope="session")
-    def wrapped_config(self) -> ConfigWrapper:
-        """
-        A wrapper around the pytest config object.
-        """
-        return self.config_wrapper
-
-    @pytest.fixture(scope="session")
-    def cfg_manager(self) -> ConfigManager:
-        """
-        A wrapper around the pytest config object.
-        """
-        return self.config_manager
     
     @pytest.fixture(scope="session")
     def accounts(self) -> List[TestAccountAPI]:

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -7,7 +7,6 @@ import pytest
 from ape.api import ReceiptAPI, TestAccountAPI
 from ape.logging import logger
 from ape.managers.chain import ChainManager
-from ape.managers.config import ConfigManager
 from ape.managers.networks import NetworkManager
 from ape.managers.project import ProjectManager
 from ape.pytest.config import ConfigWrapper
@@ -36,7 +35,7 @@ class PytestApeFixtures(ManagerAccessMixin):
             # Has reason to use traces?
             and self.config_wrapper.track_gas
         )
-    
+
     @pytest.fixture(scope="session")
     def accounts(self) -> List[TestAccountAPI]:
         """

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -105,27 +105,12 @@ class NetworkConfig(PluginConfig):
         return value
 
 
-def _create_local_config(default_provider: Optional[str] = None, **kwargs) -> NetworkConfig:
-    return _create_config(
-        required_confirmations=0,
-        default_provider=default_provider,
-        transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
-        gas_limit="max",
-        **kwargs,
-    )
-
-
-def _create_config(required_confirmations: int = 2, **kwargs) -> NetworkConfig:
-    # Put in own method to isolate `type: ignore` comments
-    return NetworkConfig(required_confirmations=required_confirmations, **kwargs)
-
-
 class EthereumConfig(PluginConfig):
-    mainnet: NetworkConfig = _create_config(block_time=13)
-    mainnet_fork: NetworkConfig = _create_local_config()
-    goerli: NetworkConfig = _create_config(block_time=15)
-    goerli_fork: NetworkConfig = _create_local_config()
-    local: NetworkConfig = _create_local_config(default_provider="test")
+    mainnet: NetworkConfig = NetworkConfig()
+    mainnet_fork: NetworkConfig = NetworkConfig()
+    goerli: NetworkConfig = NetworkConfig()
+    goerli_fork: NetworkConfig = NetworkConfig()
+    local: NetworkConfig = NetworkConfig()
     default_network: str = LOCAL_NETWORK_NAME
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,17 +6,10 @@ from tempfile import mkdtemp
 from typing import Dict
 
 import pytest
-import yaml
 from click.testing import CliRunner
 
 import ape
 from ape.exceptions import APINotImplementedError, UnknownSnapshotError
-from ape.managers.config import CONFIG_FILE_NAME
-
-# default_config_file = ape.config.PROJECT_FOLDER / CONFIG_FILE_NAME
-# NOTE: Ensure that we don't use local paths for these
-# ape.config.DATA_FOLDER = Path(mkdtemp()).resolve()
-# ape.config.PROJECT_FOLDER = Path(mkdtemp()).resolve()
 
 # Needed to test tracing support in core `ape test` command.
 pytest_plugins = ["pytester"]
@@ -212,22 +205,7 @@ def eth_tester_isolation(eth_tester_provider):
 
 @pytest.fixture(scope="session")
 def temp_config(config):
-    # @contextmanager
     def func(data: Dict):
-        # with tempfile.TemporaryDirectory() as temp_dir_str:
-        #     temp_dir = Path(temp_dir_str)
-        #     config._cached_configs = {}
-        #     config_file = temp_dir / CONFIG_FILE_NAME
-        #     config_file.touch()
-        #     config_file.write_text(yaml.dump(data))
-        #     config.load(force_reload=True)
-
-        #     with config.using_project(temp_dir):
-        #         yield
-
-        #     config_file.unlink()
-        #     config._cached_configs = {}
-    # return func
         return config.load(force_reload=True, additional_config=data)
     return func
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,10 @@ import ape
 from ape.exceptions import APINotImplementedError, UnknownSnapshotError
 from ape.managers.config import CONFIG_FILE_NAME
 
+# default_config_file = ape.config.PROJECT_FOLDER / CONFIG_FILE_NAME
 # NOTE: Ensure that we don't use local paths for these
-ape.config.DATA_FOLDER = Path(mkdtemp()).resolve()
-ape.config.PROJECT_FOLDER = Path(mkdtemp()).resolve()
+# ape.config.DATA_FOLDER = Path(mkdtemp()).resolve()
+# ape.config.PROJECT_FOLDER = Path(mkdtemp()).resolve()
 
 # Needed to test tracing support in core `ape test` command.
 pytest_plugins = ["pytester"]
@@ -211,22 +212,23 @@ def eth_tester_isolation(eth_tester_provider):
 
 @pytest.fixture(scope="session")
 def temp_config(config):
-    @contextmanager
+    # @contextmanager
     def func(data: Dict):
-        with tempfile.TemporaryDirectory() as temp_dir_str:
-            temp_dir = Path(temp_dir_str)
-            config._cached_configs = {}
-            config_file = temp_dir / CONFIG_FILE_NAME
-            config_file.touch()
-            config_file.write_text(yaml.dump(data))
-            config.load(force_reload=True)
+        # with tempfile.TemporaryDirectory() as temp_dir_str:
+        #     temp_dir = Path(temp_dir_str)
+        #     config._cached_configs = {}
+        #     config_file = temp_dir / CONFIG_FILE_NAME
+        #     config_file.touch()
+        #     config_file.write_text(yaml.dump(data))
+        #     config.load(force_reload=True)
 
-            with config.using_project(temp_dir):
-                yield
+        #     with config.using_project(temp_dir):
+        #         yield
 
-            config_file.unlink()
-            config._cached_configs = {}
-
+        #     config_file.unlink()
+        #     config._cached_configs = {}
+    # return func
+        return config.load(force_reload=True, additional_config=data)
     return func
 
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -252,8 +252,6 @@ def dependency_config(temp_config):
             }
         ]
     }
-    # with temp_config(dependencies_config):
-    #     yield
     new_config = temp_config(dependencies_config)
     return new_config
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -252,8 +252,10 @@ def dependency_config(temp_config):
             }
         ]
     }
-    with temp_config(dependencies_config):
-        yield
+    # with temp_config(dependencies_config):
+    #     yield
+    new_config = temp_config(dependencies_config)
+    return new_config
 
 
 @pytest.fixture

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -3,8 +3,6 @@ from typing import Dict
 
 import pytest
 
-from ape.pytest.config import ConfigWrapper
-from ape.utils import ManagerAccessMixin
 from ape.api import PluginConfig
 from ape.managers.config import DeploymentConfigCollection
 from ape.types import GasLimit
@@ -109,6 +107,7 @@ def test_network_gas_limit_invalid_numeric_string(temp_config):
 
 
 def test_dependencies(dependency_config):
+
     assert len(dependency_config.dependencies) == 1
     assert dependency_config.dependencies[0].name == "testdependency"
     assert dependency_config.dependencies[0].contracts_folder == "source/v0.1"


### PR DESCRIPTION
### What I did
attempt to pull out all the defaults from code into a single yaml

### Why I did it
this can be used to transparently add more detailed parameters, like in https://github.com/ApeWorX/ape-alchemy/pull/35. also allows non-coder users to understand what the default settings are, and to easily override them.

### How I did it
removed parameters and hard-coded them into the standard yaml. maybe a separate `default-config.yaml` would be better than `ape-config.yaml`.
replaced the context-based test_config with an overload to the default config that executes additional overrides (I bet this is causing lots of test failures):
` = 195 failed, 512 passed, 3 skipped, 7 xfailed, 15 warnings, 31 errors in 1125.89s (0:18:45) =`

### How to verify it
possibly additional tests should be needed, though i got it working with test_config.py

### Checklist
- [ ] All changes are completed
- [ ] finish testing (possibly go back to context-based test_config)
- [ ] possibly rename to `default-config.yaml`, distinct from `ape-config.yaml`
- [ ] New test cases have been added
- [ ] Documentation has been updated
