### PR TITLE
refactor!: use lists for logs on receipt instead of iterator

### DIFF
--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -108,21 +108,27 @@ When declaring `type="0x0"` and _not_ specifying a `gas_price`, the `gas_price` 
 
 ## Transaction Logs
 
-To get logs that occurred during a transaction, you can use the [ContractEvent.from_receipt(receipt)](../methoddocs/contracts.html?highlight=contractevent#ape.contracts.base.ContractEvent.from_receipt) and access your data from the [ContractLog](../methoddocs/types.html#ape.types.ContractLog) objects that it returns.
-
-The following is an example demonstrating how to access logs from an instance of a contract:
+In Ape, you can easily get all the events on a receipt.
+Use the `.events` property to access the ([ContractLog](../methoddocs/types.html#ape.types.ContractLog)) objects.
+Each object represents an event emitted from the call.
 
 ```python
 receipt = contract.fundMyContract(value="1 gwei", type="0x0", sender=sender)
-for log in contract.MyFundEvent.from_receipt(receipt):
+print(receipt.events)
+```
+
+To only get specific log types, use the `decode_logs()` method and pass the event ABIs as arguments:
+
+```python
+for log in receipt.decode_logs(contract.FooEvent.abi, contract.BarEvent.abi):
     print(log.amount)  # Assuming 'amount' is a property on the event.
 ```
 
-You can also access the logs from the receipt itself if you know the ABI:
+You can also use the [ContractEvent.from_receipt(receipt)](../methoddocs/contracts.html?highlight=contractevent#ape.contracts.base.ContractEvent.from_receipt) method:
 
 ```python
-event_type = contract.MyEvent
-for log in receipt.decode_logs(event_type.abi):
+receipt = contract.fooMethod(value="1 gwei", type="0x0", sender=sender)
+for log in contract.FooEvent.from_receipt(receipt):
     print(log.amount)  # Assuming 'amount' is a property on the event.
 ```
 

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -236,7 +236,7 @@ class ReceiptAPI(BaseInterfaceModel):
         abi: Optional[
             Union[List[Union[EventABI, "ContractEvent"]], Union[EventABI, "ContractEvent"]]
         ] = None,
-    ) -> Iterator[ContractLog]:
+    ) -> List[ContractLog]:
         """
         Decode the logs on the receipt.
 
@@ -244,7 +244,7 @@ class ReceiptAPI(BaseInterfaceModel):
             abi (``EventABI``): The ABI of the event to decode into logs.
 
         Returns:
-            Iterator[:class:`~ape.types.ContractLog`]
+            List[:class:`~ape.types.ContractLog`]
         """
 
     def raise_for_status(self):

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -13,7 +13,7 @@ from ape.api.explorers import ExplorerAPI
 from ape.exceptions import TransactionError
 from ape.logging import logger
 from ape.types import AddressType, ContractLog, GasLimit, TransactionSignature
-from ape.utils import BaseInterfaceModel, abstractmethod, raises_not_implemented
+from ape.utils import BaseInterfaceModel, abstractmethod, cached_property, raises_not_implemented
 
 if TYPE_CHECKING:
     from ape.contracts import ContractEvent
@@ -229,6 +229,14 @@ class ReceiptAPI(BaseInterfaceModel):
             return 0
 
         return latest_block.number - self.block_number
+
+    @cached_property
+    def events(self) -> List[ContractLog]:
+        """
+        All the events that were emitted from this call.
+        """
+
+        return self.decode_logs()  # Decodes all logs by default.
 
     @abstractmethod
     def decode_logs(

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -551,7 +551,7 @@ class ContractEvent(ManagerAccessMixin):
         )
         yield from self.query_manager.query(contract_event_query)  # type: ignore
 
-    def from_receipt(self, receipt: ReceiptAPI) -> Iterator[ContractLog]:
+    def from_receipt(self, receipt: ReceiptAPI) -> List[ContractLog]:
         """
         Get all the events from the given receipt.
 
@@ -559,10 +559,12 @@ class ContractEvent(ManagerAccessMixin):
             receipt (:class:`~ape.api.transactions.ReceiptAPI`): The receipt containing the logs.
 
         Returns:
-            Iterator[:class:`~ape.contracts.base.ContractLog`]
+            List[:class:`~ape.contracts.base.ContractLog`]
         """
         ecosystem = self.provider.network.ecosystem
-        yield from ecosystem.decode_logs(receipt.logs, self.abi)
+
+        # NOTE: Safe to use a list because a receipt should never have too many logs.
+        return list(ecosystem.decode_logs(receipt.logs, self.abi))
 
     def poll_logs(
         self,

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -1,6 +1,6 @@
 import sys
 from enum import Enum, IntEnum
-from typing import IO, Dict, Iterator, List, Optional, Union
+from typing import IO, Dict, List, Optional, Union
 
 from eth_abi import decode
 from eth_account import Account as EthAccount
@@ -158,6 +158,10 @@ class Receipt(ReceiptAPI):
 
         return self.provider.get_call_tree(self.txn_hash)
 
+    @cached_property
+    def events(self) -> List[ContractLog]:
+        return self.decode_logs()  # Decodes all logs by default.
+
     def raise_for_status(self):
         if self.gas_limit is not None and self.ran_out_of_gas:
             raise OutOfGasError()
@@ -207,13 +211,13 @@ class Receipt(ReceiptAPI):
         abi: Optional[
             Union[List[Union[EventABI, "ContractEvent"]], Union[EventABI, "ContractEvent"]]
         ] = None,
-    ) -> Iterator[ContractLog]:
+    ) -> List[ContractLog]:
         if abi is not None:
             if not isinstance(abi, (list, tuple)):
                 abi = [abi]
 
             event_abis: List[EventABI] = [a.abi if not isinstance(a, EventABI) else a for a in abi]
-            yield from self.provider.network.ecosystem.decode_logs(self.logs, *event_abis)
+            return list(self.provider.network.ecosystem.decode_logs(self.logs, *event_abis))
 
         else:
             # If ABI is not provided, decode all events
@@ -224,6 +228,8 @@ class Receipt(ReceiptAPI):
                 address: {encode_hex(keccak(text=abi.selector)): abi for abi in contract.events}
                 for address, contract in contract_types.items()
             }
