### PR TITLE
refactor: move gas tracker logic to `pytest` module [APE-875]

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -847,7 +847,7 @@ class Web3Provider(ProviderAPI, ABC):
         if skip_trace:
             return self._send_call(txn, **kwargs)
 
-        track_gas = self._test_runner is not None and self._test_runner.gas_tracker.track_gas
+        track_gas = self._test_runner is not None and self._test_runner.gas_tracker.enabled
         show_trace = kwargs.pop("show_trace", False)
         show_gas = kwargs.pop("show_gas_report", False)
         needs_trace = track_gas or show_trace or show_gas

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -847,7 +847,7 @@ class Web3Provider(ProviderAPI, ABC):
         if skip_trace:
             return self._send_call(txn, **kwargs)
 
-        track_gas = self.chain_manager._reports.track_gas
+        track_gas = self._test_runner is not None and self._test_runner.gas_tracker.track_gas
         show_trace = kwargs.pop("show_trace", False)
         show_gas = kwargs.pop("show_gas_report", False)
         needs_trace = track_gas or show_trace or show_gas

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -454,5 +454,6 @@ class ReceiptAPI(BaseInterfaceModel):
 
         call_tree = self.call_tree
         receiver = self.receiver
-        if call_tree and receiver is not None:
-            self.chain_manager._reports.append_gas(call_tree.enrich(in_line=False), receiver)
+        if call_tree and receiver is not None and self._test_runner is not None:
+            tracker = self._test_runner.gas_tracker
+            tracker.append_gas(call_tree.enrich(in_line=False), receiver)

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1273,6 +1273,16 @@ class ReportManager(BaseManager):
         console = self._get_console(file=file)
         console.print(*rich_items)
 
+    @property
+    def track_gas(self) -> bool:
+        # TODO: Delete in 0.7; call _test_runner directly if needed.
+        return self._test_runner is not None and self._test_runner.gas_tracker.enabled
+
+    def append_gas(self, *args, **kwargs):
+        # TODO: Delete in 0.7 and have all plugins call `_test_runner.gas_tracker.append_gas()`.
+        if self._test_runner:
+            self._test_runner.gas_tracker.append_gas(*args, **kwargs)
+
     def _get_console(self, file: Optional[IO[str]] = None) -> RichConsole:
         if not file:
             return get_console()

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -9,7 +9,6 @@ from typing import IO, Collection, Dict, Iterator, List, Optional, Set, Type, Un
 import click
 import pandas as pd
 from ethpm_types import ContractType
-from evm_trace.gas import merge_reports
 from rich import get_console
 from rich.console import Console as RichConsole
 
@@ -34,15 +33,8 @@ from ape.exceptions import (
 )
 from ape.logging import logger
 from ape.managers.base import BaseManager
-from ape.types import (
-    AddressType,
-    BlockID,
-    CallTreeNode,
-    ContractFunctionPath,
-    GasReport,
-    SnapshotID,
-)
-from ape.utils import BaseInterfaceModel, TraceStyles, parse_gas_table, singledispatchmethod
+from ape.types import AddressType, BlockID, CallTreeNode, SnapshotID
+from ape.utils import BaseInterfaceModel, TraceStyles, singledispatchmethod
 
 
 class BlockContainer(BaseManager):
