### PR TITLE
fix: uses system path separator in BaseProject.process_config_file [APE-843]

### DIFF
--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -143,7 +144,9 @@ class BaseProject(ProjectAPI):
             config_data["version"] = self.version
 
         contracts_folder = kwargs.get("contracts_folder") or self.contracts_folder
-        contracts_folder_config_item = str(contracts_folder).replace(str(self.path), "").strip("/")
+        contracts_folder_config_item = (
+            str(contracts_folder).replace(str(self.path), "").strip(os.path.sep)
+        )
         config_data["contracts_folder"] = contracts_folder_config_item
         self.config_file.parent.mkdir(parents=True, exist_ok=True)
         self.config_file.touch()


### PR DESCRIPTION
### What I did

Changes character `/` to `os.path.sep`

fixes: #

### How I did it

On Windows manifest for dependencies is empty because `contracts_folder_config_item` equal to `\contract`. Reason for that: predefined file path delimiter instead of system delimiter. 

### How to verify it

Compile any project with dependency on Windows

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
