### PR TITLE
fix: issue where union dicts in config would cause failure

### DIFF
--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -28,7 +28,7 @@ class PluginConfig(BaseSettings):
 
         def update(root: Dict, value_map: Dict):
             for key, val in value_map.items():
-                if key in root and isinstance(val, dict):
+                if isinstance(val, dict) and key in root and isinstance(root[key], dict):
                     root[key] = update(root[key], val)
                 else:
                     root[key] = val

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict
+from typing import Dict, Union
 
 import pytest
 
@@ -139,3 +139,14 @@ def test_plugin_config_updates_when_default_is_empty_dict():
     overrides = {"sub": {"baz": {"test": {"foo": 5}}}}
     actual = MyConfig.from_overrides(overrides)
     assert actual.sub == {"baz": {"test": SubConfig(foo=5, bar=1)}}
+
+
+@pytest.mark.parametrize("override_0,override_1", [(True, {"foo": 0}), ({"foo": 0}, True)])
+def test_plugin_config_with_union_dicts(override_0, override_1):
+    class SubConfig(PluginConfig):
+        bool_or_dict: Union[bool, Dict] = True
+        dict_or_bool: Union[Dict, bool] = {}
+
+    config = SubConfig.from_overrides({"bool_or_dict": override_0, "dict_or_bool": override_1})
+    assert config.bool_or_dict == override_0
+    assert config.dict_or_bool == override_1


### PR DESCRIPTION
### What I did

Issue where you couldnt define union dicts in your plugin configs like

```yaml
    class SubConfig(PluginConfig):
        bool_or_dict: Union[bool, Dict] = True
```

### How I did it

only iterate through default if possible

### How to verify it

can now use union dicts

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