@@ -1250,9 +1242,6 @@ class ReportManager(BaseManager):
     **NOTE**: This class is not part of the public API.
     """
 
-    track_gas: bool = False
-    gas_exclusions: List[ContractFunctionPath] = []
-    session_gas_report: Optional[GasReport] = None
     rich_console_map: Dict[str, RichConsole] = {}
 
     def show_trace(
@@ -1277,35 +1266,12 @@ class ReportManager(BaseManager):
         console.print(root)
 
     def show_gas(self, call_tree: CallTreeNode, file: Optional[IO[str]] = None):
-        console = self._get_console(file)
         tables = call_tree.as_gas_tables()
-        console.print(*tables)
+        self.echo(*tables)
 
-    def show_session_gas(
-        self,
-        file: Optional[IO[str]] = None,
-    ) -> bool:
-        if not self.session_gas_report:
-            return False
-
-        tables = parse_gas_table(self.session_gas_report)
-        console = self._get_console(file)
-        console.print(*tables)
-        return True
-
-    def append_gas(
-        self,
-        call_tree: CallTreeNode,
-        contract_address: AddressType,
-    ):
-        contract_type = self.chain_manager.contracts.get(contract_address)
-        if not contract_type:
-            # Skip unknown contracts.
-            return
-
-        gas_report = call_tree.get_gas_report(exclude=self.gas_exclusions)
-        session_report = self.session_gas_report or {}
-        self.session_gas_report = merge_reports(session_report, gas_report)
+    def echo(self, *rich_items, file: Optional[IO[str]] = None):
+        console = self._get_console(file=file)
+        console.print(*rich_items)
 
     def _get_console(self, file: Optional[IO[str]] = None) -> RichConsole:
         if not file:

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -129,8 +129,6 @@ class ReceiptCapture(ManagerAccessMixin):
 
     def __init__(self, config_wrapper: ConfigWrapper):
         self.config_wrapper = config_wrapper
-        self.chain_manager._reports.track_gas = self.config_wrapper.track_gas
-        self.chain_manager._reports.gas_exclusions = self.config_wrapper.gas_exclusions
 
     def __enter__(self):
         block_number = self._get_block_number()

--- a/src/ape/pytest/gas.py
+++ b/src/ape/pytest/gas.py
@@ -19,7 +19,7 @@ class GasTracker(ManagerAccessMixin):
         self.session_gas_report: Optional[GasReport] = None
 
     @property
-    def track_gas(self) -> bool:
+    def enabled(self) -> bool:
         return self.config_wrapper.track_gas
 
     @property

--- a/src/ape/pytest/gas.py
+++ b/src/ape/pytest/gas.py
@@ -1,0 +1,49 @@
+from typing import List, Optional
+
+from evm_trace.gas import merge_reports
+
+from ape.pytest.config import ConfigWrapper
+from ape.types import AddressType, CallTreeNode, ContractFunctionPath, GasReport
+from ape.utils import parse_gas_table
+from ape.utils.basemodel import ManagerAccessMixin
+
+
+class GasTracker(ManagerAccessMixin):
+    """
+    Class for tracking gas-used per method called in the
+    contracts in your test suite.
+    """
+
+    def __init__(self, config_wrapper: ConfigWrapper):
+        self.config_wrapper = config_wrapper
+        self.session_gas_report: Optional[GasReport] = None
+
+    @property
+    def track_gas(self) -> bool:
+        return self.config_wrapper.track_gas
+
+    @property
+    def gas_exclusions(self) -> List[ContractFunctionPath]:
+        return self.config_wrapper.gas_exclusions
+
+    def show_session_gas(self) -> bool:
+        if not self.session_gas_report:
+            return False
+
+        tables = parse_gas_table(self.session_gas_report)
+        self.chain_manager._reports.echo(*tables)
+        return True
+
+    def append_gas(
+        self,
+        call_tree: CallTreeNode,
+        contract_address: AddressType,
+    ):
+        contract_type = self.chain_manager.contracts.get(contract_address)
+        if not contract_type:
+            # Skip unknown contracts.
+            return
+
+        gas_report = call_tree.get_gas_report(exclude=self.gas_exclusions)
+        session_report = self.session_gas_report or {}
+        self.session_gas_report = merge_reports(session_report, gas_report)

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import TYPE_CHECKING, ClassVar, Dict, List, cast
+from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, cast
 
 from pydantic import BaseModel
 
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from ape.managers.project import DependencyManager, ProjectManager
     from ape.managers.query import QueryManager
     from ape.plugins import PluginManager
+    from ape.pytest.runners import PytestApeRunner
 
 
 class injected_before_use(property):
@@ -55,6 +56,8 @@ class ManagerAccessMixin:
     project_manager: ClassVar["ProjectManager"] = cast("ProjectManager", injected_before_use())
 
     query_manager: ClassVar["QueryManager"] = cast("QueryManager", injected_before_use())
+
+    _test_runner: ClassVar[Optional["PytestApeRunner"]] = None
 
     @property
     def provider(self) -> "ProviderAPI":

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -481,7 +481,7 @@ class GethDev(BaseGethProvider, TestProviderAPI):
 
         show_gas = kwargs.pop("show_gas_report", False)
         show_trace = kwargs.pop("show_trace", False)
-        track_gas = self.chain_manager._reports.track_gas
+        track_gas = self._test_runner is not None and self._test_runner.gas_tracker.track_gas
         needs_trace = show_gas or show_trace or track_gas
         if not needs_trace:
             return self._eth_call(arguments)
@@ -511,12 +511,12 @@ class GethDev(BaseGethProvider, TestProviderAPI):
             # Optimization to enrich early and in_place=True.
             call_tree.enrich()
 
-        if track_gas and call_tree and receiver is not None:
+        if track_gas and call_tree and receiver is not None and self._test_runner is not None:
             # Gas report being collected, likely for showing a report
             # at the end of a test run.
             # Use `in_place=False` in case also `show_trace=True`
             enriched_call_tree = call_tree.enrich(in_place=False)
-            self.chain_manager._reports.append_gas(enriched_call_tree, receiver)
+            self._test_runner.gas_tracker.append_gas(enriched_call_tree, receiver)
 
         if show_gas:
             enriched_call_tree = call_tree.enrich(in_place=False)

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -481,7 +481,7 @@ class GethDev(BaseGethProvider, TestProviderAPI):
 
         show_gas = kwargs.pop("show_gas_report", False)
         show_trace = kwargs.pop("show_trace", False)
-        track_gas = self._test_runner is not None and self._test_runner.gas_tracker.track_gas
+        track_gas = self._test_runner is not None and self._test_runner.gas_tracker.enabled
         needs_trace = show_gas or show_trace or track_gas
         if not needs_trace:
             return self._eth_call(arguments)


### PR DESCRIPTION
### What I did

This refactor is going to help the coverage stuff feel right I think...
Basically, the internal class `ReportManager` is great for interfacing with `rich.console` but doesn't make the most sense fore tracking session gas, so made a `GasTracker` class in `ape.pytest` and have it live there. I am going to do the same thing with a `ContractCoverage` class.

### How I did it

Move everything related to the tracking of session gas to a new class in `ape.pytest.gas` module from the internal for using rich console. **NOTE**: Not a breaking change because the class is internal

### How to verify it

* everything still works

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
