### PR TITLE
fix: issue where `ape test --showinternal` would cause crash [APE-782]

### DIFF
--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -48,11 +48,10 @@ class PytestApeRunner(ManagerAccessMixin):
             relevant_tb = list(tb_frames)
         else:
             relevant_tb = [
-                    f
-                    for f in tb_frames
-                    if Path(f.path).as_posix().startswith(base)
-                    or Path(f.path).name.startswith("test_")
-                ]
+                f
+                for f in tb_frames
+                if Path(f.path).as_posix().startswith(base) or Path(f.path).name.startswith("test_")
+            ]
 
         if relevant_tb:
             call.excinfo.traceback = PytestTraceback(relevant_tb)

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -47,17 +47,15 @@ class PytestApeRunner(ManagerAccessMixin):
         if self.config_wrapper.pytest_config.getoption("showinternal"):
             relevant_tb = list(tb_frames)
         else:
-            relevant_tb = PytestTraceback(
-                [
+            relevant_tb = [
                     f
                     for f in tb_frames
                     if Path(f.path).as_posix().startswith(base)
                     or Path(f.path).name.startswith("test_")
                 ]
-            )
 
         if relevant_tb:
-            call.excinfo.traceback = relevant_tb
+            call.excinfo.traceback = PytestTraceback(relevant_tb)
             report.longrepr = call.excinfo.getrepr(
                 funcargs=True,
                 abspath=Path.cwd(),

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -11,7 +11,7 @@ import pytest
 from ape.managers.config import CONFIG_FILE_NAME
 
 from .test_plugins import ListResult
-from .utils import NodeId, project_names, project_skipper, projects_directory
+from .utils import NodeId, __project_names__, __projects_directory__, project_skipper
 
 
 class IntegrationTestModule:
@@ -94,7 +94,7 @@ def project_dir_map(project_folder):
                 # Already copied.
                 return self.project_map[name]
 
-            project_source_dir = projects_directory / name
+            project_source_dir = __projects_directory__ / name
             project_dest_dir = project_folder / project_source_dir.name
             copy_tree(str(project_source_dir), str(project_dest_dir))
             self.project_map[name] = project_dest_dir
@@ -103,7 +103,7 @@ def project_dir_map(project_folder):
     return ProjectDirCache()
 
 
-@pytest.fixture(autouse=True, params=project_names)
+@pytest.fixture(autouse=True, params=__project_names__)
 def project(request, config, project_dir_map):
     project_dir = project_dir_map.load(request.param)
     with config.using_project(project_dir) as project:

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -142,6 +142,18 @@ E   ape.exceptions.ContractLogicError: Transaction failed.
     assert expected in str(result.stdout)
 
 
+@skip_projects_except("with-contracts")
+def test_show_internal(setup_pytester, project, pytester, eth_tester_provider):
+    _ = eth_tester_provider  # Ensure using EthTester for this test.
+    setup_pytester(project.path.name)
+    result = pytester.runpytest("--showinternal")
+    expected = """
+    raise vm_err from err
+E   ape.exceptions.ContractLogicError: Transaction failed.
+    """.strip()
+    assert expected in str(result.stdout)
+
+
 @skip_projects_except("test", "with-contracts")
 def test_test_isolation_disabled(setup_pytester, project, pytester, eth_tester_provider):
     # check the disable isolation option actually disables built-in isolation

--- a/tests/integration/cli/utils.py
+++ b/tests/integration/cli/utils.py
@@ -3,8 +3,8 @@ from typing import Callable, Dict
 
 import pytest
 
-projects_directory = Path(__file__).parent / "projects"
-project_names = [p.stem for p in projects_directory.iterdir() if p.is_dir()]
+__projects_directory__ = Path(__file__).parent / "projects"
+__project_names__ = [p.stem for p in __projects_directory__.iterdir() if p.is_dir()]
 
 
 def assert_failure(result, expected_output):
@@ -39,7 +39,7 @@ class ProjectSkipper:
     """
 
     def __init__(self):
-        self.projects: Dict[str, Dict] = {n: {} for n in project_names}
+        self.projects: Dict[str, Dict] = {n: {} for n in __project_names__}
 
     def __iter__(self):
         return iter(self.projects)


### PR DESCRIPTION
### What I did

regression from #1360  causing `--showinternal` to crash pytest terminal output

### How I did it

correct type

### How to verify it

can use `--showinternal` now
added a test

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
