### PR TITLE
feat: smarter handling of references and versions in dependency configs [APE-829]

### DIFF
--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -45,6 +45,17 @@ dependencies:
 
 will download the [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts) package with version `4.4.2`.
 
+**WARN**: The `version:` key only works when the version is published to GitHub; use the `branch:` key when the version is only available by tag.
+
+For example, to install a version based on a `git` tag, do the following:
+
+```yaml
+dependencies:
+  - name: Uniswap
+    github: Uniswap/v3-core
+    branch: v1.0.0
+```
+
 To ignore files from a dependency project, use the `exclude` setting to specify glob patterns:
 
 ```yaml
@@ -70,7 +81,7 @@ Now, in your solidity files, import `OpenZeppelin` sources via:
 import "@openzeppelin/token/ERC721/ERC721.sol";
 ```
 
-You can also set the branch and name of the dependency's contracts folder, e.g.:
+You can also set the name of the dependency's contracts folder, e.g.:
 
 ```yaml
 dependencies:

--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -56,6 +56,8 @@ dependencies:
     branch: v1.0.0
 ```
 
+The `branch:` config installs the code from that branch or tag whereas the `version:` config uses the official GitHub release API.
+
 To ignore files from a dependency project, use the `exclude` setting to specify glob patterns:
 
 ```yaml

--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -45,11 +45,11 @@ dependencies:
 
 will download the [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts) package with version `4.4.2`.
 
-**WARN**: The `version:` first attempts to use official GitHub releases, but if the release is not found, it will then check for release tags.
+**WARN**: The `version:` config first attempts to use an official GitHub release, but if the release is not found, it will check the release tags.
 If you know the version is not available as an official release, bypass the original check by using the `ref:` key.
-The `ref:` key is also used for installing branches:
+The `ref:` key is also used for installing branches.
 
-For example, to install a version based on a `git` tag, do the following:
+For example, to install a version available as a `git` tag, do the following:
 
 ```yaml
 dependencies:
@@ -58,7 +58,7 @@ dependencies:
     ref: v1.0.0
 ```
 
-The `ref:` config installs the code from that reference; the `version:` config uses the official GitHub release API and then checks the `git` references.
+The `ref:` config installs the code from that reference; the `version:` config uses the official GitHub release API, and then only if that fails will it check the `git` references.
 Often times, the `v` prefix is required when using tags.
 However, if cloning the tag fails, `ape` will retry with a `v` prefix.
 Bypass the original failing attempt by including a `v` in your dependency config.

--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -45,7 +45,7 @@ dependencies:
 
 will download the [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts) package with version `4.4.2`.
 
-**WARN**: The `version:` key only works when the version is published to GitHub; use the `branch:` key when the version is only available by tag.
+**WARN**: The `version:` key only works when the version is published to GitHub; use the `ref:` key when the version is only available by tag.
 
 For example, to install a version based on a `git` tag, do the following:
 
@@ -53,10 +53,10 @@ For example, to install a version based on a `git` tag, do the following:
 dependencies:
   - name: Uniswap
     github: Uniswap/v3-core
-    branch: v1.0.0
+    ref: v1.0.0
 ```
 
-The `branch:` config installs the code from that branch or tag whereas the `version:` config uses the official GitHub release API.
+The `ref:` config installs the code from that branch or tag whereas the `version:` config uses the official GitHub release API.
 
 To ignore files from a dependency project, use the `exclude` setting to specify glob patterns:
 
@@ -89,7 +89,7 @@ You can also set the name of the dependency's contracts folder, e.g.:
 dependencies:
   - name: DappToolsERC20
     github: dapphub/erc20
-    branch: dappnix
+    ref: dappnix
     contracts_folder: src
 ```
 

--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -45,7 +45,9 @@ dependencies:
 
 will download the [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts) package with version `4.4.2`.
 
-**WARN**: The `version:` key only works when the version is published to GitHub; use the `ref:` key when the version is only available by tag.
+**WARN**: The `version:` first attempts to use official GitHub releases, but if the release is not found, it will then check for release tags.
+If you know the version is not available as an official release, bypass the original check by using the `ref:` key.
+The `ref:` key is also used for installing branches:
 
 For example, to install a version based on a `git` tag, do the following:
 
@@ -56,7 +58,10 @@ dependencies:
     ref: v1.0.0
 ```
 
