### PR TITLE
perf: minimize unnecessary calls for poll_logs [APE-948]

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -618,14 +618,14 @@ class ContractEvent(ManagerAccessMixin):
             Iterator[:class:`~ape.types.ContractLog`]
         """
 
-        height = self.chain_manager.blocks.height
-        if start_block and start_block <= height:
-            yield from self.range(start_block, height)
-            start_block = height + 1
-            
         required_confirmations = (
             required_confirmations or self.provider.network.required_confirmations
         )
+        
+        height = self.chain_manager.blocks.height - required_confirmations
+        if start_block and start_block <= height:
+            yield from self.range(start_block, height)
+            start_block = height + 1
 
         for new_block in self.chain_manager.blocks.poll_blocks(
             start_block=start_block,

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -626,7 +626,7 @@ class ContractEvent(ManagerAccessMixin):
         required_confirmations = (
             required_confirmations or self.provider.network.required_confirmations
         )
-        
+
         # NOTE: We process historical blocks separately here to minimize rpc calls
         height = max(self.chain_manager.blocks.height - required_confirmations, 0)
         if start_block and height > 0 and start_block < height:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -618,6 +618,11 @@ class ContractEvent(ManagerAccessMixin):
             Iterator[:class:`~ape.types.ContractLog`]
         """
 
+        height = self.chain_manager.blocks.height
+        if height > start_block:
+            yield from self.range(start_block, height)
+            start_block=height + 1
+            
         required_confirmations = (
             required_confirmations or self.provider.network.required_confirmations
         )

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -623,7 +623,7 @@ class ContractEvent(ManagerAccessMixin):
         )
         
         height = self.chain_manager.blocks.height - required_confirmations
-        if start_block and start_block <= height:
+        if start_block is not None and start_block <= height:
             yield from self.range(start_block, height)
             start_block = height + 1
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -622,8 +622,8 @@ class ContractEvent(ManagerAccessMixin):
             required_confirmations or self.provider.network.required_confirmations
         )
         
-        height = self.chain_manager.blocks.height - required_confirmations
-        if start_block is not None and start_block <= height:
+        height = max(self.chain_manager.blocks.height - required_confirmations, 0)
+        if start_block and start_block < height:
             yield from self.range(start_block, height)
             start_block = height + 1
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -619,7 +619,7 @@ class ContractEvent(ManagerAccessMixin):
         """
 
         height = self.chain_manager.blocks.height
-        if start_block <= height:
+        if start_block and start_block <= height:
             yield from self.range(start_block, height)
             start_block = height + 1
             

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -621,7 +621,7 @@ class ContractEvent(ManagerAccessMixin):
         height = self.chain_manager.blocks.height
         if height > start_block:
             yield from self.range(start_block, height)
-            start_block=height + 1
+            start_block = height + 1
             
         required_confirmations = (
             required_confirmations or self.provider.network.required_confirmations

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -623,7 +623,7 @@ class ContractEvent(ManagerAccessMixin):
         )
         
         height = max(self.chain_manager.blocks.height - required_confirmations, 0)
-        if start_block and start_block < height:
+        if start_block and height > 0 and start_block < height:
             yield from self.range(start_block, height)
             start_block = height + 1
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -619,7 +619,7 @@ class ContractEvent(ManagerAccessMixin):
         """
 
         height = self.chain_manager.blocks.height
-        if height > start_block:
+        if start_block <= height:
             yield from self.range(start_block, height)
             start_block = height + 1
             

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -622,11 +622,13 @@ class ContractEvent(ManagerAccessMixin):
             required_confirmations or self.provider.network.required_confirmations
         )
         
+        # NOTE: We process historical blocks separately here to minimize rpc calls
         height = max(self.chain_manager.blocks.height - required_confirmations, 0)
         if start_block and height > 0 and start_block < height:
             yield from self.range(start_block, height)
             start_block = height + 1
 
+        # NOTE: Now we process the rest
         for new_block in self.chain_manager.blocks.poll_blocks(
             start_block=start_block,
             stop_block=stop_block,


### PR DESCRIPTION
### What I did

I added a check to see if start_block is in the past, if so it will yield from self.range called on the full range of blocks between start_block and chain head before proceeding into the new blocks iterator as currently implemented

fixes: #1436 

### How I did it

conceptually separated historical blocks from future blocks and built better handling for historical case

### How to verify it

Just fetch some events

### Checklist

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
