### PR TITLE
fix: issue where missing `@network_option` caused `IndexError`

### DIFF
--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -13,6 +13,6 @@ class NetworkBoundCommand(click.Command):
     """
 
     def invoke(self, ctx: Context) -> Any:
-        value = ctx.params["network"]
+        value = ctx.params.get("network") or networks.default_ecosystem.name
         with networks.parse_network_choice(value):
             super().invoke(ctx)

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -3,7 +3,7 @@ import shutil
 import click
 import pytest
 
-from ape.cli import get_user_selected_account, network_option
+from ape.cli import NetworkBoundCommand, get_user_selected_account, network_option
 from ape.exceptions import AccountsError
 
 OUTPUT_FORMAT = "__TEST__{}__"
@@ -167,3 +167,12 @@ def test_network_option_can_be_none(runner):
 
     result = runner.invoke(cmd, [])
     assert "Value is 'None'" in result.output
+
+
+def test_network_option_not_needed_on_network_bound_command(runner):
+    @click.command(cls=NetworkBoundCommand)
+    def cmd():
+        click.echo("Success!")
+
+    result = runner.invoke(cmd, [])
+    assert "Success" in result.output


### PR DESCRIPTION
### What I did

On `NetworkBoundCommand`, if you didn't have a `@network_option`, it would fail with an `IndexError`.
Now, it will use the default ecosystem / network.

### How I did it

If no network in options, use the default.

### How to verify it

Can now have scripts that are network-bound but not don't allow specifying networks

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
