### PR TITLE
refactor!: modify `AccountAPI.sign_transaction` to return `TransactionAPI`

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -172,7 +172,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         if not value and not kwargs.get("send_everything"):
             raise AccountsError("Must provide 'VALUE' or use 'send_everything=True'")
 
-        elif value and "send_everything" in kwargs and kwargs["send_everything"]:
+        elif value and kwargs.get("send_everything"):
             raise AccountsError("Cannot use 'send_everything=True' with 'VALUE'.")
 
         elif value:
@@ -231,7 +231,8 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         Args:
             data (Union[:class:`~ape.types.signatures.SignableMessage`, :class:`~ape.api.transactions.TransactionAPI`]):  # noqa: E501
               The message or transaction to verify.
-            signature (Optional[``_Signature``]): The :class:`~ape.types.signatures.MessageSignature`.
+            signature (Optional[:class:`~ape.types.signatures.MessageSignature`]):
+              The signature to check.
 
         Returns:
             bool: ``True`` if the data was signed by this account. ``False`` otherwise.

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -859,7 +859,7 @@ class Web3Provider(ProviderAPI, ABC):
         **kwargs,
     ) -> bytes:
         account = self.account_manager.test_accounts[0]
-        receipt = account.call(txn)
+        receipt = account.call(txn, **kwargs)
         call_tree = receipt.call_tree
         if not call_tree:
             return self._send_call(txn, **kwargs)

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -69,7 +69,7 @@ class ContractConstructor(ManagerAccessMixin):
 
         if "sender" in kwargs and isinstance(kwargs["sender"], AccountAPI):
             sender = kwargs["sender"]
-            return sender.call(txn)
+            return sender.call(txn, **kwargs)
 
         return self.provider.send_transaction(txn)
 
@@ -274,7 +274,7 @@ class ContractTransaction(ManagerAccessMixin):
         txn = self.serialize_transaction(*args, **kwargs)
 
         if "sender" in kwargs and isinstance(kwargs["sender"], AccountAPI):
-            return kwargs["sender"].call(txn)
+            return kwargs["sender"].call(txn, **kwargs)
 
         return self.provider.send_transaction(txn)
 
@@ -1069,7 +1069,7 @@ class ContractContainer(ContractTypeWrapper):
 
         if "sender" in kwargs and isinstance(kwargs["sender"], AccountAPI):
             # Handle account-related preparation if needed, such as signing
-            receipt = kwargs["sender"].call(txn)
+            receipt = kwargs["sender"].call(txn, **kwargs)
 
         else:
             txn = self.provider.prepare_transaction(txn)

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -118,7 +118,7 @@ class KeyfileAccount(AccountAPI):
             s=to_bytes(signed_msg.s),
         )
 
-    def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionAPI]:
+    def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:
         user_approves = self.__autosign or click.confirm(f"{txn}\n\nSign: ")
         if not user_approves:
             return None

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -118,19 +118,21 @@ class KeyfileAccount(AccountAPI):
             s=to_bytes(signed_msg.s),
         )
 
-    def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:
+    def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionAPI]:
         user_approves = self.__autosign or click.confirm(f"{txn}\n\nSign: ")
         if not user_approves:
             return None
 
-        signed_txn = EthAccount.sign_transaction(
+        signature = EthAccount.sign_transaction(
             txn.dict(exclude_none=True, by_alias=True), self.__key
         )
-        return TransactionSignature(
-            v=signed_txn.v,
-            r=to_bytes(signed_txn.r),
-            s=to_bytes(signed_txn.s),
+        txn.signature = TransactionSignature(
+            v=signature.v,
+            r=to_bytes(signature.r),
+            s=to_bytes(signature.s),
         )
+
+        return txn
 
     def set_autosign(self, enabled: bool, passphrase: Optional[str] = None):
         """

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -59,10 +59,13 @@ class TestAccount(TestAccountAPI):
             s=to_bytes(signed_msg.s),
         )
 
-    def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:
-        signed_txn = EthAccount.sign_transaction(txn.dict(), self.private_key)
-        return TransactionSignature(
-            v=signed_txn.v,
-            r=to_bytes(signed_txn.r),
-            s=to_bytes(signed_txn.s),
+    def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionAPI]:
+        # Signs anything that's given to it
+        signature = EthAccount.sign_transaction(txn.dict(), self.private_key)
+        txn.signature = TransactionSignature(
+            v=signature.v,
+            r=to_bytes(signature.r),
+            s=to_bytes(signature.s),
         )
+
+        return txn

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -59,7 +59,7 @@ class TestAccount(TestAccountAPI):
             s=to_bytes(signed_msg.s),
         )
 
-    def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionAPI]:
+    def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:
         # Signs anything that's given to it
         signature = EthAccount.sign_transaction(txn.dict(), self.private_key)
         txn.signature = TransactionSignature(

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -25,7 +25,8 @@ def test_create_dynamic_fee_transaction(ethereum, type_kwarg):
 def test_txn_hash(owner, eth_tester_provider):
     txn = StaticFeeTransaction()
     txn = owner.prepare_transaction(txn)
-    txn.signature = owner.sign_transaction(txn)
+    txn = owner.sign_transaction(txn)
+    assert txn
 
     actual = txn.txn_hash.hex()
     receipt = eth_tester_provider.send_transaction(txn)


### PR DESCRIPTION
BREAKING CHANGE: This is done to ensure account plugins have the ability to modify the transaction they are signing, i.e. for Gnosis Safe plugin.

### What I did

fixes: APE-388

### How I did it

When working on `ape-safe`, it became apparent that there needs to be a way for an account plugin that wraps some more complex processes with other accounts to be able to mutate the transaction to a different type.

This is also handy if the account plugin wants to make adjustments to things like gas, etc. of the transaction it is giving over to the signing process.

### How to verify it

All tests pass, check with other account plugins (Trezor, Ledger)

### Checklist

- [x] All changes are completed
- [x] All 2nd party plugins updated
~~- [ ] New test cases have been added~~
- [x] Documentation has been updated
