### PR TITLE
fix: pass through base_err on empty contract logic errors [APE-985]

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1331,7 +1331,12 @@ class Web3Provider(ProviderAPI, ABC):
         result = (
             ContractLogicError(txn=txn, **params)
             if no_reason
-            else ContractLogicError(base_err=exception, revert_message=message, txn=txn, **params)
+            else ContractLogicError(
+                base_err=exception if isinstance(exception, Exception) else None,
+                revert_message=message,
+                txn=txn,
+                **params,
+            )
         )
         return self.compiler_manager.enrich_error(result)
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1331,7 +1331,7 @@ class Web3Provider(ProviderAPI, ABC):
         result = (
             ContractLogicError(txn=txn, **params)
             if no_reason
-            else ContractLogicError(revert_message=message, txn=txn, **params)
+            else ContractLogicError(base_err=exception, revert_message=message, txn=txn, **params)
         )
         return self.compiler_manager.enrich_error(result)
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1293,7 +1293,7 @@ class Web3Provider(ProviderAPI, ABC):
             )
 
         elif "out of gas" in str(err_msg):
-            return OutOfGasError(code=err_data.get("code"), **kwargs)
+            return OutOfGasError(code=err_data.get("code"), base_err=exception, **kwargs)
 
         return VirtualMachineError(str(err_msg), code=err_data.get("code"), **kwargs)
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -937,7 +937,8 @@ class Web3Provider(ProviderAPI, ABC):
         try:
             result = self._make_request("eth_call", arguments)
         except Exception as err:
-            raise self.get_virtual_machine_error(err) from err
+            receiver = txn_dict["to"]
+            raise self.get_virtual_machine_error(err, contract_address=receiver) from err
 
         if "error" in result:
             raise ProviderError(result["error"]["message"])

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -3,7 +3,7 @@ import time
 from datetime import datetime
 from typing import IO, TYPE_CHECKING, Any, Iterator, List, Optional, Union
 
-from eth_utils import is_hex, to_int
+from eth_utils import is_0x_prefixed, is_hex, to_int
 from ethpm_types import HexBytes
 from ethpm_types.abi import EventABI, MethodABI
 from pydantic import validator
@@ -98,6 +98,16 @@ class TransactionAPI(BaseInterfaceModel):
             return HexBytes(value)
 
         return value
+
+    @validator("value", pre=True)
+    def validate_value(cls, value):
+        if isinstance(value, int):
+            return value
+
+        elif isinstance(value, str) and is_0x_prefixed(value):
+            return int(value, 16)
+
+        return int(value)
 
     @property
     def total_transfer_value(self) -> int:

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -155,6 +155,7 @@ class ContractLogicError(VirtualMachineError):
         trace: Optional[Iterator["TraceFrame"]] = None,
         contract_address: Optional["AddressType"] = None,
         source_traceback: Optional["SourceTraceback"] = None,
+        base_err: Optional[Exception] = None,
     ):
         self.txn = txn
         self.trace = trace
@@ -167,6 +168,7 @@ class ContractLogicError(VirtualMachineError):
                 pass
 
         super().__init__(
+            base_err=base_err,
             contract_address=contract_address,
             message=revert_message,
             source_traceback=source_traceback,

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -311,8 +311,8 @@ class OutOfGasError(VirtualMachineError):
     out of gas.
     """
 
-    def __init__(self, code: Optional[int] = None, txn: Optional[FailedTxn] = None):
-        super().__init__("The transaction ran out of gas.", code=code, txn=txn)
+    def __init__(self, code: Optional[int] = None, txn: Optional[FailedTxn] = None, base_err: Optional[Exception] = None):
+        super().__init__("The transaction ran out of gas.", code=code, txn=txn, base_err=base_err)
 
 
 class NetworkError(ApeException):

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -311,7 +311,12 @@ class OutOfGasError(VirtualMachineError):
     out of gas.
     """
 
-    def __init__(self, code: Optional[int] = None, txn: Optional[FailedTxn] = None, base_err: Optional[Exception] = None):
+    def __init__(
+        self,
+        code: Optional[int] = None,
+        txn: Optional[FailedTxn] = None,
+        base_err: Optional[Exception] = None,
+    ):
         super().__init__("The transaction ran out of gas.", code=code, txn=txn, base_err=base_err)
 
 

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -636,6 +636,7 @@ class CustomError(ContractLogicError):
         txn: Optional[FailedTxn] = None,
         trace: Optional[Iterator["TraceFrame"]] = None,
         contract_address: Optional["AddressType"] = None,
+        base_err: Optional[Exception] = None,
         source_traceback: Optional["SourceTraceback"] = None,
     ):
         self.abi = abi
@@ -649,6 +650,7 @@ class CustomError(ContractLogicError):
 
         super().__init__(
             message,
+            base_err=base_err,
             contract_address=contract_address,
             source_traceback=source_traceback,
             trace=trace,

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -90,6 +90,10 @@ class GethDevProcess(LoggingMixin, BaseGethProcess):
             ws_api=None,
         )
 
