### PR TITLE
refactor: return default config when network not found

### DIFF
--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -205,6 +205,9 @@ class BaseGethProvider(Web3Provider, ABC):
 
         # Use value from config file
         network_config = config.get(self.network.name)
+        if not network_config:
+            return DEFAULT_SETTINGS["uri"]
+            
         return network_config.get("uri", DEFAULT_SETTINGS["uri"])
 
     @property


### PR DESCRIPTION
### What I did

Not sure if this is the right solution, but it matches what happens in the other case when the ecosystem is not found

Currently gives a rather nasty looking AttributeError that doesn't tell you anything useful

fixes: #

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
