### PR TITLE
fix: issues with static fee transactions

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -34,7 +34,7 @@ class TransactionAPI(BaseInterfaceModel):
     nonce: Optional[int] = None  # NOTE: `Optional` only to denote using default behavior
     value: int = 0
     data: bytes = b""
-    type: Union[int, bytes, str]
+    type: int
     max_fee: Optional[int] = None
     max_priority_fee: Optional[int] = None
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -337,6 +337,7 @@ class ContractTransactionHandler(ContractMethodHandler):
         contract_transaction = self._as_transaction(*function_arguments)
         if "sender" not in kwargs and self.account_manager.default_sender is not None:
             kwargs["sender"] = self.account_manager.default_sender
+
         return contract_transaction(*function_arguments, **kwargs)
 
     def _as_transaction(self, *args) -> ContractTransaction:

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -3,7 +3,14 @@ from decimal import Decimal
 from typing import Any, Dict, List, Tuple, Type, Union
 
 from dateutil.parser import parse  # type: ignore
-from eth_utils import is_checksum_address, is_hex, is_hex_address, to_checksum_address, to_hex
+from eth_utils import (
+    is_checksum_address,
+    is_hex,
+    is_hex_address,
+    to_checksum_address,
+    to_hex,
+    to_int,
+)
 from hexbytes import HexBytes
 
 from ape.api import ConverterAPI
@@ -36,6 +43,28 @@ class HexConverter(ConverterAPI):
         """
 
         return HexBytes(value)
+
+
+class HexIntConverter(ConverterAPI):
+    """
+    Convert hex values to integers.
+    """
+
+    def is_convertible(self, value: Any) -> bool:
+        return (
+            isinstance(value, int)
+            or (isinstance(value, str) and is_hex(value))
+            or isinstance(value, HexBytes)
+        )
+
+    def convert(self, value: Any) -> int:
+        if isinstance(value, str) and is_hex(value):
+            return to_int(HexBytes(value))
+
+        elif isinstance(value, HexBytes):
+            return to_int(value)
+
+        return value
 
 
 class AddressAPIConverter(ConverterAPI):
@@ -211,7 +240,7 @@ class ConversionManager(BaseManager):
                 IntAddressConverter(),
             ],
             bytes: [HexConverter()],
-            int: [TimestampConverter()],
+            int: [TimestampConverter(), HexIntConverter()],
             Decimal: [],
             list: [ListTupleConverter()],
             tuple: [ListTupleConverter()],

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -54,14 +54,14 @@ class HexIntConverter(ConverterAPI):
         return (
             isinstance(value, int)
             or (isinstance(value, str) and is_hex(value))
-            or isinstance(value, HexBytes)
+            or isinstance(value, bytes)
         )
 
     def convert(self, value: Any) -> int:
         if isinstance(value, str) and is_hex(value):
             return to_int(HexBytes(value))
 
-        elif isinstance(value, HexBytes):
+        elif isinstance(value, bytes):
             return to_int(value)
 
         return value

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -265,7 +265,7 @@ class Ethereum(EcosystemAPI):
         status = data.get("status")
         if status:
             status = self.conversion_manager.convert(status, int)
-            status = TransactionStatusEnum(status).value
+            status = TransactionStatusEnum(status)
 
         txn_hash = data.get("hash") or data.get("txn_hash") or data.get("transaction_hash")
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -449,7 +449,7 @@ class Ethereum(EcosystemAPI):
             if kwargs["type"] is None:
                 version = TransactionType.DYNAMIC
             elif not isinstance(kwargs["type"], int):
-                version = self.conversion_manager.convert(kwargs["type"], int)
+                version = TransactionType(self.conversion_manager.convert(kwargs["type"], int))
             else:
                 version = TransactionType(kwargs["type"])
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -4,8 +4,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union
 
 from eth_abi import decode, encode
 from eth_abi.exceptions import InsufficientDataBytes
-from eth_typing import HexStr
-from eth_utils import add_0x_prefix, encode_hex, keccak, to_checksum_address
+from eth_utils import encode_hex, keccak, to_checksum_address
 from ethpm_types.abi import ABIType, ConstructorABI, EventABI, MethodABI
 from hexbytes import HexBytes
 from pydantic import Field, validator
@@ -265,10 +264,8 @@ class Ethereum(EcosystemAPI):
     def decode_receipt(self, data: dict) -> ReceiptAPI:
         status = data.get("status")
         if status:
-            if isinstance(status, str) and status.isnumeric():
-                status = int(status)
-
-            status = TransactionStatusEnum(status)
+            status = self.conversion_manager.convert(status, int)
+            status = TransactionStatusEnum(status).value
 
         txn_hash = data.get("hash") or data.get("txn_hash") or data.get("transaction_hash")
 
@@ -449,27 +446,20 @@ class Ethereum(EcosystemAPI):
         }
 
         if "type" in kwargs:
-            type_kwarg = kwargs["type"]
-            if type_kwarg is None:
-                type_kwarg = TransactionType.DYNAMIC.value
-            elif isinstance(type_kwarg, int):
-                type_kwarg = f"0{type_kwarg}"
-            elif isinstance(type_kwarg, bytes):
-                type_kwarg = type_kwarg.hex()
+            if kwargs["type"] is None:
+                version = TransactionType.DYNAMIC
+            elif not isinstance(kwargs["type"], int):
+                version = self.conversion_manager.convert(kwargs["type"], int)
+            else:
+                version = TransactionType(kwargs["type"])
 
-            suffix = type_kwarg.replace("0x", "")
-            if len(suffix) == 1:
-                type_kwarg = f"{type_kwarg.rstrip(suffix)}0{suffix}"
-
-            version_str = add_0x_prefix(HexStr(type_kwarg))
-            version = TransactionType(version_str)
         elif "gas_price" in kwargs:
             version = TransactionType.STATIC
         else:
             version = self.default_transaction_type
 
-        txn_class = transaction_types[version]
         kwargs["type"] = version.value
+        txn_class = transaction_types[version]
 
         if "required_confirmations" not in kwargs or kwargs["required_confirmations"] is None:
             # Attempt to use default required-confirmations from `ape-config.yaml`.
@@ -482,6 +472,9 @@ class Ethereum(EcosystemAPI):
 
         if isinstance(kwargs.get("chainId"), str):
             kwargs["chainId"] = int(kwargs["chainId"], 16)
+
+        elif "chainId" not in kwargs:
+            kwargs["chainId"] = self.provider.chain_id
 
         if "input" in kwargs:
             kwargs["data"] = kwargs.pop("input")

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -1,5 +1,5 @@
 import sys
-from enum import Enum, IntEnum
+from enum import Enum
 from typing import IO, Dict, List, Optional, Union
 
 from eth_abi import decode
@@ -21,7 +21,7 @@ from ape.types import ContractLog
 from ape.utils import cached_property
 
 
-class TransactionStatusEnum(IntEnum):
+class TransactionStatusEnum(Enum):
     """
     An ``Enum`` class representing the status of a transaction.
     """
@@ -42,9 +42,9 @@ class TransactionType(Enum):
     `EIP-2718 <https://eips.ethereum.org/EIPS/eip-2718>`__.
     """
 
