### PR TITLE
fix: issue where installed module names `scripts` would interfere with `ape run` [APE-1073]

### DIFF
--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -2,6 +2,7 @@ import inspect
 import os
 import sys
 import traceback
+from contextlib import contextmanager
 from pathlib import Path
 from runpy import run_module
 from typing import Any, Dict, Union
@@ -15,6 +16,47 @@ from ape.logging import logger
 from ape.managers.project import ProjectManager
 from ape.utils import get_relative_path, use_temp_sys_path
 from ape_console._cli import console
+
+
+@contextmanager
+def use_scripts_sys_path(path: Path):
+    # First, ensure there is not an existing scripts module.
+    scripts = sys.modules.get("scripts")
+    if scripts:
+        del sys.modules["scripts"]
+
+        # Sometimes, an installed module is somehow missing a __file__
+        # and mistaken by Python to be a system module. We can handle
+        # that by also checking some internal properties for the right path.
+        excl_paths = (
+            [Path(scripts.__file__).parent]
+            if scripts.__file__
+            else [
+                Path(p).parent
+                for p in getattr(getattr(scripts, "__path__", None), "_path", []) or []
+            ]
+        )
+
+    else:
+        excl_paths = None
+
+    with use_temp_sys_path(path, exclude=excl_paths):
+        yield
+
+    if scripts and sys.modules.get("scripts") != scripts:
+        sys.modules["scripts"] = scripts
+
+
+def get_module(script_path: Path) -> str:
+    mod_name = ".".join(
+        (str(script_path).replace(os.path.sep, ".").split("scripts.")[-1].split(".")[:-1])
+    )
+    return mod_name if "." in mod_name else f"scripts.{mod_name}"
+
+
+def run_script_module(script_path: Path):
+    mod_name = get_module(script_path)
+    return run_module(mod_name)
 
 
 class ScriptCommand(click.MultiCommand):
@@ -56,23 +98,14 @@ class ScriptCommand(click.MultiCommand):
             logger.error_from_exception(e, f"Exception while parsing script: {relative_filepath}")
             return None  # Prevents stalling scripts
 
-        def _module_str(_filepath: Path) -> str:
-            suffix = ".".join(
-                (str(_filepath).replace(os.path.sep, ".").split("scripts.")[-1].split(".")[:-1])
-            )
-            if "." not in suffix:
-                return f"scripts.{suffix}"
-            else:
-                return suffix
-
         # NOTE: Introspect code structure only for given patterns (do not execute it to find hooks)
         if "cli" in code.co_names:
             # If the module contains a click cli subcommand, process it and return the subcommand
             logger.debug(f"Found 'cli' command in script: {relative_filepath}")
 
-            with use_temp_sys_path(filepath.parent.parent):
+            with use_scripts_sys_path(filepath.parent.parent):
                 try:
-                    cli_ns = run_module(_module_str(filepath))
+                    cli_ns = run_script_module(filepath)
                 except Exception as e:
                     logger.error_from_exception(
                         e, f"Exception while parsing script: {relative_filepath}"
@@ -99,8 +132,8 @@ class ScriptCommand(click.MultiCommand):
             @network_option()
             def call(network):
                 _ = network  # Downstream might use this
-                with use_temp_sys_path(filepath.parent.parent):
-                    main_ns = run_module(_module_str(filepath))
+                with use_scripts_sys_path(filepath.parent.parent):
+                    main_ns = run_script_module(filepath)
 
                 main_ns["main"]()  # Execute the script
                 self._namespace[filepath.stem] = main_ns
@@ -118,8 +151,8 @@ class ScriptCommand(click.MultiCommand):
             @network_option()
             def call(network):
                 _ = network  # Downstream might use this
-                with use_temp_sys_path(filepath.parent.parent):
-                    empty_ns = run_module(_module_str(filepath))
+                with use_scripts_sys_path(filepath.parent.parent):
+                    empty_ns = run_script_module(filepath)
 
                 # Nothing to call, everything executes on loading
                 self._namespace[filepath.stem] = empty_ns

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -1,3 +1,5 @@
+import sys
+
 from .utils import skip_projects_except
 
 BAD_COMMAND = "not-a-name"
@@ -20,9 +22,9 @@ def test_run(ape_cli, runner, project):
     scripts = [s for s in project.scripts_folder.glob("*.py") if not s.name.startswith("error")]
     for script_file in scripts:
         result = runner.invoke(ape_cli, ["run", script_file.stem])
-        assert result.exit_code == 0, result.output
-        runner.invoke(ape_cli, ["run", "--interactive"], input="exit\n")
-        assert result.exit_code == 0, result.output
+        assert (
+            result.exit_code == 0
+        ), f"Unexpected exit code for '{script_file.name}'\n{result.output}"
 
         if script_file.stem.startswith("_"):
             assert "Super secret script output" not in result.output
@@ -61,7 +63,7 @@ def test_run_only_subdirs(ape_cli, runner, project):
     ]
     for each in subdirectory_scripts:
         result = runner.invoke(ape_cli, ["run", "subdirectory", each.stem])
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"Unexpected exit code for '{each.name}'"
         assert "Super secret script output" in result.output
 
 
@@ -74,9 +76,9 @@ def test_run_when_script_errors(ape_cli, runner, project):
     ]
     for script_file in scripts:
         result = runner.invoke(ape_cli, ["run", script_file.stem])
-        assert result.exit_code != 0, result.output
-        runner.invoke(ape_cli, ["run", "--interactive"], input="exit\n")
-        assert result.exit_code != 0, result.output
+        assert (
+            result.exit_code != 0
+        ), f"Unexpected exit code for '{script_file.name}'.\n{result.output}"
         assert str(result.exception) == "Expected exception"
 
 
@@ -134,3 +136,22 @@ def test_uncaught_tx_err(ape_cli, runner, project):
     assert '/scripts/txerr.py", line 12, in main' in result.output
     assert "contract.setNumber(5, sender=account)" in result.output
     assert "ERROR: (ContractLogicError) Transaction failed." in result.output
+
+
+@skip_projects_except("script")
+def test_scripts_module_already_installed(ape_cli, runner, project, mocker):
+    """
+    Make sure that if there is for some reason a python module names `scripts`
+    installed, it does not interfere with Ape's scripting mechanism.
+    """
+    mock_scripts = mocker.MagicMock()
+    mock_path = mocker.MagicMock()
+    mock_path._path = "path/to/scripts"
+    mock_scripts.__file__ = None
+    mock_scripts.__path__ = mock_path
+    sys.modules["scripts"] = mock_scripts
+
+    result = runner.invoke(ape_cli, ["run"])
+    assert result.exit_code == 0, result.output
+
+    del sys.modules["scripts"]


### PR DESCRIPTION
### What I did

`ape run` would always run the wrong deploy script after i installed ApePay.
i also made an issue there: https://github.com/ApeWorX/ApePay/issues/14

but to fix it in Ape, I can make it ignore existing modules named `scripts`, so that is what this PR does.

### How I did it

remove from both sys module and sys path to get it to work properly. was a pain to figure that out.

### How to verify it

* install ApePay (before anything fixed there)
* try running different ape script
* notice it is trying to run the deploy script from `ApePay` without this PR but with this PR it works

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
