### PR TITLE
feat(cli): add support for using test accounts in `account_option()` [APE-945]

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@
    userguides/installing_plugins
    userguides/projects
    userguides/compile
+   userguides/clis
    userguides/data
    userguides/networks
    userguides/developing_plugins

--- a/docs/userguides/clis.md
+++ b/docs/userguides/clis.md
@@ -18,12 +18,13 @@ This guide is for showcasing utilities that ship with Ape to assist in your CLI 
 
 ## Ape Context Decorator
 
-The `@ape_cli_context` gives you access to all the root Ape objects (`accounts`, `networks` etc.), the ape logger and an `abort` method for stopping execution of your CLI gracefully.
+The `@ape_cli_context` gives you access to all the root Ape objects (`accounts`, `networks` etc.), the ape logger, and an `abort` method for stopping execution of your CLI gracefully.
 Here is an example using all of those features from the `cli_ctx`:
 
 ```python
 import click
 from ape.cli import ape_cli_context
+
 
 @click.command()
 @ape_cli_context()
@@ -37,7 +38,7 @@ def cmd(cli_ctx):
 
 The `@network_option()` allows you to select an ecosystem / network / provider combination.
 When using with the `NetworkBoundCommand` cls, you can cause your CLI to connect before any of your code executes.
-This is useful if your script or command requires a connection to a node provider in order for it to run.
+This is useful if your script or command requires a provider connection in order for it to run.
 
 ```python
 import click
@@ -65,12 +66,12 @@ Use the `@account_option()` for adding an option to your CLIs to select an accou
 This option does several things:
 
 1. If you only have a single account in Ape (from both test accounts _and_ other accounts), it will use that account as the default.
-   (this case is rare, as most people have at least test accounts by default).
+   (this case is rare, as most people have more than one test account by default).
 2. If you have more than one account, it will prompt you to select the account to use.
 3. You can pass in an account alias or index to the option flag to have it use that account.
 4. It allows you to specify test accounts by using a choice of `TEST::{index_of_test_account}`.
 
-So if you use this option, no matter what, your script will have an account to use by the time the script starts.
+Thus, if you use this option, no matter what, your script will have an account to use by the time the script starts.
 Here is an example:
 
 ```python

--- a/docs/userguides/clis.md
+++ b/docs/userguides/clis.md
@@ -1,7 +1,7 @@
 # CLIs
 
 Ape uses the [click framework](https://click.palletsprojects.com/en/8.1.x/) for handling all CLI functionality.
-There are CLIs found in a couple spots in the Ape framework:
+There are CLIs found in a couple areas in the Ape framework:
 
 1. Plugins
 2. Scripts
@@ -14,11 +14,12 @@ You can read more about plugin development and CLIs in the [developing plugins g
 Scripts utilize CLIs as an option for users to develop their scripts.
 You can read more about scripting and CLIs in the [scripting guide](./scripts.md).
 
-This guide is for showcasing some of their utilities that ship with Ape to assist in your CLI development endeavors.
+This guide is for showcasing utilities that ship with Ape to assist in your CLI development endeavors.
 
 ## Ape Context Decorator
 
-The `@ape_cli_context` gives you access to all the root Ape objects as well as utilities for easily aborting the execution and access to the logger:
+The `@ape_cli_context` gives you access to all the root Ape objects (`accounts`, `networks` etc.), the ape logger and an `abort` method for stopping execution of your CLI gracefully.
+Here is an example using all of those features from the `cli_ctx`:
 
 ```python
 import click
@@ -34,8 +35,8 @@ def cmd(cli_ctx):
 
 ## Network Tools
 
-The `@network_option()` allows you to select a network choices for parsing.
-In combination with the `NetworkBoundCommand` type, you can cause the connection to occur before any code in your CLI executes.
+The `@network_option()` allows you to select an ecosystem / network / provider combination.
+When using with the `NetworkBoundCommand` cls, you can cause your CLI to connect before any of your code executes.
 This is useful if your script or command requires a connection to a node provider in order for it to run.
 
 ```python
@@ -60,13 +61,13 @@ def cmd(network):
 
 ## Account Tools
 
-Use the `@account_option()` for adding an option to your CLIs to selecting accounts.
+Use the `@account_option()` for adding an option to your CLIs to select an account.
 This option does several things:
 
 1. If you only have a single account in Ape (from both test accounts _and_ other accounts), it will use that account as the default.
    (this case is rare, as most people have at least test accounts by default).
-2. If you more than one, it will prompt you to select the account to use.
-3. You can pass in account alias or index to the option flag to have it use that account.
+2. If you have more than one account, it will prompt you to select the account to use.
+3. You can pass in an account alias or index to the option flag to have it use that account.
 4. It allows you to specify test accounts by using a choice of `TEST::{index_of_test_account}`.
 
 So if you use this option, no matter what, your script will have an account to use by the time the script starts.
@@ -84,7 +85,8 @@ def cmd(account):
     click.echo(account.alias)
 ```
 
