### PR TITLE
fix: quiet cached keys warnings [APE-1001]

### DIFF
--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -67,10 +67,9 @@ class KeyfileAccount(AccountAPI):
     def __key(self) -> HexBytes:
         if self.__cached_key is not None:
             if not self.locked:
-                click.echo(f"Using cached key for '{self.alias}'")
+                logger.warning("Using cached key for %s",self.alias)
                 return self.__cached_key
-            else:
-                self.__cached_key = None
+            self.__cached_key = None
 
         passphrase = self._prompt_for_passphrase(default="")
         key = self.__decrypt_keyfile(passphrase)

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -67,7 +67,7 @@ class KeyfileAccount(AccountAPI):
     def __key(self) -> HexBytes:
         if self.__cached_key is not None:
             if not self.locked:
-                logger.warning("Using cached key for %s",self.alias)
+                logger.warning("Using cached key for %s", self.alias)
                 return self.__cached_key
             self.__cached_key = None
 


### PR DESCRIPTION
### What I did

turn cached key warning into a `logger.warning` instead of a `click.echo`

without this I can't stop the incessant beeping with `ape_logger.set_level(logging.ERROR)`

### How I did it

changing `click.echo` to `logger.warning`.
also removed the unnecessary else statement because sourcery told me to.

### How to verify it

trust me bro, the `using cached keys` warning doesn't bother me any more 👌

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated