### PR TITLE
docs: fix generate_dev_account documentation for HDPath default [APE-980]

### DIFF
--- a/src/ape/utils/testing.py
+++ b/src/ape/utils/testing.py
@@ -39,7 +39,7 @@ def generate_dev_accounts(
         mnemonic (str): mnemonic phrase or seed words.
         number_of_accounts (int): Number of accounts. Defaults to ``10``.
         hd_path_format (str): Hard Wallets/HD Keys derivation path format.
-          Defaults to ``"m/44'/60'/0'/0/{}"``.
+          Defaults to ``"m/44'/60'/0'/{}"``.
 
     Returns:
         List[:class:`~ape.utils.GeneratedDevAccount`]: List of development accounts.


### PR DESCRIPTION
### What I did

noticed that the docs did not match what the actual default was
