### PR TITLE
feat: allow setting balance if current provider supports it

### DIFF
--- a/docs/userguides/accounts.md
+++ b/docs/userguides/accounts.md
@@ -43,7 +43,7 @@ The accounts generated from this seed are solely for testing and debugging purpo
 
 Learn more about test accounts from the [testing guide](./testing.html#accounts-fixture).
 
-If your testing provider supports this feature, it is possible to directly set the balanaces of any address, by performing the following action:
+If your testing provider supports this feature, it is possible to directly set the balances of any address by performing the following action:
 
 ```python
 account.balance += int(1e18)  # Gives `account` 1 Ether

--- a/docs/userguides/accounts.md
+++ b/docs/userguides/accounts.md
@@ -43,6 +43,12 @@ The accounts generated from this seed are solely for testing and debugging purpo
 
 Learn more about test accounts from the [testing guide](./testing.html#accounts-fixture).
 
+If your testing provider supports this feature, it is possible to directly set the balanaces of any address, by performing the following action:
+
+```python
+account.balance += int(1e18)  # Gives `account` 1 Ether
+```
+
 ## Live Network Accounts
 
 When using live networks, you need to get your accounts into Ape.
@@ -59,7 +65,7 @@ Ape will prompt you for entropy which is used to increase randomness when creati
 
 Ape will then prompt you whether you want to show your mnemonic.
 
-If you do not want to see your mnemonic you can select `n`. 
+If you do not want to see your mnemonic you can select `n`.
 
 Alternatively you can use the `--hide-mnemonic` option to skip the prompt.
 
@@ -71,7 +77,7 @@ If you elected to show your mnemonic Ape will then show you your newly generated
 
 Ape will then prompt you for a passphrase which you will need to enter twice to confirm.
 
-This passphrase is used to encrypt your account on disk, for extra security. 
+This passphrase is used to encrypt your account on disk, for extra security.
 
 You will be prompted for it each time you load your account, so make sure to remember it.
 
@@ -111,9 +117,9 @@ You can also import accounts from mnemonic seed by using the `--use-mnemonic` fl
 ape accounts import <ALIAS> --use-mnemonic
 ```
 
-It will then prompt you for the [mnemonic seed](https://en.bitcoin.it/wiki/Seed_phrase). 
+It will then prompt you for the [mnemonic seed](https://en.bitcoin.it/wiki/Seed_phrase).
 
-If you need help finding your mnemonic seed (Secret Recovery Phrase) in Metamask, see [this guide](https://metamask.zendesk.com/hc/en-us/articles/360015290032-How-to-reveal-your-Secret-Recovery-Phrase). 
+If you need help finding your mnemonic seed (Secret Recovery Phrase) in Metamask, see [this guide](https://metamask.zendesk.com/hc/en-us/articles/360015290032-How-to-reveal-your-Secret-Recovery-Phrase).
 
 In addition, you can also use a custom HDPath by using the `--hd-path` option:
 

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 
 from ape.exceptions import ConversionError
 from ape.types import AddressType, ContractCode
@@ -89,6 +89,22 @@ class BaseAddress(BaseInterface):
         """
 
         return self.provider.get_balance(self.address)
+
+    # @balance.setter
+    # NOTE: commented out because of failure noted within `__setattr__`
+    def _set_balance_(self, value: Any):
+        if isinstance(value, str):
+            value = self.conversion_manager.convert(value, int)
+
+        self.provider.set_balance(self.address, value)
+
+    def __setattr__(self, attr: str, value: Any) -> None:
+        # NOTE: Need to do this until https://github.com/pydantic/pydantic/pull/2625 is figured out
+        if attr == "balance":
+            self._set_balance_(value)
+
+        else:
+            super().__setattr__(attr, value)
 
     @property
     def code(self) -> ContractCode:


### PR DESCRIPTION
### What I did
Allow setting an account's balance directly

### How I did it
Tried to add a setter to the `balance` property, but that didn't work, so I had to override Pydantic behavior a bit

### How to verify it
Load an `Address`, any `AccountAPI` subclass, and then any `ContractInstance` and try `account.balance += "1 ether"`

### Checklist
Needs some tests

- [x] All changes are completed
- [ ] New test cases have been added
- [x] Documentation has been updated
