### PR TITLE
feat: two new `ape console` Magics [APE-726]

### DIFF
--- a/docs/userguides/console.md
+++ b/docs/userguides/console.md
@@ -122,11 +122,9 @@ Commands:
   compile   Compile select contract source files
   console   Load the console
   init      Initalize an ape project
-  ledger    Manage Ledger accounts
   networks  Manage networks
   plugins   Manage ape plugins
   run       Run scripts from the `scripts/` folder
-  template  Create a project from a Cookiecutter project template (TEMPLATE).
   test      Launches pytest and runs the tests for a project
 
 Out[1]: <Result okay>

--- a/docs/userguides/console.md
+++ b/docs/userguides/console.md
@@ -88,6 +88,17 @@ Out[1]: 1
 
 You can also add an `ape_console_extras.py` file to the global ape data directory (`$HOME/.ape/ape_console_extras.py`) and it will execute regardless of what project context you are in.  This may be useful for variables and utility functions you use across all of your projects.
 
+## Configure
+
+To automatically use other IPython extensions, add them to your `ape-config.yaml` file:
+
+```yaml
+console:
+  plugins:
+    # A plugin that lets you modify Python modules without having close/reopen your console.
+    - autoreload
+```
+
 ## Magic Commands
 
 The `ape-console` plugin ships with custom [magics](https://ipython.readthedocs.io/en/stable/interactive/magics.html#line-magics) that are available when running the `ape console` command or loading the `ape_console.plugin` IPython extension manually.

--- a/docs/userguides/console.md
+++ b/docs/userguides/console.md
@@ -90,7 +90,7 @@ You can also add an `ape_console_extras.py` file to the global ape data director
 
 ## Magic Commands
 
-The `ape-console` plugin ships with some custom [magics](https://ipython.readthedocs.io/en/stable/interactive/magics.html#line-magics).
+The `ape-console` plugin ships with custom [magics](https://ipython.readthedocs.io/en/stable/interactive/magics.html#line-magics).
 
 ### %ape
 
@@ -98,8 +98,6 @@ The `%ape` magic invokes the CLI in your `ape-console` session:
 
 ```shell
 In [1]: %ape
-WARNING: Unable to load CLI endpoint for plugin 'ape_starknet'
-        ModuleNotFoundError: No module named 'starknet_py.hash'
 Usage: cli [OPTIONS] COMMAND [ARGS]...
 
 Options:
@@ -128,7 +126,7 @@ Run any CLI command this way without exiting your session.
 
 ### %bal
 
-Get a human-readable account balance on an account, address, or account alias.
+The `%bal` magic outputs a human-readable balance on an account, contract, address, or account alias.
 
 ```shell
 In [1]: account = accounts.load("metamask0")

--- a/docs/userguides/console.md
+++ b/docs/userguides/console.md
@@ -92,6 +92,14 @@ You can also add an `ape_console_extras.py` file to the global ape data director
 
 The `ape-console` plugin ships with custom [magics](https://ipython.readthedocs.io/en/stable/interactive/magics.html#line-magics).
 
+**WARN**: When starting an embedded console (from a `-I` in `ape run` or `ape test`), you will have to load the extension manually:
+
+```shell
+In [1]: %load_ext ape_console.plugin
+```
+
+Otherwise, when launching `ape console`, the magics are automatically available.
+
 ### %ape
 
 The `%ape` magic invokes the CLI in your `ape-console` session:

--- a/docs/userguides/console.md
+++ b/docs/userguides/console.md
@@ -92,7 +92,7 @@ You can also add an `ape_console_extras.py` file to the global ape data director
 
 The `ape-console` plugin ships with custom [magics](https://ipython.readthedocs.io/en/stable/interactive/magics.html#line-magics).
 
-**WARN**: When starting an embedded console (from a `-I` in `ape run` or `ape test`), you will have to load the extension manually:
+**NOTE**: When starting an embedded console (from a `-I` in `ape run` or `ape test`), you will have to load the extension manually:
 
 ```shell
 In [1]: %load_ext ape_console.plugin

--- a/docs/userguides/console.md
+++ b/docs/userguides/console.md
@@ -87,3 +87,58 @@ Out[1]: 1
 ### Global Extras
 
 You can also add an `ape_console_extras.py` file to the global ape data directory (`$HOME/.ape/ape_console_extras.py`) and it will execute regardless of what project context you are in.  This may be useful for variables and utility functions you use across all of your projects.
+
+## Magic Commands
+
+The `ape-console` plugin ships with some custom [magics](https://ipython.readthedocs.io/en/stable/interactive/magics.html#line-magics).
+
+### %ape
+
+The `%ape` magic invokes the CLI in your `ape-console` session:
+
+```shell
+In [1]: %ape
+WARNING: Unable to load CLI endpoint for plugin 'ape_starknet'
+        ModuleNotFoundError: No module named 'starknet_py.hash'
+Usage: cli [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  -v, --verbosity LVL  One of ERROR, WARNING, SUCCESS, INFO, or DEBUG
+  --version            Show the version and exit.
+  --config             Show configuration options (using `ape-config.yaml`)
+  -h, --help           Show this message and exit.
+
+Commands:
+  accounts  Manage local accounts
+  cache     Query from caching database
+  compile   Compile select contract source files
+  console   Load the console
+  init      Initalize an ape project
+  ledger    Manage Ledger accounts
+  networks  Manage networks
+  plugins   Manage ape plugins
+  run       Run scripts from the `scripts/` folder
+  template  Create a project from a Cookiecutter project template (TEMPLATE).
+  test      Launches pytest and runs the tests for a project
+
+Out[1]: <Result okay>
+```
+
+Run any CLI command this way without exiting your session.
+
+### %bal
+
+Get a human-readable account balance on an account, address, or account alias.
+
+```shell
+In [1]: account = accounts.load("metamask0")
+
+In [2]: %bal account
+Out[2]: '0.00040634 ETH'
+
+In [3]: %bal metamask0
+Out[3]: '0.00040634 ETH'
+
+In [4]: %bal 0xE3747e6341E0d3430e6Ea9e2346cdDCc2F8a4b5b
+Out[4]: '0.00040634 ETH'
+```

--- a/docs/userguides/console.md
+++ b/docs/userguides/console.md
@@ -90,13 +90,15 @@ You can also add an `ape_console_extras.py` file to the global ape data director
 
 ## Magic Commands
 
-The `ape-console` plugin ships with custom [magics](https://ipython.readthedocs.io/en/stable/interactive/magics.html#line-magics).
-
-**NOTE**: When starting an embedded console (from a `-I` in `ape run` or `ape test`), you will have to load the extension manually:
+The `ape-console` plugin ships with custom [magics](https://ipython.readthedocs.io/en/stable/interactive/magics.html#line-magics) that are available when running the `ape console` command or loading the `ape_console.plugin` IPython extension manually.
+When starting an embedded console (from `-I` in `ape run` or `ape test`), you will have to load the extension manually.
+To do this, run the following from _any_ `IPython` environment:
 
 ```shell
 In [1]: %load_ext ape_console.plugin
 ```
+
+Or add the `ape_console.plugin` extension to your `IPython` config.
 
 Otherwise, when launching `ape console`, the magics are automatically available.
 

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -70,6 +70,9 @@ class EcosystemAPI(BaseInterfaceModel):
     fee_token_symbol: str
     """The token symbol for the currency that pays for fees, such as ETH."""
 
+    fee_token_decimals: int = 18
+    """The number of the decimals the fee token has."""
+
     _default_network: str = LOCAL_NETWORK_NAME
 
     def __repr__(self) -> str:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -939,7 +939,6 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
             Any: The return value from the contract call, or a transaction receipt.
         """
 
-        handler: Union[ContractEvent, ContractCallHandler, ContractTransactionHandler]
         if attr_name in set(super(BaseAddress, self).__dir__()):
             return super(BaseAddress, self).__getattribute__(attr_name)
 

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -79,7 +79,7 @@ class PytestApeRunner(ManagerAccessMixin):
             click.echo("Starting interactive mode. Type `exit` fail and halt current test.")
 
             namespace = {"_callinfo": call, **globals_dict, **locals_dict}
-            console(extra_locals=namespace, project=self.project_manager)
+            console(extra_locals=namespace, project=self.project_manager, embed=True)
 
             # launch ipdb instead of console
             if capman:

--- a/src/ape_console/__init__.py
+++ b/src/ape_console/__init__.py
@@ -1,0 +1,7 @@
+from ape import plugins
+from ape_console.config import ConsoleConfig
+
+
+@plugins.register(plugins.Config)
+def config_class():
+    return ConsoleConfig

--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -129,13 +129,13 @@ def console(project=None, verbose=None, extra_locals=None, embed=False):
     if environ.get("APE_TESTING"):
         _config.HistoryManager.enabled = False
 
-    shared_kwargs = {
+    ipython_kwargs = {
         "colors": "Neutral",
         "banner1": banner,
         "user_ns": namespace,
         "config": _config,
     }
     if embed:
-        IPython.embed(**shared_kwargs)
+        IPython.embed(**ipython_kwargs)
     else:
-        IPython.start_ipython(**shared_kwargs, argv=["--ext", "ape_console.plugin"])
+        IPython.start_ipython(**ipython_kwargs, argv=["--ext", "ape_console.plugin"])

--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -6,7 +6,7 @@ from importlib.machinery import SourceFileLoader
 from importlib.util import module_from_spec, spec_from_loader
 from os import environ, getcwd
 from types import ModuleType
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 import click
 import IPython  # type: ignore
@@ -17,6 +17,7 @@ from ape import project as default_project
 from ape.cli import NetworkBoundCommand, ape_cli_context, network_option
 from ape.utils.misc import _python_version
 from ape.version import version as ape_version
+from ape_console.config import ConsoleConfig
 
 CONSOLE_EXTRAS_FILENAME = "ape_console_extras.py"
 
@@ -138,4 +139,9 @@ def console(project=None, verbose=None, extra_locals=None, embed=False):
     if embed:
         IPython.embed(**ipython_kwargs)
     else:
-        IPython.start_ipython(**ipython_kwargs, argv=["--ext", "ape_console.plugin"])
+        console_config = cast(ConsoleConfig, ape.config.get_config("console"))
+        arguments = ["--ext", "ape_console.plugin"]
+        if console_config.plugins:
+            arguments.extend(["--InteractiveShellApp.extensions", *console_config.plugins])
+
+        IPython.start_ipython(**ipython_kwargs, argv=arguments)

--- a/src/ape_console/config.py
+++ b/src/ape_console/config.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from ape.api import PluginConfig
+
+
+class ConsoleConfig(PluginConfig):
+    plugins: List[str] = []
+    """Additional IPython plugins to include in your session."""

--- a/src/ape_console/plugin.py
+++ b/src/ape_console/plugin.py
@@ -39,7 +39,9 @@ class ApeConsoleMagics(Magics):
             raise ValueError("Unable to run `console` within a console.")
 
         result = runner.invoke(cli, line)
-        click.echo(result.output)
+        if result.output:
+            click.echo(result.output)
+
         return result
 
     @line_magic

--- a/src/ape_console/plugin.py
+++ b/src/ape_console/plugin.py
@@ -22,6 +22,11 @@ class ApeConsoleMagics(Magics):
 
         """
         runner = CliRunner()
+        if "console" in line.split(" "):
+            # Prevent running console within console because usually bad
+            # stuff happens when you try to do this.
+            raise ValueError("Unable to run `console` within a console.")
+
         result = runner.invoke(cli, line)
         click.echo(result.output)
         return result

--- a/src/ape_console/plugin.py
+++ b/src/ape_console/plugin.py
@@ -7,10 +7,19 @@ from IPython.core.magic import Magics, line_magic, magics_class  # type: ignore
 import ape
 from ape._cli import cli
 from ape.types import AddressType
+from ape.utils import cached_property
 
 
 @magics_class
 class ApeConsoleMagics(Magics):
+    @cached_property
+    def ipython(self):
+        ipython = get_ipython()
+        if not ipython:
+            raise ValueError("Must be called from an IPython session.")
+
+        return ipython
+
     @line_magic
     def ape(self, line: str = ""):
         """
@@ -42,13 +51,12 @@ class ApeConsoleMagics(Magics):
             %bal account
         """
 
-        ipython = get_ipython()
         if not line:
             raise ValueError("Missing argument.")
 
         provider = ape.networks.provider
         ecosystem = provider.network.ecosystem
-        result = eval(line, ipython.user_global_ns, ipython.user_ns)
+        result = eval(line, self.ipython.user_global_ns, self.ipython.user_ns)
         if isinstance(result, str) and not is_hex(result):
             # Check if is an account alias.
             address = ape.accounts.load(result).address

--- a/src/ape_console/plugin.py
+++ b/src/ape_console/plugin.py
@@ -13,7 +13,7 @@ class ApeConsoleMagics(Magics):
     @line_magic
     def ape(self, line: str = ""):
         """
-        Run Ape CLI commands with an ``ape console`` session.
+        Run Ape CLI commands within an ``ape console`` session.
 
         Usage example::
 

--- a/src/ape_console/plugin.py
+++ b/src/ape_console/plugin.py
@@ -1,0 +1,66 @@
+import click
+from click.testing import CliRunner
+from eth_utils import to_hex
+from IPython import get_ipython  # type: ignore
+from IPython.core.magic import Magics, line_magic, magics_class  # type: ignore
+
+import ape
+from ape._cli import cli
+
+
+@magics_class
+class ApeConsoleMagics(Magics):
+    @line_magic
+    def ape(self, line: str = ""):
+        """
+        Run Ape CLI commands with an ``ape console`` session.
+
+        Usage example::
+
+            %ape accounts list
+
+        """
+        runner = CliRunner()
+        result = runner.invoke(cli, line)
+        click.echo(result.output)
+        return result
+
+    @line_magic
+    def bal(self, line: str = ""):
+        """
+        Show an account balance in human-readable form.
+
+        Usage example::
+
+            account = accounts.load("me")
+            %bal account
+        """
+
+        ipython = get_ipython()
+        if not line:
+            raise ValueError("Missing argument.")
+
+        provider = ape.networks.provider
+        ecosystem = provider.network.ecosystem
+        result = eval(line, ipython.user_global_ns, ipython.user_ns)
+        if hasattr(result, "address"):
+            address = result.address
+        elif isinstance(result, str) and result.startswith("0x"):
+            address = result
+        elif isinstance(result, str) and result.isnumeric() or isinstance(result, int):
+            # Happens when excluding quotes from hex str.
+            hex_result = to_hex(int(result))
+            address = ecosystem.decode_address(hex_result)
+        elif isinstance(result, str):
+            address = ape.accounts.load(result).address
+        else:
+            raise ValueError(f"Unable to get account from '{result}'.")
+
+        decimals = ecosystem.fee_token_decimals
+        symbol = ecosystem.fee_token_symbol
+        balance = provider.get_balance(address)
+        return f"{round(balance / 10 ** decimals, 8)} {symbol}"
+
+
+def load_ipython_extension(ipython):
+    ipython.register_magics(ApeConsoleMagics)

--- a/src/ape_console/plugin.py
+++ b/src/ape_console/plugin.py
@@ -1,3 +1,5 @@
+import shlex
+
 import click
 from click.testing import CliRunner
 from eth_utils import is_hex
@@ -31,7 +33,7 @@ class ApeConsoleMagics(Magics):
 
         """
         runner = CliRunner()
-        if "console" in line.split(" "):
+        if "console" in [x.strip("\"' \t\n") for x in shlex.split(line)]:
             # Prevent running console within console because usually bad
             # stuff happens when you try to do this.
             raise ValueError("Unable to run `console` within a console.")

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -210,7 +210,7 @@ class ScriptCommand(click.MultiCommand):
             if frame:
                 del frame
 
-        return console(project=self._project, extra_locals=extra_locals)
+        return console(project=self._project, extra_locals=extra_locals, embed=True)
 
 
 @click.command(

--- a/tests/integration/cli/test_console.py
+++ b/tests/integration/cli/test_console.py
@@ -90,13 +90,19 @@ def test_console_extras(project, folder, ape_cli, runner):
     write_ape_console_extras(project, folder, EXTRAS_SCRIPT_1)
 
     result = runner.invoke(
-        ape_cli, ["console"], input="\n".join(["assert A == 1", "exit"]), catch_exceptions=False
+        ape_cli,
+        ["console"],
+        input="\n".join(["assert A == 1", "exit"]) + "\n",
+        catch_exceptions=False,
     )
     assert result.exit_code == 0, result.output
     assert no_console_error(result), result.output
 
     result = runner.invoke(
-        ape_cli, ["console"], input="\n".join(["assert a() == 1", "exit"]), catch_exceptions=False
+        ape_cli,
+        ["console"],
+        input="\n".join(["assert a() == 1", "exit"]) + "\n",
+        catch_exceptions=False,
     )
     assert result.exit_code == 0, result.output
     assert no_console_error(result), result.output
@@ -139,7 +145,8 @@ def test_console_init_extras_return(project, folder, ape_cli, runner):
                 "assert B == 2, 'unexpected B'",
                 "exit",
             ]
-        ),
+        )
+        + "\n",
         catch_exceptions=False,
     )
     assert result.exit_code == 0, result.output
@@ -151,7 +158,8 @@ def test_console_import_local_path(project, ape_cli, runner):
     result = runner.invoke(
         ape_cli,
         ["console"],
-        input="\n".join(["from dependency_in_project_only.importme import import_me", "exit"]),
+        input="\n".join(["from dependency_in_project_only.importme import import_me", "exit"])
+        + "\n",
     )
     assert result.exit_code == 0, result.output
     assert no_console_error(result), result.output
@@ -179,14 +187,13 @@ def test_console_ape_magic(ape_cli, runner):
         input="%ape --help\nexit\n",
         catch_exceptions=False,
     )
-    # Only asserts part of `--help` output is present.
-    expected_part = "-verbosity LVL  One of ERROR, WARNING, SUCCESS, INFO, or DEBUG"
-    assert expected_part in result.output
+    assert result.exit_code == 0, result.output
+    assert no_console_error(result), result.output
 
 
 @skip_projects_except("only-dependencies")
 def test_console_bal_magic(ape_cli, runner, keyfile_account):
-    cases = ["%bal acct", "%bal acct.alias", "%bal acct.address", "%bal int(acct.address, 16)"]
+    cases = ("%bal acct", "%bal acct.alias", "%bal acct.address", "%bal int(acct.address, 16)")
     cmd_ls = [f"acct = accounts.load('{keyfile_account.alias}')", *cases, "exit"]
     cmd_str = "\n".join(cmd_ls)
     result = runner.invoke(
@@ -195,5 +202,5 @@ def test_console_bal_magic(ape_cli, runner, keyfile_account):
         input=f"{cmd_str}\n",
         catch_exceptions=False,
     )
-    assert " ETH" in result.output
-    assert result.output.count(" ETH") == len(cases)
+    assert result.exit_code == 0, result.output
+    assert no_console_error(result), result.output

--- a/tests/integration/cli/test_console.py
+++ b/tests/integration/cli/test_console.py
@@ -169,3 +169,31 @@ def test_console_import_local_path_in_extras_file(project, ape_cli, runner):
     )
     assert result.exit_code == 0, result.output
     assert no_console_error(result), result.output
+
+
+@skip_projects_except("only-dependencies")
+def test_console_ape_magic(ape_cli, runner):
+    result = runner.invoke(
+        ape_cli,
+        ["console"],
+        input="%ape --help\nexit\n",
+        catch_exceptions=False,
+    )
+    # Only asserts part of `--help` output is present.
+    expected_part = "-verbosity LVL  One of ERROR, WARNING, SUCCESS, INFO, or DEBUG"
+    assert expected_part in result.output
+
+
+@skip_projects_except("only-dependencies")
+def test_console_bal_magic(ape_cli, runner, keyfile_account):
+    cases = ["%bal acct", "%bal acct.alias", "%bal acct.address", "%bal int(acct.address, 16)"]
+    cmd_ls = [f"acct = accounts.load('{keyfile_account.alias}')", *cases, "exit"]
+    cmd_str = "\n".join(cmd_ls)
+    result = runner.invoke(
+        ape_cli,
+        ["console"],
+        input=f"{cmd_str}\n",
+        catch_exceptions=False,
+    )
+    assert " ETH" in result.output
+    assert result.output.count(" ETH") == len(cases)


### PR DESCRIPTION
### What I did

Am looking for more IPython integration opportunities with tracebacks.
Ended up here. But look, this is kinda of neat and sets us up to integrate more with IPython, which ultimately is what we need...

* Creates an `%ape` magic for `ape-console` that allows running CLI commands within the `ape console` session:

```shell
ape console --network ethereum:mainnet:alchemy
In [1]: %ape accounts list
Found 1 account:
  0x1e59ce931B4CFea3fe4B875411e280e173cB7A9C (alias: 'test0')

Out[1]: <Result okay>
```

A `%bal` magic that gets a balance in human-readable form:

```shell
In [2]: account = accounts.load("metamask0")

In [3]: %bal account
Out[3]: '0.00040634 ETH'
```

### How I did it

* `start_ipython` for CLI command but use `embed` everywhere else (`ape test -I` and `ape run -I`)
* Register as an official IPython extension
* Add implementations for the said magics

### How to verify it

See above!

Would like to see much testing though and feedback on even if we want this.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
