### PR TITLE
fix: issue when CI wouldn't use a remote version of Ape [APE-1029]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,11 @@ check_untyped_defs = true
 plugins = ["pydantic.mypy"]
 
 [tool.setuptools_scm]
+# The fallback version is so that CI/CD systems will use a more accurate version.
+# Otherwise, you may have issues with plugins' pinning Ape and not using the expected version.
+# This version is purposely set to really high minor so that it should always work
+# with newer, stricter plugin releases.
+fallback_version = "0.6.999"
 write_to = "src/ape/version.py"
 
 # NOTE: you have to use single-quoted strings in TOML for regular expressions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ plugins = ["pydantic.mypy"]
 # Otherwise, you may have issues with plugins' pinning Ape and not using the expected version.
 # This version is purposely set to really high minor so that it should always work
 # with newer, stricter plugin releases.
+# NOTE: This should be bumped with every minor release!
 fallback_version = "0.6.999"
 write_to = "src/ape/version.py"
 


### PR DESCRIPTION
### What I did

Related to https://github.com/ApeWorX/github-action/pull/20

Here was my problem:

* I have a workflow that install from a remote branch of Ape. That was working!
* Yesterday, I merged a feature that allows installing plugins from a remote branch. That was also working!
* But then things went wrong.... So when installing ape, it showed the version as 0.1.0 because setuptools_scm is how we calculate the version, and pip, when cloning from a remote install, does not include tags nor will it ever.... thus, the latest version of Ape 0.6.10 would replace my branch-install after installing the plugins.. :(
* So what I didddd here is add a fallback version that should get used whenever the real version is not known..

If you don't like this for some reason.... get this... this is what happens anyway.... except before it would use 0.1.0 as the fallback version... now, I am taking control of that value... we can bump as needed, it is only when `setuptools_scm` fails, such as when doing `pip install git+` in an env where you dont gots the tags

### How I did it

add a setting to toml

### How to verify it

uhhh im doing that now, i think i should see this action... will update..

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
