### PR TITLE
refactor: utilize new evm trace [APE-649]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.2.0,<0.3.0",
         "ethpm-types>=0.3.16,<0.4",
-        "evm-trace>=0.1.0a15",
+        "evm-trace>=0.1.0a16",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1123,10 +1123,8 @@ class ReportManager(BaseManager):
             return
 
         gas_report = call_tree.get_gas_report(exclude=self.gas_exclusions)
-        if gas_report and self.session_gas_report:
-            self.session_gas_report = merge_reports(self.session_gas_report, gas_report)
-        elif gas_report:
-            self.session_gas_report = gas_report
+        session_report = self.session_gas_report or {}
+        self.session_gas_report = merge_reports(gas_report, session_report)
 
     def _get_console(self, file: Optional[IO[str]] = None) -> RichConsole:
         if not file:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1124,7 +1124,7 @@ class ReportManager(BaseManager):
 
         gas_report = call_tree.get_gas_report(exclude=self.gas_exclusions)
         session_report = self.session_gas_report or {}
-        self.session_gas_report = merge_reports(gas_report, session_report)
+        self.session_gas_report = merge_reports(session_report, gas_report)
 
     def _get_console(self, file: Optional[IO[str]] = None) -> RichConsole:
         if not file:

--- a/src/ape/types/trace.py
+++ b/src/ape/types/trace.py
@@ -165,8 +165,7 @@ class CallTreeNode(BaseInterfaceModel):
         for exclusion in exclusions:
             if exclusion.method_name is None and fnmatch(self.contract_id, exclusion.contract_name):
                 # Skip this whole contract. Search contracts from sub-calls.
-                reports = [c.get_gas_report(exclude) for c in self.calls]
-                return merge_reports(*reports) if reports else {}
+                return merge_reports(*(c.get_gas_report(exclude) for c in self.calls))
 
             for excl in exclusions:
                 if not excl.method_name:
@@ -179,8 +178,7 @@ class CallTreeNode(BaseInterfaceModel):
 
                 elif self.method_id and fnmatch(self.method_id, excl.method_name):
                     # Skip this report because of the method name exclusion criteria.
-                    reports = [c.get_gas_report(exclude) for c in self.calls]
-                    return merge_reports(*reports) if reports else {}
+                    return merge_reports(*(c.get_gas_report(exclude) for c in self.calls))
 
         reports = [c.get_gas_report(exclude) for c in self.calls]
         if self.method_id:
@@ -191,7 +189,7 @@ class CallTreeNode(BaseInterfaceModel):
             }
             reports.append(report)
 
-        return merge_reports(*reports) if reports else {}
+        return merge_reports(*reports)
 
 
 class TraceFrame(BaseInterfaceModel):


### PR DESCRIPTION
### What I did

Simplifies `merge_reports` usage because it now handles the case when it is given 0 reports.

### How I did it

Mostly delete code.

### How to verify it

Everything still works.
I already tested with `ape-hardhat` and `ape-foundry`.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
