### PR TITLE
fix: change chown to --recursive for reliability and readability [APE-1072]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,6 @@ RUN pip install --upgrade pip \
     && ape --version
 
 WORKDIR /home/harambe/project
-RUN chown -hR harambe:harambe /home/harambe
+RUN chown --recursive harambe:harambe /home/harambe
 USER harambe
 ENTRYPOINT ["ape"]


### PR DESCRIPTION
### What I did

changed chown command in dockerfile to --recursive 

may fix: # https://github.com/ApeWorX/ape/issues/1476

### How I did it

changed chown command in dockerfile to `--recursive` instead of `-hR`

### How to verify it

```
$ docker build -t ape .
$ docker run -it --entrypoint /bin/bash ape
harambe@8650e9ff7e66:~/project$ ls -la
total 8
drwxr-xr-x 1 harambe harambe 4096 May  4 15:48 .
drwxr-xr-x 1 harambe harambe 4096 Jun 12 20:55 ..
```


### Checklist

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
