### PR TITLE
fix: issue from type-ignoring `TransactionSignature`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: v0.991
     hooks:
     -   id: mypy
-        additional_dependencies: [types-PyYAML, types-requests, types-pkg-resources, types-setuptools]
+        additional_dependencies: [types-PyYAML, types-requests, types-pkg-resources, types-setuptools, pydantic]
 
 -   repo: https://github.com/executablebooks/mdformat
     rev: 0.7.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
 [tool.mypy]
 exclude = ["build/", "dist/", "docs/", "tests/integration/cli/projects/"]
 check_untyped_defs = true
+plugins = ["pydantic.mypy"]
 
 [tool.setuptools_scm]
 write_to = "src/ape/version.py"

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -377,7 +377,7 @@ class ProviderAPI(BaseInterfaceModel):
         """
 
     @raises_not_implemented
-    def revert(self, snapshot_id: SnapshotID):  # type: ignore[empty-body]
+    def revert(self, snapshot_id: SnapshotID):
         """
         Defined to make the ``ProviderAPI`` interchangeable with a
         :class:`~ape.api.providers.TestProviderAPI`, as in
@@ -388,7 +388,7 @@ class ProviderAPI(BaseInterfaceModel):
         """
 
     @raises_not_implemented
-    def set_timestamp(self, new_timestamp: int):  # type: ignore[empty-body]
+    def set_timestamp(self, new_timestamp: int):
         """
         Defined to make the ``ProviderAPI`` interchangeable with a
         :class:`~ape.api.providers.TestProviderAPI`, as in
@@ -399,7 +399,7 @@ class ProviderAPI(BaseInterfaceModel):
         """
 
     @raises_not_implemented
-    def mine(self, num_blocks: int = 1):  # type: ignore[empty-body]
+    def mine(self, num_blocks: int = 1):
         """
         Defined to make the ``ProviderAPI`` interchangeable with a
         :class:`~ape.api.providers.TestProviderAPI`, as in
@@ -410,7 +410,7 @@ class ProviderAPI(BaseInterfaceModel):
         """
 
     @raises_not_implemented
-    def set_balance(self, address: AddressType, amount: int):  # type: ignore[empty-body]
+    def set_balance(self, address: AddressType, amount: int):
         """
         Change the balance of an account.
 
@@ -671,7 +671,7 @@ class Web3Provider(ProviderAPI, ABC):
         if not hasattr(block, "base_fee"):
             raise APINotImplementedError("No base fee found in block.")
         else:
-            base_fee = block.base_fee  # type: ignore
+            base_fee = getattr(block, "base_fee")
 
         if base_fee is None:
             # Non-EIP-1559 chains or we time-travelled pre-London fork.

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -41,7 +41,7 @@ class TransactionAPI(BaseInterfaceModel):
     # If left as None, will get set to the network's default required confirmations.
     required_confirmations: Optional[int] = Field(None, exclude=True)
 
-    signature: Optional[TransactionSignature] = Field(exclude=True)
+    signature: Optional[TransactionSignature] = Field(None, exclude=True)
 
     class Config:
         allow_population_by_field_name = True
@@ -350,9 +350,7 @@ class ReceiptAPI(BaseInterfaceModel):
         return output
 
     @raises_not_implemented
-    def show_trace(  # type: ignore[empty-body]
-        self, verbose: bool = False, file: IO[str] = sys.stdout
-    ):
+    def show_trace(self, verbose: bool = False, file: IO[str] = sys.stdout):
         """
         Display the complete sequence of contracts and methods called during
         the transaction.
@@ -363,7 +361,7 @@ class ReceiptAPI(BaseInterfaceModel):
         """
 
     @raises_not_implemented
-    def show_gas_report(self, file: IO[str] = sys.stdout):  # type: ignore[empty-body]
+    def show_gas_report(self, file: IO[str] = sys.stdout):
         """
         Display a gas report for the calls made in this transaction.
         """

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -145,7 +145,7 @@ class ProjectManager(BaseManager):
 
     def _get_compiler_data(self, compile_if_needed: bool = True):
         contract_types: Iterable[ContractType] = (
-            self.contracts.values()  # type: ignore[assignment]
+            self.contracts.values()
             if compile_if_needed
             else self._get_cached_contract_types().values()
         )

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -143,9 +143,7 @@ class LogFilter(BaseModel):
         from ape import convert
         from ape.utils.abi import LogInputABICollection, is_dynamic_sized_type
 
-        if hasattr(event, "abi"):
-            event = event.abi  # type: ignore
-
+        event = getattr(event, "abi", event)
         search_topics = search_topics or {}
         topic_filter: List[Optional[HexStr]] = [encode_hex(keccak(text=event.selector))]
         abi_inputs = LogInputABICollection(event)

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -1,15 +1,11 @@
-from typing import TYPE_CHECKING, Iterator, Union
+from dataclasses import dataclass
+from typing import Iterator, Union
 
 from eth_account import Account
 from eth_account.messages import SignableMessage
 from eth_utils import to_bytes
 
 from ape.types import AddressType
