### PR TITLE
fix: issue when network config is missing, txns would fail with a config error [APE-1076]

### DIFF
--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -1,7 +1,9 @@
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, TypeVar
 
 from pydantic import BaseModel, BaseSettings
+
+T = TypeVar("T")
 
 
 class ConfigEnum(str, Enum):
@@ -48,7 +50,7 @@ class PluginConfig(BaseSettings):
     def __contains__(self, key: str) -> bool:
         return key in self.__dict__
 
-    def get(self, key: str, default: Optional[Any] = None) -> Any:
+    def get(self, key: str, default: Optional[T] = None) -> T:
         return self.__dict__.get(key, default)
 
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1037,7 +1037,7 @@ class Web3Provider(ProviderAPI, ABC):
         except TimeExhausted as err:
             raise TransactionNotFoundError(txn_hash) from err
 
-        network_config = self.network.config.get(self.network.name, {})
+        network_config: Dict = self.network.config.dict().get(self.network.name, {})
         max_retries = network_config.get("max_get_transaction_retries", DEFAULT_MAX_RETRIES_TX)
         for attempt in range(max_retries):
             try:

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1037,7 +1037,7 @@ class Web3Provider(ProviderAPI, ABC):
         except TimeExhausted as err:
             raise TransactionNotFoundError(txn_hash) from err
 
-        network_config = self.network.config.get(self.network.name)
+        network_config = self.network.config.get(self.network.name, {})
         max_retries = network_config.get("max_get_transaction_retries", DEFAULT_MAX_RETRIES_TX)
         for attempt in range(max_retries):
             try:


### PR DESCRIPTION
### What I did

Fixes an unreleased regression from https://github.com/ApeWorX/ape/pull/1458 where if a network was missing from an ecosystem (adhoc), it would fail in a bad way

### How I did it

use dict access

### How to verify it

the newly added type checking helps

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
