### PR TITLE
feat: filter out irrelevant traceback frames [APE-758]

### DIFF
--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -8,7 +8,7 @@ import importlib_metadata as metadata
 import yaml
 
 from ape.cli import Abort, ape_cli_context
-from ape.exceptions import ApeException, abort, handle_ape_exception
+from ape.exceptions import ApeException, handle_ape_exception
 from ape.logging import logger
 from ape.plugins import clean_plugin_name
 
@@ -41,7 +41,7 @@ class ApeCLI(click.MultiCommand):
                 # All exc details already outputted.
                 sys.exit(1)
             else:
-                raise abort(err) from err
+                raise Abort.from_ape_exception(err) from err
 
     @staticmethod
     def _suggest_cmd(usage_error):

--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -7,8 +7,8 @@ import click
 import importlib_metadata as metadata
 import yaml
 
-from ape.cli import Abort, abort, ape_cli_context
-from ape.exceptions import ApeException, handle_ape_exception
+from ape.cli import Abort, ape_cli_context
+from ape.exceptions import ApeException, abort, handle_ape_exception
 from ape.logging import logger
 from ape.plugins import clean_plugin_name
 

--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -37,7 +37,7 @@ class ApeCLI(click.MultiCommand):
         except click.UsageError as err:
             self._suggest_cmd(err)
         except ApeException as err:
-            if handle_ape_exception(err):
+            if handle_ape_exception(err, [ctx.obj.project_manager.path]):
                 # All exc details already outputted.
                 sys.exit(1)
             else:

--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -8,7 +8,7 @@ import importlib_metadata as metadata
 import yaml
 
 from ape.cli import Abort, abort, ape_cli_context
-from ape.exceptions import ApeException, TransactionError, handle_transaction_error
+from ape.exceptions import ApeException, handle_ape_exception
 from ape.logging import logger
 from ape.plugins import clean_plugin_name
 
@@ -36,16 +36,12 @@ class ApeCLI(click.MultiCommand):
             return super().invoke(ctx)
         except click.UsageError as err:
             self._suggest_cmd(err)
-        except TransactionError as err:
-            if handle_transaction_error(err):
+        except ApeException as err:
+            if handle_ape_exception(err):
                 # All exc details already outputted.
                 sys.exit(1)
-
             else:
                 raise abort(err) from err
-
-        except ApeException as err:
-            raise abort(err) from err
 
     @staticmethod
     def _suggest_cmd(usage_error):

--- a/src/ape/cli/__init__.py
+++ b/src/ape/cli/__init__.py
@@ -23,10 +23,9 @@ from ape.cli.options import (
     skip_confirmation_option,
 )
 from ape.cli.paramtype import AllFilePaths, Path
