### PR TITLE
fix: issue where `poll_blocks()` did not detect chain re-org

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[release]
-        
+
     - name: Build
       run: python setup.py sdist bdist_wheel
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
 
         - name: Run flake8
           run: flake8 .
-        
+
         - name: Run mdformat
           run: mdformat . --check --number
 

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -370,7 +370,7 @@ class ReceiptAPI(BaseInterfaceModel):
 
     def track_gas(self):
         """
-        Track this receipt's gas in the on-going sessional gas-report.
+        Track this receipt's gas in the on-going session gas-report.
         Requires using a provider that support transaction traces.
         This gets called when running tests with the ``--gas`` flag.
         """

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -233,6 +233,11 @@ class BlockContainer(BaseManager):
     ) -> Iterator[BlockAPI]:
         """
         Poll new blocks. Optionally set a start block to include historical blocks.
+
+        **NOTE**: When a chain reorganization occurs, this method logs an error and
+        yields the missed blocks even if they were previously yielded with different
+        block numbers.
+
         **NOTE**: This is a daemon method; it does not terminate unless an exception occurs
         or a ``stop`` is given.
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -917,7 +917,7 @@ class ContractCache(BaseManager):
         Find the method ABI from the given contract address and selector.
 
         Args:
-            contract_address (``AddressType``): The address of the contract.
+            contract (``AddressType``): The address of the contract.
             selector (``HexBytes``): The method ID.
 
         Returns:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -282,8 +282,6 @@ class BlockContainer(BaseManager):
             raise ValueError("'stop' argument must be in the future.")
 
         # Get number of last block with the necessary amount of confirmations.
-        last_yielded_hash = None
-        last_yielded_number = None
         block = None
 
         if start_block is not None:
@@ -294,9 +292,17 @@ class BlockContainer(BaseManager):
         if block:
             last_yielded_hash = block.hash
             last_yielded_number = block.number
-            time_since_last = time.time()
 
-        time.sleep(block_time)
+            # Only sleep if pre-yielded a block
+            time.sleep(block_time)
+
+        else:
+            last_yielded_hash = None
+            last_yielded_number = None
+
+        # Set `time_since_last` even if haven't yield yet.
+        # This helps with timing out the first time.
+        time_since_last = time.time()
 
         def _try_timeout():
             if time.time() - time_since_last > timeout:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -825,6 +825,8 @@ class ContractCache(BaseManager):
               plugin, you can also provide an ENS domain name.
             contract_type (Optional[``ContractType``]): Optionally provide the contract type
               in case it is not already known.
+            txn_hash (Optional[str]): The hash of the transaction responsible for deploying the
+              contract, if known. Useful for publishing. Defaults to ``None``.
 
         Returns:
             :class:`~ape.contracts.base.ContractInstance`

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -235,7 +235,7 @@ class BlockContainer(BaseManager):
         Poll new blocks. Optionally set a start block to include historical blocks.
 
         **NOTE**: When a chain reorganization occurs, this method logs an error and
-        yields the missed blocks even if they were previously yielded with different
+        yields the missed blocks, even if they were previously yielded with different
         block numbers.
 
         **NOTE**: This is a daemon method; it does not terminate unless an exception occurs

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1004,7 +1004,7 @@ class ReportManager(BaseManager):
 
     track_gas: bool = False
     gas_exclusions: List[ContractFunctionPath] = []
-    sessional_gas_report: Optional[GasReport] = None
+    session_gas_report: Optional[GasReport] = None
     rich_console_map: Dict[str, RichConsole] = {}
 
     def show_trace(
@@ -1045,10 +1045,10 @@ class ReportManager(BaseManager):
         self,
         file: Optional[IO[str]] = None,
     ) -> bool:
-        if not self.sessional_gas_report:
+        if not self.session_gas_report:
             return False
 
-        tables = parse_gas_table(self.sessional_gas_report)
+        tables = parse_gas_table(self.session_gas_report)
         console = self._get_console(file)
         console.print(*tables)
         return True
@@ -1067,10 +1067,10 @@ class ReportManager(BaseManager):
 
         parser = CallTraceParser(sender=sender, transaction_hash=transaction_hash)
         gas_report = parser._get_rich_gas_report(call_tree, exclude=self.gas_exclusions)
-        if gas_report and self.sessional_gas_report:
-            self.sessional_gas_report = merge_reports(self.sessional_gas_report, gas_report)
+        if gas_report and self.session_gas_report:
+            self.session_gas_report = merge_reports(self.session_gas_report, gas_report)
         elif gas_report:
-            self.sessional_gas_report = gas_report
+            self.session_gas_report = gas_report
 
     def _get_console(self, file: Optional[IO[str]] = None) -> RichConsole:
         if not file:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1245,6 +1245,7 @@ class ChainManager(BaseManager):
                 receipt = contract.fooBar(sender=owner)
         """
 
