### PR TITLE
fix: allow Gnosis Safe style proxies to work with earlier deployments

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -226,8 +226,8 @@ class Ethereum(EcosystemAPI):
         )
         try:
             name = ContractCall(abi, address)()
-            storage = self.provider.get_storage_at(address, 0)
-            target = self.conversion_manager.convert(storage[-20:].hex(), AddressType)
+            raw_target = self.provider.get_storage_at(address, 0)[-20:].hex()
+            target = self.conversion_manager.convert(raw_target, AddressType)
             # NOTE: `target` is set in initialized proxies
             if name in ("Gnosis Safe", "Default Callback Handler") and target != ZERO_ADDRESS:
                 return ProxyInfo(type=ProxyType.GnosisSafe, target=target)
@@ -255,7 +255,7 @@ class Ethereum(EcosystemAPI):
 
             target = ContractCall(implementation_abi, address)()
             # avoid recursion
-            if target != "0x0000000000000000000000000000000000000000":
+            if target != ZERO_ADDRESS:
                 return ProxyInfo(type=ProxyType.Delegate, target=target)
 
         except (DecodingError, TransactionError, ValueError):

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -216,19 +216,20 @@ class Ethereum(EcosystemAPI):
 
             return ProxyInfo(type=type, target=target)
 
-        # gnosis safe stores implementation in slot 0, read `masterCopy()` to be sure
+        # gnosis safe stores implementation in slot 0, read `NAME()` to be sure
         abi = MethodABI(
             type="function",
-            name="masterCopy",
+            name="NAME",
             stateMutability="view",
-            outputs=[ABIType(type="address")],
+            outputs=[ABIType(type="string")],
         )
         try:
-            master_copy = ContractCall(abi, address)()
+            name = ContractCall(abi, address)()
             storage = self.provider.get_storage_at(address, 0)
-            slot_0 = self.conversion_manager.convert(storage[-20:].hex(), AddressType)
-            if master_copy == slot_0:
-                return ProxyInfo(type=ProxyType.GnosisSafe, target=master_copy)
+            target = self.conversion_manager.convert(storage[-20:].hex(), AddressType)
+            if name in ("Gnosis Safe", "Default Callback Handler"):
+                return ProxyInfo(type=ProxyType.GnosisSafe, target=target)
+
         except (DecodingError, TransactionError):
             pass
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -19,6 +19,7 @@ from ape.types import AddressType, ContractLog, GasLimit, RawAddress, Transactio
 from ape.utils import (
     DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
     DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT,
+    ZERO_ADDRESS,
     LogInputABICollection,
     Struct,
     StructParser,
@@ -227,7 +228,8 @@ class Ethereum(EcosystemAPI):
             name = ContractCall(abi, address)()
             storage = self.provider.get_storage_at(address, 0)
             target = self.conversion_manager.convert(storage[-20:].hex(), AddressType)
-            if name in ("Gnosis Safe", "Default Callback Handler"):
+            # NOTE: `target` is set in initialized proxies
+            if name in ("Gnosis Safe", "Default Callback Handler") and target != ZERO_ADDRESS:
                 return ProxyInfo(type=ProxyType.GnosisSafe, target=target)
 
         except (DecodingError, TransactionError):


### PR DESCRIPTION
### What I did

Prior to v1.1.0, `masterCopy` was not available as an external method. This means that our proxy detection would not be able to detect it as a Gnosis Safe-style proxy. Additionally, once deployed, this style of proxy is immutable, so even if the Safe itself is upgraded to a newer version, this method still would not be available to be called.

NOTE: This slightly modifies the proxy info's target to be obtained
      dynamically from retreiving the storage for `masterCopy` directly.

### How I did it
Since `masterCopy()` is not an available method to call, but `NAME()` has always existed in every Gnosis Safe version, I decided to use that instead. I noticed that there are few different names in use, so we check that it matches one of those

### How to verify it

Go load a safe via `Contract` for every version that's been deployed

### Checklist

- [x] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
