### PR TITLE
feat: pytest `use_network` marker [APE-868]

### DIFF
--- a/docs/userguides/testing.md
+++ b/docs/userguides/testing.md
@@ -386,12 +386,29 @@ def test_unauthorized_withdraw(contract, hacker):
 
 ## Multi-chain Testing
 
-The Ape framework supports connecting to alternative providers in tests.
-The easiest way to achieve this is to use the `networks` provider context-manager.
+The Ape framework supports connecting to alternative networks / providers in tests.
+
+To run an entire test using a specific network / provider combination, use the `use_network` pytest marker:
+
+```python
+import pytest
+
+
+@pytest.mark.use_network("fantom:local:test")
+def test_my_fantom_test(chain):
+    assert chain.provider.network.ecosystem.name == "fantom"
+
+
+@pytest.mark.use_network("ethereum:local:test")
+def test_my_ethereum_test(chain):
+    assert chain.provider.network.ecosystem.name == "ethereum"
+```
+
+To switch networks mid-test, use the `networks` context-manager:
 
 ```python
 # Switch to Fantom mid test
-def test_my_fantom_test(networks):
+def test_my_multichain_test(networks):
     # The test starts in 1 ecosystem but switches to another
     assert networks.provider.network.ecosystem.name == "ethereum"
 
@@ -403,7 +420,8 @@ def test_my_fantom_test(networks):
        assert provider.network.ecosystem.name == "fantom"
 ```
 
-You can also set the network context in a context-manager pytest fixture:
+You can also set the network context in a pytest fixture.
+This is useful if certain fixtures must run in certain networks.
 
 ```python
 import pytest

--- a/src/ape/pytest/plugin.py
+++ b/src/ape/pytest/plugin.py
@@ -75,6 +75,11 @@ def pytest_configure(config):
     fixtures = PytestApeFixtures(config_wrapper, receipt_capture)
     config.pluginmanager.register(fixtures, "ape-fixtures")
 
+    # Add custom markers
+    config.addinivalue_line(
+        "markers", "use_network(choice): Run this test using the given network choice."
+    )
+
 
 def pytest_load_initial_conftests(early_config):
     """

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -163,12 +163,11 @@ class PytestApeRunner(ManagerAccessMixin):
 
     @pytest.hookimpl(tryfirst=True, hookwrapper=True)
     def pytest_runtest_call(self, item):
-        marker = item.get_closest_marker("use_network")
-        if marker:
-            if len(getattr(marker, "args", []) or []) != 1:
+        if network_marker := item.get_closest_marker("use_network"):
+            if len(getattr(network_marker, "args", []) or []) != 1:
                 raise ValueError("`use_network` marker requires single network choice argument.")
 
-            with self.network_manager.parse_network_choice(marker.args[0]):
+            with self.network_manager.parse_network_choice(network_marker.args[0]):
                 yield
 
         else:

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -161,6 +161,19 @@ class PytestApeRunner(ManagerAccessMixin):
         if warnings and not self.config_wrapper.disable_warnings:
             reporter.stats["warnings"] = warnings
 
+    @pytest.hookimpl(tryfirst=True, hookwrapper=True)
+    def pytest_runtest_call(self, item):
+        marker = item.get_closest_marker("use_network")
+        if marker:
+            if not marker.args or len(marker.args) > 1:
+                raise ValueError("`use_network` marker requires single network choice argument.")
+
+            with self.network_manager.parse_network_choice(marker.args[0]):
+                yield
+
+        else:
+            yield
+
     @pytest.hookimpl(trylast=True, hookwrapper=True)
     def pytest_collection_finish(self, session):
         """

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -165,7 +165,7 @@ class PytestApeRunner(ManagerAccessMixin):
     def pytest_runtest_call(self, item):
         marker = item.get_closest_marker("use_network")
         if marker:
-            if not marker.args or len(marker.args) > 1:
+            if len(getattr(marker, "args", []) or []) != 1:
                 raise ValueError("`use_network` marker requires single network choice argument.")
 
             with self.network_manager.parse_network_choice(marker.args[0]):

--- a/tests/integration/cli/projects/geth/tests/test_using_local_geth.py
+++ b/tests/integration/cli/projects/geth/tests/test_using_local_geth.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_provider(project, networks):
     """
     Tests that the network gets set from ape-config.yaml.
@@ -66,3 +69,13 @@ def test_call_method_excluded_from_config(accounts, contract):
     account = accounts[-4]
     receipt = contract.setAddress(account.address, sender=account)
     assert not receipt.failed
+
+
+@pytest.mark.use_network("ethereum:local:test")
+def test_switch_back_to_eth_tester(chain):
+    """
+    Test to verify the `use_network` marker works.
+    This test is in the geth project because that is the only test project
+    that has multiple providers.
+    """
+    assert chain.provider.name == "test"


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #587 
Fixes: APE-176

### How I did it

Was working on coverage when was trying to learn about adding custom markers.
It is rather easy to do, so I figured I'd knock this ticket out with my new found knowledge (it took like 15 minutes soooo it is worth it to close this out).

### How to verify it

Examples:

```python
@pytest.mark.use_network("ethereum:local:test")
def test_use_test(chain):
    assert chain.provider.name == "test"


@pytest.mark.use_network("ethereum:local:foundry")
def test_use_foundry(chain):
    assert chain.provider.name == "foundry"
```

but you can change the ecosystem and network for more realistic scenarios

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
