### PR TITLE
feat: Allow any mnemonic to be used with generate_dev_accounts [APE-625]

### DIFF
--- a/src/ape/utils/__init__.py
+++ b/src/ape/utils/__init__.py
@@ -44,6 +44,7 @@ from ape.utils.os import (
 )
 from ape.utils.process import JoinableQueue, spawn
 from ape.utils.testing import (
+    DEFAULT_HD_PATH,
     DEFAULT_NUMBER_OF_TEST_ACCOUNTS,
     DEFAULT_TEST_MNEMONIC,
     GeneratedDevAccount,
@@ -61,6 +62,7 @@ __all__ = [
     "DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT",
     "DEFAULT_NUMBER_OF_TEST_ACCOUNTS",
     "DEFAULT_TEST_MNEMONIC",
+    "DEFAULT_HD_PATH",
     "DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT",
     "EMPTY_BYTES32",
     "expand_environment_variables",

--- a/src/ape/utils/testing.py
+++ b/src/ape/utils/testing.py
@@ -2,11 +2,13 @@ from collections import namedtuple
 from typing import List
 
 from eth_account import Account
-from eth_account.hdaccount import HDPath, seed_from_mnemonic
+from eth_account.hdaccount import HDPath
+from eth_account.hdaccount.mnemonic import Mnemonic
 from hexbytes import HexBytes
 
 DEFAULT_NUMBER_OF_TEST_ACCOUNTS = 10
 DEFAULT_TEST_MNEMONIC = "test test test test test test test test test test test junk"
+DEFAULT_HD_PATH = "m/44'/60'/0'/{}"
 GeneratedDevAccount = namedtuple("GeneratedDevAccount", ("address", "private_key"))
 """
 An account key-pair generated from the test mnemonic. Set the test mnemonic
@@ -25,7 +27,7 @@ Config example::
 def generate_dev_accounts(
     mnemonic: str = DEFAULT_TEST_MNEMONIC,
     number_of_accounts: int = DEFAULT_NUMBER_OF_TEST_ACCOUNTS,
-    hd_path_format: str = "m/44'/60'/0'/{}",
+    hd_path_format: str = DEFAULT_HD_PATH,
     start_index: int = 0,
 ) -> List[GeneratedDevAccount]:
     """
@@ -37,12 +39,12 @@ def generate_dev_accounts(
         mnemonic (str): mnemonic phrase or seed words.
         number_of_accounts (int): Number of accounts. Defaults to ``10``.
         hd_path_format (str): Hard Wallets/HD Keys derivation path format.
-          Defaults to ``"m/44'/60'/0'/{}"``.
+          Defaults to ``"m/44'/60'/0'/0/{}"``.
 
     Returns:
         List[:class:`~ape.utils.GeneratedDevAccount`]: List of development accounts.
     """
-    seed = seed_from_mnemonic(mnemonic, "")
+    seed = Mnemonic.to_seed(mnemonic)
     accounts = []
 
     for i in range(start_index, start_index + number_of_accounts):

--- a/src/ape_test/__init__.py
+++ b/src/ape_test/__init__.py
@@ -5,7 +5,7 @@ from pydantic import PositiveInt
 from ape import plugins
 from ape.api import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME
-from ape.utils import DEFAULT_NUMBER_OF_TEST_ACCOUNTS, DEFAULT_TEST_MNEMONIC
+from ape.utils import DEFAULT_HD_PATH, DEFAULT_NUMBER_OF_TEST_ACCOUNTS, DEFAULT_TEST_MNEMONIC
 
 from .accounts import TestAccount, TestAccountContainer
 from .provider import LocalProvider
@@ -55,6 +55,11 @@ class Config(PluginConfig):
     disconnect_providers_after: bool = True
     """
     Set to ``False`` to keep providers connected at the end of the test run.
+    """
+
+    hd_path: str = DEFAULT_HD_PATH
+    """
+    The hd_path to use when generating the test accounts.
     """
 
 

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -14,6 +14,7 @@ class TestAccountContainer(TestAccountContainerAPI):
     _accounts: List["TestAccount"]
     _mnemonic: str
     _num_of_accounts: int
+    _hd_path: str
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -24,6 +25,7 @@ class TestAccountContainer(TestAccountContainerAPI):
         self._accounts = []
         self._mnemonic = self.config["mnemonic"]
         self._num_of_accounts = self.config["number_of_accounts"]
+        self._hd_path = self.config["hd_path"]
         for index, account in enumerate(self._dev_accounts):
             self._accounts.append(
                 TestAccount(
@@ -40,7 +42,11 @@ class TestAccountContainer(TestAccountContainerAPI):
 
     @property
     def _dev_accounts(self) -> List[GeneratedDevAccount]:
-        return generate_dev_accounts(self._mnemonic, number_of_accounts=self._num_of_accounts)
+        return generate_dev_accounts(
+            self._mnemonic,
+            number_of_accounts=self._num_of_accounts,
+            hd_path_format=self._hd_path,
+        )
 
     @property
     def aliases(self) -> Iterator[str]:
@@ -50,7 +56,12 @@ class TestAccountContainer(TestAccountContainerAPI):
     def _is_config_changed(self):
         current_mnemonic = self.config["mnemonic"]
         current_number = self.config["number_of_accounts"]
-        return self._mnemonic != current_mnemonic or self._num_of_accounts != current_number
+        current_hd_path = self.config["hd_path"]
+        return (
+            self._mnemonic != current_mnemonic
+            or self._num_of_accounts != current_number
+            or self._hd_path != current_hd_path
+        )
 
     @property
     def accounts(self) -> Iterator["TestAccount"]:
@@ -64,7 +75,9 @@ class TestAccountContainer(TestAccountContainerAPI):
     def generate_account(self) -> "TestAccountAPI":
         new_index = self._num_of_accounts + self._num_generated
         self._num_generated += 1
-        generated_account = generate_dev_accounts(self._mnemonic, 1, start_index=new_index)[0]
+        generated_account = generate_dev_accounts(
+            self._mnemonic, 1, hd_path_format=self._hd_path, start_index=new_index
+        )[0]
         acc = TestAccount(
             index=new_index,
             address_str=generated_account.address,

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -399,3 +399,31 @@ def test_dir(core_account):
 def test_is_not_contract(owner, keyfile_account):
     assert not owner.is_contract
     assert not keyfile_account.is_contract
+
+
+def test_using_different_hd_path(test_accounts, temp_config):
+    test_config = {
+        "test": {
+            "hd_path": "m/44'/60'/0'/0/{}",
+        }
+    }
+
+    old_first_account = test_accounts[0]
+    with temp_config(test_config):
+        new_first_account = test_accounts[0]
+
+        assert old_first_account.address != new_first_account.address
+
+
+def test_using_random_mnemonic(test_accounts, temp_config):
+    test_config = {
+        "test": {
+            "mnemonic": "test_mnemonic_for_ape",
+        }
+    }
+
+    old_first_account = test_accounts[0]
+    with temp_config(test_config):
+        new_first_account = test_accounts[0]
+
+        assert old_first_account.address != new_first_account.address


### PR DESCRIPTION
Refactored generate_dev_account to allow any hd path and mnemonic to be used from config

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