+        snapshot = None
         try:
             snapshot = self.snapshot()
         except APINotImplementedError:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -284,17 +284,19 @@ class BlockContainer(BaseManager):
         # Get number of last block with the necessary amount of confirmations.
         last_yielded_hash = None
         last_yielded_number = None
+        block = None
 
         if start_block is not None:
             # Front-load historical blocks.
             for block in self.range(start_block, self.height - required_confirmations + 1):
-                last_yielded_hash = block.hash
-                last_yielded_number = block.number
-                time_since_last = time.time()
                 yield block
 
+        if block:
+            last_yielded_hash = block.hash
+            last_yielded_number = block.number
+            time_since_last = time.time()
+
         time.sleep(block_time)
-        time_since_last = time.time()
 
         def _try_timeout():
             if time.time() - time_since_last > timeout:
@@ -352,15 +354,15 @@ class BlockContainer(BaseManager):
                 start = confirmable_block_number
 
             # Yield blocks
-            new_blocks_found = False
+            block = None
             for block in self.range(start, confirmable_block_number + 1):
+                yield block
+
+            if block:
                 last_yielded_hash = block.hash
                 last_yielded_number = block.number
                 time_since_last = time.time()
-                new_blocks_found = True
-                yield block
-
-            if not new_blocks_found:
+            else:
                 _try_timeout()
 
             time.sleep(block_time)

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -790,7 +790,8 @@ class ContractCache(BaseManager):
 
         return contract_type
 
-    def get_container(self, contract_type: ContractType) -> ContractContainer:
+    @classmethod
+    def get_container(cls, contract_type: ContractType) -> ContractContainer:
         """
         Get a contract container for the given contract type.
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -232,7 +232,7 @@ class BlockContainer(BaseManager):
     ) -> Iterator[BlockAPI]:
         """
         Poll new blocks. Optionally set a start block to include historical blocks.
-        **NOTE**: This is a daemon method; it does not terminate unless an exception occurrs
+        **NOTE**: This is a daemon method; it does not terminate unless an exception occurs
         or a ``stop`` is given.
 
         Usage example::

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -326,7 +326,13 @@ class BlockContainer(BaseManager):
 
             # Yield new blocks
             new_blocks_found = False
-            for block in self.range(confirmable_block_number, self.height):
+            start = (
+                last_yielded_number + 1
+                if last_yielded_number is not None
+                else self.height - required_confirmations
+            )
+            end = self.height - required_confirmations + 1
+            for block in self.range(start, end):
                 last_yielded_hash = block.hash
                 last_yielded_number = block.number
                 time_since_last = time.time()

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -343,6 +343,9 @@ class BlockContainer(BaseManager):
                 # First time iterating
                 start = confirmable_block_number
 
+            else:
+                start = confirmable_block_number
+
             # Yield blocks
             new_blocks_found = False
             for block in self.range(start, confirmable_block_number + 1):

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1293,7 +1293,7 @@ class ChainManager(BaseManager):
             timestamp (Optional[int]): Designate a time (in seconds) to begin mining.
                 Defaults to None.
             deltatime (Optional[int]): Designate a change in time (in seconds) to begin mining.
