### PR TITLE
fix: except `AttributeError` when checking for account

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -398,7 +398,7 @@ class AccountContainerAPI(BaseInterfaceModel):
             self.__getitem__(address)
             return True
 
-        except IndexError:
+        except (IndexError, AttributeError):
             return False
 
     def _verify_account_type(self, account):


### PR DESCRIPTION
### What I did

Noticed a weird bug where if you have accounts and ecosystems in the same plugin and the plugin fails verification, you get an account `AttributeError` about the ecosystem. A simple fix to except `AttributeError`. This helps the core tests pass before Starknet is updated in the case where the Starknet plugin is installed locally.

fixes: #

### How I did it

Except `AttributeError` in account checker.

### How to verify it

`tests/functional/test_accounts.py::test_accounts_contains` PASSs when the Starknet plugin fails plugin verification and is installed locally.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
