### PR TITLE
feat!: Make OutOfGasError a VirtualMachineError

### DIFF
--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -134,7 +134,7 @@ class ContractLogicError(VirtualMachineError):
         return cls(str(err))
 
 
-class OutOfGasError(TransactionError):
+class OutOfGasError(VirtualMachineError):
     """
     Raised when detecting a transaction failed because it ran
     out of gas.


### PR DESCRIPTION
### What I did

fixes: [Ape-369](https://linear.app/apeworx/issue/APE-369/make-outofgaserror-a-virtualmachineerror) 
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: APE-369
change the base class of outofgas to virtualmachineError

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
