### PR TITLE
feat: support debugging from `conftest.py` load failure [APE-668]

### DIFF
--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -164,7 +164,7 @@ class CliLogger:
         """
         message = self._create_message_from_error(err, message)
         self._logger.warning(message)
-        self._log_debug_stack_trace()
+        self.log_debug_stack_trace()
 
     def error_from_exception(self, err: Exception, message: str):
         """
@@ -174,7 +174,7 @@ class CliLogger:
         """
         message = self._create_message_from_error(err, message)
         self._logger.error(message)
-        self._log_debug_stack_trace()
+        self.log_debug_stack_trace()
 
     def _create_message_from_error(self, err: Exception, message: str):
         err_output = f"{type(err).__name__}: {err}"
@@ -185,7 +185,7 @@ class CliLogger:
 
         return message
 
-    def _log_debug_stack_trace(self):
+    def log_debug_stack_trace(self):
         stack_trace = traceback.format_exc()
         self._logger.debug(stack_trace)
 

--- a/src/ape/pytest/plugin.py
+++ b/src/ape/pytest/plugin.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from ape import networks, project
+from ape.logging import LogLevel, logger
 from ape.pytest.config import ConfigWrapper
 from ape.pytest.fixtures import PytestApeFixtures, ReceiptCapture
 from ape.pytest.runners import PytestApeRunner
@@ -87,6 +88,13 @@ def pytest_load_initial_conftests(early_config):
         try:
             project.load_contracts()
         except Exception as err:
-            raise pytest.UsageError(f"Unable to load project. Reason: {err}")
+            logger.log_debug_stack_trace()
+            message = "Unable to load project. "
+            if logger.level > LogLevel.DEBUG:
+                message = f"{message}Use `-v DEBUG` to see more info.\n"
+
+            message = f"{message}Failure reason: ({type(err).__name__}) {err}"
+            raise pytest.UsageError(message)
+
         finally:
             capture_manager.resume()


### PR DESCRIPTION
### What I did

When something went wrong while loading `conftest.py` in an Ape project, the exception was very bare and I was not able to use `-v debug`. For example, I had a `KeyError` and it looked like this:

```
ERROR: Unable to load project. Reason: 'args'
```

and so this PR does 2 things:

1. Includes Exception type in default message (while also alluding to the use of `-v debug`)

```
ERROR: Unable to load project. Use `-v DEBUG` to see more info.
Failure reason: (KeyError) 'args'
```

2. Allows `-v debug` to reveal full stack-trace:

```
...
... (more stuff but omitting here) ...
...
...
  File "My/Home/PycharmProjects/ape-vyper/ape_vyper/compiler.py", line 267, in compile
    while end_args["args"]:
KeyError: 'args'

ERROR: Unable to load project. Failure reason: (KeyError) 'args'
```

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
