### PR TITLE
fix: gas_limit of "auto" causes failure with unsupported providers

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -730,6 +730,14 @@ class Web3Provider(ProviderAPI, ABC):
         """
 
         txn_dict = txn.dict()
+
+        # "auto" does not usually work
+        if "gas" in txn_dict and txn_dict["gas"] == "auto":
+            txn_dict.pop("gas")
+            # Also pop these, they are overriden by "auto"
+            txn_dict.pop("maxFeePerGas", None)
+            txn_dict.pop("maxPriorityFeePerGas", None)
+
         try:
             block_id = kwargs.pop("block_identifier", None)
             txn_params = cast(TxParams, txn_dict)

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -934,6 +934,12 @@ class Web3Provider(ProviderAPI, ABC):
             if value is not None and not isinstance(value, str):
                 txn_dict[field] = to_hex(value)
 
+        # Remove unneeded properties
+        txn_dict.pop("gas", None)
+        txn_dict.pop("gasLimit", None)
+        txn_dict.pop("maxFeePerGas", None)
+        txn_dict.pop("maxPriorityFeePerGas", None)
+
         block_identifier = kwargs.pop("block_identifier", "latest")
         if isinstance(block_identifier, int):
             block_identifier = to_hex(block_identifier)

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -731,7 +731,7 @@ class Web3Provider(ProviderAPI, ABC):
 
         txn_dict = txn.dict()
 
-        # "auto" does not usually work
+        # NOTE: "auto" means to enter this method, so remove it from dict
         if "gas" in txn_dict and txn_dict["gas"] == "auto":
             txn_dict.pop("gas")
             # Also pop these, they are overriden by "auto"

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -117,13 +117,17 @@ class LocalProvider(TestProviderAPI, Web3Provider):
 
     def send_call(self, txn: TransactionAPI, **kwargs) -> bytes:
         data = txn.dict(exclude_none=True)
-        if "gas" not in data or data["gas"] == 0:
-            data["gas"] = int(1e12)
-
         block_id = kwargs.pop("block_identifier", None)
         state = kwargs.pop("state_override", None)
         call_kwargs = {"block_identifier": block_id, "state_override": state}
-        tx_params = cast(TxParams, txn.dict())
+
+        # Remove unneeded properties
+        data.pop("gas", None)
+        data.pop("gasLimit", None)
+        data.pop("maxFeePerGas", None)
+        data.pop("maxPriorityFeePerGas", None)
+
+        tx_params = cast(TxParams, data)
 
         try:
             return self.web3.eth.call(tx_params, **call_kwargs)


### PR DESCRIPTION
### What I did

Some providers don't support "auto", so just avoid getting gas estimation for those types by removing the argument

fixes: #1176

### How I did it
<!-- Discuss the thought process behind the change -->

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
