### PR TITLE
refactor: TransactionErrors and standardize transaction passing

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -549,7 +549,7 @@ class ProviderAPI(BaseInterfaceModel):
         if not err_msg:
             return VirtualMachineError(base_err=exception)
 
-        return VirtualMachineError(message=str(err_msg), code=err_data.get("code"))
+        return VirtualMachineError(str(err_msg), code=err_data.get("code"))
 
 
 class TestProviderAPI(ProviderAPI):
@@ -1076,9 +1076,7 @@ class Web3Provider(ProviderAPI, ABC):
             if "nonce too low" in str(vm_err):
                 # Add additional nonce information
                 new_err_msg = f"Nonce '{txn.nonce}' is too low"
-                raise VirtualMachineError(
-                    base_err=vm_err.base_err, message=new_err_msg, code=vm_err.code
-                )
+                raise VirtualMachineError(new_err_msg, base_err=vm_err.base_err, code=vm_err.code)
 
             vm_err.txn = txn
             raise vm_err from err

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -511,7 +511,7 @@ class ProviderAPI(BaseInterfaceModel):
         """
         return txn
 
-    def get_virtual_machine_error(self, exception: Exception) -> VirtualMachineError:
+    def get_virtual_machine_error(self, exception: Exception, **kwargs) -> VirtualMachineError:
         """
         Get a virtual machine error from an error returned from your RPC.
         If from a contract revert / assert statement, you will be given a
@@ -529,27 +529,29 @@ class ProviderAPI(BaseInterfaceModel):
                went wrong in the call.
         """
 
+        txn = kwargs.get("txn")
+
         if isinstance(exception, Web3ContractLogicError):
             # This happens from `assert` or `require` statements.
             message = str(exception).split(":")[-1].strip()
             if message == "execution reverted":
                 # Reverted without an error message
-                raise ContractLogicError()
+                raise ContractLogicError(txn=txn)
 
-            return ContractLogicError(revert_message=message)
+            return ContractLogicError(revert_message=message, txn=txn)
 
         if not len(exception.args):
-            return VirtualMachineError(base_err=exception)
+            return VirtualMachineError(base_err=exception, txn=txn)
 
         err_data = exception.args[0] if (hasattr(exception, "args") and exception.args) else None
         if not isinstance(err_data, dict):
-            return VirtualMachineError(base_err=exception)
+            return VirtualMachineError(base_err=exception, txn=txn)
 
         err_msg = err_data.get("message")
         if not err_msg:
-            return VirtualMachineError(base_err=exception)
+            return VirtualMachineError(base_err=exception, txn=txn)
 
-        return VirtualMachineError(str(err_msg), code=err_data.get("code"))
+        return VirtualMachineError(str(err_msg), code=err_data.get("code"), txn=txn)
 
 
 class TestProviderAPI(ProviderAPI):
@@ -713,7 +715,7 @@ class Web3Provider(ProviderAPI, ABC):
             txn_params = cast(TxParams, txn_dict)
             return self.web3.eth.estimate_gas(txn_params, block_identifier=block_id)
         except ValueError as err:
-            tx_error = self.get_virtual_machine_error(err)
+            tx_error = self.get_virtual_machine_error(err, txn=txn)
 
             # If this is the cause of a would-be revert,
             # raise ContractLogicError so that we can confirm tx-reverts.
@@ -721,7 +723,7 @@ class Web3Provider(ProviderAPI, ABC):
                 raise tx_error from err
 
             message = gas_estimation_error_message(tx_error)
-            raise TransactionError(message, base_err=tx_error) from err
+            raise TransactionError(message, base_err=tx_error, txn=txn) from err
 
     @property
     def chain_id(self) -> int:
@@ -1071,7 +1073,7 @@ class Web3Provider(ProviderAPI, ABC):
         try:
             txn_hash = self.web3.eth.send_raw_transaction(txn.serialize_transaction())
         except ValueError as err:
-            vm_err = self.get_virtual_machine_error(err)
+            vm_err = self.get_virtual_machine_error(err, txn=txn)
 
             if "nonce too low" in str(vm_err):
                 # Add additional nonce information
@@ -1098,7 +1100,7 @@ class Web3Provider(ProviderAPI, ABC):
             try:
                 self.web3.eth.call(txn_params)
             except Exception as err:
-                vm_err = self.get_virtual_machine_error(err)
+                vm_err = self.get_virtual_machine_error(err, txn=txn)
                 vm_err.txn = txn
                 raise vm_err from err
 

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -141,7 +141,7 @@ class OutOfGasError(VirtualMachineError):
     """
 
     def __init__(self, code: Optional[int] = None):
