### PR TITLE
fix: send geth process output to devnull when log level above DEBUG [APE-753]

### DIFF
--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -119,13 +119,10 @@ class GethDevProcess(LoggingMixin, BaseGethProcess):
             return path
 
         initialize_chain(genesis_data, **geth_kwargs)
-        std_out = make_logs_paths("stdout")
-        std_err = make_logs_paths("stderr")
-
         super().__init__(
             geth_kwargs,
-            stdout_logfile_path=std_out,
-            stderr_logfile_path=std_err,
+            stdout_logfile_path=make_logs_paths("stdout"),
+            stderr_logfile_path=make_logs_paths("stderr"),
         )
 
     @classmethod
@@ -154,9 +151,8 @@ class GethDevProcess(LoggingMixin, BaseGethProcess):
     def start(self):
         if self.is_running:
             raise ValueError("Already running")
-        self.is_running = True
 
-        logger.info("Launching geth: %s", " ".join(self.command))
+        self.is_running = True
         out_file = PIPE if logger.level <= LogLevel.DEBUG else DEVNULL
         self.proc = Popen(
             self.command,


### PR DESCRIPTION
### What I did

Same thing as https://github.com/ApeWorX/ape/pull/1172 but for `ape-geth`

Realized `ape test` output when using `geth` provider is extremely ridden when subprocess logs and i was like "i thought i got rid of these!!!!" but then realized `ape-geth` uses `py-geth` package and not `SubprocessProvider`, then realized how to fix.

### How I did it

overrode the `start()` method to use `DEVNULL` when not `DEBUG`

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
