### PR TITLE
feat: `run_until_complete()` support multiple coroutines [APE-653]

### DIFF
--- a/tests/functional/utils/test_misc.py
+++ b/tests/functional/utils/test_misc.py
@@ -7,6 +7,7 @@ from ape.utils.misc import (
     extract_nested_value,
     get_package_version,
     raises_not_implemented,
+    run_until_complete,
 )
 
 
@@ -46,3 +47,28 @@ def test_get_package_version():
     version = get_package_version("ape")
     # Fails if invalid version
     assert Version(version)
+
+
+def test_run_until_complete_not_coroutine():
+    expected = 3
+    actual = run_until_complete(3)
+    assert actual == expected
+
+
+def test_run_until_complete_coroutine():
+    async def foo():
+        return 3
+
+    actual = run_until_complete(foo())
+    assert actual == 3
+
+
+def test_run_until_complete_multiple_coroutines():
+    async def foo():
+        return 3
+
+    async def bar():
+        return 4
+
+    actual = run_until_complete(foo(), bar())
+    assert actual == [3, 4]


### PR DESCRIPTION
### What I did

Needing to parallelize something potentially and wanted to use this method. However, it only supports 1 coroutine at a time, which isn't super helpful for parallelization. 
Also, `ape-starknet` already had to implement this, so delete it from there and use this on next release.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
