### PR TITLE
feat: support regex in ape.reverts()

### DIFF
--- a/docs/userguides/testing.md
+++ b/docs/userguides/testing.md
@@ -247,6 +247,14 @@ def test_authorization(my_contract, owner, not_owner):
 This is the expected revert reason given when the transaction fails.
 If the message in the `ContractLogicError` raised by the transaction failure is empty or does not match the `expected_message`, then `ape.reverts()` will raise an `AssertionError`.
 
+You may also supply an `re.Pattern` object to assert on a message pattern, rather than on an exact match.
+
+```python
+# Matches explicitly "foo" or "bar"
+with ape.reverts(re.compile(r"^(foo|bar)$")):
+    ...
+```
+
 ### `dev_message`
 
 This is the expected dev message corresponding to the line in the contract's source code where the error occurred.
@@ -285,6 +293,14 @@ There are a few scenarios where `AssertionError` will be raised when using `dev_
 - If the transaction trace cannot be obtained
 
 Because `dev_message` relies on transaction tracing to function, you must use a provider like [ape-hardhat](https://github.com/ApeWorX/ape-hardhat) when testing with `dev_message`.
+
+You may also supply an `re.Pattern` object to assert on a dev message pattern, rather than on an exact match.
+
+```python
+# Matches explictly "dev: foo" or "dev: bar"
+with ape.reverts(dev_message=re.compile(r"^dev: (foo|bar)$")):
+    ...
+```
 
 ### Caveats
 

--- a/src/ape/pytest/contextmanagers.py
+++ b/src/ape/pytest/contextmanagers.py
@@ -80,11 +80,13 @@ class RevertsContextManager:
         if offending_source is None or offending_source.line_start is None:
             raise AssertionError("Could not find line that caused revert.")
 
-        assertion_error_prefix = "Expected dev revert message '{}.'".format(
+        assertion_error_message = (
             self.dev_message.pattern
             if isinstance(self.dev_message, re.Pattern)
             else self.dev_message
         )
+
+        assertion_error_prefix = f"Expected dev revert message '{assertion_error_message}'"
 
         dev_messages = contract.contract_type.dev_messages or {}
 
@@ -112,11 +114,13 @@ class RevertsContextManager:
         """
         actual = exception.revert_message
 
-        assertion_error_prefix = "Expected revert message '{}.'".format(
+        assertion_error_message = (
             self.expected_message.pattern
             if isinstance(self.expected_message, re.Pattern)
             else self.expected_message
         )
+
+        assertion_error_prefix = f"Expected revert message '{assertion_error_message}'"
 
         message_matches = (
             (self.expected_message.match(actual) is not None)

--- a/src/ape/pytest/contextmanagers.py
+++ b/src/ape/pytest/contextmanagers.py
@@ -1,5 +1,6 @@
+import re
 from collections import deque
-from typing import Optional, Type
+from typing import Optional, Type, Union
 
 import ape
 from ape.exceptions import (
@@ -11,7 +12,11 @@ from ape.exceptions import (
 
 
 class RevertsContextManager:
-    def __init__(self, expected_message: Optional[str] = None, dev_message: Optional[str] = None):
+    def __init__(
+        self,
+        expected_message: Optional[Union[str, re.Pattern]] = None,
+        dev_message: Optional[Union[str, re.Pattern]] = None,
+    ):
         self.expected_message = expected_message
         self.dev_message = dev_message
 
@@ -75,7 +80,11 @@ class RevertsContextManager:
         if offending_source is None or offending_source.line_start is None:
             raise AssertionError("Could not find line that caused revert.")
 
-        assertion_error_prefix = f"Expected dev revert message '{self.dev_message}'."
+        assertion_error_prefix = "Expected dev revert message '{}.'".format(
+            self.dev_message.pattern
+            if isinstance(self.dev_message, re.Pattern)
+            else self.dev_message
+        )
 
         dev_messages = contract.contract_type.dev_messages or {}
 
@@ -84,7 +93,13 @@ class RevertsContextManager:
 
         contract_dev_message = dev_messages[offending_source.line_start]
 
-        if contract_dev_message != self.dev_message:
+        message_matches = (
+            (self.dev_message.match(contract_dev_message) is not None)
+            if isinstance(self.dev_message, re.Pattern)
+            else (contract_dev_message == self.dev_message)
+        )
+
+        if not message_matches:
             raise AssertionError(f"{assertion_error_prefix} but got '{contract_dev_message}'.")
 
     def _check_expected_message(self, exception: ContractLogicError):
@@ -97,10 +112,19 @@ class RevertsContextManager:
         """
         actual = exception.revert_message
 
-        # Validate the expected revert message if given one.
-        if self.expected_message is not None and self.expected_message != actual:
-            assertion_error_prefix = f"Expected revert message '{self.expected_message}'"
+        assertion_error_prefix = "Expected revert message '{}.'".format(
+            self.expected_message.pattern
+            if isinstance(self.expected_message, re.Pattern)
+            else self.expected_message
+        )
 
+        message_matches = (
+            (self.expected_message.match(actual) is not None)
+            if isinstance(self.expected_message, re.Pattern)
+            else (actual == self.expected_message)
+        )
+
+        if not message_matches:
             if actual == TransactionError.DEFAULT_MESSAGE:
                 # The transaction failed without a revert message
                 # but the user is expecting one.

--- a/tests/functional/test_revert_context_manager.py
+++ b/tests/functional/test_revert_context_manager.py
@@ -112,7 +112,7 @@ def test_dev_revert_pattern_fails(owner, reverts_contract_instance, geth_provide
 
 
 @geth_process_test
-def test_both(owner, reverts_contract_instance, geth_provider):
+def test_both_message_and_dev_str(owner, reverts_contract_instance, geth_provider):
     """
     Test matching a revert message with a supplied message as well as a contract dev revert message
     with a supplied dev message.


### PR DESCRIPTION
### What I did
- Added regex support in `ape.reverts()`
- Cleared up `RevertsContextManager` tests and test docstrings

fixes: #873 
fixes: APE-311

### How I did it
Allow `expected_message` and `dev_message` in `RevertsContextManager` to accept `re.Pattern` objects

### How to verify it
```python
# Matches explictly "dev: foo" or "dev: bar"
with ape.reverts(re.compile(r"^dev: (foo|bar)$")):
    ...

# Matches explictly "dev: foo" or "dev: bar"
with ape.reverts(dev_message=re.compile(r"^dev: (foo|bar)$")):
    ...
```

### Checklist
- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
