### PR TITLE
chore: checking if typing extensions broke core alone [APE-968]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,12 @@ setup(
         "eip712>=0.2.1,<0.3",
         "ethpm-types>=0.5.0,<0.6",
         "evm-trace>=0.1.0a20",
-        "typing-extensions==4.5.0"  # Have to pin because 4.6
+        # Have to ping typing-extensions because 4.6 is completely broken.
+        # However, this shouldn't even be a dependency as it is only needed
+        # for 3.7, yet for some reason it shows up in our dependency tree.
+        # TODO: Find what problematic dependency is forcing us to install
+        #  this constantly-broken python package that we don't need at all.
+        "typing-extensions==4.5.0",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],

--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,7 @@ setup(
         "eip712>=0.2.1,<0.3",
         "ethpm-types>=0.5.0,<0.6",
         "evm-trace>=0.1.0a20",
+        "typing-extensions==4.5.0"  # Have to pin because 4.6
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],


### PR DESCRIPTION
### What I did

latest typing ext broke pydantic and thus ape
checking if broken here are only noticed in plugins
if broken, will have to pin... tho tbh not sure why this dep even shows up since we are post 3.7... someone is forcing us to install this crappy thing and it is terrible and has caused so many problems for us and the Ethereum web3 community.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
