### PR TITLE
feat: update proxy info errors

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -13,7 +13,7 @@ from pydantic import Field, validator
 from ape.api import BlockAPI, EcosystemAPI, PluginConfig, ReceiptAPI, TransactionAPI
 from ape.api.networks import LOCAL_NETWORK_NAME, ProxyInfoAPI
 from ape.contracts.base import ContractCall
-from ape.exceptions import APINotImplementedError, DecodingError, TransactionError
+from ape.exceptions import ApeException, APINotImplementedError, DecodingError
 from ape.logging import logger
 from ape.types import AddressType, ContractLog, GasLimit, RawAddress, TransactionSignature
 from ape.utils import (
@@ -231,7 +231,7 @@ class Ethereum(EcosystemAPI):
             if name in ("Gnosis Safe", "Default Callback Handler") and target != ZERO_ADDRESS:
                 return ProxyInfo(type=ProxyType.GnosisSafe, target=target)
 
-        except (DecodingError, TransactionError):
+        except (ApeException):
             pass
 
         # delegate proxy, read `proxyType()` and `implementation()`
@@ -257,7 +257,7 @@ class Ethereum(EcosystemAPI):
             if target != ZERO_ADDRESS:
                 return ProxyInfo(type=ProxyType.Delegate, target=target)
 
-        except (DecodingError, TransactionError, ValueError):
+        except (ApeException, ValueError):
             pass
 
         return None


### PR DESCRIPTION
### What I did

While working on trace back exception handling, found that chain errors weren't being caught during the proxy info method. These chain errors were interrupting the flow of caching contracts that weren't proxy or didn't have proxy info.

fixes: APE-460

### How I did it

Generalized the exceptions caught so that it would also include ChainErrors.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
