### PR TITLE
fix!: change some `str` items to `AddressType` where it makes sense

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -203,7 +203,7 @@ class ProviderAPI(BaseInterfaceModel):
         """
 
     @raises_not_implemented
-    def get_storage_at(self, address: str, slot: int) -> bytes:  # type: ignore[empty-body]
+    def get_storage_at(self, address: AddressType, slot: int) -> bytes:  # type: ignore[empty-body]
         """
         Gets the raw value of a storage slot of a contract.
 
@@ -745,12 +745,12 @@ class Web3Provider(ProviderAPI, ABC):
 
         return self.network.ecosystem.decode_block(block_data)
 
-    def get_nonce(self, address: str, **kwargs) -> int:
+    def get_nonce(self, address: AddressType, **kwargs) -> int:
         """
         Get the number of times an account has transacted.
 
         Args:
-            address (str): The address of the account.
+            address (AddressType): The address of the account.
             kwargs:
                 * ``block_identifier`` (:class:`~ape.types.BlockID`): The block ID
                   for checking a previous account nonce.
@@ -762,18 +762,18 @@ class Web3Provider(ProviderAPI, ABC):
         block_id = kwargs.pop("block_identifier", None)
         return self.web3.eth.get_transaction_count(address, block_identifier=block_id)
 
-    def get_balance(self, address: str) -> int:
+    def get_balance(self, address: AddressType) -> int:
         return self.web3.eth.get_balance(address)
 
     def get_code(self, address: AddressType) -> ContractCode:
         return self.web3.eth.get_code(address)
 
-    def get_storage_at(self, address: str, slot: int, **kwargs) -> bytes:
+    def get_storage_at(self, address: AddressType, slot: int, **kwargs) -> bytes:
         """
         Gets the raw value of a storage slot of a contract.
 
         Args:
-            address (str): The address of the contract.
+            address (AddressType): The address of the contract.
             slot (int): Storage slot to read the value of.
             kwargs:
                 * ``block_identifier`` (:class:`~ape.types.BlockID`): The block ID


### PR DESCRIPTION
### What I did

Noticed some `address: str` in the API that seems like it should be `address: AddressType`, even when working on Starknet.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