-from ape.cli.utils import Abort, abort
+from ape.cli.utils import Abort
 
 __all__ = [
-    "abort",
     "Abort",
     "account_option",
     "AccountAliasPromptChoice",

--- a/src/ape/cli/__init__.py
+++ b/src/ape/cli/__init__.py
@@ -23,9 +23,10 @@ from ape.cli.options import (
     skip_confirmation_option,
 )
 from ape.cli.paramtype import AllFilePaths, Path
-from ape.cli.utils import Abort
+from ape.cli.utils import Abort, abort
 
 __all__ = [
+    "abort",
     "Abort",
     "account_option",
     "AccountAliasPromptChoice",

--- a/src/ape/cli/utils.py
+++ b/src/ape/cli/utils.py
@@ -1,4 +1,5 @@
 from ape.exceptions import Abort
 
+# TODO: Delete as part of 0.7 breaking changes
 # Kept here for backwards compatibility.
 __all__ = ["Abort"]

--- a/src/ape/cli/utils.py
+++ b/src/ape/cli/utils.py
@@ -1,10 +1,12 @@
+import traceback
 from inspect import getframeinfo, stack
 from pathlib import Path
 from typing import Optional
 
 import click
 
-from ape.logging import logger
+from ape.exceptions import ApeException
+from ape.logging import LogLevel, logger
 
 
 class Abort(click.ClickException):
@@ -29,3 +31,16 @@ class Abort(click.ClickException):
         """
 
         logger.error(self.format_message())
+
+
+def abort(err: ApeException, show_traceback: Optional[bool] = None) -> Abort:
+    show_traceback = (
+        logger.level == LogLevel.DEBUG.value if show_traceback is None else show_traceback
+    )
+    if show_traceback:
+        tb = traceback.format_exc()
+        err_message = tb or str(err)
+    else:
+        err_message = str(err)
+
+    return Abort(f"({type(err).__name__}) {err_message}")

--- a/src/ape/cli/utils.py
+++ b/src/ape/cli/utils.py
@@ -1,31 +1,3 @@
-from inspect import getframeinfo, stack
-from pathlib import Path
-from typing import Optional
+from ape.exceptions import Abort
 
-import click
-
-from ape.logging import logger
-
-
-class Abort(click.ClickException):
-    """
-    A wrapper around a CLI exception. When you raise this error,
-    the error is nicely printed to the terminal. This is
-    useful for all user-facing errors.
-    """
-
-    def __init__(self, message: Optional[str] = None):
-        if not message:
-            caller = getframeinfo(stack()[1][0])
-            file_path = Path(caller.filename)
-            location = file_path.name if file_path.is_file() else caller.filename
-            message = f"Operation aborted in {location}::{caller.function} on line {caller.lineno}."
-
-        super().__init__(message)
-
-    def show(self, file=None):
-        """
-        Override default ``show`` to print CLI errors in red text.
-        """
-
-        logger.error(self.format_message())
+__all__ = ["Abort"]

--- a/src/ape/cli/utils.py
+++ b/src/ape/cli/utils.py
@@ -1,3 +1,4 @@
 from ape.exceptions import Abort
 
+# Kept here for backwards compatibility.
 __all__ = ["Abort"]

--- a/src/ape/cli/utils.py
+++ b/src/ape/cli/utils.py
@@ -1,12 +1,10 @@
-import traceback
 from inspect import getframeinfo, stack
 from pathlib import Path
 from typing import Optional
 
 import click
 
-from ape.exceptions import ApeException
-from ape.logging import LogLevel, logger
+from ape.logging import logger
 
 
 class Abort(click.ClickException):
@@ -31,16 +29,3 @@ class Abort(click.ClickException):
         """
 
         logger.error(self.format_message())
-
-
-def abort(err: ApeException, show_traceback: Optional[bool] = None) -> Abort:
-    show_traceback = (
-        logger.level == LogLevel.DEBUG.value if show_traceback is None else show_traceback
-    )
-    if show_traceback:
-        tb = traceback.format_exc()
-        err_message = tb or str(err)
-    else:
-        err_message = str(err)
-
-    return Abort(f"({type(err).__name__}) {err_message}")

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -378,7 +378,7 @@ class RPCTimeoutError(SubprocessTimeoutError):
         super().__init__(provider, *args, **kwargs)
 
 
-def handle_ape_exception(err: ApeException, base_paths: List[Path]):
+def handle_ape_exception(err: ApeException, base_paths: List[Path]) -> bool:
     """
     Handle a transaction error by showing relevant stack frames,
     including custom contract frames added to the exception.

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -435,9 +435,7 @@ class Abort(click.ClickException):
         logger.error(self.format_message())
 
 
-def abort(err: ApeException, show_traceback: Optional[bool] = None) -> "Abort":
-    from ape.cli import Abort
-
+def abort(err: ApeException, show_traceback: Optional[bool] = None) -> Abort:
     show_traceback = (
         logger.level == LogLevel.DEBUG.value if show_traceback is None else show_traceback
     )

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -386,7 +386,7 @@ def handle_ape_exception(err: ApeException, extra_paths: Optional[List[Path]] = 
     an exception on the exc-stack.
 
     Args:
-        err (:class:`~ape.exceptions.TransactionError`): The transaction error
+        err (:class:`~ape.exceptions.ApeException`): The transaction error
           being handled.
         extra_paths (Optional[List[Path]]): Optionally include additional
           source-path prefixes to use when finding relevant frames.

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -8,6 +8,8 @@ import click
 from eth_utils import humanize_hash
 from rich import print as rich_print
 
+from ape.logging import logger
+
 if TYPE_CHECKING:
     from ape.api.networks import NetworkAPI
     from ape.api.providers import SubprocessProvider
@@ -395,7 +397,6 @@ def handle_ape_exception(err: ApeException, base_paths: List[Path]) -> bool:
     """
 
     from ape.cli.utils import abort
-    from ape.logging import logger
 
     tb = traceback.extract_tb(sys.exc_info()[2])
     relevant_tb = [f for f in tb if any(str(p) in f.filename for p in base_paths)]

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -378,7 +378,7 @@ class RPCTimeoutError(SubprocessTimeoutError):
         super().__init__(provider, *args, **kwargs)
 
 
-def handle_ape_exception(err: ApeException, extra_paths: Optional[List[Path]] = None):
+def handle_ape_exception(err: ApeException, base_paths: List[Path]):
     """
     Handle a transaction error by showing relevant stack frames,
     including custom contract frames added to the exception.
@@ -388,20 +388,17 @@ def handle_ape_exception(err: ApeException, extra_paths: Optional[List[Path]] = 
     Args:
         err (:class:`~ape.exceptions.ApeException`): The transaction error
           being handled.
-        extra_paths (Optional[List[Path]]): Optionally include additional
-          source-path prefixes to use when finding relevant frames.
+        base_paths (List[Path]): Source base paths for allowed frames.
 
     Returns:
         bool: ``True`` if outputted something.
     """
 
-    from ape import project
     from ape.cli.utils import abort
     from ape.logging import logger
 
     tb = traceback.extract_tb(sys.exc_info()[2])
-    allowed_paths = [str(p) for p in [project.path, *(extra_paths or [])]]
-    relevant_tb = [f for f in tb if any(p in f.filename for p in allowed_paths)]
+    relevant_tb = [f for f in tb if any(str(p) in f.filename for p in base_paths)]
     if not relevant_tb:
         return False
 

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -383,9 +383,11 @@ def handle_transaction_error(err: TransactionError):
     including custom contract frames added to the exception.
     This method must be called within an ``except`` block or with
     an exception on the exc-stack.
+
     Args:
         err (:class:`~ape.exceptions.TransactionError`): The transaction error
           being handled.
+
     Returns:
         bool: ``True`` if outputted something.
     """

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -48,19 +48,25 @@ class PytestApeRunner(ManagerAccessMixin):
             relevant_tb = list(tb_frames)
         else:
             relevant_tb = PytestTraceback(
-                [f for f in tb_frames if Path(f.path).as_posix().startswith(base)]
+                [
+                    f
+                    for f in tb_frames
+                    if Path(f.path).as_posix().startswith(base)
+                    or Path(f.path).name.startswith("test_")
+                ]
             )
 
-        call.excinfo.traceback = relevant_tb
-        report.longrepr = call.excinfo.getrepr(
-            funcargs=True,
-            abspath=Path.cwd(),
-            showlocals=True,
-            style="short",
-            tbfilter=False,
-            truncate_locals=False,
-            chain=False,
-        )
+        if relevant_tb:
+            call.excinfo.traceback = relevant_tb
+            report.longrepr = call.excinfo.getrepr(
+                funcargs=True,
+                abspath=Path.cwd(),
+                showlocals=True,
+                style="short",
+                tbfilter=False,
+                truncate_locals=False,
+                chain=False,
+            )
 
         if self.config_wrapper.interactive and report.failed:
             traceback = call.excinfo.traceback[0]

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -41,14 +41,14 @@ class PytestApeRunner(ManagerAccessMixin):
         """
 
         # Find the last traceback frame within the active project
-        tb_frames: PytestTraceback = call.excinfo.traceback[::-1]
+        tb_frames: PytestTraceback = call.excinfo.traceback
         base = self.project_manager.path.as_posix()
 
         if self.config_wrapper.pytest_config.getoption("showinternal"):
             relevant_tb = list(tb_frames)
         else:
             relevant_tb = PytestTraceback(
-                reversed([f for f in tb_frames if Path(f.path).as_posix().startswith(base)])
+                [f for f in tb_frames if Path(f.path).as_posix().startswith(base)]
             )
 
         call.excinfo.traceback = relevant_tb

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -2,10 +2,12 @@ from pathlib import Path
 
 import click
 import pytest
+from _pytest._code.code import Traceback as PytestTraceback
+from rich import print as rich_print
 
 import ape
 from ape.api import ProviderContextManager
-from ape.logging import LogLevel, logger
+from ape.logging import LogLevel
 from ape.pytest.config import ConfigWrapper
 from ape.pytest.contextmanagers import RevertsContextManager
 from ape.pytest.fixtures import ReceiptCapture
@@ -38,24 +40,40 @@ class PytestApeRunner(ManagerAccessMixin):
         same console as the ``ape console`` command.
         """
 
+        # Find the last traceback frame within the active project
+        tb_frames: PytestTraceback = call.excinfo.traceback[::-1]
+        base = self.project_manager.path.as_posix()
+
+        if self.config_wrapper.pytest_config.getoption("showinternal"):
+            relevant_tb = list(tb_frames)
+        else:
+            relevant_tb = PytestTraceback(
+                reversed([f for f in tb_frames if Path(f.path).as_posix().startswith(base)])
+            )
+
+        call.excinfo.traceback = relevant_tb
+        report.longrepr = call.excinfo.getrepr(
+            funcargs=True,
+            abspath=Path.cwd(),
+            showlocals=True,
+            style="short",
+            tbfilter=False,
+            truncate_locals=False,
+            chain=False,
+        )
+
         if self.config_wrapper.interactive and report.failed:
+            traceback = call.excinfo.traceback[0]
+
+            # Suspend capsys to ignore our own output.
             capman = self.config_wrapper.get_pytest_plugin("capturemanager")
             if capman:
                 capman.suspend_global_capture(in_=True)
 
-            # find the last traceback frame within the active project
-            traceback = call.excinfo.traceback[-1]
-            for tb_frame in call.excinfo.traceback[::-1]:
-                try:
-                    Path(tb_frame.path).relative_to(self.project_manager.path)
-                    traceback = tb_frame
-                    click.echo()
-                    click.echo(f"Traceback:{traceback}")
-                    break
-                except ValueError as err:
-                    click.echo()
-                    logger.warn_from_exception(err, tb_frame)
-                    pass
+            # Show the exception info before launching the interactive session.
+            click.echo()
+            rich_print(str(report.longrepr))
+            click.echo()
 
             # get global namespace
             globals_dict = traceback.frame.f_globals
@@ -76,12 +94,11 @@ class PytestApeRunner(ManagerAccessMixin):
             locals_dict = traceback.locals
             locals_dict = {k: v for k, v in locals_dict.items() if not k.startswith("@")}
 
-            click.echo("Starting interactive mode. Type `exit` fail and halt current test.")
+            click.echo("Starting interactive mode. Type `exit` to halt current test.")
 
             namespace = {"_callinfo": call, **globals_dict, **locals_dict}
             console(extra_locals=namespace, project=self.project_manager, embed=True)
 
-            # launch ipdb instead of console
             if capman:
                 capman.resume_global_capture()
 

--- a/src/ape_console/plugin.py
+++ b/src/ape_console/plugin.py
@@ -8,7 +8,9 @@ from IPython.core.magic import Magics, line_magic, magics_class  # type: ignore
 
 import ape
 from ape._cli import cli
-from ape.exceptions import TransactionError, handle_transaction_error
+from ape.cli import abort
+from ape.exceptions import ApeException, handle_ape_exception
+from ape.logging import logger
 from ape.types import AddressType
 from ape.utils import cached_property
 
@@ -75,9 +77,10 @@ class ApeConsoleMagics(Magics):
 
 
 def custom_exception_handler(self, etype, value, tb, tb_offset=None):
-    handle_transaction_error(value)
+    if not handle_ape_exception(value):
+        logger.error(abort(value).format_message())
 
 
 def load_ipython_extension(ipython):
     ipython.register_magics(ApeConsoleMagics)
-    ipython.set_custom_exc((TransactionError,), custom_exception_handler)
+    ipython.set_custom_exc((ApeException,), custom_exception_handler)

--- a/src/ape_console/plugin.py
+++ b/src/ape_console/plugin.py
@@ -77,7 +77,7 @@ class ApeConsoleMagics(Magics):
 
 
 def custom_exception_handler(self, etype, value, tb, tb_offset=None):
-    if not handle_ape_exception(value):
+    if not handle_ape_exception(value, [self.user_ns["project"].path]):
         logger.error(abort(value).format_message())
 
 

--- a/src/ape_console/plugin.py
+++ b/src/ape_console/plugin.py
@@ -8,7 +8,7 @@ from IPython.core.magic import Magics, line_magic, magics_class  # type: ignore
 
 import ape
 from ape._cli import cli
-from ape.exceptions import ApeException, abort, handle_ape_exception
+from ape.exceptions import Abort, ApeException, handle_ape_exception
 from ape.logging import logger
 from ape.types import AddressType
 from ape.utils import cached_property
@@ -77,7 +77,7 @@ class ApeConsoleMagics(Magics):
 
 def custom_exception_handler(self, etype, value, tb, tb_offset=None):
     if not handle_ape_exception(value, [self.user_ns["project"].path]):
-        logger.error(abort(value).format_message())
+        logger.error(Abort.from_ape_exception(value).format_message())
 
 
 def load_ipython_extension(ipython):

--- a/src/ape_console/plugin.py
+++ b/src/ape_console/plugin.py
@@ -8,8 +8,7 @@ from IPython.core.magic import Magics, line_magic, magics_class  # type: ignore
 
 import ape
 from ape._cli import cli
-from ape.cli import abort
-from ape.exceptions import ApeException, handle_ape_exception
+from ape.exceptions import ApeException, abort, handle_ape_exception
 from ape.logging import logger
 from ape.types import AddressType
 from ape.utils import cached_property

--- a/src/ape_console/plugin.py
+++ b/src/ape_console/plugin.py
@@ -8,6 +8,7 @@ from IPython.core.magic import Magics, line_magic, magics_class  # type: ignore
 
 import ape
 from ape._cli import cli
+from ape.exceptions import TransactionError, handle_transaction_error
 from ape.types import AddressType
 from ape.utils import cached_property
 
@@ -73,5 +74,10 @@ class ApeConsoleMagics(Magics):
         return f"{round(balance / 10 ** decimals, 8)} {symbol}"
 
 
+def custom_exception_handler(self, etype, value, tb, tb_offset=None):
+    handle_transaction_error(value)
+
+
 def load_ipython_extension(ipython):
     ipython.register_magics(ApeConsoleMagics)
+    ipython.set_custom_exc((TransactionError,), custom_exception_handler)

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -33,10 +33,7 @@ class ScriptCommand(click.MultiCommand):
             if ctx.params["interactive"]:
                 # Print the exception trace and then launch the console
                 # Attempt to use source-traceback style printing.
-                if (
-                    not isinstance(err, TransactionError)
-                    or not handle_transaction_error(err)
-                ):
+                if not isinstance(err, TransactionError) or not handle_transaction_error(err):
                     err_info = traceback.format_exc()
                     click.echo(err_info)
 

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -10,7 +10,7 @@ import click
 from click import Command, Context
 
 from ape.cli import NetworkBoundCommand, network_option
-from ape.exceptions import TransactionError, handle_ape_exception
+from ape.exceptions import ApeException, handle_ape_exception
 from ape.logging import logger
 from ape.managers.project import ProjectManager
 from ape.utils import get_relative_path, use_temp_sys_path
@@ -33,7 +33,7 @@ class ScriptCommand(click.MultiCommand):
             if ctx.params["interactive"]:
                 # Print the exception trace and then launch the console
                 # Attempt to use source-traceback style printing.
-                if not isinstance(err, TransactionError) or not handle_ape_exception(err):
+                if not isinstance(err, ApeException) or not handle_ape_exception(err):
                     err_info = traceback.format_exc()
                     click.echo(err_info)
 

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -13,7 +13,7 @@ from ape.cli import NetworkBoundCommand, network_option
 from ape.exceptions import TransactionError, handle_transaction_error
 from ape.logging import logger
 from ape.managers.project import ProjectManager
-from ape.utils import cached_property, get_relative_path, use_temp_sys_path
+from ape.utils import get_relative_path, use_temp_sys_path
 from ape_console._cli import console
 
 
@@ -124,7 +124,7 @@ class ScriptCommand(click.MultiCommand):
 
             return call
 
-    @cached_property
+    @property
     def _project(self) -> ProjectManager:
         """
         A class representing the project that is active at runtime.
@@ -140,9 +140,9 @@ class ScriptCommand(click.MultiCommand):
 
         return project
 
-    @cached_property
+    @property
     def commands(self) -> Dict[str, Union[click.Command, click.Group]]:
-        if not self._project.scripts_folder.exists():
+        if not self._project.scripts_folder.is_dir():
             return {}
 
         return self._get_cli_commands(self._project.scripts_folder)

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -10,7 +10,7 @@ import click
 from click import Command, Context
 
 from ape.cli import NetworkBoundCommand, network_option
-from ape.exceptions import TransactionError, handle_transaction_error
+from ape.exceptions import TransactionError, handle_ape_exception
 from ape.logging import logger
 from ape.managers.project import ProjectManager
 from ape.utils import get_relative_path, use_temp_sys_path
@@ -33,7 +33,7 @@ class ScriptCommand(click.MultiCommand):
             if ctx.params["interactive"]:
                 # Print the exception trace and then launch the console
                 # Attempt to use source-traceback style printing.
-                if not isinstance(err, TransactionError) or not handle_transaction_error(err):
+                if not isinstance(err, TransactionError) or not handle_ape_exception(err):
                     err_info = traceback.format_exc()
                     click.echo(err_info)
 

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -33,7 +33,9 @@ class ScriptCommand(click.MultiCommand):
             if ctx.params["interactive"]:
                 # Print the exception trace and then launch the console
                 # Attempt to use source-traceback style printing.
-                if not isinstance(err, ApeException) or not handle_ape_exception(err):
+                if not isinstance(err, ApeException) or not handle_ape_exception(
+                    err, [ctx.obj.project_manager.path]
+                ):
                     err_info = traceback.format_exc()
                     click.echo(err_info)
 

--- a/tests/integration/cli/projects/with-contracts/scripts/txerr.py
+++ b/tests/integration/cli/projects/with-contracts/scripts/txerr.py
@@ -1,0 +1,12 @@
+import ape
+
+
+def main():
+    """
+    Cause an uncaught contract logic error to test traceback output.
+    """
+    account = ape.accounts.test_accounts[0]
+    contract = account.deploy(ape.project.ContractA)
+
+    # Fails.
+    contract.setNumber(5, sender=account)

--- a/tests/integration/cli/projects/with-contracts/tests/test_contract.py
+++ b/tests/integration/cli/projects/with-contracts/tests/test_contract.py
@@ -7,3 +7,10 @@ def test_contract_interaction_in_tests(project, contract_from_fixture, owner):
     contract_from_fixture.setNumber(456, sender=owner)
     actual = contract_from_fixture.myNumber()
     assert actual == 456
+
+
+def test_fail_txn_err_handling(project, contract_from_fixture, owner):
+    contract_in_test = owner.deploy(project.ContractA)
+
+    # Errors (uncaught)
+    contract_in_test.setNumber(5, sender=owner)

--- a/tests/integration/cli/test_console.py
+++ b/tests/integration/cli/test_console.py
@@ -221,7 +221,7 @@ def test_console_bal_magic(ape_cli, runner, keyfile_account):
 @skip_projects_except("with-contracts")
 def test_uncaught_txn_err(ape_cli, runner, mocker):
     # For some reason, not showing in result.output, so captured another way.
-    handler = mocker.patch("ape_console.plugin.handle_transaction_error")
+    handler = mocker.patch("ape_console.plugin.handle_ape_exception")
     cmd_ls = [
         "%load_ext ape_console.plugin",
         "account = accounts.test_accounts[0]",

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -1,3 +1,5 @@
+import re
+
 from .utils import skip_projects_except
 
 BAD_COMMAND = "not-a-name"
@@ -126,3 +128,15 @@ def test_try_run_script_missing_cli_decorator(ape_cli, runner, project):
 
     result = runner.invoke(ape_cli, ["run", "error_forgot_click"])
     assert "Usage: cli run" in result.output
+
+
+@skip_projects_except("with-contracts")
+def test_uncaught_tx_err(ape_cli, runner, project):
+    result = runner.invoke(ape_cli, ["run", "txerr"], terminal_width=200)
+    pattern = (
+        r"\s+File\s+\"[/\w\-]*\s+[/\w\-.]*\", line 12, "
+        r"in main\s+contract.setNumber\(5, sender=account\)\n+ERROR: "
+        r"\(ContractLogicError\) Transaction failed\."
+    )
+    actual = re.findall(pattern, result.output)
+    assert len(actual) == 1

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -1,5 +1,3 @@
-import re
-
 from .utils import skip_projects_except
 
 BAD_COMMAND = "not-a-name"
@@ -133,10 +131,6 @@ def test_try_run_script_missing_cli_decorator(ape_cli, runner, project):
 @skip_projects_except("with-contracts")
 def test_uncaught_tx_err(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["run", "txerr"])
-    pattern = (
-        r"\s+File\s+\"[/\w\-]*\s+[/\w\-.]*\", line 12, "
-        r"in main\s+contract.setNumber\(5, sender=account\)\n+ERROR: "
-        r"\(ContractLogicError\) Transaction failed\."
-    )
-    actual = re.findall(pattern, result.output)
-    assert len(actual) == 1, result.output
+    assert '/scripts/txerr.py", line 12, in main' in result.output
+    assert "contract.setNumber(5, sender=account)" in result.output
+    assert "ERROR: (ContractLogicError) Transaction failed." in result.output

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -132,11 +132,11 @@ def test_try_run_script_missing_cli_decorator(ape_cli, runner, project):
 
 @skip_projects_except("with-contracts")
 def test_uncaught_tx_err(ape_cli, runner, project):
-    result = runner.invoke(ape_cli, ["run", "txerr"], terminal_width=200)
+    result = runner.invoke(ape_cli, ["run", "txerr"])
     pattern = (
         r"\s+File\s+\"[/\w\-]*\s+[/\w\-.]*\", line 12, "
         r"in main\s+contract.setNumber\(5, sender=account\)\n+ERROR: "
         r"\(ContractLogicError\) Transaction failed\."
     )
     actual = re.findall(pattern, result.output)
-    assert len(actual) == 1
+    assert len(actual) == 1, result.output

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -138,9 +138,6 @@ def test_uncaught_txn_err(setup_pytester, project, pytester, eth_tester_provider
     expected = """
     contract_in_test.setNumber(5, sender=owner)
 E   ape.exceptions.ContractLogicError: Transaction failed.
-        contract_from_fixture = <ContractA 0x274b028b03A250cA03644E6c578D81f019eE1323>
-        contract_in_test = <ContractA 0xBcF7FFFD8B256Ec51a36782a52D0c34f6474D951>
-        owner      = <TestAccount 0x1e59ce931B4CFea3fe4B875411e280e173cB7A9C>
     """.strip()
     assert expected in str(result.stdout)
 

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -178,9 +178,9 @@ def test_gas_flag_when_not_supported(setup_pytester, project, pytester, eth_test
 @geth_process_test
 @skip_projects_except("geth")
 def test_gas_flag_in_tests(geth_provider, setup_pytester, project, pytester):
-    passes, failed = setup_pytester(project.path.name)
+    passed, failed = setup_pytester(project.path.name)
     result = pytester.runpytest("--gas")
-    run_gas_test(result, passes, failed)
+    run_gas_test(result, passed, failed)
 
 
 @geth_process_test
@@ -207,13 +207,13 @@ def test_gas_flag_set_in_config(geth_provider, setup_pytester, project, pytester
 @geth_process_test
 @skip_projects_except("geth")
 def test_gas_flag_exclude_using_cli_option(geth_provider, setup_pytester, project, pytester):
-    passes, failed = setup_pytester(project.path.name)
+    passed, failed = setup_pytester(project.path.name)
     # NOTE: Includes both a mutable and a view method.
     expected = filter_expected_methods("fooAndBar", "myNumber")
     # Also ensure can filter out whole class
     expected = expected.replace(TOKEN_B_GAS_REPORT, "")
     result = pytester.runpytest("--gas", "--gas-exclude", "*:fooAndBar,*:myNumber,tokenB:*")
-    run_gas_test(result, passes, failed, expected_report=expected)
+    run_gas_test(result, passed, failed, expected_report=expected)
 
 
 @geth_process_test
@@ -221,7 +221,7 @@ def test_gas_flag_exclude_using_cli_option(geth_provider, setup_pytester, projec
 def test_gas_flag_exclusions_set_in_config(
     geth_provider, setup_pytester, project, pytester, switch_config
 ):
-    passes, failed = setup_pytester(project.path.name)
+    passed, failed = setup_pytester(project.path.name)
     # NOTE: Includes both a mutable and a view method.
     expected = filter_expected_methods("fooAndBar", "myNumber")
     # Also ensure can filter out whole class
@@ -242,12 +242,12 @@ def test_gas_flag_exclusions_set_in_config(
     """
     with switch_config(project, config_content):
         result = pytester.runpytest("--gas")
-        run_gas_test(result, passes, failed, expected_report=expected)
+        run_gas_test(result, passed, failed, expected_report=expected)
 
 
 @geth_process_test
 @skip_projects_except("geth")
 def test_gas_flag_excluding_contracts(geth_provider, setup_pytester, project, pytester):
-    passes, failed = setup_pytester(project.path.name)
+    passed, failed = setup_pytester(project.path.name)
     result = pytester.runpytest("--gas", "--gas-exclude", "TestContractVy,TokenA")
-    run_gas_test(result, passes, failed, expected_report=TOKEN_B_GAS_REPORT)
+    run_gas_test(result, passed, failed, expected_report=TOKEN_B_GAS_REPORT)


### PR DESCRIPTION
### What I did

fixes: #442 
Fixes: APE-157

* Removes noisy framework traceback frames in `ape console` during `TransactionError` handling
* Removes noisy framework traceback frames in `ape run` during `TransactionError` handling
* Remove noisy framework traceback frames in `ape test` during `TransactionError` handling.

This makes the PR #1337 a lot simpler to follow and smaller.
There is also a lot of benefit to this alone so wanted to include it incase #1337 does not make it in the next release.

### How I did it

 * filter out frames that didn't occur in the local Ape project during the handling of `TransactionError` in CLI, pytest plugin, and IPython plugin.

### How to verify it

Cause unhandled TransactionError (e.g. ContractLogicError) in all 3 environments.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
