### PR TITLE
fix: sort methods in gas report [APE-1052]

### DIFF
--- a/src/ape/utils/trace.py
+++ b/src/ape/utils/trace.py
@@ -143,9 +143,8 @@ def parse_gas_table(report: "GasReport") -> List[Table]:
         table.add_column("Max.", justify="right")
         table.add_column("Mean", justify="right")
         table.add_column("Median", justify="right")
-
         has_at_least_1_row = False
-        for method_call, gases in method_calls.items():
+        for method_call, gases in sorted(method_calls.items()):
             if not gases:
                 continue
 

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -21,10 +21,10 @@ EXPECTED_GAS_REPORT = rf"""
 
   Method +Times called +Min. +Max. +Mean +Median
  ─+
-  myNumber +\d +\d+ + \d+ + \d+ + \d+
-  setNumber +\d +\d+ + \d+ + \d+ + \d+
   fooAndBar +\d +\d+ + \d+ + \d+ + \d+
+  myNumber +\d +\d+ + \d+ + \d+ + \d+
   setAddress +\d +\d+ + \d+ + \d+ + \d+
+  setNumber +\d +\d+ + \d+ + \d+ + \d+
 
  +TokenA Gas
 


### PR DESCRIPTION
### What I did

This helps with reproducing gas reports during testing and bug fixing, but will also help uses locate methods in gas report.

### How I did it

use sorted

### How to verify it

methods always sorted

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
