### PR TITLE
fix: issue where missing click decorator in CLI scripts caused all scripts to fail

### DIFF
--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -69,6 +69,10 @@ class ScriptCommand(click.MultiCommand):
 
             self._namespace[filepath.stem] = cli_ns
             cli_obj = cli_ns["cli"]
+            if not isinstance(cli_obj, Command):
+                logger.warning("Found `cli()` method but it is not a click command.")
+                return None
+
             cli_obj.name = filepath.stem if cli_obj.name in ("cli", "", None) else cli_obj.name
             return cli_obj
 

--- a/tests/integration/cli/projects/script/scripts/error_forgot_click.py
+++ b/tests/integration/cli/projects/script/scripts/error_forgot_click.py
@@ -1,0 +1,7 @@
+def cli():
+    """
+    This script tests the scenario when a cli script is missing
+    a click-decorator. The script itself is not runnable by Ape,
+    but it will cause a warning. Primarily, it is important that
+    it does not cause the entire scripts-integration to fail.
+    """

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -50,7 +50,11 @@ def test_run_subdirectories(ape_cli, runner, project):
 
 @skip_projects_except("script")
 def test_run_when_script_errors(ape_cli, runner, project):
-    scripts = [s for s in project.scripts_folder.glob("*.py") if s.name.startswith("error")]
+    scripts = [
+        s
+        for s in project.scripts_folder.glob("*.py")
+        if s.name.startswith("error") and not s.name.endswith("forgot_click.py")
+    ]
     for script_file in scripts:
         result = runner.invoke(ape_cli, ["run", script_file.stem])
         assert result.exit_code != 0, result.output
@@ -84,3 +88,15 @@ def test_run_adhoc_network(ape_cli, runner, project):
     # Show that it attempts to connect
     assert result.exit_code == 1, result.output
     assert "No node found on 'http://127.0.0.1:9545" in result.output
+
+
+@skip_projects_except("script")
+def test_try_run_script_missing_cli_decorator(ape_cli, runner, project):
+    """
+    Shows that we cannot run a script defining a `cli()` method without
+    it being a click command. The script is not recognized, so you get
+    a usage error.
+    """
+
+    result = runner.invoke(ape_cli, ["run", "error_forgot_click"])
+    assert "Usage: cli run" in result.output


### PR DESCRIPTION
### What I did

Had a script with missing click decorator; it causes Ape to crash in an unusual way without letting me run any scripts.

### How I did it

Make sure that `cli` is a click command before moving forward. Else, return `None`.

### How to verify it

Have a "script" like this:

```python
def cli():
    print("I am not real")
```

and try to run it. You should get a warning and it shouldn't be able to run.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
