### PR TITLE
added option for setting the password to unlock accounts as `env` variables [APE-997]

### DIFF
--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 from typing import Iterator, Optional
+from os import environ
 
 import click
 from eth_account import Account as EthAccount
@@ -14,154 +15,164 @@ from ape.types import AddressType, MessageSignature, SignableMessage, Transactio
 
 
 class InvalidPasswordError(AccountsError):
-    """
-    Raised when password to unlock an account is incorrect.
-    """
+	"""
+	Raised when password to unlock an account is incorrect.
+	"""
 
-    def __init__(self):
-        super().__init__("Invalid password")
+	def __init__(self):
+		super().__init__("Invalid password")
 
 
 class AccountContainer(AccountContainerAPI):
-    @property
-    def _keyfiles(self) -> Iterator[Path]:
-        return self.data_folder.glob("*.json")
+	@property
+	def _keyfiles(self) -> Iterator[Path]:
+		return self.data_folder.glob("*.json")
 
-    @property
-    def aliases(self) -> Iterator[str]:
-        for p in self._keyfiles:
-            yield p.stem
+	@property
+	def aliases(self) -> Iterator[str]:
+		for p in self._keyfiles:
+			yield p.stem
 
-    @property
-    def accounts(self) -> Iterator[AccountAPI]:
-        for keyfile in self._keyfiles:
-            yield KeyfileAccount(keyfile_path=keyfile)
+	@property
+	def accounts(self) -> Iterator[AccountAPI]:
+		for keyfile in self._keyfiles:
+			yield KeyfileAccount(keyfile_path=keyfile)
 
-    def __len__(self) -> int:
-        return len([*self._keyfiles])
+	def __len__(self) -> int:
+		return len([*self._keyfiles])
 
 
 # NOTE: `AccountAPI` is an BaseInterfaceModel
 class KeyfileAccount(AccountAPI):
-    keyfile_path: Path
-    locked: bool = True
-    __autosign: bool = False
-    __cached_key: Optional[HexBytes] = None
+	keyfile_path: Path
+	locked: bool = True
+	__autosign: bool = False
+	__cached_key: Optional[HexBytes] = None
 
-    def __repr__(self):
-        return f"<{self.__class__.__name__} address={self.address} alias={self.alias}>"
+	def __repr__(self):
+		return f"<{self.__class__.__name__} address={self.address} alias={self.alias}>"
 
-    @property
-    def alias(self) -> str:
-        return self.keyfile_path.stem
+	@property
+	def alias(self) -> str:
+		return self.keyfile_path.stem
 
-    @property
-    def keyfile(self) -> dict:
-        return json.loads(self.keyfile_path.read_text())
+	@property
+	def keyfile(self) -> dict:
+		return json.loads(self.keyfile_path.read_text())
 
-    @property
-    def address(self) -> AddressType:
-        return self.network_manager.ethereum.decode_address(self.keyfile["address"])
+	@property
+	def address(self) -> AddressType:
+		return self.network_manager.ethereum.decode_address(self.keyfile["address"])
 
-    @property
-    def __key(self) -> HexBytes:
-        if self.__cached_key is not None:
-            if not self.locked:
-                click.echo(f"Using cached key for '{self.alias}'")
-                return self.__cached_key
-            else:
-                self.__cached_key = None
+	@property
+	def __key(self) -> HexBytes:
+		if self.__cached_key is not None:
+			if not self.locked:
+				click.echo(f"Using cached key for '{self.alias}'")
+				return self.__cached_key
+			else:
+				self.__cached_key = None
 
-        passphrase = self._prompt_for_passphrase(default="")
-        key = self.__decrypt_keyfile(passphrase)
+		passphrase = self._prompt_for_passphrase(default="")
+		key = self.__decrypt_keyfile(passphrase)
 
-        if click.confirm(f"Leave '{self.alias}' unlocked?"):
-            self.locked = False
-            self.__cached_key = key
+		if click.confirm(f"Leave '{self.alias}' unlocked?"):
+			self.locked = False
+			self.__cached_key = key
 
-        return key
+		return key
 
-    def unlock(self, passphrase: Optional[str] = None):
-        passphrase = passphrase or self._prompt_for_passphrase(
-            f"Enter passphrase to permanently unlock '{self.alias}'"
-        )
-        self.__cached_key = self.__decrypt_keyfile(passphrase)
-        self.locked = False
+	def unlock(self, passphrase: Optional[str] = None):
+		if not passphrase:
+			# Check if environment variable is available
+			env_variable = f"APE_ACCOUNTS_{self.alias}_PASSPHRASE"
+			passphrase = environ.get(env_variable, None)
 
-    def lock(self):
-        self.locked = True
+			if passphrase:
+				# Passphrase found in environment variable
+				click.echo(f"Using passphrase for account '{self.alias}' from environment variable")
+			else:
+				# Passphrase not found, prompt for it
+				passphrase = self._prompt_for_passphrase(f"Enter passphrase to permanently unlock '{self.alias}'")
 
-    def change_password(self):
-        self.locked = True  # force entering passphrase to get key
-        key = self.__key
+		# Rest of the code to unlock the account using the passphrase
+		self.__cached_key = self.__decrypt_keyfile(passphrase)
+		self.locked = False
 
-        passphrase = self._prompt_for_passphrase("Create new passphrase", confirmation_prompt=True)
-        self.keyfile_path.write_text(json.dumps(EthAccount.encrypt(key, passphrase)))
+	def lock(self):
+		self.locked = True
 
