### PR TITLE
fix: issue preventing geth provider from showing custom solidity errors

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -8,6 +8,7 @@ import sys
 import time
 from abc import ABC
 from concurrent.futures import ThreadPoolExecutor
+from itertools import tee
 from logging import FileHandler, Formatter, Logger, getLogger
 from pathlib import Path
 from signal import SIGINT, SIGTERM, signal
@@ -31,6 +32,7 @@ from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI
 from ape.api.query import BlockTransactionQuery
 from ape.api.transactions import ReceiptAPI, TransactionAPI
 from ape.exceptions import (
+    ApeException,
     APINotImplementedError,
     BlockNotFoundError,
     ContractLogicError,
@@ -1274,9 +1276,31 @@ class Web3Provider(ProviderAPI, ABC):
     ) -> ContractLogicError:
         message = str(exception).split(":")[-1].strip()
         params: Dict = {"trace": trace, "contract_address": contract_address}
+        no_reason = message == "execution reverted"
+
+        if isinstance(exception, Web3ContractLogicError) and no_reason:
+            # Check for custom exception data and use that as the message instead.
+            # This allows compiler exeption enrichment to function.
+            try:
+                if trace:
+                    trace, err_trace = tee(trace)
+                elif txn:
+                    err_trace = self.provider.get_transaction_trace(txn.txn_hash.hex())
+
+                data = list(err_trace)[-1].raw
+                memory = data.get("memory", [])
+                return_value = "".join([x[2:] for x in memory[4:]])
+                if return_value:
+                    message = f"0x{return_value}"
+                    no_reason = False
+
+            except (ApeException, NotImplementedError):
+                # Either provider does not support or isn't a custom exception.
+                pass
+
         result = (
             ContractLogicError(txn=txn, **params)
-            if message == "execution reverted"
+            if no_reason
             else ContractLogicError(revert_message=message, txn=txn, **params)
         )
         return self.compiler_manager.enrich_error(result)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -489,5 +489,12 @@ def error_contract_container(get_contract_type):
 
 
 @pytest.fixture
-def error_contract(owner, error_contract_container):
+def error_contract(owner, error_contract_container, eth_tester_provider):
+    _ = eth_tester_provider  # Ensure uses eth tester
+    return owner.deploy(error_contract_container)
+
+
+@pytest.fixture
+def error_contract_geth(owner, error_contract_container, geth_provider):
+    _ = geth_provider  # Ensure uses geth
     return owner.deploy(error_contract_container)

--- a/tests/functional/test_geth.py
+++ b/tests/functional/test_geth.py
@@ -382,3 +382,11 @@ def assert_rich_output(rich_capture: List[str], expected: str):
     if expected_len > actual_len:
         rest = "\n".join(expected_lines[actual_len:])
         pytest.fail(f"Missing expected lines: {rest}")
+
+
+def test_custom_error(error_contract_geth, not_owner):
+    contract = error_contract_geth
+    with pytest.raises(contract.Unauthorized) as err:
+        contract.withdraw(sender=not_owner)
+
+    assert err.value.inputs == {"addr": not_owner.address, "counter": 123}


### PR DESCRIPTION
### What I did

Fix needed to make custom solidity errors work during enrichment.

### How I did it

Place data in message of `ContractLogicError` so that compiler data enrichment works.

### How to verify it

Can now get custom errors when using `ape-geth`

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
