### PR TITLE
feat: convenience property for getting receipt from a transaction [APE-744]

### DIFF
--- a/src/ape/pytest/contextmanagers.py
+++ b/src/ape/pytest/contextmanagers.py
@@ -45,17 +45,12 @@ class RevertsContextManager:
         if contract.contract_type.pcmap is None:
             raise AssertionError("Compiler does not support source code mapping.")
 
-        try:
-            txn_hash = txn.txn_hash.hex()
-        except SignatureError as exc:
-            raise AssertionError(
-                "Cannot check dev message; "
-                "transaction failed before signing, "
-                "likely during gas estimation."
-            ) from exc
+        receipt = txn.receipt
+        if not receipt:
+            raise AssertionError("Cannot check dev message. Transaction never published.")
 
         try:
-            trace = deque(txn.provider.get_transaction_trace(txn_hash=txn_hash))
+            trace = deque(receipt.trace)
         except APINotImplementedError as exc:
             raise AssertionError(
                 "Cannot check dev message; provider must support transaction tracing."

--- a/src/ape/pytest/contextmanagers.py
+++ b/src/ape/pytest/contextmanagers.py
@@ -7,7 +7,6 @@ from ape.exceptions import (
     APINotImplementedError,
     ContractLogicError,
     ProviderError,
-    SignatureError,
     TransactionError,
 )
 

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -114,6 +114,12 @@ def test_revert_specify_gas(sender, contract_instance, gas):
         contract_instance.setNumber(5, sender=sender, gas=gas)
 
 
+def test_revert_no_message_specify_gas(owner, contract_instance):
+    expected = "Transaction failed."  # Default message
+    with pytest.raises(ContractLogicError, match=expected):
+        contract_instance.setNumber(5, sender=owner, gas=200000)
+
+
 def test_revert_static_fee_type(sender, contract_instance):
     with pytest.raises(ContractLogicError, match="!authorized"):
         contract_instance.setNumber(5, sender=sender, type=0)

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -122,16 +122,13 @@ def test_decode_logs_unspecified_abi_gets_all_logs(owner, contract_instance):
 
 def test_get_failed_receipt(owner, vyper_contract_instance, eth_tester_provider):
     # Setting to '5' always fails.
-    transaction = vyper_contract_instance.setNumber.as_transaction(5, sender=owner, gas=100000)
 
-    # Publish failing txn
-    try:
-        owner.call(transaction)
-    except ContractLogicError:
-        pass
-
-    receipt = eth_tester_provider.get_receipt(transaction.txn_hash.hex())
-    assert receipt.failed
+    with pytest.raises(ContractLogicError) as err:
+        vyper_contract_instance.setNumber(5, sender=owner, gas=100000)
+        assert err.value.txn
+        receipt = err.value.txn.receipt
+        assert receipt
+        assert receipt.failed
 
 
 def test_receipt_raise_for_status_out_of_gas_error(mocker, ethereum):


### PR DESCRIPTION
### What I did

Adds `.receipt` property to `TransactionAPI` which simplifies usage when we need to check trace stuff from exceptions.
simplifies things for showing traceback lines too.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
