### PR TITLE
feat: reduced docker build size to 448MB from 1.7GB [APE-702]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,13 +31,12 @@ LABEL maintainer="ApeWorX" \
 RUN useradd --create-home --shell /bin/bash harambe
 
 COPY --from=builder /wheels /wheels
-WORKDIR /home/harambe/project
-
 COPY ./recommended-plugins.txt ./recommended-plugins.txt
 
 RUN pip install --upgrade pip \
     pip install --no-cache-dir --find-links=/wheels -r ./recommended-plugins.txt \
     && ape --version
 
+WORKDIR /home/harambe/project
 USER harambe
 ENTRYPOINT ["ape"]


### PR DESCRIPTION
### What I did

1. remove apt-get commands as they were no longer needed and a security issue
2. use a docker python build image to build the wheel files
3. copy the wheel files to a new docker image using -slim
4. install the wheel files

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

reducing docker build size because it is big and annoying

### How to verify it

`docker build . && docker images`

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [x] Documentation has been updated
