### PR TITLE
fix: validation error accept none type gas baseFeePerGas [APE-1036]

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -806,6 +806,9 @@ class Web3Provider(ProviderAPI, ABC):
         except BlockNotFound as err:
             raise BlockNotFoundError(block_id) from err
 
+        if "baseFeePerGas" in block_data and block_data.get("baseFeePerGas") is None:
+            block_data["baseFeePerGas"] = 0
+
         return self.network.ecosystem.decode_block(block_data)
 
     def get_nonce(self, address: AddressType, **kwargs) -> int:

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -806,6 +806,7 @@ class Web3Provider(ProviderAPI, ABC):
         except BlockNotFound as err:
             raise BlockNotFoundError(block_id) from err
 
+        # Some nodes (like anvil) will not have a base fee if set to 0.
         if "baseFeePerGas" in block_data and block_data.get("baseFeePerGas") is None:
             block_data["baseFeePerGas"] = 0
 


### PR DESCRIPTION
### What I did

updated src/ape/api/providers.py `web3provider getblock` to accept none type gas `baseFeePerGas`

fixes: # https://github.com/SilverBackLtd/silverback/issues/2

### How I did it

resolves nonetype error for basefeepergas

### How to verify it

run a silverback test with geth provider

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
