### PR TITLE
fix: scripts not running unless click script in scripts folder [APE-634]

### DIFF
--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -54,7 +54,10 @@ class ScriptCommand(click.MultiCommand):
             suffix = ".".join(
                 (str(_filepath).replace(os.path.sep, ".").split("scripts.")[-1].split(".")[:-1])
             )
-            return f"scripts.{suffix}"
+            if "/" not in suffix:
+                return f"scripts.{suffix}"
+            else:
+                return suffix
 
         # NOTE: Introspect code structure only for given patterns (do not execute it to find hooks)
         if "cli" in code.co_names:

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -54,7 +54,7 @@ class ScriptCommand(click.MultiCommand):
             suffix = ".".join(
                 (str(_filepath).replace(os.path.sep, ".").split("scripts.")[-1].split(".")[:-1])
             )
-            if "/" not in suffix:
+            if "." not in suffix:
                 return f"scripts.{suffix}"
             else:
                 return suffix

--- a/tests/integration/cli/projects/only-script-subdirs/scripts/subdirectory/subdirectory_click_print.py
+++ b/tests/integration/cli/projects/only-script-subdirs/scripts/subdirectory/subdirectory_click_print.py
@@ -1,0 +1,6 @@
+import click
+
+
+@click.command()
+def cli():
+    click.echo("Super secret script output")  # noqa: T001

--- a/tests/integration/cli/projects/only-script-subdirs/scripts/subdirectory/subdirectory_main_print.py
+++ b/tests/integration/cli/projects/only-script-subdirs/scripts/subdirectory/subdirectory_main_print.py
@@ -1,0 +1,2 @@
+def main():
+    print("Super secret script output")  # noqa: T001

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -48,6 +48,23 @@ def test_run_subdirectories(ape_cli, runner, project):
         assert "Super secret script output" in result.output
 
 
+@skip_projects_except("only-script-subdirs")
+def test_run_only_subdirs(ape_cli, runner, project):
+    result = runner.invoke(ape_cli, ["run"])
+    assert result.exit_code == 0, result.output
+    # By default, no commands are run
+    assert "Super secret script output" not in result.output
+    subdirectory_scripts = [
+        s
+        for s in (project.scripts_folder / "subdirectory").rglob("*.py")
+        if not s.name.startswith("error")
+    ]
+    for each in subdirectory_scripts:
+        result = runner.invoke(ape_cli, ["run", "subdirectory", each.stem])
+        assert result.exit_code == 0
+        assert "Super secret script output" in result.output
+
+
 @skip_projects_except("script")
 def test_run_when_script_errors(ape_cli, runner, project):
     scripts = [


### PR DESCRIPTION
### What I did

changed the suffix to be able to detect `.` from subdirectories to fix bug where subdirectory scripts would not run unless there was a click script in the `/scripts/` folder. 

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1302
fixes: APE-630

### How I did it

detects `.` in the suffix in order to see if it is in the main scripts folder or is in a subdirectory, then returns the suffix accordingly

### How to verify it

tests run, can also try in a project with scripts only in subdirectories (this is working for me)

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
