### PR TITLE
feat: way to get compilers easier [APE-607]

### DIFF
--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -34,7 +34,6 @@ class CompilerManager(BaseManager):
         try:
             return self.__getattribute__(name)
         except AttributeError:
-            # Check if a contract.
             pass
 
         compiler = self.get_compiler(name)

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -45,6 +45,14 @@ class PytestApeFixtures(ManagerAccessMixin):
         return self.account_manager.test_accounts
 
     @pytest.fixture(scope="session")
+    def compilers(self):
+        """
+        Access compiler classes directly.
+        """
+
+        return self.compiler_manager
+
+    @pytest.fixture(scope="session")
     def chain(self) -> ChainManager:
         """
         Manipulate the blockchain, such as mine or change the pending timestamp.

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -47,7 +47,7 @@ class PytestApeFixtures(ManagerAccessMixin):
     @pytest.fixture(scope="session")
     def compilers(self):
         """
-        Access compiler classes directly.
+        Access compiler manager directly.
         """
 
         return self.compiler_manager

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -44,3 +44,17 @@ def test_missing_compilers_error_message(
         project_with_source_files_contract.ContractA.deploy(
             sender.address, sender.address, sender=sender
         )
+
+
+def test_get_compiler(compilers):
+    compiler = compilers.get_compiler("ethpm")
+    assert compiler.name == "ethpm"
+    assert compilers.get_compiler("foobar") is None
+
+
+def test_getattr(compilers):
+    compiler = compilers.ethpm
+    assert compiler.name == "ethpm"
+
+    with pytest.raises(AttributeError, match=r"No attribute or compiler named 'foobar'\."):
+        _ = compilers.foobar


### PR DESCRIPTION
### What I did

Noticed that it is not the easiest to get a hold of one of the compiler API implementation classes, like `ape-solidity`.
Perhaps there are use-cases (like weird Solidity stuff) where one may need the Solidity compiler at their fingertips.

Before, you had to do this:

```python
project.compiler_manager.registered_compilers[".sol"]
```

but now you can do this:

```python
compilers.solidity
```

### How I did it

* Adds method `get_compiler()` to `CompilerManager` that allows getting a compiler by name
* Adds `__getattr__` so you can do the ape-fancy dances that uses `get_compiler()`
* Adds `compilers` pytest fixture to our pytest integration.


### How to verify it

Use solidity in a fixture or in a test. Call the methods.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
