### PR TITLE
fix: issue where compiled dependencies before their time

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -343,7 +343,7 @@ class DependencyAPI(BaseInterfaceModel):
         with self.config_manager.using_project(project.path):
             # Load dependencies of dependencies before loading dependencies.
             self.project_manager._load_dependencies()
-            compiler_data = self.project_manager.compiler_data
+            compiler_data = self.project_manager._get_compiler_data(compile_if_needed=False)
 
         sources = self._get_sources(project)
 


### PR DESCRIPTION
### What I did

Fixes regression from #1183 where accidentally compiled dependencies before their time when extracting the compiler data needed to compile it later.

### How I did it

Made it so you don't have to compile dependencies to get compiler data.

### How to verify it

* Tests work again in `ape-solidity` (brownie-style dependencies work again)
* Can still compile the yearn repos related to what #1183 fixed

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
