### PR TITLE
feat: private transaction support [APE-915]

### DIFF
--- a/docs/userguides/contracts.md
+++ b/docs/userguides/contracts.md
@@ -168,6 +168,19 @@ contract = Contract("0x123...")
 receipt = contract(sender=sender, gas=40000, data="0x123")
 ```
 
+### Private Transactions
+
+If you are using a provider that implements `send_private_transaction()`, you are able to use the `private=True` kwarg to privately publish your transaction.
+For example, EVM providers likely will use the `eth_sendPrivateTransaction` RPC to achieve this.
+
+To send a private transaction, do the following:
+
+```python
+receipt = contract.set_number(sender=dev, private=True)
+```
+
+The `private=True` is available on all contract interaction.
+
 ## Decoding and Encoding Inputs
 
 If you want to separately decode and encode inputs without sending a transaction or making a call, you can achieve this with Ape.

--- a/docs/userguides/contracts.md
+++ b/docs/userguides/contracts.md
@@ -170,7 +170,7 @@ receipt = contract(sender=sender, gas=40000, data="0x123")
 
 ### Private Transactions
 
-If you are using a provider that implements `send_private_transaction()`, you are able to use the `private=True` kwarg to privately publish your transaction.
+If you are using a provider that allows private mempool transactions, you are able to use the `private=True` kwarg to publish your transaction into a private mempool.
 For example, EVM providers likely will use the `eth_sendPrivateTransaction` RPC to achieve this.
 
 To send a private transaction, do the following:

--- a/docs/userguides/contracts.md
+++ b/docs/userguides/contracts.md
@@ -179,7 +179,7 @@ To send a private transaction, do the following:
 receipt = contract.set_number(sender=dev, private=True)
 ```
 
-The `private=True` is available on all contract interaction.
+The `private=True` is available on all contract interactions.
 
 ## Decoding and Encoding Inputs
 

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -101,8 +101,8 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
             txn (:class:`~ape.api.transactions.TransactionAPI`): An invoke-transaction.
             send_everything (bool): ``True`` will send the difference from balance and fee.
               Defaults to ``False``.
-            private (bool): ``True`` will use the `eth_sendPrivateTransaction` RPC method.
-              Provider needs to implement `send_private_transaction` method.
+            private (bool): ``True`` with use the
+              :meth:`~ape.api.providers.ProviderAPI.send_private_transaction` method.
             **signer_options: Additional kwargs given to the signer to modify the signing operation.
 
         Returns:
@@ -144,10 +144,11 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         if not txn.sender:
             txn.sender = self.address
 
-        if private:
-            return self.provider.send_private_transaction(signed_txn)
-        else:
-            return self.provider.send_transaction(signed_txn)
+        return (
+            self.provider.send_private_transaction(signed_txn)
+            if private
+            else self.provider.send_transaction(signed_txn)
+        )
 
     def transfer(
         self,

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -94,6 +94,8 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
               not have enough funds.
             :class:`~ape.exceptions.TransactionError`: When the required confirmations are negative.
             :class:`~ape.exceptions.SignatureError`: When the user does not sign the transaction.
+            :class:`~ape.exceptions.APINotImplementedError`: When setting ``private=True`` and using
+              a provider that does not support private transactions.
 
         Args:
             txn (:class:`~ape.api.transactions.TransactionAPI`): An invoke-transaction.
@@ -157,6 +159,10 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
     ) -> ReceiptAPI:
         """
         Send funds to an account.
+
+        Raises:
+            :class:`~ape.exceptions.APINotImplementedError`: When setting ``private=True``
+              and using a provider that does not support private transactions.
 
         Args:
             account (str): The account to send funds to.

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -168,7 +168,9 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
             account (str): The account to send funds to.
             value (str): The amount to send.
             data (str): Extra data to include in the transaction.
-            private (bool): ``True`` will use the `eth_sendPrivateTransaction` RPC method.
+            private (bool): ``True`` asks the provider to make the transaction
+              private. For example, EVM providers uses the RPC ``eth_sendPrivateTransaction``
+              to achieve this. Local providers may ignore this value.
 
         Returns:
             :class:`~ape.api.transactions.ReceiptAPI`

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -919,7 +919,9 @@ class NetworkAPI(BaseInterfaceModel):
         if provider_name in self.providers:
             self._default_provider = provider_name
         else:
-            raise NetworkError(f"Provider '{provider_name}' not found in network '{self.name}'.")
+            raise NetworkError(
+                f"Provider '{provider_name}' not found in network '{self.ecosystem.name}:{self.name}'."
+            )
 
     def use_default_provider(
         self, provider_settings: Optional[Dict] = None

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -920,7 +920,8 @@ class NetworkAPI(BaseInterfaceModel):
             self._default_provider = provider_name
         else:
             raise NetworkError(
-                f"Provider '{provider_name}' not found in network '{self.ecosystem.name}:{self.name}'."
+                f"Provider '{provider_name}' not found in network "
+                f"'{self.ecosystem.name}:{self.name}'."
             )
 
     def use_default_provider(

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -409,7 +409,14 @@ class ProviderAPI(BaseInterfaceModel):
         self, txn: TransactionAPI
     ) -> ReceiptAPI:
         """
