### PR TITLE
feat: add datetime block [APE-734]

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1,5 +1,6 @@
 import atexit
 import ctypes
+import datetime
 import logging
 import platform
 import shutil
@@ -82,6 +83,10 @@ class BlockAPI(BaseInterfaceModel):
     )  # NOTE: genesis block has no parent hash
     size: int
     timestamp: int
+
+    @property
+    def datetime(self) -> datetime.datetime:
+        return datetime.datetime.fromtimestamp(self.timestamp, tz=datetime.timezone.utc)
 
     @root_validator(pre=True)
     def convert_parent_hash(cls, data):

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -1,5 +1,6 @@
 import sys
 import time
+from datetime import datetime
 from typing import IO, TYPE_CHECKING, Any, Iterator, List, Optional, Union
 
 from eth_utils import is_hex, to_int
@@ -282,6 +283,14 @@ class ReceiptAPI(BaseInterfaceModel):
     @cached_property
     def block(self) -> "BlockAPI":
         return self.chain_manager.blocks[self.block_number]
+
+    @property
+    def timestamp(self) -> int:
+        return self.block.timestamp
+
+    @property
+    def datetime(self) -> datetime:
+        return self.block.datetime
 
     @cached_property
     def events(self) -> ContractLogContainer:

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -22,6 +22,7 @@ from ape.types import AddressType, ContractLogContainer, TraceFrame, Transaction
 from ape.utils import BaseInterfaceModel, abstractmethod, cached_property, raises_not_implemented
 
 if TYPE_CHECKING:
+    from ape.api.providers import BlockAPI
     from ape.contracts import ContractEvent
 
 
@@ -277,6 +278,10 @@ class ReceiptAPI(BaseInterfaceModel):
             return 0
 
         return latest_block.number - self.block_number
+
+    @cached_property
+    def block(self) -> "BlockAPI":
+        return self.chain_manager.blocks[self.block_number]
 
     @cached_property
     def events(self) -> ContractLogContainer:

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -246,6 +246,11 @@ def test_block_range_out_of_order(chain_that_mined_5):
     assert "stop_block: '0' cannot be less than start_block: '3'." in str(err.value)
 
 
+def test_block_timestamp(chain):
+    chain.mine()
+    assert chain.blocks.head.timestamp == chain.blocks.head.datetime.timestamp()
+
+
 def test_set_pending_timestamp(chain):
     start_timestamp = chain.pending_timestamp
     chain.pending_timestamp += 3600

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -227,9 +227,9 @@ def test_poll_logs(chain, vyper_contract_instance, eth_tester_provider, owner, P
 
     actual = [logs.get() for _ in range(size)]
     assert all(a.newNum == e for a, e in zip(actual, (1, 33, 7)))
-    assert actual[0].block_number == start_block + 1
-    assert actual[1].block_number == actual[0].block_number + 1
-    assert actual[2].block_number == actual[1].block_number + 1
+    assert actual[0].block_number == actual[0].block.number == start_block + 1
+    assert actual[1].block_number == actual[1].block.number == actual[0].block_number + 1
+    assert actual[2].block_number == actual[2].block.number == actual[1].block_number + 1
 
 
 def test_poll_logs_timeout(vyper_contract_instance, eth_tester_provider, owner, PollDaemon):

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -11,7 +11,7 @@ def invoke_receipt(vyper_contract_instance, owner):
 
 
 def test_receipt_properties(chain, invoke_receipt):
-    assert chain.blocks.head.number == invoke_receipt.block_number
+    assert invoke_receipt.block_number == chain.blocks.head.number
     assert chain.blocks.head.timestamp == invoke_receipt.timestamp
     assert chain.blocks.head.datetime == invoke_receipt.datetime
 

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -12,8 +12,8 @@ def invoke_receipt(vyper_contract_instance, owner):
 
 def test_receipt_properties(chain, invoke_receipt):
     assert invoke_receipt.block_number == chain.blocks.head.number
-    assert chain.blocks.head.timestamp == invoke_receipt.timestamp
-    assert chain.blocks.head.datetime == invoke_receipt.datetime
+    assert invoke_receipt.timestamp == chain.blocks.head.timestamp
+    assert invoke_receipt.datetime == chain.blocks.head.datetime
 
 
 def test_show_trace(invoke_receipt):

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -10,6 +10,12 @@ def invoke_receipt(vyper_contract_instance, owner):
     return vyper_contract_instance.setNumber(1, sender=owner)
 
 
+def test_receipt_properties(chain, invoke_receipt):
+    assert chain.blocks.head.number == invoke_receipt.block_number
+    assert chain.blocks.head.timestamp == invoke_receipt.timestamp
+    assert chain.blocks.head.datetime == invoke_receipt.datetime
+
+
 def test_show_trace(invoke_receipt):
     # See trace-supported provider plugin tests for better tests (e.g. ape-hardhat)
     with pytest.raises(APINotImplementedError):


### PR DESCRIPTION
### What I did

Add some linked data to `ReceiptAPI` and extra processing on `BlockAPI.timestamp` to get a datetime obj

fixes: #1257

### How I did it

Uses `ChainManager.blocks` to fetch the blocks in order to take advantage of the query manager

### How to verify it

Call the methods directly and via `AccountHistoryContainer.query`/`BlockContainer.query` to verify if any issues are introduced

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
