### PR TITLE
fix: skip deployments when not connected [APE-680]

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -593,6 +593,9 @@ class ContractCache(BaseManager):
 
     @property
     def _deployments(self) -> Dict:
+        if not self.network_manager.active_provider:
+            return {}
+
         deployments = self._full_deployments
         return deployments.get(self._ecosystem_name, {}).get(self._data_network_name, {})
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -565,6 +565,9 @@ class ContractCache(BaseManager):
 
     @property
     def _is_live_network(self) -> bool:
+        if not self.network_manager.active_provider:
+            return False
+
         return self._network.name != LOCAL_NETWORK_NAME and not self._network.name.endswith("-fork")
 
     @property

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -386,6 +386,13 @@ def test_deployments_mapping_cache_location(chain):
     assert split_mapping_location[-2] == "ethereum"
 
 
+def test_deployments_when_offline(chain, networks_disconnected, vyper_contract_container):
+    """
+    Ensure you don't get `ProviderNotConnectedError` here.
+    """
+    assert chain.contracts.get_deployments(vyper_contract_container) == []
+
+
 def test_get_deployments_local(chain, owner, contract_0, contract_1):
     # Arrange
     chain.contracts._local_deployments_mapping = {}


### PR DESCRIPTION
### What I did

Allow things to not fail when not connected. Prevents me from having to connect to a provider for no reason while testing something. Otherwise would get `ProviderNotConnectedError`.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
