### PR TITLE
docs: add anonymized analytics

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
     "sphinx_rtd_theme",
+    "sphinx_plausible",
 ]
 autosummary_generate = True
 
@@ -48,6 +49,8 @@ source_suffix = [".rst", ".md"]
 # The master toctree document.
 master_doc = "index"
 
+# Configure Pluasible
+plausible_domain = "docs.apeworx.io"
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Project information -----------------------------------------------------
 
 project = "ape"
-copyright = "2021, ApeWorX LTD"
+copyright = "2023, ApeWorX LTD"
 author = "ApeWorX Team"
 extensions = [
     "myst_parser",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,7 @@ def get_versions() -> List[str]:
     versions = [
         d.name
         for d in build_dir.iterdir()
-        if d.is_dir and pattern.match(d.stem) and "beta" not in d.name and "alpha" not in d.name
+        if d.is_dir() and pattern.match(d.stem) and "beta" not in d.name and "alpha" not in d.name
     ]
 
     return versions

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ extras_require = {
         "Sphinx>=6.1.3,<7.0",  # Documentation generator
         "sphinx_rtd_theme>=1.2.0rc3,<2",  # Readthedocs.org theme
         "sphinxcontrib-napoleon>=0.7",  # Allow Google-style documentation
+        "sphinx-plausible>=0.1.2,<0.2.0",
     ],
     "release": [  # `release` GitHub Action job uses this
         "setuptools",  # Installation tool


### PR DESCRIPTION
### What I did

It would be really helpful for us to monitor growth by seeing our analytics from the docs page

fixes: APE-453

### How I did it

I chose Plausible because they are privacy-preserving and open source

### How to verify it

Once docs are released (on main) should be able to see the page
