### PR TITLE
fix(networks): avoid persistent fork [APE-1030]

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -587,8 +587,10 @@ class ProviderContextManager(ManagerAccessMixin):
         if self.empty:
             return
 
-        # Clear last provider
+        # Clear last provider and disconnect
         exiting_provider_id = self.provider_stack.pop()
+        self.connected_providers.pop(exiting_provider_id).disconnect()
+        # If stack is empty, reset to initial state
         if not self.provider_stack:
             self.network_manager.active_provider = None
             return


### PR DESCRIPTION
### What I did

When popping a provider off the stack, it should disconnect in order to reset the connection in scenarios where the provider is an ephemeral fork or locally provisioned network

fixes: #1433

### How I did it

Disconnect after popping a provider off the stack

### How to verify it

Noticing now that #933 made a change exactly counter to this, I am thinking that there is a relevant change necessary in `ape_test` that will make these both function properly together. Maybe the behavior should be configurable?

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] Ensure that tests still function appropriately (test providers don't disconnect until the end of a test per #933)
- [ ] Ensure that console usage functions appropriately (repeated calls to `network.fork()` use fresh fork chain)
- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
