### PR TITLE
feat: create abi files per contract

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -91,7 +91,23 @@ class ProjectAPI(BaseInterfaceModel):
         if it exists and is valid.
         """
 
-        return _load_manifest_from_file(self.manifest_cachefile)
+        manifest = _load_manifest_from_file(self.manifest_cachefile)
+        if manifest is not None:
+            manifest.contract_types = self.contracts
+        return manifest
+
+    @property
+    def contracts(self) -> Dict[str, ContractType]:
+        contracts = {}
+        for p in self._cache_folder.glob("*.json"):
+            if p == self.manifest_cachefile:
+                continue
+            contract_name = p.name.replace(".json", "")
+            contract_type = ContractType().parse_file(p)
+            if contract_type.name is None:
+                contract_type.name = contract_name
+            contracts[contract_type.name] = contract_type
+        return contracts
 
     @property
     def _cache_folder(self) -> Path:

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -196,6 +196,11 @@ class BaseProject(ProjectAPI):
             )
             # Cache the updated manifest so `self.cached_manifest` reads it next time
             self.manifest_cachefile.write_text(manifest.json())
+            if compiled_contract_types:
+                for name, contract_type in compiled_contract_types.items():
+                    (self.project_manager.local_project._cache_folder / f"{name}.json").write_text(
+                        contract_type.json()
+                    )
             return manifest
 
     def _compile(self, project_sources: _ProjectSources) -> Dict[str, ContractType]:


### PR DESCRIPTION
### What I did

Creating multiple abi files for compile

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: APE-479

### How I did it

Changed ape.managers.project.types.create_manifest to have seperate files.

### How to verify it

Just run compile command and /abis folder should have compiled contracts as seperate.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