-And when invoking the command from the CLI, it would like something like (where `<prefix>` is either `ape run` for scripts or `ape <custom-plugin-cmd>` for plugins):
+And when invoking the command from the CLI, it would look like the following:
+(where `<prefix>` is either `ape run` for scripts or `ape <custom-plugin-cmd>` for plugins)
 
 ```shell
 <prefix> cmd  # Use the default account.

--- a/docs/userguides/clis.md
+++ b/docs/userguides/clis.md
@@ -1,0 +1,129 @@
+# CLIs
+
+Ape uses the [click framework](https://click.palletsprojects.com/en/8.1.x/) for handling all CLI functionality.
+There are CLIs found in a couple spots in the Ape framework:
+
+1. Plugins
+2. Scripts
+
+Both plugins and scripts utilize `click` for their CLIs.
+
+For plugins, CLIs are an option for extending the framework.
+You can read more about plugin development and CLIs in the [developing plugins guide](./developing_plugins.md).
+
+Scripts utilize CLIs as an option for users to develop their scripts.
+You can read more about scripting and CLIs in the [scripting guide](./scripts.md).
+
+This guide is for showcasing some of their utilities that ship with Ape to assist in your CLI development endeavors.
+
+## Ape Context Decorator
+
+The `@ape_cli_context` gives you access to all the root Ape objects as well as utilities for easily aborting the execution and access to the logger:
+
+```python
+import click
+from ape.cli import ape_cli_context
+
+@click.command()
+@ape_cli_context()
+def cmd(cli_ctx):
+    cli_ctx.logger.info("Test")
+    account = cli_ctx.account_manager.load("metamask")
+    cli_ctx.abort(f"Bad account: {account.address}")
+```
+
+## Network Tools
+
+The `@network_option()` allows you to select a network choices for parsing.
+In combination with the `NetworkBoundCommand` type, you can cause the connection to occur before any code in your CLI executes.
+This is useful if your script or command requires a connection to a node provider in order for it to run.
+
+```python
+import click
+from ape import networks
+from ape.cli import network_option, NetworkBoundCommand
+
+
+@click.command()
+@network_option()
+def cmd(network):
+    # Choices like "ethereum" or "polygon:local:test".
+    click.echo(network)
+
+
+@click.command(cls=NetworkBoundCommand)
+@network_option()
+def cmd(network):
+    # Fails if we are not connected.
+    click.echo(networks.provider.network.name)
+```
+
+## Account Tools
+
+Use the `@account_option()` for adding an option to your CLIs to selecting accounts.
+This option does several things:
+
+1. If you only have a single non-development account in Ape, it will use that account as the default.
+2. If you more than one, it will prompt you to select the account to use.
+3. You can pass in account alias or index to the option flag to have it use that account.
+4. It allows you to specify test accounts by using a choice of `TEST::{index_of_test_account}`.
+
+So if you use this option, no matter what, your script will have an account to use by the time the script starts.
+Here is an example:
+
+```python
+import click
+from ape.cli import account_option
+
+
+@click.command()
+@account_option()
+def cmd(account):
+    # Will prompt the user to select an account if needed.
+    click.echo(account.alias)
+```
+
+And when invoking the command from the CLI, it would like something like (where `<prefix>` is either `ape run` for scripts or `ape <custom-plugin-cmd>` for plugins):
+
+```shell
+<prefix> cmd  # Use the default account.
+<prefix> cmd --account 0  # Use first account that would show up in `get_user_selected_account()`.
+<prefix> cmd --account metamask  # Use account with alias "metamask".
+<prefix> cmd --account TEST::0  # Use the test account at index 0.
+```
+
+Alternatively, you can call the `get_user_selected_account()` directly to have more control of when the account gets selected:
+
+```python
+import click
+from ape.cli import get_user_selected_account
+
+
+@click.command()
+def cmd():
+    account = get_user_selected_account("Select an account to use")
+    click.echo(f"You selected {account.address}.")
+```
+
+Similarly, there are a couple custom arguments for aliases alone that are useful when making CLIs for account creation.
+If you use `@existing_alias_argument()` and specify an alias does not already exist, it will error.
+And visa-versa when using `@non_existing_alias_argument()`
+
+```python
+import click
+from ape.cli import existing_alias_argument, non_existing_alias_argument
+
+
+@click.command()
+@existing_alias_argument()
+def delete_account(alias):
+    # We know the alias is an existing account at this point.
+    click.echo(alias)
+
+
+@click.command()
+@non_existing_alias_argument()
+def create_account(alias):
+    # We know the alias is not yet used in Ape at this point.
+    click.echo(alias)
+```

--- a/docs/userguides/clis.md
+++ b/docs/userguides/clis.md
@@ -63,7 +63,8 @@ def cmd(network):
 Use the `@account_option()` for adding an option to your CLIs to selecting accounts.
 This option does several things:
 
-1. If you only have a single non-development account in Ape, it will use that account as the default.
+1. If you only have a single account in Ape (from both test accounts _and_ other accounts), it will use that account as the default.
+   (this case is rare, as most people have at least test accounts by default).
 2. If you more than one, it will prompt you to select the account to use.
 3. You can pass in account alias or index to the option flag to have it use that account.
 4. It allows you to specify test accounts by using a choice of `TEST::{index_of_test_account}`.

--- a/docs/userguides/developing_plugins.md
+++ b/docs/userguides/developing_plugins.md
@@ -100,6 +100,7 @@ If you try to define them together and use `ape` as a library as well, there is 
 
 For common `click` usages, use the `ape.cli` namespace.
 For example, use the [@existing_alias_argument() decorator](../methoddocs/cli.html#ape.cli.arguments.existing_alias_argument)) when you need a CLI argument for specifying an existing account alias:
+Follow [this guide](./clis.md) to learn more about what you can do with the utilities found in `ape.cli`.
 
 ```python
 import click

