### PR TITLE
chore: remove unused arguments on non-public API

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -412,9 +412,4 @@ class ReceiptAPI(BaseInterfaceModel):
         call_tree = self.call_tree
         receiver = self.receiver
         if call_tree and receiver is not None:
-            self.chain_manager._reports.append_gas(
-                call_tree.enrich(in_line=False),
-                receiver,
-                sender=self.sender,
-                transaction_hash=self.txn_hash,
-            )
+            self.chain_manager._reports.append_gas(call_tree.enrich(in_line=False), receiver)

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1116,8 +1116,6 @@ class ReportManager(BaseManager):
         self,
         call_tree: CallTreeNode,
         contract_address: AddressType,
-        sender: Optional[AddressType] = None,
-        transaction_hash: Optional[str] = None,
     ):
         contract_type = self.chain_manager.contracts.get(contract_address)
         if not contract_type:


### PR DESCRIPTION
### What I did

Noticed these args weren't used anymore but never got deleted.
Note, this is not a breaking change because this is not a public API (it is internal to the framework)

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
