### PR TITLE
docs: fix broken userguide links

### DIFF
--- a/docs/userguides/clis.md
+++ b/docs/userguides/clis.md
@@ -9,10 +9,10 @@ There are CLIs found in a couple areas in the Ape framework:
 Both plugins and scripts utilize `click` for their CLIs.
 
 For plugins, CLIs are an option for extending the framework.
-You can read more about plugin development and CLIs in the [developing plugins guide](./developing_plugins.md).
+You can read more about plugin development and CLIs in the [developing plugins guide](./developing_plugins.html).
 
 Scripts utilize CLIs as an option for users to develop their scripts.
-You can read more about scripting and CLIs in the [scripting guide](./scripts.md).
+You can read more about scripting and CLIs in the [scripting guide](./scripts.html).
 
 This guide is for showcasing utilities that ship with Ape to assist in your CLI development endeavors.
 

--- a/docs/userguides/developing_plugins.md
+++ b/docs/userguides/developing_plugins.md
@@ -100,7 +100,7 @@ If you try to define them together and use `ape` as a library as well, there is 
 
 For common `click` usages, use the `ape.cli` namespace.
 For example, use the [@existing_alias_argument() decorator](../methoddocs/cli.html#ape.cli.arguments.existing_alias_argument)) when you need a CLI argument for specifying an existing account alias:
-Follow [this guide](./clis.md) to learn more about what you can do with the utilities found in `ape.cli`.
+Follow [this guide](./clis.html) to learn more about what you can do with the utilities found in `ape.cli`.
 
 ```python
 import click

--- a/docs/userguides/scripts.md
+++ b/docs/userguides/scripts.md
@@ -8,7 +8,7 @@ The `ape run` command will register and run Python files defined under the `scri
 Place scripts in your project's `scripts/` directory.
 Follow [this guide](./projects.html) to learn more about the Ape project structure.
 If your scripts take advantage of utilities from our [`ape.cli`](../methoddocs/cli.html#ape-cli) submodule, you can build a [Click](https://click.palletsprojects.com/) command line interface by defining a `click.Command` or `click.Group` object called `cli` in your file:
-Follow [this guide](./clis.md) to learn more about what you can do with the utilities found in `ape.cli`.
+Follow [this guide](./clis.html) to learn more about what you can do with the utilities found in `ape.cli`.
 
 ```python
 import click


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
I fixed some links that were leading to 404 pages in the documentation.
fixes: #

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