+        # TODO: Remove after using any release greater than py-geth 3.12.0
+        if "miner_threads" in geth_kwargs:
+            del geth_kwargs["miner_threads"]
+
         # Ensure a clean data-dir.
         self._clean()
 

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -211,7 +211,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
                 new_message = (
                     f"Sender '{sender}' cannot afford txn gas {txn_gas} with account balance {bal}."
                 )
-                return VirtualMachineError(new_message, **kwargs)
+                return VirtualMachineError(new_message, base_err=exception, **kwargs)
 
             else:
                 return VirtualMachineError(base_err=exception, **kwargs)
@@ -224,8 +224,8 @@ class LocalProvider(TestProviderAPI, Web3Provider):
                 # (Notice the `b'` is within the `"` on the first str).
                 err_message = HexBytes(literal_eval(err_message)).hex()
 
-            err_message = None if err_message == "0x" else err_message
-            contract_err = ContractLogicError(revert_message=err_message, **kwargs)
+            err_message = TransactionError.DEFAULT_MESSAGE if err_message == "0x" else err_message
+            contract_err = ContractLogicError(base_err=exception, revert_message=err_message, **kwargs)
             return self.compiler_manager.enrich_error(contract_err)
 
         else:

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -225,7 +225,9 @@ class LocalProvider(TestProviderAPI, Web3Provider):
                 err_message = HexBytes(literal_eval(err_message)).hex()
 
             err_message = TransactionError.DEFAULT_MESSAGE if err_message == "0x" else err_message
-            contract_err = ContractLogicError(base_err=exception, revert_message=err_message, **kwargs)
+            contract_err = ContractLogicError(
+                base_err=exception, revert_message=err_message, **kwargs
+            )
             return self.compiler_manager.enrich_error(contract_err)
 
         else:

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -102,32 +102,42 @@ def test_call_use_block_identifier(contract_instance, owner, chain):
 
 def test_revert(sender, contract_instance):
     # 'sender' is not the owner so it will revert (with a message)
-    with pytest.raises(ContractLogicError, match="!authorized"):
+    with pytest.raises(ContractLogicError, match="!authorized") as err:
         contract_instance.setNumber(5, sender=sender)
+
+    assert err.value.txn is not None
 
 
 def test_revert_no_message(owner, contract_instance):
     # The Contract raises empty revert when setting number to 5.
     expected = "Transaction failed."  # Default message
-    with pytest.raises(ContractLogicError, match=expected):
+    with pytest.raises(ContractLogicError, match=expected) as err:
         contract_instance.setNumber(5, sender=owner)
+
+    assert err.value.txn is not None
 
 
 @pytest.mark.parametrize("gas", ("200000", 200000, "max", "auto", "0x235426"))
 def test_revert_specify_gas(sender, contract_instance, gas):
-    with pytest.raises(ContractLogicError, match="!authorized"):
+    with pytest.raises(ContractLogicError, match="!authorized") as err:
         contract_instance.setNumber(5, sender=sender, gas=gas)
+
+    assert err.value.txn is not None
 
 
 def test_revert_no_message_specify_gas(owner, contract_instance):
     expected = "Transaction failed."  # Default message
-    with pytest.raises(ContractLogicError, match=expected):
+    with pytest.raises(ContractLogicError, match=expected) as err:
         contract_instance.setNumber(5, sender=owner, gas=200000)
+
+    assert err.value.txn is not None
 
 
 def test_revert_static_fee_type(sender, contract_instance):
-    with pytest.raises(ContractLogicError, match="!authorized"):
+    with pytest.raises(ContractLogicError, match="!authorized") as err:
         contract_instance.setNumber(5, sender=sender, type=0)
+
+    assert err.value.txn is not None
 
 
 def test_revert_custom_exception(not_owner, error_contract):

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 import pytest
-from eth_tester.exceptions import TransactionFailed
+from eth_tester.exceptions import TransactionFailed  # type: ignore
 from eth_typing import HexStr
 from eth_utils import ValidationError
 

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from eth_tester.exceptions import TransactionFailed
 from eth_typing import HexStr
 from eth_utils import ValidationError
 
@@ -196,3 +197,9 @@ def test_set_timestamp_handle_same_time_race_condition(mocker, eth_tester_provid
 
     mocker.patch.object(eth_tester_provider.evm_backend, "time_travel", side_effect=side_effect)
     eth_tester_provider.set_timestamp(123)
+
+
+def test_get_virtual_machine_error_when_txn_failed_includes_base_error(eth_tester_provider):
+    txn_failed = TransactionFailed()
+    actual = eth_tester_provider.get_virtual_machine_error(txn_failed)
+    assert actual.base_err == txn_failed


### PR DESCRIPTION
### What I did

base error was missing on txn failed
looking at this in a debug perspective for some solidity crap

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