-        Send a transaction through a private mempool (if supported by the Provider)
+        Send a transaction through a private mempool (if supported by the Provider).
+
+        Args:
+            txn (:class:`~ape.api.transactions.TransactionAPI`): The transaction
+              to privately publish.
+
+        Returns:
+            :class:`~ape.api.transactions.ReceiptAPI`
         """
 
     @raises_not_implemented

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -427,7 +427,7 @@ class ProviderAPI(BaseInterfaceModel):
         :class:`ape.managers.chain.ChainManager`.
 
         Raises:
-            NotImplementedError: Unless overridden.
+            :class:`~ape.exceptions.APINotImplementedError`: Unless overriden.
         """
 
     @raises_not_implemented
@@ -438,7 +438,7 @@ class ProviderAPI(BaseInterfaceModel):
         :class:`ape.managers.chain.ChainManager`.
 
         Raises:
-            NotImplementedError: Unless overridden.
+            :class:`~ape.exceptions.APINotImplementedError`: Unless overriden.
         """
 
     @raises_not_implemented
@@ -449,7 +449,7 @@ class ProviderAPI(BaseInterfaceModel):
         :class:`ape.managers.chain.ChainManager`.
 
         Raises:
-            NotImplementedError: Unless overridden.
+            :class:`~ape.exceptions.APINotImplementedError`: Unless overriden.
         """
 
     @raises_not_implemented
@@ -460,7 +460,7 @@ class ProviderAPI(BaseInterfaceModel):
         :class:`ape.managers.chain.ChainManager`.
 
         Raises:
-            NotImplementedError: Unless overridden.
+            :class:`~ape.exceptions.APINotImplementedError`: Unless overriden.
         """
 
     @raises_not_implemented

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -404,7 +404,7 @@ class ProviderAPI(BaseInterfaceModel):
             Iterator[:class:`~ape.types.ContractLog`]
         """
 
-    def send_private_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
+    def send_private_transaction(self, txn: TransactionAPI, **kwargs) -> ReceiptAPI:
         """
         Send a transaction through a private mempool (if supported by the Provider).
 
@@ -415,6 +415,7 @@ class ProviderAPI(BaseInterfaceModel):
         Args:
             txn (:class:`~ape.api.transactions.TransactionAPI`): The transaction
               to privately publish.
+            **kwargs: Additional kwargs to be optionally handled by the provider.
 
         Returns:
             :class:`~ape.api.transactions.ReceiptAPI`

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -422,6 +422,10 @@ class ProviderAPI(BaseInterfaceModel):
         if self.network.name == LOCAL_NETWORK_NAME or self.network.name.endswith("-fork"):
             # Send the transaction as normal so testers can verify private=True
             # and the txn still goes through.
+            logger.warning(
+                f"private=True is set but connected to network '{self.network.name}' ."
+                f"Using regular '{self.send_transaction.__name__}()' method (not private)."
+            )
             return self.send_transaction(txn)
 
         # What happens normally from `raises_not_implemented()` decorator.

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -405,6 +405,14 @@ class ProviderAPI(BaseInterfaceModel):
         """
 
     @raises_not_implemented