-    STATIC = "0x00"
-    ACCESS_LIST = "0x01"  # EIP-2930
-    DYNAMIC = "0x02"  # EIP-1559
+    STATIC = 0
+    ACCESS_LIST = 1  # EIP-2930
+    DYNAMIC = 2  # EIP-1559
 
 
 class AccessList(BaseModel):
@@ -80,7 +80,7 @@ class StaticFeeTransaction(BaseTransaction):
 
     gas_price: Optional[int] = Field(None, alias="gasPrice")
     max_priority_fee: Optional[int] = Field(None, exclude=True)
-    type: Union[str, int, bytes] = Field(TransactionType.STATIC.value, exclude=True)
+    type: int = Field(TransactionType.STATIC.value, exclude=True)
     max_fee: Optional[int] = Field(None, exclude=True)
 
     @root_validator(pre=True, allow_reuse=True)
@@ -98,7 +98,7 @@ class DynamicFeeTransaction(BaseTransaction):
 
     max_priority_fee: Optional[int] = Field(None, alias="maxPriorityFeePerGas")
     max_fee: Optional[int] = Field(None, alias="maxFeePerGas")
-    type: Union[int, str, bytes] = Field(TransactionType.DYNAMIC.value)
+    type: int = Field(TransactionType.DYNAMIC.value)
     access_list: List[AccessList] = Field(default_factory=list, alias="accessList")
 
     @validator("type", allow_reuse=True)
