### PR TITLE
fix: issue where dependency contract type would not compile

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -248,7 +248,7 @@ class DependencyAPI(BaseInterfaceModel):
         with tempfile.TemporaryDirectory() as temp_dir:
             project = self._get_project(Path(temp_dir))
             contracts_folder = project.contracts_folder.absolute()
-            contracts_folder.mkdir()
+            contracts_folder.mkdir(parents=True, exist_ok=True)
             for source_id, source_obj in sources.items():
                 content = source_obj.content or ""
                 absolute_path = contracts_folder / source_id

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -100,7 +100,7 @@ class BaseProject(ProjectAPI):
         if self.config_file.is_file():
             return True
 
-        logger.warning(
+        logger.debug(
             f"'{self.path.name}' is not an 'ApeProject', but attempting to process as one."
         )
 

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -22,6 +22,10 @@ def already_downloaded_dependencies(temp_config, config, oz_dependencies_config)
     manifests_directory = Path(__file__).parent / "data" / "manifests"
     oz_manifests = manifests_directory / "OpenZeppelin"
     oz_manifests_dest = config.packages_folder / "OpenZeppelin"
+
+    if oz_manifests_dest.is_dir():
+        shutil.rmtree(oz_manifests_dest)
+
     shutil.copytree(oz_manifests, oz_manifests_dest)
     with temp_config(oz_dependencies_config):
         yield

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -45,6 +45,13 @@ def test_dependency_with_longer_contracts_folder(dependency_config, config, proj
     assert actual == expected
 
 
+def test_access_dependency_contracts(already_downloaded_dependencies, project_manager):
+    name = "OpenZeppelin"
+    oz_442 = project_manager.dependencies[name]["4.4.2"]
+    contract = oz_442.AccessControl
+    assert contract.contract_type.name == "AccessControl"
+
+
 def test_dependency_with_non_version_version_id(recwarn, dependency_manager):
     dependency_config = {
         "github": "apeworx/testfoobartest",


### PR DESCRIPTION
### What I did

When working on the brownie-style deps ticket, I forgot to include this part!
So dependencies no longer compile by default. However, when you request them, they will compile.
They compile only once! Once they are part of their cached manifest, they don't need to compile again. Both in session and out.

### How I did it

idk see code, just some refactoring and stuff

### How to verify it

First time:

```sh
(yoko) ➜  ape-demo-project git:(main) ✗ ape console

In [1]: dep = project.dependencies["ds-test"]["master"]

In [2]: dep.DSTest
INFO: Compiling 'test.sol'.
Out[2]: <DSTest>

In [3]: dep.DSTest
Out[3]: <DSTest>
```

Notice it only compiled the first time we request it.
Second time:

```
In [1]: dep = project.dependencies["ds-test"]["master"]

In [2]: dep.DSTest
Out[2]: <DSTest>
```

Notice it does not need to compile at all because it did last session.

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
