### PR TITLE
feat: `ape accounts export <ALIAS>` exports private key

### DIFF
--- a/docs/userguides/accounts.md
+++ b/docs/userguides/accounts.md
@@ -125,6 +125,18 @@ If you use the `--hd-path` option, you will need to pass the [HDPath](https://he
 
 If you do not use the `--hd-path` option, Ape will use the default HDPath of (Ethereum network, first account).
 
+You can also [export](../commands/accounts.html#accounts-export) the private key of an account:
+
+```bash
+ape accounts export <ALIAS>
+```
+
+Ape will ask you for the password to the account and then give you the private key of that account.
+
+You can then use that private key with [import](../commands/accounts.html#accounts-import).
+
+You can alternatively load the private key into [Metamask wallet](https://metamask.zendesk.com/hc/en-us/articles/360015489331-How-to-import-an-account#h_01G01W07NV7Q94M7P1EBD5BYM4).
+
 Then, in your scripts, you can [load](../methoddocs/managers.html#ape.managers.accounts.AccountManager.load) an account:
 
 ```python

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -64,7 +64,7 @@ def _list(cli_ctx, show_all_plugins):
             click.echo()
 
 
-@cli.command(short_help="Create a new keyfile account with a random mnemonic seed phrase")
+@cli.command(short_help="Create an account with a random mnemonic seed phrase")
 @click.option(
     "--hide-mnemonic",
     help="Hide the newly generated mnemonic from the terminal",
@@ -113,9 +113,7 @@ def generate(cli_ctx, alias, hide_mnemonic, word_count, custom_hd_path):
 
 
 # Different name because `import` is a keyword
-@cli.command(
-    name="import", short_help="Add a new keyfile account by entering a private key or seed phrase"
-)
+@cli.command(name="import", short_help="Import an account by private key or seed phrase")
 @click.option(
     "--use-mnemonic", "import_from_mnemonic", help="Import a key from a mnemonic", is_flag=True
 )

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -157,7 +157,7 @@ def _import(cli_ctx, alias, import_from_mnemonic, custom_hd_path):
     )
 
 
-@cli.command(short_help="Unlock an account and export the private key")
+@cli.command(short_help="Export an account private key")
 @ape_cli_context()
 @existing_alias_argument()
 def export(cli_ctx, alias):

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -99,7 +99,7 @@ def generate(cli_ctx, alias, hide_mnemonic, word_count, custom_hd_path):
         num_words=word_count, account_path=custom_hd_path
     )
     if not hide_mnemonic and click.confirm("Show mnemonic?", default=True):
-        cli_ctx.logger.info(f"Newly generated mnemonic is: {mnemonic}")
+        cli_ctx.logger.info(f"Newly generated mnemonic is: {click.style(mnemonic, bold=True)}")
     passphrase = click.prompt(
         "Create Passphrase to encrypt account",
         hide_input=True,
@@ -163,7 +163,9 @@ def export(cli_ctx, alias):
     account = json.loads(path.read_text())
     password = click.prompt("Enter password to decrypt account", hide_input=True)
     private_key = EthAccount.decrypt(account, password)
-    cli_ctx.logger.success(f"Account 0x{account['address']} private key: {private_key.hex()}")
+    cli_ctx.logger.success(
+        f"Account 0x{account['address']} private key: {click.style(private_key.hex(), bold=True)})"
+    )
 
 
 @cli.command(short_help="Change the password of an existing account")

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -157,7 +157,7 @@ def _import(cli_ctx, alias, import_from_mnemonic, custom_hd_path):
 
 @cli.command(short_help="Export an account private key")
 @ape_cli_context()
-@existing_alias_argument()
+@existing_alias_argument(account_type=KeyfileAccount)
 def export(cli_ctx, alias):
     path = _get_container().data_folder.joinpath(f"{alias}.json")
     account = json.loads(path.read_text())

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -157,10 +157,10 @@ def _import(cli_ctx, alias, import_from_mnemonic, custom_hd_path):
     )
 
 
-@cli.command(name="export", short_help="Unlock an account and export the private key")
+@cli.command(short_help="Unlock an account and export the private key")
 @ape_cli_context()
 @existing_alias_argument()
-def _export(cli_ctx, alias):
+def export(cli_ctx, alias):
     path = _get_container().data_folder.joinpath(f"{alias}.json")
     account = json.loads(path.read_text())
     password = click.prompt("Enter password to decrypt account", hide_input=True)

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -157,6 +157,17 @@ def _import(cli_ctx, alias, import_from_mnemonic, custom_hd_path):
     )
 
 
+@cli.command(name="export", short_help="Unlock an account and export the private key")
+@ape_cli_context()
+@existing_alias_argument()
+def _export(cli_ctx, alias):
+    path = _get_container().data_folder.joinpath(f"{alias}.json")
+    account = json.loads(path.read_text())
+    password = click.prompt("Enter password to decrypt account", hide_input=True)
+    private_key = EthAccount.decrypt(account, password)
+    cli_ctx.logger.success(f"Account 0x{account['address']} private key: {private_key.hex()}")
+
+
 @cli.command(short_help="Change the password of an existing account")
 @existing_alias_argument(account_type=KeyfileAccount)
 @ape_cli_context()

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -142,7 +142,7 @@ def test_import_mnemonic_custom_hdpath(
 
 @run_once
 def test_export(ape_cli, runner, temp_keyfile):
-    address = json.loads(temp_keyfile.read_text())['address']
+    address = json.loads(temp_keyfile.read_text())["address"]
     # export key
     result = runner.invoke(
         ape_cli,

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -141,6 +141,30 @@ def test_import_mnemonic_custom_hdpath(
 
 
 @run_once
+def test_import_then_export(ape_cli, runner, temp_account, temp_keyfile_path):
+    assert not temp_keyfile_path.is_file()
+    #import key
+    result = runner.invoke(
+        ape_cli,
+        ["accounts", "import", ALIAS],
+        input="\n".join([f"0x{PRIVATE_KEY}", PASSWORD, PASSWORD]),
+    )
+    assert result.exit_code == 0, result.output
+    assert temp_account.address in result.output
+    assert ALIAS in result.output
+    assert temp_keyfile_path.is_file()
+    #export key
+    result = runner.invoke(
+        ape_cli,
+        ["accounts", "export", ALIAS],
+        input="\n".join([PASSWORD, PASSWORD]),
+    )
+    assert result.exit_code == 0, result.output
+    assert f"0x{PRIVATE_KEY}" in result.output
+    # assert temp_account.address in result.output
+
+
+@run_once
 def test_import_invalid_mnemonic(ape_cli, runner):
     # Add account from invalid mnemonic
     result = runner.invoke(

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -143,7 +143,7 @@ def test_import_mnemonic_custom_hdpath(
 @run_once
 def test_import_then_export(ape_cli, runner, temp_account, temp_keyfile_path):
     assert not temp_keyfile_path.is_file()
-    #import key
+    # import key
     result = runner.invoke(
         ape_cli,
         ["accounts", "import", ALIAS],
@@ -153,7 +153,7 @@ def test_import_then_export(ape_cli, runner, temp_account, temp_keyfile_path):
     assert temp_account.address in result.output
     assert ALIAS in result.output
     assert temp_keyfile_path.is_file()
-    #export key
+    # export key
     result = runner.invoke(
         ape_cli,
         ["accounts", "export", ALIAS],

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -152,7 +152,7 @@ def test_export(ape_cli, runner, temp_keyfile):
     assert result.exit_code == 0, result.output
     assert f"0x{PRIVATE_KEY}" in result.output
     assert address in result.output
-    breakpoint()
+
 
 @run_once
 def test_import_invalid_mnemonic(ape_cli, runner):

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -152,7 +152,7 @@ def test_export(ape_cli, runner, temp_keyfile):
     assert result.exit_code == 0, result.output
     assert f"0x{PRIVATE_KEY}" in result.output
     assert address in result.output
-
+    breakpoint()
 
 @run_once
 def test_import_invalid_mnemonic(ape_cli, runner):

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -141,18 +141,8 @@ def test_import_mnemonic_custom_hdpath(
 
 
 @run_once
-def test_import_then_export(ape_cli, runner, temp_account, temp_keyfile_path):
-    assert not temp_keyfile_path.is_file()
-    # import key
-    result = runner.invoke(
-        ape_cli,
-        ["accounts", "import", ALIAS],
-        input="\n".join([f"0x{PRIVATE_KEY}", PASSWORD, PASSWORD]),
-    )
-    assert result.exit_code == 0, result.output
-    assert temp_account.address in result.output
-    assert ALIAS in result.output
-    assert temp_keyfile_path.is_file()
+def test_export(ape_cli, runner, temp_keyfile):
+    address = json.loads(temp_keyfile.read_text())['address']
     # export key
     result = runner.invoke(
         ape_cli,
@@ -161,7 +151,7 @@ def test_import_then_export(ape_cli, runner, temp_account, temp_keyfile_path):
     )
     assert result.exit_code == 0, result.output
     assert f"0x{PRIVATE_KEY}" in result.output
-    # assert temp_account.address in result.output
+    assert address in result.output
 
 
 @run_once


### PR DESCRIPTION
### What I did
created a click command in ape accounts cli to export private keys from keyfiles

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: APE-345
fixes: APE-328

### How I did it
created a click account that loads the alias keyfile and then decrypts the private key with a password prompt

### How to verify it
tests coming soon

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
