### PR TITLE
feat: use bytecode if available when using JSON compiler

### DIFF
--- a/docs/userguides/compile.md
+++ b/docs/userguides/compile.md
@@ -36,6 +36,9 @@ contract.my_method()
 2. **Pre-existing Contract Types**: If you have a contract type JSON that was compiled elsewhere, you can include it in your project.
    This is useful if you are unable or unwilling to install a compiler.
 
+3. **Pre-existing Contract Binary**: If you have an artifact with binary compiled elsewhere, you can include it in your project.
+  This is useful if you want to use contracts from much larger projects as dependency for your test cases.
+
 **WARN**: You may have to adjust the name and source ID of the contract type in the JSON to match the new file name in your project.
 
 ## Other Compiler Plugins

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -39,6 +39,10 @@ class InterfaceCompiler(CompilerAPI):
             ):
                 # Raw contract type JSON
                 contract_type_data = data
+                if "deployedBytecode" in data:
+                    contract_type_data["runtimeBytecode"] = {"bytecode": data["deployedBytecode"]}
+                if "bytecode" in data:
+                    contract_type_data["deploymentBytecode"] = {"bytecode": data["bytecode"]}
 
             else:
                 logger.warning(f"Unable to parse {ContractType.__name__} from '{source_id}'.")


### PR DESCRIPTION
### What I did

Include bytecode if present when using JSON compiler.

fixes: #1227

fixes: APE-462

### How I did it

I wanted to use contracts coming from much larger repo with their own toolchain. I figured the easiest way would be to compile it as an artifact and use the resulting JSON as test dependency within ape. I looked at how ape_vyper provides the bytecode and replicated that in JSON compiler.

### How to verify it

Use [any JSON artifact](https://gist.github.com/sajal/8c793c5066c3684a6178906aa248f347), put it in your contracts directory and use in test cases/console.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] New test cases have been added
- [x] Documentation has been updated
