### PR TITLE
fix: issue with str type in `is_contract()`

### DIFF
--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -1,5 +1,7 @@
 from typing import Any, List
 
+from hexbytes import HexBytes
+
 from ape.exceptions import ConversionError
 from ape.types import AddressType, ContractCode
 from ape.utils import BaseInterface, abstractmethod
@@ -129,7 +131,7 @@ class BaseAddress(BaseInterface):
         ``True`` when there is code associated with the address.
         """
 
-        return len(self.code) > 0
+        return len(HexBytes(self.code)) > 0
 
 
 class Address(BaseAddress):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,6 +156,14 @@ def eth_tester_provider():
 
 
 @pytest.fixture
+def mock_provider(mock_web3, eth_tester_provider):
+    web3 = eth_tester_provider.web3
+    eth_tester_provider._web3 = mock_web3
+    yield eth_tester_provider
+    eth_tester_provider._web3 = web3
+
+
+@pytest.fixture
 def networks_connected_to_tester(eth_tester_provider):
     return eth_tester_provider.network_manager
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -394,3 +394,8 @@ def test_dir(core_account):
         "transfer",
     ]
     assert sorted(actual) == sorted(expected)
+
+
+def test_is_not_contract(owner, keyfile_account):
+    assert not owner.is_contract
+    assert not keyfile_account.is_contract

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -507,3 +507,7 @@ def test_decode_ambiguous_input(solidity_contract_instance, calldata_with_addres
     )
     with pytest.raises(ContractError, match=expected):
         method.decode_input(anonymous_calldata)
+
+
+def test_is_contract(contract_instance):
+    assert contract_instance.is_contract

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -511,3 +511,16 @@ def test_decode_ambiguous_input(solidity_contract_instance, calldata_with_addres
 
 def test_is_contract(contract_instance):
     assert contract_instance.is_contract
+
+
+def test_is_contract_when_code_is_str(mock_provider, owner):
+    """
+    Tests the cases when an ecosystem uses str for ContractCode.
+    """
+    # Set up the provider to return str instead of HexBytes for code.
+    mock_provider._web3.eth.get_code.return_value = "0x123"
+    assert owner.is_contract
+
+    # When the return value is the string "0x", it should not code as having code.
+    mock_provider._web3.eth.get_code.return_value = "0x"
+    assert not owner.is_contract

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -22,7 +22,6 @@ from tests.functional.data.python import TRACE_RESPONSE
 TRANSACTION_HASH = "0x053cba5c12172654d894f66d5670bab6215517a94189a9ffc09bc40a589ec04d"
 
 
-@geth_process_test
 @pytest.fixture
 def mock_geth(geth_provider, mock_web3):
     provider = Geth(


### PR DESCRIPTION
### What I did

Noticed from a mistake in someone's code that we are not properly handling the case when `get_code()` returns a `str`, as it says it might. In some ecosystems, it might, I suppose.

### How I did it

Wrap the code in `HexBytes` before checking the length.

** Else `len("0x")` will be truthy **

### How to verify it

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