+    def send_private_transaction(  # type: ignore[empty-body]
+        self, txn: TransactionAPI
+    ) -> ReceiptAPI:
+        """
+        Send a transaction through a private mempool (if supported by the Provider)
+        """
+
+    @raises_not_implemented
     def snapshot(self) -> SnapshotID:  # type: ignore[empty-body]
         """
         Defined to make the ``ProviderAPI`` interchangeable with a

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -66,10 +66,11 @@ class ContractConstructor(ManagerAccessMixin):
         elif "sender" not in kwargs and self.account_manager.default_sender is not None:
             return self.account_manager.default_sender.call(txn, **kwargs)
 
-        if private:
-            return self.provider.send_private_transaction(txn)
-        else:
-            return self.provider.send_transaction(txn)
+        return (
+            self.provider.send_private_transaction(txn)
+            if private
+            else self.provider.send_transaction(txn)
+        )
 
 
 class ContractCall(ManagerAccessMixin):

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -273,16 +273,18 @@ class ContractTransaction(ManagerAccessMixin):
             self.address, self.abi, *arguments, **kwargs
         )
 
-    def __call__(self, private: bool = False, *args, **kwargs) -> ReceiptAPI:
+    def __call__(self, *args, **kwargs) -> ReceiptAPI:
         txn = self.serialize_transaction(*args, **kwargs)
+        private = kwargs.get("private", False)
 
         if "sender" in kwargs and isinstance(kwargs["sender"], AccountAPI):
             return kwargs["sender"].call(txn, **kwargs)
 
-        if private:
-            return self.provider.send_private_transaction(txn)
-        else:
-            return self.provider.send_transaction(txn)
+        return (
+            self.provider.send_private_transaction(txn)
+            if private
+            else self.provider.send_transaction(txn)
+        )
 
 
 class ContractTransactionHandler(ContractMethodHandler):

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -1237,6 +1237,7 @@ class ContractContainer(ContractTypeWrapper):
 
     def deploy(self, *args, publish: bool = False, **kwargs) -> ContractInstance:
         txn = self(*args, **kwargs)
+        private = kwargs.get("private", False)
 
         if "sender" in kwargs and isinstance(kwargs["sender"], AccountAPI):
             # Handle account-related preparation if needed, such as signing
@@ -1244,7 +1245,11 @@ class ContractContainer(ContractTypeWrapper):
 
         else:
             txn = self.provider.prepare_transaction(txn)
-            receipt = self.provider.send_transaction(txn)
+            receipt = (
+                self.provider.send_private_transaction(txn)
+                if private
+                else self.provider.send_transaction(txn)
+            )
 
         address = receipt.contract_address
         if not address:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -57,7 +57,7 @@ class ContractConstructor(ManagerAccessMixin):
             self.deployment_bytecode, self.abi, *arguments, **kwargs
         )
 
-    def __call__(self, *args, **kwargs) -> ReceiptAPI:
+    def __call__(self, private: bool = False, *args, **kwargs) -> ReceiptAPI:
         txn = self.serialize_transaction(*args, **kwargs)
 
         if "sender" in kwargs and isinstance(kwargs["sender"], AccountAPI):
@@ -66,7 +66,10 @@ class ContractConstructor(ManagerAccessMixin):
         elif "sender" not in kwargs and self.account_manager.default_sender is not None:
             return self.account_manager.default_sender.call(txn, **kwargs)
 
-        return self.provider.send_transaction(txn)
+        if private:
+            return self.provider.send_private_transaction(txn)
+        else:
+            return self.provider.send_transaction(txn)
 
 
 class ContractCall(ManagerAccessMixin):
@@ -270,13 +273,16 @@ class ContractTransaction(ManagerAccessMixin):
             self.address, self.abi, *arguments, **kwargs
         )
 
-    def __call__(self, *args, **kwargs) -> ReceiptAPI:
+    def __call__(self, private: bool = False, *args, **kwargs) -> ReceiptAPI:
         txn = self.serialize_transaction(*args, **kwargs)
 
         if "sender" in kwargs and isinstance(kwargs["sender"], AccountAPI):
             return kwargs["sender"].call(txn, **kwargs)
 
-        return self.provider.send_transaction(txn)
+        if private:
+            return self.provider.send_private_transaction(txn)
+        else:
+            return self.provider.send_transaction(txn)
 
 
 class ContractTransactionHandler(ContractMethodHandler):

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -254,11 +254,15 @@ def raises_not_implemented(fn):
     """
 
     def inner(*args, **kwargs):
