### PR TITLE
test: skip if plugin installed [APE-1051]

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,11 @@ from typing import Dict, Optional
 import pytest
 import yaml
 from click.testing import CliRunner
-from ape.types import AddressType
 
 import ape
 from ape.exceptions import APINotImplementedError, UnknownSnapshotError
 from ape.managers.config import CONFIG_FILE_NAME
+from ape.types import AddressType
 
 # NOTE: Ensure that we don't use local paths for these
 ape.config.DATA_FOLDER = Path(mkdtemp()).resolve()
@@ -317,7 +317,9 @@ def skip_if_plugin_installed(*plugin_names: str):
 
             # Converters
             elif name in ("ens",):
-                address_converters = [type(n).__name__ for n in ape.chain.conversion_manager._converters[AddressType]]
+                address_converters = [
+                    type(n).__name__ for n in ape.chain.conversion_manager._converters[AddressType]
+                ]
                 if any(x.startswith(name.upper()) for x in address_converters):
                     return pytest.mark.skip(msg_f.format(name))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional
 import pytest
 import yaml
 from click.testing import CliRunner
+from ape.types import AddressType
 
 import ape
 from ape.exceptions import APINotImplementedError, UnknownSnapshotError
@@ -294,3 +295,33 @@ def _make_keyfile_account(base_path: Path, alias: str, params: Dict, funder):
     acct = ape.accounts.load(alias)
     funder.transfer(acct, "25 ETH")  # Auto-fund this account
     return acct
+
+
+def skip_if_plugin_installed(*plugin_names: str):
+    """
+    A simple decorator for skipping a test if a plugin is installed.
+    **NOTE**: For performance reasons, this method is not very good.
+    It only works for common ApeWorX supported plugins and is only
+    meant for assisting testing in Core (NOT a public utility).
+    """
+    names = [n.lower().replace("-", "_").replace("ape_", "") for n in plugin_names]
+    msg_f = "Cannot run this test when plugin '{}' installed."
+
+    def wrapper(fn):
+        for name in names:
+            # Compilers
+            if name in ("solidity", "vyper"):
+                compiler = ape.compilers.get_compiler(name)
+                if compiler:
+                    return pytest.mark.skip(msg_f.format(name))
+
+            # Converters
+            elif name in ("ens",):
+                address_converters = [type(n).__name__ for n in ape.chain.conversion_manager._converters[AddressType]]
+                if any(x.startswith(name.upper()) for x in address_converters):
+                    return pytest.mark.skip(msg_f.format(name))
+
+        # noop
+        return fn
+
+    return wrapper

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -10,6 +10,7 @@ import ape
 from ape.contracts import ContractInstance
 from ape.exceptions import APINotImplementedError, ChainError, ConversionError
 from ape_ethereum.transactions import Receipt, TransactionStatusEnum
+from tests.conftest import skip_if_plugin_installed
 
 
 @pytest.fixture
@@ -598,6 +599,7 @@ def test_contracts_get_all_include_non_contract_address(vyper_contract_instance,
     assert actual[vyper_contract_instance.address] == vyper_contract_instance.contract_type
 
 
+@skip_if_plugin_installed("ens")
 def test_contracts_get_multiple_attempts_to_convert(chain):
     with pytest.raises(ConversionError):
         chain.contracts.get_multiple(("test.eth",))

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -3,18 +3,7 @@ from pathlib import Path
 import pytest
 
 from ape.exceptions import APINotImplementedError, CompilerError
-
-
-@pytest.fixture
-def skip_if_vyper_or_solidity_installed(compilers):
-    registered_compilers = compilers.registered_compilers
-    skip_msg = "Cannot have {0} plugin installed to run test!"
-    if ".vy" in registered_compilers:
-        pytest.skip(skip_msg.format("Vyper"))
-    elif ".sol":
-        pytest.skip(skip_msg.format("Solidity"))
-
-    yield
+from tests.conftest import skip_if_plugin_installed
 
 
 def test_get_imports(project, compilers):
@@ -27,17 +16,15 @@ def test_missing_compilers_without_source_files(project):
     assert result == []
 
 
-def test_missing_compilers_with_source_files(
-    project_with_source_files_contract, skip_if_vyper_or_solidity_installed
-):
+@skip_if_plugin_installed("vyper", "solidity")
+def test_missing_compilers_with_source_files(project_with_source_files_contract):
     result = project_with_source_files_contract.extensions_with_missing_compilers()
     assert ".vy" in result
     assert ".sol" in result
 
 
-def test_missing_compilers_error_message(
-    project_with_source_files_contract, sender, skip_if_vyper_or_solidity_installed
-):
+@skip_if_plugin_installed("vyper", "solidity")
+def test_missing_compilers_error_message(project_with_source_files_contract, sender):
     missing_exts = project_with_source_files_contract.extensions_with_missing_compilers()
     expected = (
         "ProjectManager has no attribute or contract named 'ContractA'. "


### PR DESCRIPTION
### What I did

Adds internal test decorator for skipping core tests if the given plugins are installed.
to improve test readability. note, the decorator's impl is not that great because i wanted to keep it fast (prevent importing or looking up package).. however, it wont always work, it is just for our core tests so not that important.

### How I did it

if

### How to verify it

tests pass

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