-
-if TYPE_CHECKING:
-    from dataclasses import dataclass
-else:
-    from pydantic.dataclasses import dataclass
 
 
 @dataclass(frozen=True)

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -1,11 +1,15 @@
-from typing import Iterator, Union
+from typing import TYPE_CHECKING, Iterator, Union
 
 from eth_account import Account
 from eth_account.messages import SignableMessage
 from eth_utils import to_bytes
-from pydantic.dataclasses import dataclass
 
 from ape.types import AddressType
+
+if TYPE_CHECKING:
+    from dataclasses import dataclass
+else:
+    from pydantic.dataclasses import dataclass
 
 
 @dataclass(frozen=True)

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -1,9 +1,9 @@
-from dataclasses import dataclass
 from typing import Iterator, Union
 
 from eth_account import Account
 from eth_account.messages import SignableMessage
 from eth_utils import to_bytes
+from pydantic.dataclasses import dataclass
 
 from ape.types import AddressType
 

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -112,7 +112,7 @@ class KeyfileAccount(AccountAPI):
             return None
 
         signed_msg = EthAccount.sign_message(msg, self.__key)
-        return MessageSignature(  # type: ignore
+        return MessageSignature(
             v=signed_msg.v,
             r=to_bytes(signed_msg.r),
             s=to_bytes(signed_msg.s),
@@ -126,7 +126,7 @@ class KeyfileAccount(AccountAPI):
         signed_txn = EthAccount.sign_transaction(
             txn.dict(exclude_none=True, by_alias=True), self.__key
         )
-        return TransactionSignature(  # type: ignore
+        return TransactionSignature(
             v=signed_txn.v,
             r=to_bytes(signed_txn.r),
             s=to_bytes(signed_txn.s),

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -466,7 +466,7 @@ class Ethereum(EcosystemAPI):
             kwargs["data"] = kwargs.pop("input")
 
         if all(field in kwargs for field in ("v", "r", "s")):
-            kwargs["signature"] = TransactionSignature(  # type: ignore
+            kwargs["signature"] = TransactionSignature(
                 v=kwargs["v"],
                 r=bytes(kwargs["r"]),
                 s=bytes(kwargs["s"]),

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -382,7 +382,7 @@ class GethDev(BaseGethProvider, TestProviderAPI):
         return self.get_block("latest").number or 0
 
     @raises_not_implemented
-    def revert(self, snapshot_id: SnapshotID):  # type: ignore[empty-body]
+    def revert(self, snapshot_id: SnapshotID):
         # TODO: Replace with impl below after
         #  https://github.com/ethereum/go-ethereum/issues/26154 resolved
         pass
@@ -409,11 +409,11 @@ class GethDev(BaseGethProvider, TestProviderAPI):
         self._make_request("debug_setHead", [block_number_hex_str])
 
     @raises_not_implemented
-    def set_timestamp(self, new_timestamp: int):  # type: ignore[empty-body]
+    def set_timestamp(self, new_timestamp: int):
         pass
 
     @raises_not_implemented
-    def mine(self, num_blocks: int = 1):  # type: ignore[empty-body]
+    def mine(self, num_blocks: int = 1):
         pass
 
     def send_call(self, txn: TransactionAPI, **kwargs: Any) -> bytes:

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -53,7 +53,7 @@ class TestAccount(TestAccountAPI):
 
     def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
         signed_msg = EthAccount.sign_message(msg, self.private_key)
-        return MessageSignature(  # type: ignore
+        return MessageSignature(
             v=signed_msg.v,
             r=to_bytes(signed_msg.r),
             s=to_bytes(signed_msg.s),
@@ -61,7 +61,7 @@ class TestAccount(TestAccountAPI):
 
     def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:
         signed_txn = EthAccount.sign_transaction(txn.dict(), self.private_key)
-        return TransactionSignature(  # type: ignore
+        return TransactionSignature(
             v=signed_txn.v,
             r=to_bytes(signed_txn.r),
             s=to_bytes(signed_txn.s),

--- a/tests/functional/utils/test_misc.py
+++ b/tests/functional/utils/test_misc.py
@@ -28,7 +28,7 @@ def test_add_spacing_to_strings():
 
 
 def test_raises_not_implemented():
-    @raises_not_implemented  # type: ignore[empty-body]
+    @raises_not_implemented
     def unimplemented_api_method():
         pass
 


### PR DESCRIPTION
### What I did

Figured out how to remove a gazillion type ignores!
This fixes an issue where typing concerns of Signature objects were ignored.

### How I did it

Followed advice from https://github.com/python/mypy/issues/6239

by utilizing the Pydantic plugin that ships with Pydantic.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
