### PR TITLE
fix: dynamic fee conversion [APE-781]

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -79,6 +79,10 @@ class TransactionAPI(BaseInterfaceModel):
 
         return value
 
+    @validator("max_fee", "max_priority_fee", pre=True, allow_reuse=True)
+    def convert_fees(cls, value):
+        return cls.conversion_manager.convert(value, int)
+
     @validator("data", pre=True)
     def validate_data(cls, value):
         if isinstance(value, str):

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -81,7 +81,10 @@ class TransactionAPI(BaseInterfaceModel):
 
     @validator("max_fee", "max_priority_fee", pre=True, allow_reuse=True)
     def convert_fees(cls, value):
-        return cls.conversion_manager.convert(value, int)
+        if isinstance(value, str):
+            return cls.conversion_manager.convert(value, int)
+
+        return value
 
     @validator("data", pre=True)
     def validate_data(cls, value):

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -26,8 +26,13 @@ def test_create_dynamic_fee_transaction(ethereum, type_kwarg):
     "fee_kwargs",
     (
         {"max_fee": "100 gwei"},
+        {"max_fee": int(100e9)},
         {"max_priority_fee": "1 gwei"},
+        {"max_priority_fee": int(1e9)},
         {"max_priority_fee": "1 gwei", "max_fee": "100 gwei"},
+        {"max_priority_fee": int(1e9), "max_fee": "100 gwei"},
+        {"max_priority_fee": "1 gwei", "max_fee": int(100e9)},
+        {"max_priority_fee": int(1e9), "max_fee": int(100e9)},
     ),
 )
 def test_create_dynamic_fee_kwargs(ethereum, fee_kwargs):

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -1,7 +1,7 @@
 import pytest
 from hexbytes import HexBytes
 
-from ape_ethereum.transactions import StaticFeeTransaction, TransactionType
+from ape_ethereum.transactions import DynamicFeeTransaction, StaticFeeTransaction, TransactionType
 
 
 @pytest.mark.parametrize("type_kwarg", (0, "0x0", b"\x00", "0", HexBytes("0x0"), HexBytes("0x00")))
@@ -20,6 +20,23 @@ def test_create_access_list_transaction(ethereum, type_kwarg):
 def test_create_dynamic_fee_transaction(ethereum, type_kwarg):
     txn = ethereum.create_transaction(type=type_kwarg)
     assert txn.type == TransactionType.DYNAMIC.value
+
+
+@pytest.mark.parametrize(
+    "fee_kwargs",
+    (
+        {"max_fee": "100 gwei"},
+        {"max_priority_fee": "1 gwei"},
+        {"max_priority_fee": "1 gwei", "max_fee": "100 gwei"},
+    ),
+)
+def test_create_dynamic_fee_kwargs(ethereum, fee_kwargs):
+    txn = ethereum.create_transaction(**fee_kwargs)
+    assert isinstance(txn, DynamicFeeTransaction)
+    if "max_priority_fee" in fee_kwargs:
+        assert txn.max_priority_fee == int(1e9)
+    if "max_fee" in fee_kwargs:
+        assert txn.max_fee == int(100e9)
 
 
 def test_txn_hash(owner, eth_tester_provider, ethereum):


### PR DESCRIPTION
### What I did

Dynamic fee overrides weren't processing via their validators, so I added that

fixes: #1369

### How I did it

Using Validators

### How to verify it

Test suite passes, any normal usage of this should function

### Checklist

- [x] All changes are completed
- [x] New test cases have been added
~~- [x] Documentation has been updated~~
