### PR TITLE
feat!: update `TransactionError` arg order

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -109,19 +109,15 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         gas_limit = txn.gas_limit
 
         if not isinstance(gas_limit, int):
-            raise TransactionError(message="Transaction not prepared.")
+            raise TransactionError("Transaction not prepared.")
 
         # The conditions below should never reached but are here for mypy's sake.
         # The `max_fee` was either set manaully or from `prepare_transaction()`.
         # The `gas_limit` was either set manually or from `prepare_transaction()`.
         if max_fee is None:
-            raise TransactionError(
-                message="`max_fee` failed to get set in transaction preparation."
-            )
+            raise TransactionError("`max_fee` failed to get set in transaction preparation.")
         elif gas_limit is None:
-            raise TransactionError(
-                message="`gas_limit` failed to get set in transaction preparation."
-            )
+            raise TransactionError("`gas_limit` failed to get set in transaction preparation.")
 
         total_fees = max_fee * gas_limit
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -710,7 +710,7 @@ class Web3Provider(ProviderAPI, ABC):
                 raise tx_error from err
 
             message = gas_estimation_error_message(tx_error)
-            raise TransactionError(base_err=tx_error, message=message) from err
+            raise TransactionError(message, base_err=tx_error) from err
 
     @property
     def chain_id(self) -> int:
@@ -931,7 +931,7 @@ class Web3Provider(ProviderAPI, ABC):
         """
 
         if required_confirmations < 0:
-            raise TransactionError(message="Required confirmations cannot be negative.")
+            raise TransactionError("Required confirmations cannot be negative.")
 
         timeout = (
             timeout if timeout is not None else self.provider.network.transaction_acceptance_timeout
@@ -1040,7 +1040,7 @@ class Web3Provider(ProviderAPI, ABC):
         if txn.required_confirmations is None:
             txn.required_confirmations = self.network.required_confirmations
         elif not isinstance(txn.required_confirmations, int) or txn.required_confirmations < 0:
-            raise TransactionError(message="'required_confirmations' must be a positive integer.")
+            raise TransactionError("'required_confirmations' must be a positive integer.")
 
         return txn
 

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -61,7 +61,7 @@ class TransactionAPI(BaseInterfaceModel):
         to submit the transaction.
         """
         if self.max_fee is None:
-            raise TransactionError(message="Max fee must not be null.")
+            raise TransactionError("Max fee must not be null.")
 
         return self.value + self.max_fee
 
@@ -278,9 +278,7 @@ class ReceiptAPI(BaseInterfaceModel):
                 sender_nonce = self.provider.get_nonce(self.sender)
                 iteration += 1
                 if iteration == iterations_timeout:
-                    raise TransactionError(
-                        message="Timeout waiting for sender's nonce to increase."
-                    )
+                    raise TransactionError("Timeout waiting for sender's nonce to increase.")
 
         if self.required_confirmations == 0:
             # The transaction might not yet be confirmed but

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -86,16 +86,16 @@ class TransactionError(ContractError):
 
     def __init__(
         self,
-        base_err: Optional[Exception] = None,
         message: Optional[str] = None,
+        base_err: Optional[Exception] = None,
         code: Optional[int] = None,
         txn: Optional["TransactionAPI"] = None,
     ):
-        self.base_err = base_err
         if not message:
             message = str(base_err) if base_err else self.DEFAULT_MESSAGE
-
         self.message = message
+
+        self.base_err = base_err
         self.code = code
         self.txn = txn
 

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -163,7 +163,7 @@ class Receipt(ReceiptAPI):
             raise OutOfGasError()
         elif self.status != TransactionStatusEnum.NO_ERROR:
             txn_hash = HexBytes(self.txn_hash).hex()
-            raise TransactionError(message=f"Transaction '{txn_hash}' failed.")
+            raise TransactionError(f"Transaction '{txn_hash}' failed.")
 
     def show_trace(self, verbose: bool = False, file: IO[str] = sys.stdout):
         call_tree = self.call_tree

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -92,7 +92,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
                 raise ape_err from err
             else:
                 message = gas_estimation_error_message(ape_err)
-                raise TransactionError(base_err=ape_err, message=message) from ape_err
+                raise TransactionError(message, base_err=ape_err) from ape_err
 
     @property
     def chain_id(self) -> int:


### PR DESCRIPTION
### What I did

Align `TransactionError` with other Exceptions to take message as the first position argument. This will allow for passing message w/o the keyword. This PR is a first pass before further updating `TransactionError` with logic for trace backs.

### How I did it

Reorganized exception arg ordering and removed message keyword from calls.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
