### PR TITLE
fix: hex string converter [APE-1082]

### DIFF
--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -48,13 +48,18 @@ class HexConverter(ConverterAPI):
 class HexIntConverter(ConverterAPI):
     """
     Convert hex values to integers.
+
+    **NOTE** If value is a ``str``, it must begin with "0x".
     """
 
     def is_convertible(self, value: Any) -> bool:
         return (isinstance(value, str) and is_hex(value)) or isinstance(value, bytes)
 
     def convert(self, value: Any) -> int:
-        return to_int(HexBytes(value))
+        if isinstance(value, bytes) or (value.startswith("0x") and isinstance(value, str)):
+            return to_int(HexBytes(value))
+        else:
+            return int(value)
 
 
 class AddressAPIConverter(ConverterAPI):

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Tuple, Type, Union
 
 from dateutil.parser import parse  # type: ignore
 from eth_utils import (
+    is_0x_prefixed,
     is_checksum_address,
     is_hex,
     is_hex_address,
@@ -56,7 +57,7 @@ class HexIntConverter(ConverterAPI):
         return (isinstance(value, str) and is_hex(value)) or isinstance(value, bytes)
 
     def convert(self, value: Any) -> int:
-        if isinstance(value, bytes) or (value.startswith("0x") and isinstance(value, str)):
+        if isinstance(value, bytes) or (isinstance(value, str) and is_0x_prefixed(value)):
             return to_int(HexBytes(value))
         else:
             return int(value)

--- a/tests/functional/conversion/test_hex.py
+++ b/tests/functional/conversion/test_hex.py
@@ -1,0 +1,18 @@
+import pytest
+
+from ape import chain
+
+
+def test_hex_str():
+    hex_value = "0xA100"
+    int_value = "100"
+    hex_expected = 41216
+    int_expected = 100
+    assert chain.conversion_manager.convert(hex_value, int) == hex_expected
+    assert chain.conversion_manager.convert(int_value, int) == int_expected
+
+
+def test_missing_prefix():
+    hex_value = "A100"
+    with pytest.raises(ValueError):
+        chain.conversion_manager.convert(hex_value, int)


### PR DESCRIPTION
### What I did
Hex to integer conversion now requires a prefix of "0x" for string values otherwise the value is not converted.
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1435 

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
