### PR TITLE
fix: handle missing contract type JSONs [APE-650]

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -95,11 +95,13 @@ class ProjectAPI(BaseInterfaceModel):
         if it exists and is valid.
         """
         if self._cached_manifest is None:
-            manifest = _load_manifest_from_file(self.manifest_cachefile)
-            if manifest is not None:
-                manifest.contract_types = self.contracts
-            self._cached_manifest = manifest
-        return self._cached_manifest
+            self._cached_manifest = _load_manifest_from_file(self.manifest_cachefile)
+            if self._cached_manifest is None:
+                return None
+
+        manifest = self._cached_manifest
+        manifest.contract_types = self.contracts
+        return manifest
 
     @property
     def contracts(self) -> Dict[str, ContractType]:

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -103,6 +103,7 @@ class ProjectAPI(BaseInterfaceModel):
         if manifest.contract_types and not self.contracts:
             # Extract contract types from cached manifest.
             # This helps migrate to >= 0.6.3.
+            # TODO: Remove once Ape 0.7 is released.
             for contract_type in manifest.contract_types.values():
                 if not contract_type.name:
                     continue

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -420,12 +420,12 @@ class ProjectManager(BaseManager):
 
         # Contract not found. Re-compile in the case that it was deleted from the cache,
         # or the user is migrating to >= 0.6.3.
-        self.project_manager.load_contracts(use_cache=False)
+        self.local_project.create_manifest(use_cache=False)
         result = self._get_attr(attr_name)
         if result:
             return result
 
-        # Still not found after re-compile. Contract really doesn't exist.q
+        # Still not found after re-compile. Contract really doesn't exist.
         message = f"{self.__class__.__name__} has no attribute or contract named '{attr_name}'."
         missing_exts = self.extensions_with_missing_compilers([])
         if missing_exts:

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -265,3 +265,13 @@ def test_compile_only_dependency(ape_cli, runner, project, clean_cache, caplog):
 def test_raw_compiler_output_bytecode(ape_cli, runner, project):
     assert project.RawVyperOutput.contract_type.runtime_bytecode.bytecode
     assert project.RawSolidityOutput.contract_type.deployment_bytecode.bytecode
+
+
+@skip_projects_except("with-contracts")
+def test_compile_after_deleting_cache_file(ape_cli, runner, project):
+    assert project.RawVyperOutput
+    path = project.local_project._cache_folder / "RawVyperOutput.json"
+    path.unlink()
+
+    # Should still work (will have to figure it out its missing and put back).
+    assert project.RawVyperOutput


### PR DESCRIPTION
### What I did

Follow up to https://github.com/ApeWorX/ape/pull/1298

Right now, if you migrate from 0.6.2 to the soon-to-be 0.6.3, you will get issues where Ape cannot find your contracts because of some recent in-memory caching advancements. This PR does 2 things:

1. Allows migration to 0.6.3 by searching for the missing contract and recompiling it
2. Handles the case where if you manually delete a file JSON from your .build cache, it will re-compile it and give it back to you.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

* Install ape 0.6.2 and compile a project
* Switch to ape env with this branch installed
* Try to run a script or tests that uses one of the compiled scripts
* Before, it would fail saying the contract was not found, which may be confusing. Now, it will seemlessly work like nothing every happened (migration).
Additionally, if you delete a contract type JSON, Ape will now notice that and recompile them and things will still work as well.

**Basically, there is no reason to get a `ContractTypeNotFound` error in a local project for your own contracts when they actually exist.**

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
