### PR TITLE
fix: include active namespace in interactive script console

### DIFF
--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -21,6 +21,7 @@ class ScriptCommand(click.MultiCommand):
 
         super().__init__(*args, **kwargs)
         self._namespace = {}
+        self._command_called = None
 
     def invoke(self, ctx: Context) -> Any:
         try:

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -176,8 +176,8 @@ class ScriptCommand(click.MultiCommand):
         return result
 
     def _launch_console(self):
-        # TODO: Figure out how to pull out namespace for `extra_locals`
-        extra_locals = {**self._namespace.get(self._command_called, {})}
+        active_locals = {k: v for k, v in globals().items() if not k.startswith("__")}
+        extra_locals = {**self._namespace.get(self._command_called, {}), **active_locals}
         return console(project=self._project, extra_locals=extra_locals)
 
 

--- a/tests/integration/cli/projects/script/scripts/error.py
+++ b/tests/integration/cli/projects/script/scripts/error.py
@@ -1,2 +1,3 @@
 def main():
+    local_variable = "test foo bar"  # noqa[F841]
     raise Exception("Expected exception")

--- a/tests/integration/cli/projects/script/scripts/error_cli.py
+++ b/tests/integration/cli/projects/script/scripts/error_cli.py
@@ -3,5 +3,5 @@ import click
 
 @click.command(short_help="Use a subcommand")
 def cli():
-    local_variable = "test foo bar"
-    raise Exception(f"Expected exception - {local_variable}")  # noqa: T001
+    local_variable = "test foo bar"  # noqa[F841]
+    raise Exception("Expected exception")  # noqa: T001

--- a/tests/integration/cli/projects/script/scripts/error_cli.py
+++ b/tests/integration/cli/projects/script/scripts/error_cli.py
@@ -3,4 +3,5 @@ import click
 
 @click.command(short_help="Use a subcommand")
 def cli():
-    raise Exception("Expected exception")  # noqa: T001
+    local_variable = "test foo bar"
+    raise Exception(f"Expected exception - {local_variable}")  # noqa: T001

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -62,8 +62,15 @@ def test_run_when_script_errors(ape_cli, runner, project):
 @skip_projects_except("script")
 def test_run_interactive(ape_cli, runner, project):
     scripts = [s for s in project.scripts_folder.glob("*.py") if s.name.startswith("error")]
-    result = runner.invoke(ape_cli, ["run", "--interactive", scripts[0].stem], input="exit\n")
+
+    # Show active local is available
+    user_input = "local_variable\nexit\n"
+
+    result = runner.invoke(ape_cli, ["run", "--interactive", scripts[0].stem], input=user_input)
     assert result.exit_code == 0, result.output
+
+    # Verify output from local_variable appears in output.
+    assert "test foo bar" in result.output
 
 
 @skip_projects_except("script")

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -63,13 +63,13 @@ def test_run_when_script_errors(ape_cli, runner, project):
 def test_run_interactive(ape_cli, runner, project):
     scripts = [s for s in project.scripts_folder.glob("*.py") if s.name.startswith("error")]
 
-    # Show active local is available
+    # Show that the variable namespace from the script is available in the console.
     user_input = "local_variable\nexit\n"
 
     result = runner.invoke(ape_cli, ["run", "--interactive", scripts[0].stem], input=user_input)
     assert result.exit_code == 0, result.output
 
-    # Verify output from local_variable appears in output.
+    # From script: local_variable = "test foo bar"
     assert "test foo bar" in result.output
 
 


### PR DESCRIPTION
### What I did

Adds locals to the namespace when using `-I` and error occurs

fixes: #1280

### How I did it

`globals()`

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
