### PR TITLE
fix: fixes for source tracing [APE-972]

### DIFF
--- a/src/ape/api/compiler.py
+++ b/src/ape/api/compiler.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Set, Tuple
 
@@ -7,7 +8,7 @@ from evm_trace.geth import TraceFrame as EvmTraceFrame
 from evm_trace.geth import create_call_node_data
 from semantic_version import Version  # type: ignore
 
-from ape.exceptions import ContractLogicError
+from ape.exceptions import APINotImplementedError, ContractLogicError
 from ape.types.trace import SourceTraceback, TraceFrame
 from ape.utils import BaseInterfaceModel, abstractmethod, raises_not_implemented
 
@@ -114,6 +115,22 @@ class CompilerAPI(BaseInterfaceModel):
 
     def __str__(self) -> str:
         return self.name
+
+    @cached_property
+    def supports_source_tracing(self) -> bool:
+        """
+        Returns ``True`` if this compiler is able to provider a source
+        traceback for a given trace.
+        """
+        try:
+            self.trace_source(None, None, None)  # type: ignore
+        except APINotImplementedError:
+            return False
+        except Exception:
+            # Task failed successfully.
+            return True
+
+        return True
 
     def enrich_error(self, err: ContractLogicError) -> ContractLogicError:
         """

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -729,7 +729,9 @@ class Web3Provider(ProviderAPI, ABC):
                 raise tx_error from err
 
             message = gas_estimation_error_message(tx_error)
-            raise TransactionError(message, base_err=tx_error, txn=txn) from err
+            raise TransactionError(
+                message, base_err=tx_error, txn=txn, source_traceback=tx_error.source_traceback
+            ) from err
 
     @cached_property
     def chain_id(self) -> int:

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -483,7 +483,7 @@ class ReceiptAPI(BaseInterfaceModel):
     def track_gas(self):
         """
         Track this receipt's gas in the on-going session gas-report.
-        Requires using a provider that support transaction traces.
+        Requires using a provider that supports transaction traces.
         This gets called when running tests with the ``--gas`` flag.
         """
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -768,7 +768,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
         if not self._cached_receipt and self.txn_hash:
             try:
                 receipt = self.chain_manager.get_receipt(self.txn_hash)
-            except (TransactionNotFoundError, ValueError):
+            except (TransactionNotFoundError, ValueError, ChainError):
                 return None
 
             self._cached_receipt = receipt

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -614,16 +614,16 @@ class TransactionHistory(BaseManager):
         try:
             address = self.provider.network.ecosystem.decode_address(account_or_hash)
             return self._get_account_history(address)
-        except Exception:
+        except Exception as err:
             # Use Transaction hash
             try:
                 return self._get_receipt(account_or_hash)
             except Exception:
                 pass
 
-            # If we get here, we failed to get an account or receipt.
-            # Raise top-level exception.
-            raise
+            raise ChainError(
+                f"'{account_or_hash}' is not a known address or transaction hash."
+            ) from err
 
     def _get_receipt(self, txn_hash: str) -> ReceiptAPI:
         receipt = self._hash_to_receipt_map.get(txn_hash)

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -82,7 +82,17 @@ class ProjectManager(BaseManager):
             pathlib.Path
         """
 
-        return self.config_manager.contracts_folder
+        folder = self.config_manager.contracts_folder
+        if folder is None:
+            # This happens when using normal Python REPL
+            # and perhaps other times when loading a project before config.
+            self.config_manager.load()
+            folder = self.config_manager.contracts_folder
+            if folder is None:
+                # Was set explicitly to `None` in config.
+                return self.path / "contracts"
+
+        return folder
 
     @property
     def source_paths(self) -> List[Path]:

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -5,6 +5,7 @@ from typing import Dict, Iterator, List, Optional
 import pytest
 
 from ape.api import ReceiptAPI, TestAccountAPI
+from ape.exceptions import ChainError
 from ape.logging import logger
 from ape.managers.chain import ChainManager
 from ape.managers.networks import NetworkManager
@@ -162,7 +163,11 @@ class ReceiptCapture(ManagerAccessMixin):
             self.capture(txn.txn_hash.hex())
 
     def capture(self, transaction_hash: str):
-        receipt = self.chain_manager.history[transaction_hash]
+        try:
+            receipt = self.chain_manager.history[transaction_hash]
+        except ChainError:
+            return
+
         if not receipt:
             return
 

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -301,6 +301,7 @@ __all__ = [
     "ContractLog",
     "ContractLogContainer",
     "ContractType",
+    "ControlFlow",
     "GasReport",
     "MessageSignature",
     "PackageManifest",
@@ -310,7 +311,6 @@ __all__ = [
     "SnapshotID",
     "Source",
     "SourceTraceback",
-    "ControlFlow",
     "TraceFrame",
     "TransactionSignature",
 ]

--- a/src/ape/types/trace.py
+++ b/src/ape/types/trace.py
@@ -661,15 +661,20 @@ class SourceTraceback(BaseModel):
         )
         self.last.extend(location, pcs=pcs, ws_start=start)
 
