### PR TITLE
feat: Add argument to control caching, block explorer fetching, forced disk cache updates [APE-913]

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -963,7 +963,11 @@ class ContractCache(BaseManager):
         return contract_types
 
     def get(
-        self, address: AddressType, default: Optional[ContractType] = None
+        self,
+        address: AddressType,
+        default: Optional[ContractType] = None,
+        cache: bool = True,
+        update_cache: bool = True,
     ) -> Optional[ContractType]:
         """
         Get a contract type by address.
@@ -975,6 +979,10 @@ class ContractCache(BaseManager):
             address (AddressType): The address of the contract.
             default (Optional[ContractType]): A default contract when none is found.
               Defaults to ``None``.
+            cache (bool): Cache the result for live networks
+              Defaults to ``True``.
+            update_cache (bool): Update the cache with the new contract
+              Defaults to ``False``.
 
         Returns:
             Optional[ContractType]: The contract type if it was able to get one,
@@ -999,6 +1007,8 @@ class ContractCache(BaseManager):
             return default
 
         contract_type = self._get_contract_type_from_disk(address_key)
+
+        # Handle the case where no contract is cached on disk
         if not contract_type:
             # Contract could be a minimal proxy
             proxy_info = self._local_proxies.get(address_key) or self._get_proxy_info_from_disk(
@@ -1007,22 +1017,26 @@ class ContractCache(BaseManager):
 
             if not proxy_info:
                 proxy_info = self.provider.network.ecosystem.get_proxy_info(address_key)
-                if proxy_info and self._is_live_network:
+                if proxy_info and self._is_live_network and (cache or update_cache):
                     self._cache_proxy_info_to_disk(address_key, proxy_info)
 
             if proxy_info:
                 self._local_proxies[address_key] = proxy_info
-                return self.get(proxy_info.target, default=default)
+                return self.get(proxy_info.target, default=default, cache=cache)
 
             if not self.provider.get_code(address_key):
                 if default:
                     self._local_contract_types[address_key] = default
-                    self._cache_contract_to_disk(address_key, default)
+                    if cache or update_cache:
+                        self._cache_contract_to_disk(address_key, default)
 
                 return default
 
-            # Also gets cached to disk for faster lookup next time.
             contract_type = self._get_contract_type_from_explorer(address_key)
+
+            # Cache to disk for faster lookup next time.
+            if contract_type and (cache or update_cache):
+                self._cache_contract_to_disk(address, contract_type)
 
         # Cache locally for faster in-session look-up.
         if contract_type:
@@ -1031,14 +1045,16 @@ class ContractCache(BaseManager):
         if not contract_type:
             if default:
                 self._local_contract_types[address_key] = default
-                self._cache_contract_to_disk(address_key, default)
+                if cache or update_cache:
+                    self._cache_contract_to_disk(address_key, default)
 
             return default
 
         if default and default != contract_type:
             # Replacing contract type
             self._local_contract_types[address_key] = default
-            self._cache_contract_to_disk(address_key, default)
+            if cache or update_cache:
+                self._cache_contract_to_disk(address_key, default)
             return default
 
         return contract_type
@@ -1062,6 +1078,8 @@ class ContractCache(BaseManager):
         address: Union[str, AddressType],
         contract_type: Optional[ContractType] = None,
         txn_hash: Optional[str] = None,
+        cache: bool = True,
+        update_cache: bool = False,
     ) -> ContractInstance:
         """
         Get a contract at the given address. If the contract type of the contract is known,
@@ -1080,10 +1098,17 @@ class ContractCache(BaseManager):
               in case it is not already known.
             txn_hash (Optional[str]): The hash of the transaction responsible for deploying the
               contract, if known. Useful for publishing. Defaults to ``None``.
