### PR TITLE
fix: better handling of `showlocals` in pytest traceback [APE-936]

### DIFF
--- a/src/ape/pytest/config.py
+++ b/src/ape/pytest/config.py
@@ -45,6 +45,10 @@ class ConfigWrapper(ManagerAccessMixin):
         return self.pytest_config.getoption("--gas") or self.ape_test_config.gas.show
 
     @cached_property
+    def show_internal(self) -> bool:
+        return self.pytest_config.getoption("showinternal")
+
+    @cached_property
     def gas_exclusions(self) -> List[ContractFunctionPath]:
         """
         The combination of both CLI values and config values.

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -48,7 +48,7 @@ class PytestApeRunner(ManagerAccessMixin):
         tb_frames: PytestTraceback = call.excinfo.traceback
         base = self.project_manager.path.as_posix()
 
-        if self.config_wrapper.pytest_config.getoption("showinternal"):
+        if self.config_wrapper.show_internal:
             relevant_tb = list(tb_frames)
         else:
             relevant_tb = [
@@ -59,13 +59,18 @@ class PytestApeRunner(ManagerAccessMixin):
 
         if relevant_tb:
             call.excinfo.traceback = PytestTraceback(relevant_tb)
+
+            # Only show locals if not digging into the framework's traceback.
+            # Else, it gets way too noisy.
+            show_locals = not self.config_wrapper.show_internal
+
             report.longrepr = call.excinfo.getrepr(
                 funcargs=True,
                 abspath=Path.cwd(),
-                showlocals=True,
+                showlocals=show_locals,
                 style="short",
                 tbfilter=False,
-                truncate_locals=False,
+                truncate_locals=True,
                 chain=False,
             )
 


### PR DESCRIPTION
### What I did

When using `--showinternal`, the locals in the traceback is overwhelming.
This disables it when using internal tb.
Also, even when not, it wil be truncated now to be less overwhelming when dealing with large reprs, like dicts and stuff

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
