### PR TITLE
feat: add default sender manager

### DIFF
--- a/docs/userguides/accounts.md
+++ b/docs/userguides/accounts.md
@@ -57,6 +57,21 @@ If your testing provider supports this feature, it is possible to directly set t
 account.balance += int(1e18)  # Gives `account` 1 Ether
 ```
 
+### Default Sender Support
+
+In order to eliminate the usage of sender in contract calls, you can use `use_sender` context manager.
+
+```python
+with accounts.use_sender(0): # Use first account from test mnemonic
+  contract.myFunction(1)
+
+with accounts.use_sender("<address>"): # Impersonate an account
+  contract.myFunction(1)
+
+with accounts.use_sender(a): # a is a `TestAccountAPI` object
+  contract.myFunction(1)
+```
+
 ## Live Network Accounts
 
 When using live networks, you need to get your accounts into Ape.
@@ -157,6 +172,24 @@ Then, in your scripts, you can [load](../methoddocs/managers.html#ape.managers.a
 from ape import accounts
 
 account = accounts.load("<ALIAS>")
+```
+
+### Default Sender Support
+
+In order to reduce repetition of adding `sender` in your contract calls, you can use `use_sender` context manager.
+
+```python
+with accounts.use_sender(0):
+  contract.myFunction(1)
+
+with accounts.use_sender("<address>"):
+  contract.myFunction(1)
+
+with accounts.use_sender("<alias>"):
+  contract.myFunction(1)
+
+with accounts.use_sender(a): # a is a `AccountAPI` object
+  contract.myFunction(1)
 ```
 
 ## Automation

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -70,6 +70,8 @@ class ContractConstructor(ManagerAccessMixin):
         if "sender" in kwargs and isinstance(kwargs["sender"], AccountAPI):
             sender = kwargs["sender"]
             return sender.call(txn, **kwargs)
+        elif "sender" not in kwargs and self.account_manager.default_sender is not None:
+            return self.account_manager.default_sender.call(txn, **kwargs)
 
         return self.provider.send_transaction(txn)
 
@@ -333,6 +335,8 @@ class ContractTransactionHandler(ContractMethodHandler):
     def __call__(self, *args, **kwargs) -> ReceiptAPI:
         function_arguments = self._convert_tuple(args)
         contract_transaction = self._as_transaction(*function_arguments)
+        if "sender" not in kwargs and self.account_manager.default_sender is not None:
+            kwargs["sender"] = self.account_manager.default_sender
         return contract_transaction(*function_arguments, **kwargs)
 
     def _as_transaction(self, *args) -> ContractTransaction:

--- a/tests/functional/test_default_sender_context_manager.py
+++ b/tests/functional/test_default_sender_context_manager.py
@@ -1,0 +1,65 @@
+import pytest
+
+from ape.exceptions import SignatureError
+from ape.pytest.contextmanagers import RevertsContextManager as reverts
+
+
+def test_default_sender_test_account(solidity_contract_instance, owner, test_accounts):
+    with test_accounts.use_sender(owner):
+        tx = solidity_contract_instance.setNumber(1)
+        assert tx.transaction.sender == owner.address
+    with pytest.raises(SignatureError):
+        solidity_contract_instance.setNumber(2)
+
+    with test_accounts.use_sender(owner.address):
+        tx = solidity_contract_instance.setNumber(1)
+        assert tx.transaction.sender == owner.address
+
+    with test_accounts.use_sender(owner.index):
+        tx = solidity_contract_instance.setNumber(1)
+        assert tx.transaction.sender == owner.address
+
+
+def test_default_sender_account(
+    solidity_contract_container, networks_connected_to_tester, accounts, keyfile_account
+):
+    owner = accounts[0]
+    passphrase = "a"
+
+    with accounts.use_sender(owner) as acct:
+        acct.set_autosign(True, passphrase)
+        contract = owner.deploy(solidity_contract_container, 0)
+
+    with accounts.use_sender(owner) as acct:
+        acct.set_autosign(True, passphrase)
+        tx = contract.setNumber(1)
+        assert tx.transaction.sender == owner.address
+
+    with pytest.raises(SignatureError):
+        contract.setNumber(2)
+
+    with accounts.use_sender(owner.address) as acct:
+        acct.set_autosign(True, passphrase)
+        tx = contract.setNumber(1)
+        assert tx.transaction.sender == owner.address
+
+    with accounts.use_sender(owner.alias) as acct:
+        acct.set_autosign(True, passphrase)
+        tx = contract.setNumber(1)
+        assert tx.transaction.sender == owner.address
+
+    with accounts.use_sender(0) as acct:
+        acct.set_autosign(True, passphrase)
+        tx = contract.setNumber(1)
+        assert tx.transaction.sender == owner.address
+
+
+def test_nested_default_sender(solidity_contract_instance, owner, test_accounts):
+    with test_accounts.use_sender(owner):
+        tx = solidity_contract_instance.setNumber(1)
+        assert tx.transaction.sender == owner.address
+        with test_accounts.use_sender(test_accounts[0]):
+            with reverts():
+                solidity_contract_instance.setNumber(2)
+        solidity_contract_instance.setNumber(3)
+        assert tx.transaction.sender == owner.address


### PR DESCRIPTION
### What I did

Added the support for default_sender in contract transactions

fixes: #

### How I did it

Implemented a new context manager to use in tests.

### How to verify it

Run the tests.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