-    def add_builtin_jump(self, name: str, _type: str, compiler_name: str):
+    def add_builtin_jump(
+        self,
+        name: str,
+        _type: str,
+        compiler_name: str,
+        source_path: Optional[Path] = None,
+        pcs: Optional[Set[int]] = None,
+    ):
+        pcs = pcs or set()
         closure = Closure(name=name)
         depth = self.last.depth - 1 if self.last else 0
-        statement = Statement(type=_type)
+        statement = Statement(type=_type, pcs=pcs)
         flow = ControlFlow(
-            statements=[statement],
-            closure=closure,
-            source_path=Path("<internal>") / compiler_name,
-            depth=depth,
+            closure=closure, depth=depth, statements=[statement], source_path=source_path
         )
         self.append(flow)
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -305,7 +305,12 @@ class Ethereum(EcosystemAPI):
             status = self.conversion_manager.convert(status, int)
             status = TransactionStatusEnum(status)
 
-        txn_hash = data.get("hash") or data.get("txn_hash") or data.get("transaction_hash")
+        txn_hash = None
+        hash_key_choices = ("hash", "txHash", "txnHash", "transactionHash", "transaction_hash")
+        for choice in hash_key_choices:
+            if choice in data:
+                txn_hash = data[choice]
+                break
 
         if txn_hash:
             txn_hash = txn_hash.hex() if isinstance(txn_hash, HexBytes) else txn_hash

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -110,5 +110,10 @@ class InterfaceCompiler(CompilerAPI):
         inputs = ecosystem.decode_calldata(abi, input_data)
         error_class = contract.get_error_by_signature(abi.signature)
         return error_class(
-            abi, inputs, txn=err.txn, trace=err.trace, contract_address=err.contract_address
+            abi,
+            inputs,
+            txn=err.txn,
+            trace=err.trace,
+            contract_address=err.contract_address,
+            source_traceback=err.source_traceback,
         )

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -58,3 +58,7 @@ def test_getattr(compilers):
 
     with pytest.raises(AttributeError, match=r"No attribute or compiler named 'foobar'\."):
         _ = compilers.foobar
+
+
+def test_supports_tracing(compilers):
+    assert not compilers.ethpm.supports_source_tracing

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -333,3 +333,13 @@ def test_sources(project_with_source_files_contract):
     project = project_with_source_files_contract
     assert "ApeContract0.json" in project.sources
     assert project.sources["ApeContract0.json"].content
+
+
+def test_contracts_folder(project, config):
+    expected = project.path / "contracts"
+    assert project.contracts_folder == expected
+
+    # Show that even when None in the config, it won't be None here.
+    config.contracts_folder = None
+    assert config.contracts_folder is None
+    assert project.contracts_folder == expected

--- a/tests/functional/test_receipt_capture.py
+++ b/tests/functional/test_receipt_capture.py
@@ -1,6 +1,7 @@
-from ape.pytest.fixtures import ReceiptCapture
-from ape.pytest.config import ConfigWrapper
 import pytest
+
+from ape.pytest.config import ConfigWrapper
+from ape.pytest.fixtures import ReceiptCapture
 
 
 @pytest.fixture

--- a/tests/functional/test_receipt_capture.py
+++ b/tests/functional/test_receipt_capture.py
@@ -1,0 +1,23 @@
+from ape.pytest.fixtures import ReceiptCapture
+from ape.pytest.config import ConfigWrapper
+import pytest
+
+
+@pytest.fixture
+def pytest_config(mocker):
+    return mocker.MagicMock()
+
+
+@pytest.fixture
+def config_wrapper(pytest_config):
+    return ConfigWrapper(pytest_config)
+
+
+@pytest.fixture
+def receipt_capture(config_wrapper):
+    return ReceiptCapture(config_wrapper)
+
+
+def test_when_txn_hash_not_exists_does_not_error(receipt_capture):
+    actual = receipt_capture.capture("123")
+    assert actual is None

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -94,7 +94,6 @@ def run_gas_test(
     result.assert_outcomes(passed=expected_passed, failed=expected_failed), "\n".join(
         result.outlines
     )
-
     gas_header_line_index = None
     for index, line in enumerate(result.outlines):
         if "Gas Profile" in line:


### PR DESCRIPTION
### What I did

Fixes several things that came up from people trying to use the source tracing feature....

1. Add ability to check if compiler supports it (will need this in Coverage feature anyway)
2. Performance improvement by preventing the calculation of the source traceback more than once in certain situations
3. **Critical issue** causing never-ending loop (hanging) when trying to create the source traceback. For this reason, we may want to patch Core ape after this...
4. Better error when txn hash is not found
5. Issue where `contracts_folder` was `None` when it should not have been (only happened when using normal Python REPLs).
6. PC values are now present in the source traceback but also requires that `ape-vyper` PR

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