-        super().__init__(message="The transaction ran out of gas.", code=code)
+        super().__init__("The transaction ran out of gas.", code=code)
 
 
 class NetworkError(ApeException):

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -115,8 +115,10 @@ class ContractLogicError(VirtualMachineError):
     such as from an assert/require statement.
     """
 
-    def __init__(self, revert_message: Optional[str] = None):
-        super().__init__(message=revert_message)
+    def __init__(
+        self, revert_message: Optional[str] = None, txn: Optional["TransactionAPI"] = None
+    ):
+        super().__init__(message=revert_message, txn=txn)
 
     @property
     def revert_message(self):

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -144,12 +144,6 @@ class OutOfGasError(VirtualMachineError):
         super().__init__(message="The transaction ran out of gas.", code=code)
 
 
-class ContractDeployError(TransactionError):
-    """
-    Raised when a problem occurs when deploying a contract.
-    """
-
-
 class NetworkError(ApeException):
     """
     Raised when a problem occurs when using blockchain networks.

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -191,7 +191,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
                 new_message = (
                     f"Sender '{sender}' cannot afford txn gas {txn_gas} with account balance {bal}."
                 )
-                return VirtualMachineError(message=new_message)
+                return VirtualMachineError(new_message)
 
             else:
                 return VirtualMachineError(base_err=exception)

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -76,7 +76,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         try:
             return estimate_gas(txn_dict, block_identifier=block_id)  # type: ignore
         except (ValidationError, TransactionFailed) as err:
-            ape_err = self.get_virtual_machine_error(err, sender=txn.sender)
+            ape_err = self.get_virtual_machine_error(err, txn=txn)
             gas_match = self._INVALID_NONCE_PATTERN.match(str(ape_err))
             if gas_match:
                 # Sometimes, EthTester is confused about the sender nonce
@@ -92,7 +92,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
                 raise ape_err from err
             else:
                 message = gas_estimation_error_message(ape_err)
-                raise TransactionError(message, base_err=ape_err) from ape_err
+                raise TransactionError(message, base_err=ape_err, txn=txn) from ape_err
 
     @property
     def chain_id(self) -> int:
@@ -134,13 +134,13 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         except ValidationError as err:
             raise VirtualMachineError(base_err=err) from err
         except TransactionFailed as err:
-            raise self.get_virtual_machine_error(err, sender=txn.sender) from err
+            raise self.get_virtual_machine_error(err, txn=txn) from err
 
     def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
         try:
             txn_hash = self.web3.eth.send_raw_transaction(txn.serialize_transaction())
         except (ValidationError, TransactionFailed) as err:
-            vm_err = self.get_virtual_machine_error(err, sender=txn.sender)
+            vm_err = self.get_virtual_machine_error(err, txn=txn)
             vm_err.txn = txn
             raise vm_err from err
 
@@ -157,7 +157,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
             try:
                 self.web3.eth.call(txn_params)
             except (ValidationError, TransactionFailed) as err:
-                vm_err = self.get_virtual_machine_error(err, sender=txn.sender)
+                vm_err = self.get_virtual_machine_error(err, txn=txn)
                 vm_err.txn = txn
                 raise vm_err from err
 
@@ -183,23 +183,24 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         self.evm_backend.mine_blocks(num_blocks)
 
     def get_virtual_machine_error(self, exception: Exception, **kwargs) -> VirtualMachineError:
+        txn = kwargs.get("txn")
         if isinstance(exception, ValidationError):
             match = self._CANNOT_AFFORD_GAS_PATTERN.match(str(exception))
             if match:
                 txn_gas, bal = match.groups()
-                sender = kwargs["sender"]
+                sender = getattr(txn, "sender")
                 new_message = (
                     f"Sender '{sender}' cannot afford txn gas {txn_gas} with account balance {bal}."
                 )
-                return VirtualMachineError(new_message)
+                return VirtualMachineError(new_message, txn=txn)
 
             else:
-                return VirtualMachineError(base_err=exception)
+                return VirtualMachineError(base_err=exception, txn=txn)
 
         elif isinstance(exception, TransactionFailed):
             err_message = str(exception).split("execution reverted: ")[-1] or None
             err_message = None if err_message == "b''" else err_message
-            return ContractLogicError(revert_message=err_message)
+            return ContractLogicError(revert_message=err_message, txn=txn)
 
         else:
-            return VirtualMachineError(base_err=exception)
+            return VirtualMachineError(base_err=exception, txn=txn)


### PR DESCRIPTION
### What I did

Prepping for tracing errors in `TransactionErrors` based classes. Also, standardizing the call signature for `get_virtual_machine_error` error handling. Moving web3 logic to `Web3Provider` and made `ProviderAPI` return a simple `VirtualMachineError` that can be overridden in other ecosystems.

fixes: #

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