+
+            decoded_logs: List[ContractLog] = []
             for log in self.logs:
                 contract_address = log["address"]
                 if contract_address not in selectors:
@@ -235,9 +241,13 @@ class Receipt(ReceiptAPI):
                     # Likely a library log
                     library_log = self._decode_ds_note(log)
                     if library_log:
-                        yield library_log
+                        decoded_logs.append(library_log)
                 else:
-                    yield from self.provider.network.ecosystem.decode_logs([log], event_abi)
+                    decoded_logs.extend(
+                        list(self.provider.network.ecosystem.decode_logs([log], event_abi))
+                    )
+
+            return decoded_logs
 
     def _decode_ds_note(self, log: Dict) -> Optional[ContractLog]:
         # The first topic encodes the function selector

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -158,10 +158,6 @@ class Receipt(ReceiptAPI):
 
         return self.provider.get_call_tree(self.txn_hash)
 
-    @cached_property
-    def events(self) -> List[ContractLog]:
-        return self.decode_logs()  # Decodes all logs by default.
-
     def raise_for_status(self):
         if self.gas_limit is not None and self.ran_out_of_gas:
             raise OutOfGasError()

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -37,12 +37,12 @@ def test_contract_logs_from_receipts(owner, contract_instance, assert_log_values
     receipt_2 = contract_instance.setNumber(3, sender=owner)
 
     def assert_receipt_logs(receipt: ReceiptAPI, num: int):
-        logs = [log for log in event_type.from_receipt(receipt)]
+        logs = event_type.from_receipt(receipt)
         assert len(logs) == 1
         assert_log_values(logs[0], num)
 
         # Also verify can we logs the other way
-        logs = [log for log in receipt.decode_logs(event_type)]
+        logs = receipt.decode_logs(event_type)
         assert len(logs) == 1
         assert_log_values(logs[0], num)
 

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -24,7 +24,7 @@ def test_show_gas_report(invoke_receipt):
 
 def test_decode_logs_specify_abi(invoke_receipt, vyper_contract_instance):
     abi = vyper_contract_instance.NumberChange.abi
-    logs = [log for log in invoke_receipt.decode_logs(abi=abi)]
+    logs = invoke_receipt.decode_logs(abi=abi)
     assert len(logs) == 1
     assert logs[0].newNum == 1
     assert logs[0].event_name == "NumberChange"
@@ -37,7 +37,7 @@ def test_decode_logs_specify_abi_as_event(
 ):
     spy = mocker.spy(eth_tester_provider.web3.eth, "get_logs")
     abi = vyper_contract_instance.NumberChange
-    logs = [log for log in invoke_receipt.decode_logs(abi=abi)]
+    logs = invoke_receipt.decode_logs(abi=abi)
     assert len(logs) == 1
     assert logs[0].newNum == 1
     assert logs[0].event_name == "NumberChange"
@@ -48,38 +48,34 @@ def test_decode_logs_specify_abi_as_event(
     assert spy.call_count == 0
 
 
-def test_decode_logs_with_ds_notes(ds_note_test_contract, owner):
+def test_events_with_ds_notes(ds_note_test_contract, owner):
     contract = ds_note_test_contract
     receipt = contract.test_0(sender=owner)
-    logs = [log for log in receipt.decode_logs()]
-    assert len(logs) == 1
-    assert logs[0].event_name == "foo"
-    assert logs[0].log_index == 0
-    assert logs[0].transaction_index == 0
+    assert len(receipt.events) == 1
+    assert receipt.events[0].event_name == "foo"
+    assert receipt.events[0].log_index == 0
+    assert receipt.events[0].transaction_index == 0
 
     receipt = contract.test_1(sender=owner)
-    logs = [log for log in receipt.decode_logs()]
-    assert len(logs) == 1
-    assert logs[0].event_name == "foo"
-    assert logs[0].event_arguments == {"a": 1}
-    assert logs[0].log_index == 0
-    assert logs[0].transaction_index == 0
+    assert len(receipt.events) == 1
+    assert receipt.events[0].event_name == "foo"
+    assert receipt.events[0].event_arguments == {"a": 1}
+    assert receipt.events[0].log_index == 0
+    assert receipt.events[0].transaction_index == 0
 
     receipt = contract.test_2(sender=owner)
-    logs = [log for log in receipt.decode_logs()]
-    assert len(logs) == 1
-    assert logs[0].event_name == "foo"
-    assert logs[0].event_arguments == {"a": 1, "b": 2}
-    assert logs[0].log_index == 0
-    assert logs[0].transaction_index == 0
+    assert len(receipt.events) == 1
+    assert receipt.events[0].event_name == "foo"
+    assert receipt.events[0].event_arguments == {"a": 1, "b": 2}
+    assert receipt.events[0].log_index == 0
+    assert receipt.events[0].transaction_index == 0
 
     receipt = contract.test_3(sender=owner)
-    logs = [log for log in receipt.decode_logs()]
-    assert len(logs) == 1
-    assert logs[0].event_name == "foo"
-    assert logs[0].event_arguments == {"a": 1, "b": 2, "c": 3}
-    assert logs[0].log_index == 0
-    assert logs[0].transaction_index == 0
+    assert len(receipt.events) == 1
+    assert receipt.events[0].event_name == "foo"
+    assert receipt.events[0].event_arguments == {"a": 1, "b": 2, "c": 3}
+    assert receipt.events[0].log_index == 0
+    assert receipt.events[0].transaction_index == 0
 
 
 def test_decode_logs(owner, contract_instance, assert_log_values):
@@ -91,7 +87,7 @@ def test_decode_logs(owner, contract_instance, assert_log_values):
     receipt_2 = contract_instance.setNumber(3, sender=owner)
 
     def assert_receipt_logs(receipt: ReceiptAPI, num: int):
-        logs = [log for log in receipt.decode_logs(event_type)]
+        logs = receipt.decode_logs(event_type)
         assert len(logs) == 1
         assert_log_values(logs[0], num)
 
@@ -100,11 +96,17 @@ def test_decode_logs(owner, contract_instance, assert_log_values):
     assert_receipt_logs(receipt_2, 3)
 
 
+def test_events(owner, contract_instance, assert_log_values):
+    receipt = contract_instance.setNumber(1, sender=owner)
+    assert len(receipt.events) == 1
+    assert_log_values(receipt.events[0], 1)
+
+
 def test_decode_logs_multiple_event_types(owner, contract_instance, assert_log_values):
     foo_happened = contract_instance.FooHappened
     bar_happened = contract_instance.BarHappened
     receipt = contract_instance.fooAndBar(sender=owner)
-    logs = [log for log in receipt.decode_logs([foo_happened, bar_happened])]
+    logs = receipt.decode_logs([foo_happened, bar_happened])
     assert len(logs) == 2
     assert logs[0].foo == 0
     assert logs[1].bar == 1
@@ -112,7 +114,7 @@ def test_decode_logs_multiple_event_types(owner, contract_instance, assert_log_v
 
 def test_decode_logs_unspecified_abi_gets_all_logs(owner, contract_instance):
     receipt = contract_instance.fooAndBar(sender=owner)
-    logs = [log for log in receipt.decode_logs()]
+    logs = receipt.decode_logs()  # Same as doing `receipt.events`
     assert len(logs) == 2
     assert logs[0].foo == 0
     assert logs[1].bar == 1


### PR DESCRIPTION
### What I did

Since we know the number of logs should be small enough on receipts, if we decoding logs for a specific receipt, uses lists instead of iterators.

This simplifies tests for everyone.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