-        raise APINotImplementedError(
-            f"Attempted to call method '{fn.__qualname__}', method not supported."
-        )
+        raise _create_raises_not_implemented_error(fn)
 
     return inner
+
+
+def _create_raises_not_implemented_error(fn):
+    return APINotImplementedError(
+        f"Attempted to call method '{fn.__qualname__}', method not supported."
+    )
 
 
 def to_int(value) -> int:

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ape import Contract
+from ape.contracts import ContractInstance
 from ape.exceptions import NetworkError, ProjectError
 from ape_ethereum.ecosystem import ProxyType
 
@@ -43,6 +44,14 @@ def test_deploy_and_not_publish(mocker, owner, contract_container, dummy_live_ne
     dummy_live_network.__dict__["explorer"] = mock_explorer
     contract_container.deploy(0, sender=owner, publish=False, required_confirmations=0)
     assert not mock_explorer.call_count
+
+
+def test_deploy_privately(owner, contract_container):
+    deploy_0 = owner.deploy(contract_container, 3, private=True)
+    assert isinstance(deploy_0, ContractInstance)
+
+    deploy_1 = contract_container.deploy(3, sender=owner, private=True)
+    assert isinstance(deploy_1, ContractInstance)
 
 
 def test_deployment_property(chain, owner, project_with_contract, eth_tester_provider):

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -9,7 +9,13 @@ from pydantic import BaseModel
 from ape import Contract
 from ape.api import TransactionAPI
 from ape.contracts import ContractInstance
-from ape.exceptions import ChainError, ContractError, ContractLogicError, CustomError
+from ape.exceptions import (
+    APINotImplementedError,
+    ChainError,
+    ContractError,
+    ContractLogicError,
+    CustomError,
+)
 from ape.types import AddressType
 from ape.utils import ZERO_ADDRESS
 from ape_ethereum.transactions import TransactionStatusEnum
@@ -781,3 +787,13 @@ def test_fallback_as_transaction(fallback_contract, owner, eth_tester_provider):
 def test_fallback_estimate_gas_cost(fallback_contract, owner):
     estimate = fallback_contract.estimate_gas_cost(sender=owner)
     assert estimate > 0
+
+
+def test_private_transaction(vyper_contract_instance, owner):
+    receipt = vyper_contract_instance.setNumber(2, sender=owner, private=True)
+    assert not receipt.failed
+
+
+def test_private_transaction_live_network(vyper_contract_instance, owner, dummy_live_network):
+    with pytest.raises(APINotImplementedError):
+        vyper_contract_instance.setNumber(2, sender=owner, private=True)

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -225,7 +225,7 @@ def test_ecosystems_when_default_provider_not_exists(temp_config, caplog, networ
     err = caplog.records[-1].message
     assert err == (
         f"Failed setting default provider: "
-        f"Provider '{bad_provider}' not found in network 'ethereum:ggoerli'."
+        f"Provider '{bad_provider}' not found in network 'ethereum:goerli'."
     )
 
 

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -225,7 +225,7 @@ def test_ecosystems_when_default_provider_not_exists(temp_config, caplog, networ
     err = caplog.records[-1].message
     assert err == (
         f"Failed setting default provider: "
-        f"Provider '{bad_provider}' not found in network 'goerli'."
+        f"Provider '{bad_provider}' not found in network 'ethereum:ggoerli'."
     )
 
 


### PR DESCRIPTION
### What I did

1. Added send_private_transaction as an abstract method to ProviderAPI
2. Added a `private` bool to `transfer` and `call` methods of AccountAPI to test that a "not implemented" error is raised

fixes: https://github.com/ApeWorX/ape/issues/1112

### How I did it

Pretty much as described in https://github.com/ApeWorX/ape/issues/1112. Will follow up with a PR on ape-alchemy that actually implements the `send_private_transaction` abstract method created here.

### How to verify it

WIP

### Checklist

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
