### PR TITLE
fix: add missing 0x prefix to Signature representation

### DIFF
--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -21,12 +21,7 @@ class _Signature:
         yield self.s
 
     def __repr__(self) -> str:
-        return (
-            f"<{self.__class__.__name__} "
-            f"v={self.v} "
-            f"r={to_hex(self.r)} "
-            f"s={to_hex(self.s)}>"
-        )
+        return f"<{self.__class__.__name__} v={self.v} r={to_hex(self.r)} s={to_hex(self.s)}>"
 
     def encode_vrs(self) -> bytes:
         return to_bytes(self.v) + self.r + self.s

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -2,7 +2,7 @@ from typing import Iterator, Union
 
 from eth_account import Account
 from eth_account.messages import SignableMessage
-from eth_utils import add_0x_prefix, to_bytes
+from eth_utils import to_bytes, to_hex
 from pydantic.dataclasses import dataclass
 
 from ape.types import AddressType
@@ -24,8 +24,8 @@ class _Signature:
         return (
             f"<{self.__class__.__name__} "
             f"v={self.v} "
-            f"r={add_0x_prefix(self.r.hex())} "
-            f"s={add_0x_prefix(self.s.hex())}>"
+            f"r={to_hex(self.r)} "
+            f"s={to_hex(self.s)}>"
         )
 
     def encode_vrs(self) -> bytes:

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -2,7 +2,7 @@ from typing import Iterator, Union
 
 from eth_account import Account
 from eth_account.messages import SignableMessage
-from eth_utils import to_bytes
+from eth_utils import add_0x_prefix, to_bytes
 from pydantic.dataclasses import dataclass
 
 from ape.types import AddressType
@@ -21,7 +21,12 @@ class _Signature:
         yield self.s
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__} v={self.v} r={self.r.hex()} s={self.s.hex()}>"
+        return (
+            f"<{self.__class__.__name__} "
+            f"v={self.v} "
+            f"r={add_0x_prefix(self.r.hex())} "
+            f"s={add_0x_prefix(self.s.hex())}>"
+        )
 
     def encode_vrs(self) -> bytes:
         return to_bytes(self.v) + self.r + self.s

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -2,7 +2,7 @@ import pytest
 from eth_utils import to_hex
 from ethpm_types.abi import EventABI
 
-from ape.types import ContractLog, LogFilter
+from ape.types import ContractLog, LogFilter, TransactionSignature
 from ape.utils import ZERO_ADDRESS
 
 TXN_HASH = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa222222222222222222222222"
@@ -103,3 +103,8 @@ def test_topic_filter_encoding():
         None,
         "0x0000000000000000000000008c44cc5c0f5cd2f7f17b9aca85d456df25a61ae8",
     ]
+
+
+def test_signature_repr():
+    signature = TransactionSignature(v=0, r=b"123", s=b"456")
+    assert repr(signature) == "<TransactionSignature v=0 r=0x313233 s=0x343536>"


### PR DESCRIPTION
### What I did

Adds missing 0x prefix to `TransactionSignature` repr.
Am debugging something and this was a red herring.

### How I did it

Use `to_hex` from `eth_utils` to handle multiple byte suptypes.

### How to verify it

Set a breakpoint and analyze the signature on a signed txn.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
