### PR TITLE
refactor: update contract method repr to display info nicer [APE-939]

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -138,6 +138,11 @@ class ContractMethodHandler(ManagerAccessMixin):
         self.abis = abis
 
     def __repr__(self) -> str:
+        # `<ContractName 0x1234...AbCd>.method_name`
+        return f"{self.contract.__repr__()}.{self.abis[-1].name}"
+
+    def __str__(self) -> str:
+        # `method_name(type1 arg1, ...) -> return_type`
         abis = sorted(self.abis, key=lambda abi: len(abi.inputs or []))
         return abis[-1].signature
 

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -159,8 +159,16 @@ def test_repr(vyper_contract_instance):
         rf"<TestContract((Sol)|(Vy)) {vyper_contract_instance.address}>",
         repr(vyper_contract_instance),
     )
-    assert repr(vyper_contract_instance.setNumber) == "setNumber(uint256 num)"
-    assert repr(vyper_contract_instance.myNumber) == "myNumber() -> uint256"
+    assert (
+        repr(vyper_contract_instance.setNumber)
+        == "<TestContractVy 0xF7F78379391C5dF2Db5B66616d18fF92edB82022>.setNumber"
+    )
+    assert str(vyper_contract_instance.setNumber) == "setNumber(uint256 num)"
+    assert (
+        repr(vyper_contract_instance.myNumber)
+        == "<TestContractVy 0xF7F78379391C5dF2Db5B66616d18fF92edB82022>.myNumber"
+    )
+    assert str(vyper_contract_instance.myNumber) == "myNumber() -> uint256"
     assert (
         repr(vyper_contract_instance.NumberChange) == "NumberChange(bytes32 b, uint256 prevNum, "
         "string dynData, uint256 indexed newNum, string indexed dynIndexed)"


### PR DESCRIPTION
### What I did

Was noticing that the printout I get in IPython wasn't really as helpful as I would like it

Before:
```py
functools.partial(withdraw(address creator, uint256 stream_id) -> uint256, <TestAccount 0xc89D42189f0450C2b2c3c61f58Ec5d628176A1E7>, 0)
```

After:
```py
functools.partial(<Stream 0x274b028b03A250cA03644E6c578D81f019eE1323>.withdraw, <TestAccount 0xc89D42189f0450C2b2c3c61f58Ec5d628176A1E7>, 0)
```


### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] New test cases have been added
- [x] Documentation has been updated