--- a/docs/userguides/scripts.md
+++ b/docs/userguides/scripts.md
@@ -8,6 +8,7 @@ The `ape run` command will register and run Python files defined under the `scri
 Place scripts in your project's `scripts/` directory.
 Follow [this guide](./projects.html) to learn more about the Ape project structure.
 If your scripts take advantage of utilities from our [`ape.cli`](../methoddocs/cli.html#ape-cli) submodule, you can build a [Click](https://click.palletsprojects.com/) command line interface by defining a `click.Command` or `click.Group` object called `cli` in your file:
+Follow [this guide](./clis.md) to learn more about what you can do with the utilities found in `ape.cli`.
 
 ```python
 import click

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -131,10 +131,11 @@ class AccountAliasPromptChoice(PromptChoice):
             if not idx_str.isnumeric():
                 self.fail(f"Cannot reference test account by '{value}'.", param=param)
 
-            try:
+            account_idx = int(idx_str)
+            if 0 <= account_idx < len(accounts.test_accounts):
                 return accounts.test_accounts[int(idx_str)]
-            except IndexError:
-                self.fail(f"Index '{idx_str}' is not valid.", param=param)
+
+            self.fail(f"Index '{idx_str}' is not valid.", param=param)
 
         if value and value in accounts.aliases:
             return accounts.load(value)

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -146,8 +146,7 @@ class AccountAliasPromptChoice(PromptChoice):
     def print_choices(self):
         super().print_choices()
         len_test_accounts = len(accounts.test_accounts) - 1
-        click.echo(f"Or 'TEST::account_idx', where `account_idx` is in [0..{len_test_accounts}]")
-        click.echo()
+        click.echo(f"Or 'TEST::account_idx', where `account_idx` is in [0..{len_test_accounts}]\n")
 
     @property
     def choices(self) -> List[str]:

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -127,15 +127,14 @@ class AccountAliasPromptChoice(PromptChoice):
         self, value: Any, param: Optional[Parameter], ctx: Optional[Context]
     ) -> Optional[AccountAPI]:
         if isinstance(value, str) and value.startswith("TEST::"):
-            try:
-                account_idx = int(value.replace("TEST::", ""))
-            except ValueError:
+            idx_str = value.replace("TEST::", "")
+            if not idx_str.isnumeric():
                 self.fail(f"Cannot reference test account by '{value}'.", param=param)
 
             try:
-                return accounts.test_accounts[account_idx]
+                return accounts.test_accounts[int(idx_str)]
             except IndexError:
-                self.fail(f"Index '{account_idx}' is not valid.", param=param)
+                self.fail(f"Index '{idx_str}' is not valid.", param=param)
 
         if value and value in accounts.aliases:
             return accounts.load(value)

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -51,6 +51,20 @@ class Alias(click.Choice):
 class PromptChoice(click.ParamType):
     """
     A choice option or argument from user selection.
+
+    Usage example::
+
+        def choice_callback(ctx, param, value):
+            return param.type.get_user_selected_choice()
+
+        @click.command()
+        @click.option(
+            "--choice",
+            type=PromptChoice(["foo", "bar"]),
+            callback=choice_callback,
+        )
+        def cmd(choice):
+            click.echo(f"__expected_{choice}")
     """
 
     def __init__(self, choices):
@@ -60,7 +74,6 @@ class PromptChoice(click.ParamType):
         """
         Echo the choices to the terminal.
         """
-
         choices = dict(enumerate(self.choices, 0))
         did_print = False
         for idx, choice in choices.items():
