### PR TITLE
fix: set homedir owner to harambe [APE-976]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,6 @@ RUN pip install --upgrade pip \
     && ape --version
 
 WORKDIR /home/harambe/project
+RUN chown -hR harambe:harambe /home/harambe
 USER harambe
 ENTRYPOINT ["ape"]


### PR DESCRIPTION
### What I did

set the dockerfile homedir owner to user harambe

fixes: #1447
fixes: APE-975

### How I did it

add chown to dockerfile

### How to verify it
```
$docker build -t ape .
$ docker run -it --entrypoint /bin/bash ape
harambe@8a0cb64afbeb:~/project$ cd ..
harambe@8a0cb64afbeb:~$ ls -la
total 32
drwxr-xr-x 1 harambe harambe 4096 May 26 19:11 .
drwxr-xr-x 1 root    root    4096 May 26 19:10 ..
-rw-r--r-- 1 harambe harambe  220 Mar 27  2022 .bash_logout
-rw-r--r-- 1 harambe harambe 3526 Mar 27  2022 .bashrc
-rw-r--r-- 1 harambe harambe  807 Mar 27  2022 .profile
drwxr-xr-x 1 harambe harambe 4096 May 26 19:11 project
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
