### PR TITLE
fix: use cached path

### DIFF
--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -246,13 +246,11 @@ class ProjectManager(BaseManager):
                 self.path, self.contracts_folder
             )
 
-        project = self._cached_projects[self.path.name]
-        project.path = self.path
-        return project
+        return self._cached_projects[self.path.name]
 
     def extract_manifest(self) -> PackageManifest:
         """
-        Extracts a package manifest from the project
+        Extracts a package manifest from the project.
 
         Returns:
             ethpm_types.manifest.PackageManifest


### PR DESCRIPTION
### What I did

Another failed test in `ape-solidity` caught this issue where the path was being mistakenly reset, causing issues with calculated contracts folder

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