@@ -116,7 +116,7 @@ class AccessListTransaction(BaseTransaction):
     """
 
     gas_price: Optional[int] = Field(None, alias="gasPrice")
-    type: Union[int, str, bytes] = Field(TransactionType.ACCESS_LIST.value)
+    type: int = Field(TransactionType.ACCESS_LIST.value)
     access_list: List[AccessList] = Field(default_factory=list, alias="accessList")
 
     @validator("type", allow_reuse=True)
@@ -148,7 +148,7 @@ class Receipt(ReceiptAPI):
 
     @property
     def failed(self) -> bool:
-        return self.status != TransactionStatusEnum.NO_ERROR
+        return self.status != TransactionStatusEnum.NO_ERROR.value
 
     @cached_property
     def call_tree(self) -> Optional[CallTreeNode]:

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -1,5 +1,5 @@
 import sys
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import IO, Dict, List, Optional, Union
 
 from eth_abi import decode
@@ -21,7 +21,7 @@ from ape.types import ContractLog
 from ape.utils import cached_property
 
 
-class TransactionStatusEnum(Enum):
+class TransactionStatusEnum(IntEnum):
     """
     An ``Enum`` class representing the status of a transaction.
     """
@@ -148,7 +148,7 @@ class Receipt(ReceiptAPI):
 
     @property
     def failed(self) -> bool:
-        return self.status != TransactionStatusEnum.NO_ERROR.value
+        return self.status != TransactionStatusEnum.NO_ERROR
 
     @cached_property
     def call_tree(self) -> Optional[CallTreeNode]:

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -149,7 +149,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         )
 
         if receipt.failed:
-            txn_dict = receipt.transaction.dict()
+            txn_dict = txn.dict()
             txn_dict["nonce"] += 1
             txn_params = cast(TxParams, txn_dict)
 

--- a/tests/functional/conversion/test_timestamp.py
+++ b/tests/functional/conversion/test_timestamp.py
@@ -25,9 +25,8 @@ def test_convert_string_timestamp(args):
     "args",
     (
         [
-            "0000",
-            "2003",
-            "9999999999",
+            "100.0",
+            "foobar",
             "2001-01-01 12:15:12 123",
         ]
     ),

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -36,6 +36,14 @@ def test_contract_calls(owner, contract_instance):
     assert contract_instance.myNumber() == 2
 
 
+@pytest.mark.parametrize("type_param", (0, "0", HexBytes(0)))
+def test_static_fee_txn(owner, vyper_contract_instance, type_param):
+    receipt = vyper_contract_instance.setNumber(4, sender=owner, type=type_param)
+    assert vyper_contract_instance.myNumber() == 4
+    assert not receipt.failed
+    assert receipt.type == 0
+
+
 def test_invoke_transaction(owner, contract_instance):
     # Test mutable method call with invoke_transaction
     receipt = contract_instance.invoke_transaction("setNumber", 3, sender=owner)
@@ -91,6 +99,11 @@ def test_revert_no_message(owner, contract_instance):
 def test_revert_specify_gas(sender, contract_instance, gas):
     with pytest.raises(ContractLogicError, match="!authorized"):
         contract_instance.setNumber(5, sender=sender, gas=gas)
+
+
+def test_revert_static_fee_type(sender, contract_instance):
+    with pytest.raises(ContractLogicError, match="!authorized"):
+        contract_instance.setNumber(5, sender=sender, type=0)
 
 
 def test_call_using_block_identifier(

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -161,3 +161,7 @@ def test_receipt_raise_for_status_out_of_gas_error(mocker, ethereum):
     )
     with pytest.raises(OutOfGasError):
         receipt.raise_for_status()
+
+
+def test_receipt_chain_id(invoke_receipt, eth_tester_provider):
+    assert invoke_receipt.chain_id == eth_tester_provider.chain_id


### PR DESCRIPTION
### What I did

I noticed while debugging https://github.com/ApeWorX/ape-optimism/issues/12 that the issue was because of static fee transactions. I was able to reproduce with Ethereum as well.

### How I did it

* Remove `Union` type from `TransactionAPI` and require the transaction type to be an `int`.
* Make a `HexIntConverter` class
* Fix weird chain ID issues on receipt's transactions that I found during txn-replay for extracting revert messages.

### How to verify it

* `contract.method(arg, sender=me, type=0)`
* Also make sure works in reverts testing

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
