### PR TITLE
docs: updated readme to remove workdir from docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ docker run \
 --volume $HOME/.vvm:/home/harambe/.vvm \
 --volume $HOME/.solcx:/home/harambe/.solcx \
 --volume $PWD:/home/harambe/project \
---workdir /home/harambe/project \
 apeworx/ape compile
 ```
 


### PR DESCRIPTION
### What I did

updated readme.md to remove reference to workdir for docker run command as workdir is already included in dockerfile

### How I did it

workdir is already included in dockerfile thus doesn't need to be included in docker run command in README.md

### How to verify it

review README.md

### Checklist

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
