### PR TITLE
refactor: make dependency compile method public [APE-641]

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -307,6 +307,12 @@ class DependencyAPI(BaseInterfaceModel):
         return None
 
     def compile(self) -> PackageManifest:
+        """
+        Compile the contract types in this dependency into
+        a package manifest. NOTE: By default, dependency's
+        compile lazily.
+        """
+
         manifest = self.extract_manifest()
         if manifest.contract_types:
             # Already compiled

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -299,14 +299,14 @@ class DependencyAPI(BaseInterfaceModel):
         return container
 
     def get(self, contract_name: str) -> Optional["ContractContainer"]:
-        manifest = self._get_compiled_manifest()
+        manifest = self.compile()
         if hasattr(manifest, contract_name):
             contract_type = getattr(manifest, contract_name)
             return self.chain_manager.contracts.get_container(contract_type)
 
         return None
 
-    def _get_compiled_manifest(self) -> PackageManifest:
+    def compile(self) -> PackageManifest:
         manifest = self.extract_manifest()
         if manifest.contract_types:
             # Already compiled


### PR DESCRIPTION
### What I did

I'd like to be able to call this when working with Vyper dependency interface imports.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
