### PR TITLE
feat: show source code lines / traceback from `ReceiptAPI` [APE-708]

### DIFF
--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -5,4 +5,3 @@ queries:
 
 paths:
   - src
-

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.2.1,<0.3",
         "ethpm-types>=0.5.0,<0.6",
-        "evm-trace>=0.1.0a18",
+        "evm-trace>=0.1.0a19",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require = {
     ],
     "lint": [
         "black>=23.3.0,<24",  # Auto-formatter and linter
-        "mypy>=0.991",  # Static type analyzer
+        "mypy>=0.991,<1",  # Static type analyzer
         "types-PyYAML",  # Needed due to mypy typeshed
         "types-requests",  # Needed due to mypy typeshed
         "types-setuptools",  # Needed due to mypy typeshed

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
         "web3[tester]>=6.0.0,<7",
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.2.1,<0.3",
-        "ethpm-types>=0.4.5,<0.5",
+        "ethpm-types>=0.5.0,<0.6",
         "evm-trace>=0.1.0a18",
     ],
     entry_points={

--- a/src/ape/api/compiler.py
+++ b/src/ape/api/compiler.py
@@ -2,12 +2,13 @@ from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Set, Tuple
 
 from ethpm_types import ContractType, HexBytes
+from ethpm_types.contract_type import ContractSource
 from evm_trace.geth import TraceFrame as EvmTraceFrame
 from evm_trace.geth import create_call_node_data
 from semantic_version import Version  # type: ignore
 
 from ape.exceptions import ContractLogicError
-from ape.types.trace import ContractSource, SourceTraceback, TraceFrame
+from ape.types.trace import SourceTraceback, TraceFrame
 from ape.utils import BaseInterfaceModel, abstractmethod, raises_not_implemented
 
 

--- a/src/ape/api/compiler.py
+++ b/src/ape/api/compiler.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Set, Tuple
 
 from ethpm_types import ContractType, HexBytes
-from ethpm_types.contract_type import ContractSource
+from ethpm_types.source import ContractSource
 from evm_trace.geth import TraceFrame as EvmTraceFrame
 from evm_trace.geth import create_call_node_data
 from semantic_version import Version  # type: ignore

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -1,7 +1,7 @@
 import os.path
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import yaml
 from ethpm_types import Checksum, ContractType, PackageManifest, Source
@@ -171,17 +171,20 @@ class ProjectAPI(BaseInterfaceModel):
 
     @classmethod
     def _create_source_dict(
-        cls, contract_filepaths: List[Path], base_path: Path
+        cls, contract_filepaths: Union[Path, List[Path]], base_path: Path
     ) -> Dict[str, Source]:
+        filepaths = (
+            [contract_filepaths] if isinstance(contract_filepaths, Path) else contract_filepaths
+        )
         source_imports: Dict[str, List[str]] = cls.compiler_manager.get_imports(
-            contract_filepaths, base_path
+            filepaths, base_path
         )  # {source_id: [import_source_ids, ...], ...}
         source_references: Dict[str, List[str]] = cls.compiler_manager.get_references(
             imports_dict=source_imports
         )  # {source_id: [referring_source_ids, ...], ...}
 
         source_dict: Dict[str, Source] = {}
-        for source_path in contract_filepaths:
+        for source_path in filepaths:
             key = str(get_relative_path(source_path, base_path))
             source_dict[key] = Source(
                 checksum=Checksum(

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -357,7 +357,7 @@ class DependencyAPI(BaseInterfaceModel):
                 # Create content, including sub-directories.
                 source_path.parent.mkdir(parents=True, exist_ok=True)
                 source_path.touch()
-                source_path.write_text(content)
+                source_path.write_text(str(content))
 
             # Handle import remapping entries indicated in the manifest file
             target_config_file = project.path / project.config_file_name

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -19,7 +19,13 @@ from ape.exceptions import (
     TransactionNotFoundError,
 )
 from ape.logging import logger
-from ape.types import AddressType, ContractLogContainer, TraceFrame, TransactionSignature
+from ape.types import (
+    AddressType,
+    ContractLogContainer,
+    SourceTraceback,
+    TraceFrame,
+    TransactionSignature,
+)
 from ape.utils import BaseInterfaceModel, abstractmethod, cached_property, raises_not_implemented
 
 if TYPE_CHECKING:
@@ -428,6 +434,15 @@ class ReceiptAPI(BaseInterfaceModel):
 
         return output
 
+    @property
+    @raises_not_implemented
+    def source_traceback(self) -> SourceTraceback:  # type: ignore[empty-body]
+        """
+        A pythonic style traceback for both failing and non-failing receipts.
+        Requires a provider that implements
+        :meth:~ape.api.providers.ProviderAPI.get_transaction_trace`.
+        """
+
     @raises_not_implemented
     def show_trace(self, verbose: bool = False, file: IO[str] = sys.stdout):
         """
@@ -443,6 +458,14 @@ class ReceiptAPI(BaseInterfaceModel):
     def show_gas_report(self, file: IO[str] = sys.stdout):
         """
         Display a gas report for the calls made in this transaction.
+        """
+
+    @raises_not_implemented
+    def show_source_traceback(self):
+        """
+        Show a receipt traceback mapping to lines in the source code.
+        Only works when the contract type and source code are both available,
+        like in local projects.
         """
 
     def track_gas(self):

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -756,7 +756,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
         if not self._cached_receipt and self.txn_hash:
             try:
                 receipt = self.chain_manager.get_receipt(self.txn_hash)
-            except TransactionNotFoundError:
+            except (TransactionNotFoundError, ValueError):
                 return None
 
             self._cached_receipt = receipt

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -1,4 +1,5 @@
 import sys
+import tempfile
 import time
 import traceback
 from collections import deque
@@ -689,7 +690,13 @@ def _get_custom_python_traceback(
         if lineno is None:
             continue
 
-        filename = exec_item.source_path.as_posix()
+        if exec_item.source_path is None:
+            # File is not local. Create a temporary file in its place.
+            # This is necessary for tracebacks to work in Python.
+            temp_file = tempfile.NamedTemporaryFile(prefix="unknown_contract_")
+            filename = temp_file.name
+        else:
+            filename = exec_item.source_path.as_posix()
 
         # Raise an exception at the correct line number.
         py_code: CodeType = compile(

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -2,11 +2,11 @@ import shutil
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Type, Union
 
-from ethpm_types import Compiler
 from ethpm_types import ContractInstance as EthPMContractInstance
 from ethpm_types import ContractType, PackageManifest, PackageMeta, Source
-from ethpm_types.contract_type import BIP122_URI, ContractSource
+from ethpm_types.contract_type import BIP122_URI
 from ethpm_types.manifest import PackageName
+from ethpm_types.source import Compiler, ContractSource
 from ethpm_types.utils import AnyUrl
 
 from ape.api import DependencyAPI, ProjectAPI

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterable, List, Optional, Type, Union
 from ethpm_types import Compiler
 from ethpm_types import ContractInstance as EthPMContractInstance
 from ethpm_types import ContractType, PackageManifest, PackageMeta, Source
-from ethpm_types.contract_type import BIP122_URI
+from ethpm_types.contract_type import BIP122_URI, ContractSource
 from ethpm_types.manifest import PackageName
 from ethpm_types.utils import AnyUrl
 
@@ -16,7 +16,6 @@ from ape.exceptions import APINotImplementedError, ProjectError
 from ape.logging import logger
 from ape.managers.base import BaseManager
 from ape.managers.project.types import ApeProject, BrownieProject
-from ape.types.trace import ContractSource
 from ape.utils import get_relative_path
 
 
@@ -731,19 +730,17 @@ class ProjectManager(BaseManager):
         destination.write_text(artifact.json())
 
     def _create_contract_source(self, contract_type: ContractType) -> Optional[ContractSource]:
-        source_id = contract_type.source_id
-        if not source_id:
+        if not contract_type.source_id:
             return None
 
-        src = self._lookup_source(source_id)
+        src = self._lookup_source(contract_type.source_id)
         if not src:
             return None
 
-        source_path = self.lookup_path(source_id)
-        if not source_path:
+        try:
+            return ContractSource.create(contract_type, src, self.contracts_folder)
+        except (ValueError, FileNotFoundError):
             return None
-
-        return ContractSource(contract_type=contract_type, source=src, source_path=source_path)
 
     def _lookup_source(self, source_id: str) -> Optional[Source]:
         source_path = self.lookup_path(source_id)

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -77,12 +77,13 @@ class _ProjectSources:
 
         cached_source = self.cached_sources[source_id]
         cached_checksum = cached_source.calculate_checksum()
-
         source_file = self.contracts_folder / source_path
-        checksum = compute_checksum(
-            source_file.read_text("utf8").encode("utf8"),
-            algorithm=cached_checksum.algorithm,
-        )
+
+        # ethpm_types strips trailing white space and ensures
+        # a newline at the end so content so `splitlines()` works.
+        # We need to do the same here for to prevent the endless recompiling bug.
+        content = f"{source_file.read_text('utf8').rstrip()}\n"
+        checksum = compute_checksum(content.encode("utf8"), algorithm=cached_checksum.algorithm)
 
         # NOTE: Filter by checksum to only update what's needed
         return checksum != cached_checksum.hash  # Contents changed

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -22,7 +22,14 @@ from web3.types import FilterParams
 
 from ape.types.address import AddressType, RawAddress
 from ape.types.signatures import MessageSignature, SignableMessage, TransactionSignature
-from ape.types.trace import CallTreeNode, GasReport, TraceFrame
+from ape.types.trace import (
+    CallTreeNode,
+    Closure,
+    ControlFlow,
+    GasReport,
+    SourceTraceback,
+    TraceFrame,
+)
 from ape.utils import BaseInterfaceModel, cached_property
 from ape.utils.misc import to_int
 
@@ -295,6 +302,7 @@ __all__ = [
     "Bytecode",
     "CallTreeNode",
     "Checksum",
+    "Closure",
     "Compiler",
     "ContractLog",
     "ContractLogContainer",
@@ -307,6 +315,8 @@ __all__ = [
     "SignableMessage",
     "SnapshotID",
     "Source",
+    "SourceTraceback",
+    "ControlFlow",
     "TraceFrame",
     "TransactionSignature",
 ]

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -16,14 +16,14 @@ from ethpm_types import (
     Source,
 )
 from ethpm_types.abi import EventABI
-from ethpm_types.source import Closure, ControlFlow
+from ethpm_types.source import Closure
 from hexbytes import HexBytes
 from pydantic import BaseModel, root_validator, validator
 from web3.types import FilterParams
 
 from ape.types.address import AddressType, RawAddress
 from ape.types.signatures import MessageSignature, SignableMessage, TransactionSignature
-from ape.types.trace import CallTreeNode, GasReport, SourceTraceback, TraceFrame
+from ape.types.trace import CallTreeNode, ControlFlow, GasReport, SourceTraceback, TraceFrame
 from ape.utils import BaseInterfaceModel, cached_property
 from ape.utils.misc import to_int
 

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -16,20 +16,14 @@ from ethpm_types import (
     Source,
 )
 from ethpm_types.abi import EventABI
+from ethpm_types.source import Closure, ControlFlow
 from hexbytes import HexBytes
 from pydantic import BaseModel, root_validator, validator
 from web3.types import FilterParams
 
 from ape.types.address import AddressType, RawAddress
 from ape.types.signatures import MessageSignature, SignableMessage, TransactionSignature
-from ape.types.trace import (
-    CallTreeNode,
-    Closure,
-    ControlFlow,
-    GasReport,
-    SourceTraceback,
-    TraceFrame,
-)
+from ape.types.trace import CallTreeNode, GasReport, SourceTraceback, TraceFrame
 from ape.utils import BaseInterfaceModel, cached_property
 from ape.utils.misc import to_int
 

--- a/src/ape/types/trace.py
+++ b/src/ape/types/trace.py
@@ -294,7 +294,10 @@ class SourceFunction(Closure):
 
     @validator("ast", pre=True)
     def validate_ast(cls, value):
-        if value.classification is not ASTClassification.FUNCTION:
+        if (
+            value.classification is not ASTClassification.FUNCTION
+            or "function" not in str(value.ast_type).lower()
+        ):
             raise ValueError(
                 f"`ast` must be a function definition (classification={value.classification})."
             )

--- a/src/ape/types/trace.py
+++ b/src/ape/types/trace.py
@@ -297,7 +297,7 @@ class SourceFunction(Closure):
     def validate_ast(cls, value):
         if (
             value.classification is not ASTClassification.FUNCTION
-            or "function" not in str(value.ast_type).lower()
+            and "function" not in str(value.ast_type).lower()
         ):
             raise ValueError(
                 f"`ast` must be a function definition (classification={value.classification})."

--- a/src/ape/types/trace.py
+++ b/src/ape/types/trace.py
@@ -588,14 +588,20 @@ class SourceTraceback(BaseModel):
 
         return f"{header}{builder}"
 
-    def add_jump(self, location: SourceLocation, function: Function, source_path: Path, depth: int):
+    def add_jump(
+        self,
+        location: SourceLocation,
+        function: Function,
+        depth: int,
+        source_path: Optional[Path] = None,
+    ):
         """
         Add an execution sequence from a jump.
 
         Args:
             location (``SourceLocation``): The location to add.
             function (``Function``): The function executing.
-            source_path (``Path``): The path of the source file.
+            source_path (Optional[``Path``]): The path of the source file.
             depth (int): The depth of the function call in the call tree.
         """
 
@@ -607,7 +613,7 @@ class SourceTraceback(BaseModel):
 
         Statement.update_forward_refs()
         ControlFlow.update_forward_refs()
-        self._add(asts, content, source_path, function, depth)
+        self._add(asts, content, function, depth, source_path=source_path)
 
     def extend_last(self, location: SourceLocation):
         """
@@ -646,9 +652,9 @@ class SourceTraceback(BaseModel):
         self,
         asts: List[ASTNode],
         content: Content,
-        source_path: Path,
         function: Function,
         depth: int,
+        source_path: Optional[Path] = None,
     ):
         statement = SourceStatement(asts=asts, content=content)
         exec_sequence = ControlFlow(

--- a/src/ape/types/trace.py
+++ b/src/ape/types/trace.py
@@ -371,6 +371,15 @@ class SourceStatement(Statement):
     content: SourceContent
     """The source code content connected to the AST node."""
 
+    def __len__(self):
+        return len(self.content.as_list())
+
+    def __getitem__(self, idx: int) -> str:
+        return self.content.as_list()[idx]
+
+    def __iter__(self) -> Iterator[str]:
+        yield from self.content.as_list()
+
     @validator("content", pre=True)
     def validate_content(cls, value):
         if len(value) < 1:
@@ -496,6 +505,9 @@ class ControlFlow(BaseModel):
             return self.statements[idx]
         except IndexError as err:
             raise IndexError(f"Statement index '{idx}' out of range.") from err
+
+    def __len__(self) -> int:
+        return len(self.statements)
 
     @property
     def source_statements(self) -> List[SourceStatement]:

--- a/src/ape/types/trace.py
+++ b/src/ape/types/trace.py
@@ -377,7 +377,7 @@ class SourceStatement(Statement):
     def __getitem__(self, idx: int) -> str:
         return self.content.as_list()[idx]
 
-    def __iter__(self) -> Iterator[str]:
+    def __iter__(self) -> Iterator[str]:  # type: ignore[override]
         yield from self.content.as_list()
 
     @validator("content", pre=True)

--- a/src/ape/types/trace.py
+++ b/src/ape/types/trace.py
@@ -1,8 +1,11 @@
 from fnmatch import fnmatch
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
+from ethpm_types import ASTNode, BaseModel, ContractType, HexBytes, PCMap, Source
+from ethpm_types.ast import ASTClassification, SourceLocation
 from evm_trace.gas import merge_reports
-from pydantic import Field
+from pydantic import Field, validator
 from rich.table import Table
 from rich.tree import Tree
 
@@ -225,3 +228,727 @@ class TraceFrame(BaseInterfaceModel):
     """
     The raw trace frame from the provider.
     """
+
+
+class SourceContent(BaseModel):
+    """
+    A wrapper around source code line numbers mapped to the content
+    string of those lines.
+    """
+
+    __root__: Dict[int, str]
+
+    @property
+    def begin_lineno(self) -> int:
+        return self.line_numbers[0] if self.line_numbers else -1
+
+    @property
+    def end_lineno(self) -> int:
+        return self.line_numbers[-1] if self.line_numbers else -1
+
+    @property
+    def line_numbers(self) -> List[int]:
+        """
+        All line number in order for this piece of content.
+        """
+        return sorted(list(self.__root__.keys()))
+
+    def items(self):
+        return self.__root__.items()
+
+    def as_list(self) -> List[str]:
+        return list(self.__root__.values())
+
+    def __getitem__(self, lineno: int) -> str:
+        return self.__root__[lineno]
+
+    def __iter__(self):
+        yield from self.__root__
+
+    def __len__(self) -> int:
+        return len(self.__root__)
+
+
+class Closure(BaseModel):
+    """
+    A wrapper around code ran, such as a function.
+    """
+
+    name: str
+    """The name of the definition."""
+
+
+class SourceFunction(Closure):
+    """
+    Data about a function in a contract with known source code.
+    """
+
+    ast: ASTNode
+    """The function definition AST node."""
+
+    offset: int
+    """The line number of the first AST after the signature."""
+
+    content: SourceContent
+    """The function's line content after the signature, mapped by line numbers."""
+
+    @validator("ast", pre=True)
+    def validate_ast(cls, value):
+        if value.classification is not ASTClassification.FUNCTION:
+            raise ValueError("`ast` must be a function definition.")
+
+        return value
+
+    def __str__(self) -> str:
+        return self.name
+
+    def __repr__(self) -> str:
+        preview = self.name[:18].rstrip()
+        return f"<SourceFunction {preview} ... >"
+
+    def get_content(self, location: SourceLocation) -> SourceContent:
+        """
+        Get the source content for the given location.
+
+        Args:
+            location (``SourceLocation``): The location of the content.
+
+        Returns:
+            :class:`~ape.types.trace.SourceContent`
+        """
+
+        start = max(location[0], self.offset)
+        stop = location[2] + 1
+        content = {n: self.content[n] for n in range(start, stop) if n in self.content}
+        return SourceContent(__root__=content)
+
+    def get_content_asts(self, location: SourceLocation) -> List[ASTNode]:
+        """
+        Get all AST nodes for the given location.
+
+        Args:
+            location (``SourceLocation``): The location of the content.
+
+        Returns:
+            ``List[ASTNode]``: AST nodes objects.
+        """
+
+        return [
+            a
+            for a in self.ast.get_nodes_at_line(location)
+            if a.lineno >= location[0] and a.classification is not ASTClassification.FUNCTION
+        ]
+
+
+class Statement(BaseModel):
+    """
+    A class representing an item in a control flow, either a source statement
+    or implicit compiler code.
+    """
+
+    type: str
+
+    def __repr__(self) -> str:
+        return f"<Statement type={self.type}>"
+
+
+class SourceStatement(Statement):
+    """
+    A class mapping an AST node to some source code content.
+    """
+
+    type: str = "source"
+
+    asts: List[ASTNode]
+    """The AST nodes from this statement."""
+
+    content: SourceContent
+    """The source code content connected to the AST node."""
+
+    @validator("content", pre=True)
+    def validate_content(cls, value):
+        if len(value) < 1:
+            raise ValueError("Must have at least 1 line of content.")
+
+        return value
+
+    @validator("asts", pre=True)
+    def validate_asts(cls, value):
+        if len(value) < 1:
+            raise ValueError("Must have at least 1 AST node.")
+
+        return value
+
+    @property
+    def begin_lineno(self) -> int:
+        """
+        The first line number.
+        """
+
+        return self.asts[0].lineno
+
+    @property
+    def ws_begin_lineno(self) -> int:
+        """
+        The first line number including backfilled whitespace lines
+        (for output debugging purposes).
+        """
+
+        # NOTE: Whitespace only include when above or besides a statement;
+        # not below.
+
+        # Whitespace lines should already be present in content.
+        return self.content.begin_lineno
+
+    @property
+    def end_lineno(self) -> int:
+        """
+        The last line number.
+        """
+
+        return self.asts[-1].end_lineno
+
+    @property
+    def location(self) -> SourceLocation:
+        return self.begin_lineno, -1, self.end_lineno, -1
+
+    def __str__(self) -> str:
+        # Include whitespace lines.
+        return self.to_str()
+
+    def __repr__(self) -> str:
+        # Excludes whitespace lines.
+        return self.to_str(begin_lineno=self.begin_lineno)
+
+    def to_str(self, begin_lineno: Optional[int] = None):
+        begin_lineno = self.ws_begin_lineno if begin_lineno is None else begin_lineno
+        content = ""
+        for lineno, line in self.content.items():
+            if lineno < begin_lineno:
+                continue
+
+            elif content:
+                # Indent first.
+                content = f"{content.rstrip()}\n"
+
+            content = f"{content}    {lineno} {line}"
+
+        return content
+
+
+class ControlFlow(BaseModel):
+    """
+    A collection of linear source nodes up until a jump.
+    """
+
+    statements: List[Statement]
+    """
+    The source node statements.
+    """
+
+    closure: Closure
+    """
+    The defining closure, such as a function or module, of the code sequence.
+    """
+
+    source_path: Path
+    """
+    The path to the local contract file.
+    Only exists when is from a local contract.
+    """
+
+    depth: int
+    """
+    The depth at which this flow was executed,
+    where 1 is the first calling function.
+    """
+
+    def __str__(self) -> str:
+        return f"{self.source_header}\n{self.format()}"
+
+    def __repr__(self) -> str:
+        representation = f"<control path, {self.source_path.name} {self.closure.name}"
+
+        if len(self.statements) > 0:
+            representation = f"{representation} num_statements={len(self.statements)}"
+
+        if self.begin_lineno is None:
+            return f"{representation}>"
+
+        else:
+            # Include line number info.
+            end_lineno = self.end_lineno or self.begin_lineno
+            line_range = (
+                f"line {self.begin_lineno}"
+                if self.begin_lineno == end_lineno
+                else f"lines {self.begin_lineno}-{end_lineno}"
+            )
+            return f"{representation}, {line_range}>"
+
+    def __getitem__(self, idx: int) -> Statement:
+        try:
+            return self.statements[idx]
+        except IndexError as err:
+            raise IndexError(f"Statement index '{idx}' out of range.") from err
+
+    @property
+    def source_statements(self) -> List[SourceStatement]:
+        """
+        All statements coming directly from a contract's source.
+        Excludes implicit-compiler statements.
+        """
+        return [x for x in self.statements if isinstance(x, SourceStatement)]
+
+    @property
+    def begin_lineno(self) -> Optional[int]:
+        """
+        The first line number in the sequence.
+        """
+        stmts = self.source_statements
+        return stmts[0].begin_lineno if stmts else None
+
+    @property
+    def ws_begin_lineno(self) -> Optional[int]:
+        """
+        The first line number in the sequence, including whitespace.
+        """
+        stmts = self.source_statements
+        return stmts[0].ws_begin_lineno if stmts else None
+
+    @property
+    def line_numbers(self) -> List[int]:
+        """
+        The list of all line numbers as part of this node.
+        """
+
+        if self.begin_lineno is None:
+            return []
+
+        elif self.end_lineno is None:
+            return [self.begin_lineno]
+
+        return list(range(self.begin_lineno, self.end_lineno + 1))
+
+    @property
+    def content(self) -> SourceContent:
+        result: Dict[int, str] = {}
+        for node in self.source_statements:
+            result = {**result, **node.content.__root__}
+
+        return SourceContent(__root__=result)
+
+    @property
+    def source_header(self) -> str:
+        return f"File {self.source_path}, in {self.closure.name}".rstrip()
+
+    @property
+    def end_lineno(self) -> Optional[int]:
+        """
+        The last line number.
+        """
+        stmts = self.source_statements
+        return stmts[-1].end_lineno if stmts else None
+
+    def extend(self, location: SourceLocation, ws_start: Optional[int] = None):
+        """
+        Extend this node's content with other content that follows it directly.
+
+        Raises:
+            ValueError: When there is a gap in content.
+
+        Args:
+            location (SourceLocation): The location of the content, in the form
+              (lineno, col_offset, end_lineno, end_coloffset).
+            ws_start (Optional[int]): Optionally provide a white-space starting point
+              to back-fill.
+        """
+
+        if ws_start is not None and ws_start > location[0]:
+            # No new lines.
+            return
+
+        function = self.closure
+        if not isinstance(function, SourceFunction):
+            # No source code supported for closure type.
+            return
+
+        # NOTE: Use non-ws prepending location to fetch AST nodes.
+        asts = function.get_content_asts(location)
+        if not asts:
+            return
+
+        location = (
+            (ws_start, location[1], location[2], location[3]) if ws_start is not None else location
+        )
+        content = function.get_content(location)
+        start = (
+            max(location[0], self.end_lineno + 1) if self.end_lineno is not None else location[0]
+        )
+        end = location[0] + len(content) - 1
+        if end < start:
+            # No new lines.
+            return
+
+        elif start - end > 1:
+            raise ValueError(
+                "Cannot extend when gap in lines > 1. "
+                "If because of whitespace lines, must include it the given content."
+            )
+
+        content_start = len(content) - (end - start) - 1
+        new_lines = {no: ln.rstrip() for no, ln in content.items() if no >= content_start}
+        if new_lines:
+            # Add the next statement in this sequence.
+            content = SourceContent(__root__=new_lines)
+            statement = SourceStatement(asts=asts, content=content)
+            self.statements.append(statement)
+
+        else:
+            # Add ASTs to latest statement.
+            self.source_statements[-1].asts.extend(asts)
+
+    def format(self, use_arrow: bool = True) -> str:
+        """
+        Format this trace node into a string presentable to the user.
+        """
+
+        # NOTE: Only show last 2 statements.
+        relevant_stmts = self.statements[-2:]
+        content = ""
+        end_lineno = self.content.end_lineno
+
+        for stmt in relevant_stmts:
+            for lineno, line in getattr(stmt, "content", {}).items():
+                if not content and not line.strip():
+                    # Prevent starting on whitespace.
+                    continue
+
+                if content:
+                    # Add newline to carry over from last.
+                    content = f"{content.rstrip()}\n"
+
+                space = "       " if lineno < end_lineno or not use_arrow else "  -->  "
+                content = f"{content}{space}{lineno} {line}"
+
+        return content
+
+    @property
+    def next_statement(self) -> Optional[SourceStatement]:
+        """
+        Returns the next statement that _would_ execute
+        if the program were to progress to the next line.
+        """
+
+        # Check for more statements that _could_ execute.
+        if not self.statements:
+            return None
+
+        last_stmt = self.source_statements[-1]
+        function = self.closure
+        if not isinstance(function, SourceFunction):
+            return None
+
+        rest_asts = [a for a in function.ast.children if a.lineno > last_stmt.end_lineno]
+        if not rest_asts:
+            # At the end of a function.
+            return None
+
+        # Filter out to only the ASTs for the next statement.
+        next_stmt_start = min(rest_asts, key=lambda x: x.lineno).lineno
+        next_stmt_asts = [a for a in rest_asts if a.lineno == next_stmt_start]
+        content_dict = {}
+        for ast in next_stmt_asts:
+            sub_content = function.get_content(ast.line_numbers)
+            content_dict = {**sub_content.__root__}
+
+        if not content_dict:
+            return None
+
+        sorted_dict = {k: content_dict[k] for k in sorted(content_dict)}
+        content = SourceContent(__root__=sorted_dict)
+        return SourceStatement(asts=next_stmt_asts, content=content)
+
+
+class SourceTraceback(BaseModel):
+    """
+    A full execution traceback including source code.
+    """
+
+    __root__: List[ControlFlow]
+
+    def __str__(self) -> str:
+        return self.format()
+
+    def __repr__(self) -> str:
+        return f"<ape.types.SourceTraceback control_paths={len(self.__root__)}>"
+
+    def __len__(self) -> int:
+        return len(self.__root__)
+
+    def __iter__(self):
+        yield from self.__root__
+
+    def __getitem__(self, idx: int) -> ControlFlow:
+        try:
+            return self.__root__[idx]
+        except IndexError as err:
+            raise IndexError(f"Control flow index '{idx}' out of range.") from err
+
+    def __setitem__(self, key, value):
+        return self.__root__.__setitem__(key, value)
+
+    def append(self, __object) -> None:
+        self.__root__.append(__object)
+
+    def extend(self, __iterable) -> None:
+        if not isinstance(__iterable, SourceTraceback):
+            raise TypeError("Can only extend another traceback object.")
+
+        self.__root__.extend(__iterable.__root__)
+
+    @property
+    def last(self) -> Optional[ControlFlow]:
+        return self.__root__[-1] if len(self.__root__) else None
+
+    @property
+    def execution(self) -> List[ControlFlow]:
+        return list(self.__root__)
+
+    def format(self) -> str:
+        if not len(self.__root__):
+            # No calls.
+            return ""
+
+        header = "Traceback (most recent call last)"
+        indent = "  "
+        last_depth = None
+        segments = []
+        for control_flow in reversed(self.__root__):
+            if last_depth is None or control_flow.depth == last_depth - 1:
+                last_depth = control_flow.depth
+                segment = f"{indent}{control_flow.source_header}\n{control_flow.format()}"
+
+                # Try to include next statement for display purposes.
+                next_stmt = control_flow.next_statement
+                if next_stmt:
+                    if (
+                        next_stmt.begin_lineno is not None
+                        and control_flow.end_lineno is not None
+                        and next_stmt.begin_lineno > control_flow.end_lineno + 1
+                    ):
+                        # Include whitespace.
+                        for ws_no in range(control_flow.end_lineno + 1, next_stmt.begin_lineno):
+                            function = control_flow.closure
+                            if not isinstance(function, SourceFunction):
+                                continue
+
+                            ws = function.content[ws_no]
+                            segment = f"{segment}\n       {ws_no} {ws}".rstrip()
+
+                    for no, line in next_stmt.content.items():
+                        segment = f"{segment}\n       {no} {line}".rstrip()
+
+                segments.append(segment)
+
+        builder = ""
+        for idx, segment in enumerate(reversed(segments)):
+            builder = f"{builder}\n{segment}"
+
+            if idx < len(segments) - 1:
+                builder = f"{builder}\n"
+
+        return f"{header}{builder}"
+
+    def add_jump(
+        self, location: SourceLocation, function: SourceFunction, source_path: Path, depth: int
+    ):
+        """
+        Add an execution sequence from a jump.
+
+        Args:
+            location (``SourceLocation``): The location to add.
+            function (:class:`~ape.types.trace.SourceFunction`): The function executing.
+            source_path (``Path``): The path of the source file.
+            depth (int): The depth of the function call in the call tree.
+        """
+
+        # Exclude signature ASTs.
+        asts = function.get_content_asts(location)
+        content = function.get_content(location)
+        if not asts or not content:
+            return
+
+        Statement.update_forward_refs()
+        ControlFlow.update_forward_refs()
+        self._add(asts, content, source_path, function, depth)
+
+    def extend_last(self, location: SourceLocation):
+        """
+        Extend the last node with more content.
+
+        Args:
+            location (``SourceLocation``): The location of the new content.
+        """
+
+        if not self.last:
+            raise ValueError(
+                "`progress()` should only be called when "
+                "there is at least 1 ongoing execution trail."
+            )
+
+        start = (
+            1
+            if self.last is not None and self.last.end_lineno is None
+            else self.last.end_lineno + 1
+        )
+        self.last.extend(location, ws_start=start)
+
+    def _add(
+        self,
+        asts: List[ASTNode],
+        content: SourceContent,
+        source_path: Path,
+        function: SourceFunction,
+        depth: int,
+    ):
+        statement = SourceStatement(asts=asts, content=content)
+        exec_sequence = ControlFlow(
+            statements=[statement], source_path=source_path, closure=function, depth=depth
+        )
+        self.append(exec_sequence)
+
+
+class ContractSource(BaseModel):
+    """
+    A contract type wrapper that enforces all the necessary
+    properties needed for doing source-code processing,
+    such as coverage or showing source code lines during an exception.
+    """
+
+    contract_type: ContractType
+    """The contract type with AST, PCMap, and other necessary properties."""
+
+    source: Source
+    """The source code wrapper."""
+
+    source_path: Path
+    """The path to the source."""
+
+    _function_ast_cache: Dict[str, ASTNode] = {}
+
+    @validator("contract_type", pre=True)
+    def _validate_contract_type(cls, contract_type):
+        if contract_type.source_id is None:
+            raise ValueError("ContractType missing source_id")
+        if contract_type.ast is None:
+            raise ValueError("ContractType missing ast")
+        if contract_type.pcmap is None:
+            raise ValueError("ContractType missing pcmap")
+
+        return contract_type
+
+    @property
+    def source_id(self) -> str:
+        """The contract type source ID."""
+
+        return self.contract_type.source_id  # type: ignore[return-value]
+
+    @property
+    def ast(self) -> ASTNode:
+        """The contract type AST node."""
+
+        return self.contract_type.ast  # type: ignore[return-value]
+
+    @property
+    def pcmap(self) -> PCMap:
+        """The contract type PCMap."""
+
+        return self.contract_type.pcmap  # type: ignore[return-value]
+
+    def __repr__(self) -> str:
+        return f"<{self.source_path.name}::{self.contract_type.name or 'unknown'}>"
+
+    def lookup_function(
+        self, location: SourceLocation, method_id: Optional[HexBytes] = None
+    ) -> Optional[SourceFunction]:
+        """
+        Lookup a function by location.
+
+        Args:
+            location (``SourceLocation``): The location to search.
+            method_id (Optional[HexBytes]): Optionally provide a method ID
+              to use to craft a nicer name. Defaults to using the combined
+              lines of the function signature content.
+
+        Returns:
+            Optional[:class:`~ape.types.trace.SourceFunction`]: The function, if one is
+            found.
+        """
+
+        ast = self.ast.get_defining_function(location)
+        if not ast:
+            return None
+
+        signature_lines, content_lines = self._parse_function(ast)
+        offset = ast.lineno + len(signature_lines)
+
+        # Check if method ID points to a calling method.
+        name = None
+        if method_id and method_id.hex() in self._function_ast_cache:
+            cached_fn = self._function_ast_cache[method_id.hex()]
+            if (
+                cached_fn.lineno == ast.lineno
+                and cached_fn.end_lineno == ast.end_lineno
+                and method_id in self.contract_type.methods
+            ):
+                # Is the same function. It's safe to use the method ABI name.
+                method = self.contract_type.methods[method_id]
+                name = method.name
+
+        elif method_id and method_id in self.contract_type.methods:
+            # Not in cache yet. Assume is calling.
+            method = self.contract_type.methods[method_id]
+            name = method.name
+            self._function_ast_cache[method_id.hex()] = ast
+
+        if name is None:
+            name = "".join([x.strip() for x in signature_lines]).rstrip()
+
+        content_dict = {offset + i: ln for i, ln in enumerate(content_lines)}
+        content = SourceContent(__root__=content_dict)
+        SourceFunction.update_forward_refs()
+
+        return SourceFunction(
+            ast=ast,
+            name=name,
+            offset=offset,
+            content=content,
+        )
+
+    def _parse_function(self, function: ASTNode) -> Tuple[List[str], List[str]]:
+        """
+        Parse function AST into two groups. One being the list of
+        lines making up the signature and the other being the content
+        lines of the function.
+        """
+
+        start = function.lineno - 1
+        end = function.end_lineno
+        lines = self.source[start:end]
+
+        content_start = None
+        for child in function.children:
+            # Find smallest lineno after signature-related ASTs.
+            if (
+                child.lineno > function.lineno
+                and child.classification != ASTClassification.FUNCTION
+                and (content_start is None or child.lineno < content_start)
+            ):
+                content_start = child.lineno
+
+        if content_start is None:
+            # Shouldn't happen, but just in case, use only the first line.
+            content_start = function.lineno + 1
+
+        offset = content_start - function.lineno
+        return lines[:offset], lines[offset:]

--- a/src/ape/types/trace.py
+++ b/src/ape/types/trace.py
@@ -295,7 +295,9 @@ class SourceFunction(Closure):
     @validator("ast", pre=True)
     def validate_ast(cls, value):
         if value.classification is not ASTClassification.FUNCTION:
-            raise ValueError("`ast` must be a function definition.")
+            raise ValueError(
+                f"`ast` must be a function definition (classification={value.classification})."
+            )
 
         return value
 

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -176,19 +176,10 @@ class Receipt(ReceiptAPI):
     @property
     def source_traceback(self) -> SourceTraceback:
         contract_type = self.contract_type
-        if not contract_type or not contract_type.source_id:
+        if not contract_type:
             return SourceTraceback.parse_obj([])
 
-        ext = f".{contract_type.source_id.split('.')[-1]}"
-        if ext not in self.compiler_manager.registered_compilers:
-            return SourceTraceback.parse_obj([])
-
-        compiler = self.compiler_manager.registered_compilers[ext]
-
-        try:
-            return compiler.trace_source(contract_type, self.trace, HexBytes(self.data))
-        except NotImplementedError:
-            return SourceTraceback.parse_obj([])
+        return SourceTraceback.create(contract_type, self.trace, HexBytes(self.data))
 
     def raise_for_status(self):
         if self.gas_limit is not None and self.ran_out_of_gas:

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -184,7 +184,7 @@ class GethDevProcess(LoggingMixin, BaseGethProcess):
         self._clean()
 
     def _clean(self):
-        if self.data_dir.exists():
+        if self.data_dir.is_dir():
             shutil.rmtree(self.data_dir)
 
 

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -135,12 +135,13 @@ def test_compile_when_contract_type_collision(ape_cli, runner, project, clean_ca
 
 @skip_projects_except("multiple-interfaces")
 def test_compile_when_source_contains_return_characters(ape_cli, runner, project, clean_cache):
-    # NOTE: This tests a bugfix where a source file contained return-characters
-    # and that triggered endless re-compiles because it technically contains extra
-    # bytes than the ones that show up in the text.
-
-    # Change the contents of a file to contain the '\r' character.
+    """
+    This tests a bugfix where a source file contained return-characters
+    and that triggered endless re-compiles because it technically contains extra
+    bytes than the ones that show up in the text.
+    """
     source_path = project.contracts_folder / "Interface.json"
+    # Change the contents of a file to contain the '\r' character.
     modified_source_text = f"{source_path.read_text()}\r"
     source_path.unlink()
     source_path.touch()


### PR DESCRIPTION
### What I did

fixes: #867 
Fixes: APE-217
Fixes: APE-577

* Adds `traceback` property to `ReceiptAPI` with implementation in `ape_ethereum`
* Adds `show_source_traceback()` method to `ReceiptAPI` the same.

### How I did it

* Using AST, trace execution, and PCMap. Only works with Vyper at first.

### How to verify it

Create `interfaces/IRegistryF.vy`:

```python
# @version 0.3.7

@external
def register_f(addr: address):
    pass
```

Create `RegistryF.vy`:

```python
# @version 0.3.7

addr: public(address)

@external
def register_f(addr2: address):
    assert self.addr != addr2, "doubling."
    self.addr = addr2
```

Create `JustFail.vy`:

```python
# @version 0.3.7

import interfaces.IRegistryF as IRegistryF

_balance: public(uint256)
registry: public(IRegistryF)

@external
def __init__(registry: IRegistryF):
    self.registry = registry

@external
def addBalance_f(
    num: uint256
) -> uint256:
    assert num != self._balance
    self.registry.register(msg.sender)
    self._balance = self._balance + self.addInterest(num)

    # Run some loops.
    for i in [1, 2, 3, 4, 5]:
        if i == num:
            break

    # Fail in the middle (is test)
    # Fails because was already set above.
    self.registry.register_f(msg.sender)

    for i in [1, 2, 3, 4, 5]:
        if i != num:
            continue

    return self._balance

@internal
def addInterest(num: uint256) -> uint256:
    return 123 + num
```

Create a script `tb.py`:

```python
import ape
from ape.exceptions import ContractLogicError


def main():
    account = ape.accounts.test_accounts[0]
    registry = ape.project.RegistryF.deploy(sender=account)
    contract = ape.project.JustFail.deploy(registry, sender=account)
    txn = contract.addBalance_f.as_transaction(123)

    try:
        account.call(txn)
    except ContractLogicError:
        pass

    receipt = txn.provider.get_receipt(txn.txn_hash.hex())
    receipt.show_source_traceback()
```

It should show:

```shell
Traceback (most recent call last)
  File /home/ApeProjects/ape-playground/contracts/JustFail.vy, in addBalance_f(uint256 num) -> uint256
       20     # Run some loops.
       21     for i in [1, 2, 3, 4, 5]:
       22         if i == num:
       23             break
       24
       25     # Fail in the middle (is test)
       26     # Fails because was already set above.
  -->  27     self.registry.register_f(msg.sender)
       28
       29     for i in [1, 2, 3, 4, 5]:
       30         if i != num:
       31             continue

  File /home/ApeProjects/ape-playground/contracts/RegistryF.vy, in register_f(address addr2)
  -->  7     assert self.addr != addr2, "doubling."
       8     self.addr = addr2
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
