### PR TITLE
fix: issue preventing Ethereum forked network config from working [APE-844]

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -417,10 +417,11 @@ class EcosystemAPI(BaseInterfaceModel):
               :class:`~ape.api.networks.NetworkAPI`
         """
 
-        if network_name in self.networks:
-            return self.networks[network_name]
-        else:
-            raise NetworkNotFoundError(network_name)
+        name = network_name.replace("_", "-")
+        if name in self.networks:
+            return self.networks[name]
+
+        raise NetworkNotFoundError(network_name)
 
     def get_network_data(self, network_name: str) -> Dict:
         """
@@ -674,7 +675,7 @@ class NetworkAPI(BaseInterfaceModel):
 
     @property
     def _network_config(self) -> Dict:
-        return self.config.get(self.name, {})
+        return self.config.get(self.name.replace("-", "_"), {})
 
     @cached_property
     def gas_limit(self) -> GasLimit:

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -251,9 +251,6 @@ class EcosystemAPI(BaseInterfaceModel):
         Args:
             network_name (str): The name of the network to add.
             network (:class:`~ape.api.networks.NetworkAPI`): The network to add.
-
-        Returns:
-            :class:`~ape.api.networks.NetworkAPI`
         """
         if network_name in self.networks:
             raise NetworkError(f"Unable to overwrite existing network '{network_name}'.")

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -250,6 +250,7 @@ class EcosystemAPI(BaseInterfaceModel):
 
         Args:
             network_name (str): The name of the network to add.
+            network (:class:`~ape.api.networks.NetworkAPI`): The network to add.
 
         Returns:
             :class:`~ape.api.networks.NetworkAPI`

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -227,3 +227,14 @@ def test_configure_default_txn_type(temp_config, ethereum):
         ethereum._default_network = "mainnet-fork"
         assert ethereum.default_transaction_type == TransactionType.STATIC
         ethereum._default_network = LOCAL_NETWORK_NAME
+
+
+@pytest.mark.parametrize("network_name", (LOCAL_NETWORK_NAME, "mainnet-fork", "mainnet_fork"))
+def test_gas_limit_local_networks(ethereum, network_name):
+    network = ethereum.get_network(network_name)
+    assert network.gas_limit == "max"
+
+
+def test_gas_limit_live_networks(ethereum):
+    network = ethereum.get_network("goerli")
+    assert network.gas_limit == "auto"


### PR DESCRIPTION
### What I did

noticed i couldnt configure my forked networks 
fixed it

### How I did it

hyphen underscore swap

### How to verify it

```python
ethereum.mainnet_fork.gas_limit
>> max  # the default, before would say auto which is the default default when config is missing
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
