### PR TITLE
fix: issue where `contracts_folder` was not honored in dependency

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -376,7 +376,10 @@ class DependencyAPI(BaseInterfaceModel):
         # for later usage via imports. For legacy reasons, many dependency-esque projects
         # are not meant to compile on their own.
 
-        with self.config_manager.using_project(project_path):
+        with self.config_manager.using_project(
+            project_path,
+            contracts_folder=(project_path / self.contracts_folder).expanduser().resolve(),
+        ):
             project = self._get_project(project_path)
             sources = self._get_sources(project)
             dependencies = self.project_manager._extract_manifest_dependencies()

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -273,27 +273,30 @@ class ConfigManager(BaseInterfaceModel):
             Generator
         """
 
-        contracts_folder = contracts_folder or project_folder / "contracts"
         initial_project_folder = self.project_manager.path
         initial_contracts_folder = self.contracts_folder
 
-        if (
-            initial_project_folder == project_folder
-            and initial_contracts_folder == contracts_folder
+        if initial_project_folder == project_folder and (
+            not contracts_folder or initial_contracts_folder == contracts_folder
         ):
             # Already in project.
             yield self.project_manager
             return
 
         self.PROJECT_FOLDER = project_folder
-        self.contracts_folder = contracts_folder
+        self.contracts_folder = (
+            contracts_folder if contracts_folder else project_folder / "contracts"
+        )
         self.project_manager.path = project_folder
         os.chdir(project_folder)
         clean_config = False
 
         try:
             # Process and reload the project's configuration
-            clean_config = self.project_manager.local_project.process_config_file()
+            project = self.project_manager.get_project(
+                project_folder, contracts_folder=contracts_folder
+            )
+            clean_config = project.process_config_file(contracts_folder=contracts_folder)
             self.load(force_reload=True)
             yield self.project_manager
 

--- a/src/ape/managers/project/dependency.py
+++ b/src/ape/managers/project/dependency.py
@@ -9,7 +9,6 @@ from ethpm_types.utils import AnyUrl
 from pydantic import FileUrl, HttpUrl, root_validator
 
 from ape.api import DependencyAPI
-from ape.api.projects import _load_manifest_from_file
 from ape.exceptions import ProjectError
 from ape.utils import ManagerAccessMixin, cached_property, github_client, load_config
 
@@ -164,9 +163,4 @@ class LocalDependency(DependencyAPI):
         return FileUrl(f"file://{path}", scheme="file")
 
     def extract_manifest(self) -> PackageManifest:
-        if self._target_manifest_cache_file.is_file():
-            manifest = _load_manifest_from_file(self._target_manifest_cache_file)
-            if manifest:
-                return manifest
-
         return self._extract_local_manifest(self.path)

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -337,7 +337,7 @@ class ProjectManager(BaseManager):
 
                 return None
 
-            contracts_folder = contracts_folder or find_contracts_folder(path)
+            contracts_folder = find_contracts_folder(path) or contracts_folder
 
         def _try_create_project(proj_cls: Type[ProjectAPI]) -> Optional[ProjectAPI]:
             with self.config_manager.using_project(

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -302,7 +302,11 @@ class ProjectManager(BaseManager):
             ):
                 return cached_project
 
-        contracts_folder = contracts_folder or path / "contracts"
+        contracts_folder = (
+            (path / contracts_folder).expanduser().resolve()
+            if contracts_folder
+            else path / "contracts"
+        )
         if not contracts_folder.is_dir():
             extensions = list(self.compiler_manager.registered_compilers.keys())
             path_patterns_to_ignore = self.config_manager.compiler.ignore_files
@@ -333,7 +337,7 @@ class ProjectManager(BaseManager):
 
                 return None
 
-            contracts_folder = find_contracts_folder(path) or contracts_folder
+            contracts_folder = contracts_folder or find_contracts_folder(path)
 
         def _try_create_project(proj_cls: Type[ProjectAPI]) -> Optional[ProjectAPI]:
             with self.config_manager.using_project(

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -142,9 +142,8 @@ class BaseProject(ProjectAPI):
         if self.version:
             config_data["version"] = self.version
 
-        contracts_folder_config_item = (
-            str(self.contracts_folder).replace(str(self.path), "").strip("/")
-        )
+        contracts_folder = kwargs.get("contracts_folder") or self.contracts_folder
+        contracts_folder_config_item = str(contracts_folder).replace(str(self.path), "").strip("/")
         config_data["contracts_folder"] = contracts_folder_config_item
         self.config_file.parent.mkdir(parents=True, exist_ok=True)
         self.config_file.touch()


### PR DESCRIPTION
### What I did

A strange issue that preventing `cairo` dependencies from working.
Also, it explains some of the weird things seen in tests regarding projects.
Basically, the contracts folder in the config was not honored for dependencies.

fixes: APE-562

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
