### PR TITLE
docs: fix `gas_limit` example in config guide

### DIFF
--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -137,7 +137,8 @@ Set the gas limit for a given network:
 ```yaml
 ethereum:
   default_network: mainnet-fork
-  gas_limit: max
+  mainnet_fork:
+    gas_limit: max
 ```
 
 You may use one of:


### PR DESCRIPTION
Update docs. Current setup throws:

```sh
pydantic.error_wrappers.ValidationError: 1 validation error for EthereumConfig
gas_limit
  extra fields not permitted (type=value_error.extra)
```