-The `ref:` config installs the code from that branch or tag whereas the `version:` config uses the official GitHub release API.
+The `ref:` config installs the code from that reference; the `version:` config uses the official GitHub release API and then checks the `git` references.
+Often times, the `v` prefix is required when using tags.
+However, if cloning the tag fails, `ape` will retry with a `v` prefix.
+Bypass the original failing attempt by including a `v` in your dependency config.
 
 To ignore files from a dependency project, use the `exclude` setting to specify glob patterns:
 

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -299,6 +299,15 @@ class ProjectError(ApeException):
     """
 
 
+class UnknownVersionError(ProjectError):
+    """
+    Raised when trying to install an unknown version of a package.
+    """
+
+    def __init__(self, version: str, name: str):
+        super().__init__(f"Unknown version '{version}' for repo '{name}'.")
+
+
 class ConversionError(ApeException):
     """
     Raised when unable to convert a value.

--- a/src/ape/managers/project/dependency.py
+++ b/src/ape/managers/project/dependency.py
@@ -138,7 +138,7 @@ class GithubDependency(DependencyAPI):
                             self.github, temp_project_path, branch=self.version
                         )
                     except Exception:
-                        # Raise the UnknownVersionError still on the stack.
+                        # Raise the UnknownVersionError.
                         raise err
 
             return self._extract_local_manifest(temp_project_path)

--- a/src/ape/managers/project/dependency.py
+++ b/src/ape/managers/project/dependency.py
@@ -127,13 +127,19 @@ class GithubDependency(DependencyAPI):
                     github_client.download_package(
                         self.github, self.version or "latest", temp_project_path
                     )
-                except UnknownVersionError:
+                except UnknownVersionError as err:
                     logger.warning(
                         f"No official release found for version '{self.version}'. "
                         "Use `ref:` instead of `version:` for release tags. "
                         "Checking for matching tags..."
                     )
-                    github_client.clone_repo(self.github, temp_project_path, branch=self.version)
+                    try:
+                        github_client.clone_repo(
+                            self.github, temp_project_path, branch=self.version
+                        )
+                    except Exception:
+                        # Raise the UnknownVersionError still on the stack.
+                        raise err
 
             return self._extract_local_manifest(temp_project_path)
 

--- a/src/ape/utils/github.py
+++ b/src/ape/utils/github.py
@@ -27,7 +27,7 @@ class GitProcessWrapper:
         return git_cmd_path
 
     def clone(self, url: str, target_path: Optional[Path] = None, branch: Optional[str] = None):
-        command = [self.git, "clone", url]
+        command = [self.git, "-c", "advice.detachedHead=false", "clone", url]
 
         if target_path:
             command.append(str(target_path))

--- a/tests/functional/utils/test_github.py
+++ b/tests/functional/utils/test_github.py
@@ -58,11 +58,13 @@ class TestGithubClient:
 
         cmd = git_patch.call_args[0][0]
         assert cmd[0].endswith("git")
-        assert cmd[1] == "clone"
-        assert cmd[2] == "https://github.com/dapphub/ds-test.git"
-        # cmd[3] is the temporary output path
-        assert cmd[4] == "--branch"
-        assert cmd[5] == "master"
+        assert cmd[1] == "-c"
+        assert cmd[2] == "advice.detachedHead=false"
+        assert cmd[3] == "clone"
+        assert cmd[4] == "https://github.com/dapphub/ds-test.git"
+        # cmd[5] is the temporary output path
+        assert cmd[6] == "--branch"
+        assert cmd[7] == "master"
 
     def test_get_release(self, github_client_with_mocks, mock_repo):
         github_client_with_mocks.get_release(REPO_PATH, "0.1.0")


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1381 
Fixes: APE-820

### How I did it

* document stuff about tags
* if version not found, try as a reference
* if missing `v` prefix, try with `v` prefix.

### How to verify it

this will work now:

```
dependencies:
  - name: Uniswap
    github: Uniswap/v3-core
    version: 1.0.0
```

tho youll get a warning.

best to do this:

```

dependencies:
  - name: Uniswap
    github: Uniswap/v3-core
    ref: v1.0.0
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
