### PR TITLE
test: added testing for `accounts generate` seed phrase length

### DIFF
--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -213,15 +213,16 @@ def test_generate_24_words(ape_cli, runner, temp_keyfile_path):
     assert not temp_keyfile_path.is_file()
     # Generate new private key
     show_mnemonic = ""
+    word_count = 24
     result = runner.invoke(
         ape_cli,
-        ["accounts", "generate", ALIAS, "--word-count", 24],
+        ["accounts", "generate", ALIAS, "--word-count", word_count],
         input="\n".join(["random entropy", show_mnemonic, PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
     assert "Newly generated mnemonic is" in result.output
     mnemonic_length = len(result.output.split(":")[4].split("\n")[0].split())
-    assert mnemonic_length == 24
+    assert mnemonic_length == word_count
     assert ETHEREUM_DEFAULT_PATH in result.output
     assert ALIAS in result.output
     assert temp_keyfile_path.is_file()
@@ -251,15 +252,16 @@ def test_generate_24_words_and_custom_hdpath(ape_cli, runner, temp_keyfile_path)
     assert not temp_keyfile_path.is_file()
     # Generate new private key
     show_mnemonic = ""
+    word_count = 24
     result = runner.invoke(
         ape_cli,
-        ["accounts", "generate", ALIAS, "--word-count", 24, "--hd-path", CUSTOM_HDPATH],
+        ["accounts", "generate", ALIAS, "--word-count", word_count, "--hd-path", CUSTOM_HDPATH],
         input="\n".join(["random entropy", show_mnemonic, PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
     assert "Newly generated mnemonic is" in result.output
     mnemonic_length = len(result.output.split(":")[4].split("\n")[0].split())
-    assert mnemonic_length == 24
+    assert mnemonic_length == word_count
     assert CUSTOM_HDPATH in result.output
     assert ALIAS in result.output
     assert temp_keyfile_path.is_file()

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -168,6 +168,8 @@ def test_generate_default(ape_cli, runner, temp_keyfile_path):
     )
     assert result.exit_code == 0, result.output
     assert "Newly generated mnemonic is" in result.output
+    mnemonic_length = len(result.output.split(":")[4].split("\n")[0].split())
+    assert mnemonic_length == 12
     assert ETHEREUM_DEFAULT_PATH in result.output
     assert ALIAS in result.output
     assert temp_keyfile_path.is_file()
@@ -217,7 +219,9 @@ def test_generate_24_words(ape_cli, runner, temp_keyfile_path):
         input="\n".join(["random entropy", show_mnemonic, PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
-    assert "Newly generated mnemonic is" in result.output  # should check for 24 words
+    assert "Newly generated mnemonic is" in result.output
+    mnemonic_length = len(result.output.split(":")[4].split("\n")[0].split())
+    assert mnemonic_length == 24
     assert ETHEREUM_DEFAULT_PATH in result.output
     assert ALIAS in result.output
     assert temp_keyfile_path.is_file()
@@ -235,6 +239,8 @@ def test_generate_custom_hdpath(ape_cli, runner, temp_keyfile_path):
     )
     assert result.exit_code == 0, result.output
     assert "Newly generated mnemonic is" in result.output
+    mnemonic_length = len(result.output.split(":")[4].split("\n")[0].split())
+    assert mnemonic_length == 12
     assert CUSTOM_HDPATH in result.output
     assert ALIAS in result.output
     assert temp_keyfile_path.is_file()
@@ -251,7 +257,9 @@ def test_generate_24_words_and_custom_hdpath(ape_cli, runner, temp_keyfile_path)
         input="\n".join(["random entropy", show_mnemonic, PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
-    assert "Newly generated mnemonic is" in result.output  # should check for 24 words
+    assert "Newly generated mnemonic is" in result.output
+    mnemonic_length = len(result.output.split(":")[4].split("\n")[0].split())
+    assert mnemonic_length == 24
     assert CUSTOM_HDPATH in result.output
     assert ALIAS in result.output
     assert temp_keyfile_path.is_file()


### PR DESCRIPTION
### What I did
added testing for seed phrase length output

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: APE-346

### How I did it
parsing seed phrase from runner output message

```
word_count = 24
...
mnemonic_length = len(result.output.split(":")[4].split("\n")[0].split())
assert mnemonic_length == word_count
```

### How to verify it
tests are passing

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