@@ -86,6 +99,19 @@ class PromptChoice(click.ParamType):
 
     def fail_from_invalid_choice(self, param):
         return self.fail("Invalid choice.", param=param)
+
+    def get_user_selected_choice(self) -> str:
+        choices = "\n".join(self.choices)
+        choice = click.prompt(f"Select one of the following:\n{choices}").strip()
+        if not choice.isnumeric():
+            return choice
+
+        # User input an index.
+        choice_idx = int(choice)
+        if 0 <= choice_idx < len(self.choices):
+            return self.choices[choice_idx]
+
+        raise IndexError(f"Choice index '{choice_idx}' out of range.")
 
 
 def get_user_selected_account(

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -63,7 +63,7 @@ class TestAccountManager(list, ManagerAccessMixin):
     def __len__(self) -> int:
         return len(list(self.accounts))
 
-    def __iter__(self) -> Iterator[TestAccountAPI]:
+    def __iter__(self) -> Iterator[AccountAPI]:
         yield from self.accounts
 
     @singledispatchmethod

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -63,6 +63,9 @@ class TestAccountManager(list, ManagerAccessMixin):
     def __len__(self) -> int:
         return len(list(self.accounts))
 
+    def __iter__(self) -> Iterator[TestAccountAPI]:
+        yield from self.accounts
+
     @singledispatchmethod
     def __getitem__(self, account_id):
         raise NotImplementedError(f"Cannot use {type(account_id)} as account ID.")

--- a/src/ape_test/__init__.py
+++ b/src/ape_test/__init__.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import PositiveInt
+from pydantic import NonNegativeInt
 
 from ape import plugins
 from ape.api import PluginConfig
@@ -42,7 +42,7 @@ class Config(PluginConfig):
     The mnemonic to use when generating the test accounts.
     """
 
-    number_of_accounts: PositiveInt = DEFAULT_NUMBER_OF_TEST_ACCOUNTS
+    number_of_accounts: NonNegativeInt = DEFAULT_NUMBER_OF_TEST_ACCOUNTS
     """
     The number of test accounts to generate in the provider.
     """

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -450,3 +450,8 @@ def test_using_random_mnemonic(test_accounts, temp_config):
         new_first_account = test_accounts[0]
 
         assert old_first_account.address != new_first_account.address
+
+
+def test_iter_test_accounts(test_accounts):
+    actual = list(iter(test_accounts))
+    assert len(actual) == len(test_accounts)

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -199,6 +199,7 @@ def test_account_option_uses_single_account_as_default(runner, keyfile_account):
     When there is only 1 keyfile account, that is the default
     when no option is given.
     """
+
     @click.command()
     @account_option()
     def cmd(account):
@@ -210,7 +211,9 @@ def test_account_option_uses_single_account_as_default(runner, keyfile_account):
     assert expected in result.output
 
 
-def test_account_prompts_when_more_than_one_keyfile_account(runner, keyfile_account, second_keyfile_account):
+def test_account_prompts_when_more_than_one_keyfile_account(
+    runner, keyfile_account, second_keyfile_account
+):
     @click.command()
     @account_option()
     def cmd(account):

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -3,7 +3,7 @@ import shutil
 import click
 import pytest
 
-from ape.cli import NetworkBoundCommand, get_user_selected_account, network_option
+from ape.cli import NetworkBoundCommand, account_option, get_user_selected_account, network_option
 from ape.exceptions import AccountsError
 
 OUTPUT_FORMAT = "__TEST__{}__"
@@ -176,3 +176,18 @@ def test_network_option_not_needed_on_network_bound_command(runner):
 
     result = runner.invoke(cmd, [])
     assert "Success" in result.output
+
+
+def test_account_option(runner, keyfile_account):
+    def get_expected(acct):
+        return f"__expected_output__: {acct.address}"
+
+    @click.command()
+    @account_option()
+    def cmd(account):
+        _expected = get_expected(account)
+        click.echo(_expected)
+
+    expected = get_expected(keyfile_account)
+    result = runner.invoke(cmd, [])
+    assert expected in result.output


### PR DESCRIPTION
### What I did

Support using test accounts in `account_option` through special syntax `TEST::{i}`

fixes: #854

By having the `TEST::` prefix, we disambiguate from any "normal" alias (e.g. for built-in loaded accounts), allowing people to make a call to a script for testing purposes using a pre-funded test account that functions on a development or mainnet fork environment. This is safer or more simple than what people are currently doing, which is maintaining their own expansive scripts for doing what is essentially the same thing

### How I did it

Just added support for parsing additional choices to `AccountAliasPromptChoice`

### How to verify it

Try making some different scripts, see if there's any UX gotchas

Example:
```sh
$ ape run scriptname --account TEST::0 --network ::test
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