-    def delete(self):
-        passphrase = self._prompt_for_passphrase(
-            f"Enter passphrase to delete '{self.alias}'", default=""
-        )
-        self.__decrypt_keyfile(passphrase)
-        self.keyfile_path.unlink()
+	def change_password(self):
+		self.locked = True  # force entering passphrase to get key
+		key = self.__key
 
-    def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
-        user_approves = self.__autosign or click.confirm(f"{msg}\n\nSign: ")
-        if not user_approves:
-            return None
+		passphrase = self._prompt_for_passphrase("Create new passphrase", confirmation_prompt=True)
+		self.keyfile_path.write_text(json.dumps(EthAccount.encrypt(key, passphrase)))
 
-        signed_msg = EthAccount.sign_message(msg, self.__key)
-        return MessageSignature(
-            v=signed_msg.v,
-            r=to_bytes(signed_msg.r),
-            s=to_bytes(signed_msg.s),
-        )
+	def delete(self):
+		passphrase = self._prompt_for_passphrase(
+			f"Enter passphrase to delete '{self.alias}'", default=""
+		)
+		self.__decrypt_keyfile(passphrase)
+		self.keyfile_path.unlink()
 
-    def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:
-        user_approves = self.__autosign or click.confirm(f"{txn}\n\nSign: ")
-        if not user_approves:
-            return None
+	def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
+		user_approves = self.__autosign or click.confirm(f"{msg}\n\nSign: ")
+		if not user_approves:
+			return None
 
-        signature = EthAccount.sign_transaction(
-            txn.dict(exclude_none=True, by_alias=True), self.__key
-        )
-        txn.signature = TransactionSignature(
-            v=signature.v,
-            r=to_bytes(signature.r),
-            s=to_bytes(signature.s),
-        )
+		signed_msg = EthAccount.sign_message(msg, self.__key)
+		return MessageSignature(
+			v=signed_msg.v,
+			r=to_bytes(signed_msg.r),
+			s=to_bytes(signed_msg.s),
+		)
 
-        return txn
+	def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:
+		user_approves = self.__autosign or click.confirm(f"{txn}\n\nSign: ")
+		if not user_approves:
+			return None
 
-    def set_autosign(self, enabled: bool, passphrase: Optional[str] = None):
-        """
-        Allow this account to automatically sign messages and transactions.
+		signature = EthAccount.sign_transaction(
+			txn.dict(exclude_none=True, by_alias=True), self.__key
+		)
+		txn.signature = TransactionSignature(
+			v=signature.v,
+			r=to_bytes(signature.r),
+			s=to_bytes(signature.s),
+		)
 
-        Args:
-            enabled (bool): ``True`` to enable, ``False`` to disable.
-            passphrase (Optional[str]): Optionally provide the passphrase.
-              If not provided, you will be prompted to enter it.
-        """
-        if enabled:
-            self.unlock(passphrase=passphrase)
-            logger.warning("Danger! This account will now sign any transaction it's given.")
+		return txn
 
-        self.__autosign = enabled
-        if not enabled:
-            # Re-lock if was turning off
-            self.locked = True
-            self.__cached_key = None
+	def set_autosign(self, enabled: bool, passphrase: Optional[str] = None):
+		"""
+		Allow this account to automatically sign messages and transactions.
 
-    def _prompt_for_passphrase(self, message: Optional[str] = None, **kwargs):
-        message = message or f"Enter passphrase to unlock '{self.alias}'"
-        return click.prompt(
-            message,
-            hide_input=True,
-            **kwargs,
-        )
+		Args:
+			enabled (bool): ``True`` to enable, ``False`` to disable.
+			passphrase (Optional[str]): Optionally provide the passphrase.
+			  If not provided, you will be prompted to enter it.
+		"""
+		if enabled:
+			self.unlock(passphrase=passphrase)
+			logger.warning("Danger! This account will now sign any transaction it's given.")
 
-    def __decrypt_keyfile(self, passphrase: str) -> HexBytes:
-        try:
-            return EthAccount.decrypt(self.keyfile, passphrase)
-        except ValueError as err:
-            raise InvalidPasswordError() from err
+		self.__autosign = enabled
+		if not enabled:
+			# Re-lock if was turning off
+			self.locked = True
+			self.__cached_key = None
+
+	def _prompt_for_passphrase(self, message: Optional[str] = None, **kwargs):
+		message = message or f"Enter passphrase to unlock '{self.alias}'"
+		return click.prompt(
+			message,
+			hide_input=True,
+			**kwargs,
+		)
+
+	def __decrypt_keyfile(self, passphrase: str) -> HexBytes:
+		try:
+			return EthAccount.decrypt(self.keyfile, passphrase)
+		except ValueError as err:
+			raise InvalidPasswordError() from err


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->
Added the option for setting the password to unlock accounts from env variables

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: https://github.com/ApeWorX/ape/issues/1233

### How I did it
Added a check to see if the `password`  is set in the `environment` or not. 

<!-- Discuss the thought process behind the change -->

### How to verify it
- Open a console by using `ape console` will the fastest way to test this. Now follow the steps
```py
# Step 1 -> export the password or save it as env var 
export APE_ACCOUNTS_test_PASSPHRASE="a"
# Step 2 
ape console
# Step 3 -> Run these commands assuming you have an account named test.
account = accounts.load("test")
account.unlock()
```

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