+            cache (bool): Cache the result for live networks
+              Defaults to ``True``.
+            update_cache (bool): Re-fetch ContractType from the block explorer and update the cache
+              Defaults to ``False``.
 
         Returns:
             :class:`~ape.contracts.base.ContractInstance`
         """
+
+        if update_cache and not cache:
+            raise ValueError("update_cache=True cannot be set with cache=False")
 
         if self.conversion_manager.is_type(address, AddressType):
             contract_address = cast(AddressType, address)
@@ -1095,7 +1120,9 @@ class ContractCache(BaseManager):
 
         try:
             # Always attempt to get an existing contract type to update caches
-            contract_type = self.get(contract_address, default=contract_type)
+            contract_type = self.get(
+                contract_address, default=contract_type, cache=cache, update_cache=update_cache
+            )
         except Exception as err:
             if contract_type:
                 # If a default contract type was provided, don't error and use it.
@@ -1204,10 +1231,6 @@ class ContractCache(BaseManager):
         except Exception as err:
             logger.error(f"Unable to fetch contract type at '{address}' from explorer.\n{err}")
             return None
-
-        if contract_type:
-            # Cache contract so faster look-up next time.
-            self._cache_contract_to_disk(address, contract_type)
 
         return contract_type
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1143,7 +1143,8 @@ class ContractCache(BaseManager):
             contract_type = self.get(
                 contract_address,
                 default=contract_type,
-                fetch_from_explorer=fetch_from_explorer,
+                # If a contract type was provided, disable block explorer fetching
+                fetch_from_explorer=fetch_from_explorer if contract_type is None else False,
                 cache_to_disk=cache_to_disk,
                 force_disk_cache_update=force_disk_cache_update,
             )

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1149,7 +1149,6 @@ class ContractCache(BaseManager):
                 force_disk_cache_update=force_disk_cache_update,
             )
         except Exception as err:
-            print(err)
             if contract_type:
                 # If a default contract type was provided, don't error and use it.
                 logger.error(str(err))

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1058,11 +1058,6 @@ class ContractCache(BaseManager):
         elif contract_type_from_memory is not None and contract_type_from_memory != default:
             # If a contract type was not provided, and one was found in the memory cache, use it
             contract_type = contract_type_from_memory
-        else:
-            raise ValueError(
-                "No contract type was provided, and no contract types were found in memory,"
-                "on disk, or on block explorer."
-            )
 
         # Update the memory and disk cache if a valid contract type was found
         if contract_type:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1056,6 +1056,7 @@ class ContractCache(BaseManager):
             # If a contract type was not provided, and one was found from disk, use it
             contract_type = contract_type_from_disk
         elif contract_type_from_memory is not None and contract_type_from_memory != default:
+            # If a contract type was not provided, and one was found in the memory cache, use it
             contract_type = contract_type_from_memory
         else:
             raise ValueError(

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -980,7 +980,7 @@ class ContractCache(BaseManager):
             address (AddressType): The address of the contract.
             default (Optional[ContractType]): A default contract when none is found.
               Defaults to ``None``.
-            cache_to_disk (bool): Cache the fetched contract type to  (live networks only).
+            cache_to_disk (bool): Cache the fetched contract type to disk (live networks only).
               Defaults to ``True``.
             fetch_from_explorer (bool): Fetch the contract type from the block explorer.
               Defaults to ``True``.


### PR DESCRIPTION
### What I did

Implement booleans with default values to control:
- if retrieved storage types will be cached to disk (useful when working with minimal ABIs) 
- if the `get` method will attempt to retrieve a contract type from the block explorer
- if a forced disk cache update is performed after contract type is retrieved

fixes: #1419 

### How I did it

Add three boolean args (`cache_to_disk: bool = True`, `fetch_from_explorer: bool = True`, `force_disk_cache_update: bool = False`) to two `ContractCache` methods defined in ape / managers / chain.py:
- `get`
- `instance_at`

Add `if` checks before calls to:
- `_cache_contract_to_disk`
- `_cache_proxy_info_to_disk`

Move the caching logic out of `_get_contract_type_from_explorer` into the parent `get` method so it can be managed separately (`_get_contract_type_from_explorer` should be a single-concern method, and it is only called by `get` so this should not break any other functionality).

Refactor the contract type logic inside `get`:
- Track types retrieved from memory, disk cache, and from the block explorer separately
- After retrieving, determine the 'canonical' contract type by comparing against `None` and `default` contract type
- Then manage updates to the cache

Treat calls to `instance_at` with a value for `contract_type` with special behavior:
- If a contract type was provided, assume it was done with the intention of skipping the block explorer fetch, so `fetch_from_explorer` is overridden to `False`.

Wherever contract types are compared to default values, explicitly check against `contract_type is None` instead of `not contract_type`.

### Backwards Compatibility
A default call to `instance_at` (no `contract_type`, `cache_to_disk: bool = True`, `fetch_from_explorer: bool = True`) must preserve the expected behavior of earlier Ape releases (check memory, check the block explorer, cache the result to disk).

### How to verify it
Simple script to verify behavior against a known Uniswap V3 LP address, can observe the caching behavior in a separate terminal:

```
from ethpm_types import ContractType
import os

os.environ['ETHERSCAN_API_KEY'] = 'edit me'

POOL_ADDRESS = "0xCBCDF9626BC03E24F779434178A73A0B4BAD62ED"
V2_FILE_PATH = "./v2lp.json"
V3_FILE_PATH = "./v3lp.json"

with ape.networks.ethereum.mainnet.use_provider("geth"):

    print("Loading contract with UniswapV2 LP ABI (cache disabled)")
    contract_v2_no_cache = ape.Contract(
        address=POOL_ADDRESS,
        contract_type=ContractType.parse_file(V2_FILE_PATH),
        cache_to_disk=False,
    )

    print("Loading contract with UniswapV3 LP ABI (cache disabled)")        
    contract_v3_no_cache = ape.Contract(
        address=POOL_ADDRESS,
        contract_type=ContractType.parse_file(V3_FILE_PATH),
        cache_to_disk=False,        
    )
    
    print("Loading contract with UniswapV2 LP ABI (cache enabled)")        
    contract_v2_cached = ape.Contract(
        address=POOL_ADDRESS,
        contract_type=ContractType.parse_file(V2_FILE_PATH),        
    )
      
    print("Loading contract with UniswapV3 LP ABI (cache enabled)")        
    contract_v3_cached = ape.Contract(
        address=POOL_ADDRESS,
        contract_type=ContractType.parse_file(V3_FILE_PATH),        
    )
    
    print("Loading contract without ABI (cache enabled, block explorer fetch enabled)")
    contract_v3_from_explorer = ape.Contract(
        address=POOL_ADDRESS,        
    )    

    print("Loading contract with UniswapV2 LP ABI (forced disk cache update)")        
    contract_v2_forced = ape.Contract(
        address=POOL_ADDRESS,
        contract_type=ContractType.parse_file(V2_FILE_PATH),        
        force_disk_cache_update=True,
    )
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated