### PR TITLE
fix: issues with dependencies of dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
         name: black

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require = {
         "hypothesis-jsonschema==0.19.0",  # JSON Schema fuzzer extension
     ],
     "lint": [
-        "black>=22.10.0,<23",  # auto-formatter and linter
+        "black>=22.12.0,<23",  # auto-formatter and linter
         "mypy>=0.991",  # Static type analyzer
         "types-PyYAML",  # Needed due to mypy typeshed
         "types-requests",  # Needed due to mypy typeshed

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -100,10 +100,10 @@ class ProjectAPI(BaseInterfaceModel):
         folder.mkdir(exist_ok=True, parents=True)
         return folder
 
-    def configure(self, **kwargs) -> bool:
+    def process_config_file(self, **kwargs) -> bool:
         """
-        Returns ``True`` if had to configure the project.
-        Implemented in base-classes.
+        Process the project's config file.
+        Returns ``True`` if had to create a temporary ``ape-config.yaml`` file.
         """
 
         return False

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -290,7 +290,7 @@ class DependencyAPI(BaseInterfaceModel):
 
     def _extract_local_manifest(self, project_path: Path) -> PackageManifest:
         cached_manifest = (
-            PackageManifest.parse_file(self._target_manifest_cache_file)
+            _load_manifest_from_file(self._target_manifest_cache_file)
             if self._target_manifest_cache_file.is_file()
             else None
         )

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -278,6 +278,8 @@ class DependencyAPI(BaseInterfaceModel):
                 source_path = contracts_folder / get_relative_path(
                     absolute_path, contracts_folder.absolute()
                 )
+
+                # Create content, including sub-directories.
                 source_path.parent.mkdir(parents=True, exist_ok=True)
                 source_path.touch()
                 source_path.write_text(content)

--- a/src/ape/managers/project/dependency.py
+++ b/src/ape/managers/project/dependency.py
@@ -147,4 +147,7 @@ class LocalDependency(DependencyAPI):
         return self.version
 
     def extract_manifest(self) -> PackageManifest:
+        if self._target_manifest_cache_file.is_file():
+            return PackageManifest.parse_file(self._target_manifest_cache_file)
+
         return self._extract_local_manifest(self.path)

--- a/src/ape/managers/project/dependency.py
+++ b/src/ape/managers/project/dependency.py
@@ -8,6 +8,7 @@ from ethpm_types import PackageManifest
 from pydantic import root_validator
 
 from ape.api import DependencyAPI
+from ape.api.projects import _load_manifest_from_file
 from ape.exceptions import ProjectError
 from ape.utils import ManagerAccessMixin, cached_property, github_client, load_config
 
@@ -148,6 +149,8 @@ class LocalDependency(DependencyAPI):
 
     def extract_manifest(self) -> PackageManifest:
         if self._target_manifest_cache_file.is_file():
-            return PackageManifest.parse_file(self._target_manifest_cache_file)
+            manifest = _load_manifest_from_file(self._target_manifest_cache_file)
+            if manifest:
+                return manifest
 
         return self._extract_local_manifest(self.path)

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -60,6 +60,9 @@ class ProjectManager(BaseManager):
         in this project's ``ape-config.yaml`` file.
         """
 
+        # Ensure project is configured first. This will migrate dependency configs
+        # if they are specified alternative ways, such as in brownie-projects.
+        self._project.configure()
         return self._load_dependencies()
 
     # NOTE: Using these paths should handle the case when the folder doesn't exist
@@ -501,12 +504,6 @@ class ProjectManager(BaseManager):
             Dict[str, ``ContractType``]: A dictionary of contract names to their
             types for each compiled contract.
         """
-
-        # NOTE: Always load dependencies even when there is no contracts folder.
-        #  This is to support projects that only use dependencies.
-        self._load_dependencies()
-        if not self.contracts_folder.is_dir():
-            return {}
 
         in_source_cache = self.contracts_folder / ".cache"
         if not use_cache and in_source_cache.is_dir():

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -62,7 +62,7 @@ class ProjectManager(BaseManager):
 
         # Ensure project is configured first. This will migrate dependency configs
         # if they are specified alternative ways, such as in brownie-projects.
-        self._project.configure()
+        self._project.process_config_file()
         return self._load_dependencies()
 
     # NOTE: Using these paths should handle the case when the folder doesn't exist

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -148,14 +148,21 @@ class BaseProject(ProjectAPI):
 
         with open(self.config_file, "w") as f:
             yaml.safe_dump(config_data, f)
-            return True
+
+        return True
 
     @contextmanager
-    def _configured(self, **kwargs):
+    def _as_ape_project(self, **kwargs):
+        # Create and clean-up the temporary ape-config.yaml file if there is one.
+
         created_temporary_config_file = False
         try:
             created_temporary_config_file = self.configure(**kwargs)
+            if created_temporary_config_file:
+                self.config_manager.load(force_reload=True)
+
             yield
+
         finally:
             if created_temporary_config_file and self.config_file.is_file():
                 self.config_file.unlink()
@@ -163,9 +170,9 @@ class BaseProject(ProjectAPI):
     def create_manifest(
         self, file_paths: Optional[List[Path]] = None, use_cache: bool = True
     ) -> PackageManifest:
-        # Create a config file if one doesn't exist to forward values from
-        # the root project's 'ape-config.yaml' 'dependencies:' config.
-        with self._configured():
+        # Read the project config and migrate project-settings to Ape settings if needed.
+        with self._as_ape_project():
+            self.project_manager._load_dependencies()
             manifest = self._get_base_manifest(use_cache=use_cache)
             source_paths: List[Path] = list(
                 set(
@@ -222,17 +229,17 @@ class ApeProject(BaseProject):
 
 
 class BrownieProject(BaseProject):
-    BROWNIE_CONFIG_FILE_NAME = "brownie-config.yaml"
+    config_file_name = "brownie-config.yaml"
 
     @property
     def brownie_config_path(self) -> Path:
-        return self.path / self.BROWNIE_CONFIG_FILE_NAME
+        return self.path / self.config_file_name
 
     @property
     def is_valid(self) -> bool:
         return self.brownie_config_path.is_file()
 
-    def configure(self):
+    def configure(self, **kwargs) -> bool:
         # Migrate the brownie-config.yaml file to ape-config.yaml
 
         migrated_config_data: Dict[str, Any] = {}
@@ -303,4 +310,4 @@ class BrownieProject(BaseProject):
 
             migrated_config_data["solidity"] = migrated_solidity_config
 
-        super().configure(**migrated_config_data)
+        return super().configure(**kwargs, **migrated_config_data)

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -129,7 +129,7 @@ class BaseProject(ProjectAPI):
 
         return files
 
-    def configure(self, **kwargs) -> bool:
+    def process_config_file(self, **kwargs) -> bool:
         if self.config_file.is_file():
             # Don't override existing config file.
             return False
@@ -157,7 +157,7 @@ class BaseProject(ProjectAPI):
 
         created_temporary_config_file = False
         try:
-            created_temporary_config_file = self.configure(**kwargs)
+            created_temporary_config_file = self.process_config_file(**kwargs)
             if created_temporary_config_file:
                 self.config_manager.load(force_reload=True)
 
@@ -239,7 +239,7 @@ class BrownieProject(BaseProject):
     def is_valid(self) -> bool:
         return self.brownie_config_path.is_file()
 
-    def configure(self, **kwargs) -> bool:
+    def process_config_file(self, **kwargs) -> bool:
         # Migrate the brownie-config.yaml file to ape-config.yaml
 
         migrated_config_data: Dict[str, Any] = {}
@@ -310,4 +310,4 @@ class BrownieProject(BaseProject):
 
             migrated_config_data["solidity"] = migrated_solidity_config
 
-        return super().configure(**kwargs, **migrated_config_data)
+        return super().process_config_file(**kwargs, **migrated_config_data)

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -158,7 +158,7 @@ def test_brownie_project_configure(config, base_projects_directory):
         expected_config_file.unlink()
 
     project = BrownieProject(path=project_path, contracts_folder="contracts")
-    project.configure()
+    project.process_config_file()
     assert expected_config_file.is_file()
 
     with open(expected_config_file) as ape_config_file:

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -204,7 +204,7 @@ def test_compile_with_dependency(ape_cli, runner, project, contract_path):
         cmd.append(contract_path)
 
     result = runner.invoke(ape_cli, cmd, catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     for name in (
         "default",
         "renamed-contracts-folder",
@@ -212,7 +212,7 @@ def test_compile_with_dependency(ape_cli, runner, project, contract_path):
         "renamed-complex-contracts-folder",
         "renamed-contracts-folder-specified-in-config",
     ):
-        assert name in project.dependencies
+        assert name in list(project.dependencies.keys())
         assert type(project.dependencies[name]["local"]["name"]) == ContractContainer
 
 


### PR DESCRIPTION
### What I did

Regression from https://github.com/ApeWorX/ape/pull/1152
We changed dependencies so that they would not compile at download time.
We did this to better support dependencies that are not meant to be compile-able entirely on their own, such as `chainlink-brownie-contracts`. So now dependencies only get compiled if they are needed to be. And once compiled, their artifacts remain in the cached manifest file in `.ape/packages/`. This explains why some people didn't have this problem locally - their dependencies were already fully contract-type-ified.

So the fix here:  realizing the huge flaw in our change - config files... When we cache a project's sources, we need to also know its configuration if we plan to compile it at a later time, especially if that config tells you to how to do mappings and explains other info regarding dependencies of dependencies. That's whats happening.

### How I did it

* Track the expected names of config file per project
* Include config file in cached manifest
* When compiling, check if compiler settings are in manifest. If yes, use it for compiling.
* When requesting a dependency, make sure we run `process_config_file()` on that dependency project first.

### How to verify it
<!-- Discuss any methods that should be used to verify the change -->

### Checklist
<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