-                Defaults to None
+                Defaults to None.
         """
         if timestamp and deltatime:
             raise ValueError("Cannot give both `timestamp` and `deltatime` arguments together.")

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -675,15 +675,15 @@ class ContractCache(BaseManager):
             logger.warning("No addresses provided.")
             return {}
 
-        def get_contract_type(address: AddressType):
-            address = self.conversion_manager.convert(address, AddressType)
-            contract_type = self.get(address)
+        def get_contract_type(addr: AddressType):
+            addr = self.conversion_manager.convert(addr, AddressType)
+            ct = self.get(addr)
 
-            if not contract_type:
-                logger.warning(f"Failed to locate contract at '{address}'.")
-                return address, None
+            if not ct:
+                logger.warning(f"Failed to locate contract at '{addr}'.")
+                return addr, None
             else:
-                return address, contract_type
+                return addr, ct
 
         converted_addresses: List[AddressType] = []
         for address in converted_addresses:

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -182,4 +182,4 @@ class PytestApeRunner(ManagerAccessMixin):
         #  which may run pytest many times in-process.
         self.receipt_capture.clear()
         self.chain_manager.contracts.clear_local_caches()
-        self.chain_manager._reports.sessional_gas_report = None
+        self.chain_manager._reports.session_gas_report = None

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -309,8 +309,9 @@ def chain_that_mined_5(chain):
 
 class PollDaemonThread(threading.Thread):
     def __init__(self, name, poller, handler, stop_condition, *args, **kwargs):
-        kwargs["name"] = f"ape_poll_{name}"
-        super().__init__(*args, **kwargs)
+        kwargs_dict = dict(**kwargs)
+        kwargs_dict["name"] = f"ape_poll_{name}"
+        super().__init__(*args, **kwargs_dict)
         self._poller = poller
         self._handler = handler
         self._do_stop = stop_condition

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -531,17 +531,16 @@ def test_poll_blocks_reorg(chain_that_mined_5, eth_tester_provider, owner, PollD
 
     assert blocks.full()
 
-    block_numbers: List[int] = [blocks.get().number for _ in range(6)]
-
-    # Show that there are duplicate blocks
-    assert len(set(block_numbers)) < len(block_numbers)
-
     # Show that re-org was detected
     expected_error = (
         "Chain has reorganized since returning the last block. "
         "Try adjusting the required network confirmations."
     )
     assert expected_error in caplog.records[-1].message
+
+    # Show that there are duplicate blocks
+    block_numbers: List[int] = [blocks.get().number for _ in range(6)]
+    assert len(set(block_numbers)) < len(block_numbers)
 
 
 def test_poll_blocks_timeout(

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -527,7 +527,13 @@ def test_poll_blocks_reorg(chain_that_mined_5, eth_tester_provider, owner, PollD
 
         # Simulate re-org by reverting to the snapshot
         chain_that_mined_5.restore(snapshot)
-        chain_that_mined_5.mine(5)
+
+        # Allow it time to trigger realizing there was a re-org
+        time.sleep(1)
+        chain_that_mined_5.mine(2)
+        time.sleep(1)
+
+        chain_that_mined_5.mine(3)
 
     assert blocks.full()
 
@@ -536,6 +542,7 @@ def test_poll_blocks_reorg(chain_that_mined_5, eth_tester_provider, owner, PollD
         "Chain has reorganized since returning the last block. "
         "Try adjusting the required network confirmations."
     )
+    assert caplog.records, "Didn't detect re-org"
     assert expected_error in caplog.records[-1].message
 
     # Show that there are duplicate blocks

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -1,6 +1,7 @@
 import time
 from datetime import datetime, timedelta
 from queue import Queue
+from typing import List
 
 import pytest
 from ethpm_types import ContractType
@@ -508,6 +509,39 @@ def test_poll_blocks(chain_that_mined_5, eth_tester_provider, owner, PollDaemon)
     third = blocks.get().number
     assert first == second - 1
     assert second == third - 1
+
+
+def test_poll_blocks_reorg(chain_that_mined_5, eth_tester_provider, owner, PollDaemon, caplog):
+    blocks: Queue = Queue(maxsize=6)
+    poller = chain_that_mined_5.blocks.poll_blocks()
+
+    with PollDaemon("blocks", poller, blocks.put, blocks.full):
+        # Sleep first to ensure listening before mining.
+        time.sleep(1)
+
+        snapshot = chain_that_mined_5.snapshot()
+        chain_that_mined_5.mine(2)
+
+        # Wait to allow blocks before re-org to get yielded
+        time.sleep(5)
+
+        # Simulate re-org by reverting to the snapshot
+        chain_that_mined_5.restore(snapshot)
+        chain_that_mined_5.mine(5)
+
+    assert blocks.full()
+
+    block_numbers: List[int] = [blocks.get().number for _ in range(6)]
+
+    # Show that there are duplicate blocks
+    assert len(set(block_numbers)) < len(block_numbers)
+
+    # Show that re-org was detected
+    expected_error = (
+        "Chain has reorganized since returning the last block. "
+        "Try adjusting the required network confirmations."
+    )
+    assert expected_error in caplog.records[-1].message
 
 
 def test_poll_blocks_timeout(


### PR DESCRIPTION
### What I did

Fixes an issue where a re-org was never detected.
Additionally, when a chain reorganization occurs, `poll_blocks()` yields the missed blocks even if they were previously yielded with different block numbers.
There are also spelling fixes and other small fixes in the `chain.py` module.

### How I did it

Noticed reorg detection wasn't working.
Realized `chain.py` had several warnings (thanks Pycharm)
Fixed everything and added a test.

### How to verify it

Poll blocks on mainnet; you should get a sequential amount of blocks (nothing changed).
Poll blocks with unreasonable small required confs to test reorg works.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
