### PR TITLE
feat: include raw trace-frame data in `TraceFrame` class. [APE-646]

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1107,6 +1107,7 @@ class Web3Provider(ProviderAPI, ABC):
             gas=evm_frame.gas,
             gas_cost=evm_frame.gas_cost,
             depth=evm_frame.depth,
+            raw=evm_frame.dict(),
         )
 
     def _make_request(self, endpoint: str, parameters: List) -> Any:

--- a/src/ape/types/trace.py
+++ b/src/ape/types/trace.py
@@ -216,3 +216,8 @@ class TraceFrame(BaseInterfaceModel):
     """
     The number of external jumps away the initially called contract (starts at 0).
     """
+
+    raw: Dict = Field({}, exclude=True, repr=False)
+    """
+    The raw trace frame from the provider.
+    """


### PR DESCRIPTION
### What I did

Similar to `CallTreeNode`, allow the raw trace data to be accessible from the frame. This permits plugins to make ecosystem-specific assumptions about the data if they choose to.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
