### PR TITLE
fix: remove trezor/ledger from reccomended plugins [APE-681]

### DIFF
--- a/recommended-plugins.txt
+++ b/recommended-plugins.txt
@@ -4,9 +4,7 @@ ape-etherscan
 ape-foundry
 ape-hardhat
 ape-infura
-ape-ledger
 ape-solidity
 ape-template
 ape-tokens
-ape-trezor
 ape-vyper


### PR DESCRIPTION
Because these aren't necessarily something every user would have we can remove them from the recommended-plugins install to make that process a bit simpler/faster