### PR TITLE
feat: sources and source path lookup improvements [APE-628]

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -110,6 +110,7 @@ class ProjectAPI(BaseInterfaceModel):
                 contract_type.name = contract_name
 
             contracts[contract_type.name] = contract_type
+
         return contracts
 
     @property

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -177,7 +177,7 @@ class CompilerManager(BaseManager):
 
         for ext, compiler in self.registered_compilers.items():
             try:
-                sources = [p for p in contract_filepaths if p.suffix == ext]
+                sources = [p for p in contract_filepaths if p.suffix == ext and p.is_file()]
                 imports = compiler.get_imports(contract_filepaths=sources, base_path=base_path)
             except NotImplementedError:
                 imports = None

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -508,7 +508,7 @@ class ProjectManager(BaseManager):
 
         return extensions_found
 
-    def lookup_path(self, key_contract_path: Path) -> Optional[Path]:
+    def lookup_path(self, key_contract_path: Union[Path, str]) -> Optional[Path]:
         """
         Figure out the full path of the contract from the given ``key_contract_path``.
 
@@ -519,13 +519,14 @@ class ProjectManager(BaseManager):
         returns ``<absolute-project-path>/<contracts-folder>/HelloWorld.sol``.
 
         Args:
-            key_contract_path (pathlib.Path): A sub-path to a contract.
+            key_contract_path (pathlib.Path, str): A sub-path to a contract or a source ID.
 
         Returns:
             pathlib.Path: The path if it exists, else ``None``.
         """
 
-        ext = key_contract_path.suffix or None
+        path = Path(key_contract_path)
+        ext = path.suffix or None
 
         def find_in_dir(dir_path: Path) -> Optional[Path]:
 
@@ -539,7 +540,7 @@ class ProjectManager(BaseManager):
                 ext_okay = ext == file_path.suffix if ext is not None else True
 
                 # File found
-                if file_path.stem == key_contract_path.stem and ext_okay:
+                if file_path.stem == path.stem and ext_okay:
                     return file_path
 
             return None

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -4,7 +4,7 @@ from typing import Dict, Iterable, List, Optional, Type, Union
 
 from ethpm_types import Compiler
 from ethpm_types import ContractInstance as EthPMContractInstance
-from ethpm_types import ContractType, PackageManifest, PackageMeta
+from ethpm_types import ContractType, PackageManifest, PackageMeta, Source
 from ethpm_types.contract_type import BIP122_URI
 from ethpm_types.manifest import PackageName
 from ethpm_types.utils import AnyUrl
@@ -63,6 +63,10 @@ class ProjectManager(BaseManager):
         """
 
         return self._load_dependencies()
+
+    @property
+    def sources(self) -> Dict[str, Source]:
+        return ProjectAPI._create_source_dict(self.source_paths, self.contracts_folder)
 
     # NOTE: Using these paths should handle the case when the folder doesn't exist
     @property

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -98,7 +98,7 @@ class ProjectManager(BaseManager):
             return files
 
         for extension in self.compiler_manager.registered_compilers:
-            files.extend(self.contracts_folder.rglob(f"*{extension}"))
+            files.extend((x for x in self.contracts_folder.rglob(f"*{extension}") if x.is_file()))
 
         return files
 

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -66,6 +66,10 @@ class ProjectManager(BaseManager):
 
     @property
     def sources(self) -> Dict[str, Source]:
+        """
+        A mapping of source identifier to ``ethpm_types.Source`` object.
+        """
+
         return ProjectAPI._create_source_dict(self.source_paths, self.contracts_folder)
 
     # NOTE: Using these paths should handle the case when the folder doesn't exist

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -319,3 +319,11 @@ def test_get_project_figure_out_contracts_path(project):
     project_path = WITH_DEPS_PROJECT / "renamed_contracts_folder"
     project = project.get_project(project_path)
     assert project.contracts_folder == project_path / "sources"
+
+
+def test_lookup_path(project_with_source_files_contract):
+    project = project_with_source_files_contract
+    actual_from_str = project.lookup_path("ContractA.sol")
+    actual_from_path = project.lookup_path(Path("ContractA.sol"))
+    expected = project.contracts_folder / "ContractA.sol"
+    assert actual_from_str == actual_from_path == expected

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -327,3 +327,9 @@ def test_lookup_path(project_with_source_files_contract):
     actual_from_path = project.lookup_path(Path("ContractA.sol"))
     expected = project.contracts_folder / "ContractA.sol"
     assert actual_from_str == actual_from_path == expected
+
+
+def test_sources(project_with_source_files_contract):
+    project = project_with_source_files_contract
+    assert "ApeContract0.json" in project.sources
+    assert project.sources["ApeContract0.json"].content


### PR DESCRIPTION
### What I did

* Adds `sources` property to `ProjectManager` so I can get source content by source ID easier.
* Improves `lookup_path` math to handle source ID arg types
* Fixes more issues related to directories with matching source file extensions getting sucked into places they shouldn't

e.g.:

```python
# Get line content from a Source in Ape
source = project.sources[ct.source_id]
line = source[line_index]

# Lookup real path to a source using a source ID.
src_path = project.lookup_path(ct.source_id)
```

### How I did it

* use internal project api `classmethod` for building source dict. NOTE: No compilation is necessary!
* wrap arg in `Path()` so it always works.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
