### PR TITLE
feat: automatically add `--verbosity` to scripts and other CLI fixes [APE-1091]

### DIFF
--- a/src/ape/cli/__init__.py
+++ b/src/ape/cli/__init__.py
@@ -21,6 +21,7 @@ from ape.cli.options import (
     network_option,
     output_format_option,
     skip_confirmation_option,
+    verbosity_option,
 )
 from ape.cli.paramtype import AllFilePaths, Path
 from ape.cli.utils import Abort
@@ -47,4 +48,5 @@ __all__ = [
     "Path",
     "PromptChoice",
     "skip_confirmation_option",
+    "verbosity_option",
 ]

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -147,11 +147,15 @@ class AccountAliasPromptChoice(PromptChoice):
     """
 
     def __init__(
-        self, account_type: Optional[Type[AccountAPI]] = None, prompt_message: Optional[str] = None
+        self,
+        account_type: Optional[Type[AccountAPI]] = None,
+        prompt_message: Optional[str] = None,
+        name: str = "account",
     ):
         # NOTE: we purposely skip the constructor of `PromptChoice`
         self._account_type = account_type
         self._prompt_message = prompt_message or "Select an account"
+        self.name = name
 
     def convert(
         self, value: Any, param: Optional[Parameter], ctx: Optional[Context]

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -67,8 +67,11 @@ class PromptChoice(click.ParamType):
             click.echo(f"__expected_{choice}")
     """
 
-    def __init__(self, choices):
+    def __init__(self, choices, name: Optional[str] = None):
         self.choices = choices
+        # Since we purposely skip the super() constructor, we need to make
+        # sure the class still has a name.
+        self.name = name or "option"
 
     def print_choices(self):
         """

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import click
 from ethpm_types import ContractType
@@ -12,8 +12,10 @@ from ape.cli.choices import (
 )
 from ape.cli.utils import Abort
 from ape.exceptions import ContractError
-from ape.logging import DEFAULT_LOG_LEVEL, LogLevel, logger
+from ape.logging import DEFAULT_LOG_LEVEL, CliLogger, LogLevel, logger
 from ape.managers.base import ManagerAccessMixin
+
+_VERBOSITY_VALUES = ("--verbosity", "-v")
 
 
 class ApeCliContextObject(ManagerAccessMixin):
@@ -45,31 +47,31 @@ class ApeCliContextObject(ManagerAccessMixin):
         raise Abort(msg)
 
 
-def verbosity_option(cli_logger=None):
+def verbosity_option(cli_logger: Optional[CliLogger] = None):
     """A decorator that adds a `--verbosity, -v` option to the decorated
     command.
     """
-
     _logger = cli_logger or logger
-    level_names = [lvl.name for lvl in LogLevel]
-    names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"
+    kwarguments = _create_verbosity_kwargs(_logger=_logger)
+    return lambda f: click.option(*_VERBOSITY_VALUES, **kwarguments)(f)
+
+
+def _create_verbosity_kwargs(_logger: Optional[CliLogger] = None) -> Dict:
+    cli_logger = _logger or logger
 
     def set_level(ctx, param, value):
-        _logger._load_from_sys_argv(default=value.upper())
+        cli_logger._load_from_sys_argv(default=value.upper())
 
-    def decorator(f):
-        return click.option(
-            "--verbosity",
-            "-v",
-            callback=set_level,
-            default=DEFAULT_LOG_LEVEL,
-            metavar="LVL",
-            expose_value=False,
-            help=f"One of {names_str}",
-            is_eager=True,
-        )(f)
-
-    return decorator
+    level_names = [lvl.name for lvl in LogLevel]
+    names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"
+    return {
+        "callback": set_level,
+        "default": DEFAULT_LOG_LEVEL,
+        "metavar": "LVL",
+        "expose_value": False,
+        "help": f"One of {names_str}",
+        "is_eager": True,
+    }
 
 
 def ape_cli_context():

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -45,16 +45,17 @@ class ApeCliContextObject(ManagerAccessMixin):
         raise Abort(msg)
 
 
-def verbosity_option(cli_logger):
+def verbosity_option(cli_logger=None):
     """A decorator that adds a `--verbosity, -v` option to the decorated
     command.
     """
 
+    _logger = cli_logger or logger
     level_names = [lvl.name for lvl in LogLevel]
     names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"
 
     def set_level(ctx, param, value):
-        cli_logger._load_from_sys_argv(default=value.upper())
+        _logger._load_from_sys_argv(default=value.upper())
 
     def decorator(f):
         return click.option(

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -107,15 +107,16 @@ class CliLogger:
         self._web3_http_provider_logger = _get_logger("web3.providers.HTTPProvider")
         self._load_from_sys_argv()
 
-    def _load_from_sys_argv(self, default: Optional[str] = None):
+    def _load_from_sys_argv(self, default: Optional[Union[str, int]] = None):
         """
         Load from sys.argv to beat race condition with `click`.
         """
-        log_level = default or DEFAULT_LOG_LEVEL
+
+        log_level = _get_level(level=default)
         level_names = [lvl.name for lvl in LogLevel]
         for arg_i in range(len(sys.argv) - 1):
             if sys.argv[arg_i] == "-v" or sys.argv[arg_i] == "--verbosity":
-                level = sys.argv[arg_i + 1].upper()
+                level = _get_level(sys.argv[arg_i + 1].upper())
 
                 if level in level_names:
                     log_level = level
@@ -197,6 +198,15 @@ def _get_logger(name: str) -> logging.Logger:
     handler.setFormatter(ApeColorFormatter())
     cli_logger.handlers = [handler]
     return cli_logger
+
+
+def _get_level(level: Optional[Union[str, int]] = None) -> str:
+    if level is None:
+        return DEFAULT_LOG_LEVEL
+    elif isinstance(level, int) or level.isnumeric():
+        return LogLevel(int(level)).name
+
+    return level
 
 
 logger = CliLogger()

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -119,7 +119,7 @@ class ScriptCommand(click.MultiCommand):
                 logger.warning("Found `cli()` method but it is not a click command.")
                 return None
 
-            params = [x.name for x in cli_obj.params]
+            params = [getattr(x, "name", None) for x in cli_obj.params]
             if "verbosity" not in params:
                 option_kwargs = _create_verbosity_kwargs()
                 option = Option(_VERBOSITY_VALUES, **option_kwargs)

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -8,9 +8,10 @@ from runpy import run_module
 from typing import Any, Dict, Union
 
 import click
-from click import Command, Context
+from click import Command, Context, Option
 
-from ape.cli import NetworkBoundCommand, network_option
+from ape.cli import NetworkBoundCommand, network_option, verbosity_option
+from ape.cli.options import _create_verbosity_kwargs
 from ape.exceptions import ApeException, handle_ape_exception
 from ape.logging import logger
 from ape.managers.project import ProjectManager
@@ -118,6 +119,12 @@ class ScriptCommand(click.MultiCommand):
                 logger.warning("Found `cli()` method but it is not a click command.")
                 return None
 
+            params = [x.name for x in cli_obj.params]
+            if "verbosity" not in params:
+                option_kwargs = _create_verbosity_kwargs()
+                option = Option(["--verbosity", "-v"], **option_kwargs)
+                cli_obj.params.append(option)
+
             cli_obj.name = filepath.stem if cli_obj.name in ("cli", "", None) else cli_obj.name
             return cli_obj
 
@@ -130,6 +137,7 @@ class ScriptCommand(click.MultiCommand):
                 name=relative_filepath.stem,
             )
             @network_option()
+            @verbosity_option()
             def call(network):
                 _ = network  # Downstream might use this
                 with use_scripts_sys_path(filepath.parent.parent):

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -11,7 +11,7 @@ import click
 from click import Command, Context, Option
 
 from ape.cli import NetworkBoundCommand, network_option, verbosity_option
-from ape.cli.options import _create_verbosity_kwargs
+from ape.cli.options import _VERBOSITY_VALUES, _create_verbosity_kwargs
 from ape.exceptions import ApeException, handle_ape_exception
 from ape.logging import logger
 from ape.managers.project import ProjectManager
@@ -122,7 +122,7 @@ class ScriptCommand(click.MultiCommand):
             params = [x.name for x in cli_obj.params]
             if "verbosity" not in params:
                 option_kwargs = _create_verbosity_kwargs()
-                option = Option(["--verbosity", "-v"], **option_kwargs)
+                option = Option(_VERBOSITY_VALUES, **option_kwargs)
                 cli_obj.params.append(option)
 
             cli_obj.name = filepath.stem if cli_obj.name in ("cli", "", None) else cli_obj.name

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -9,8 +9,10 @@ from ape.cli import (
     account_option,
     get_user_selected_account,
     network_option,
+    verbosity_option,
 )
 from ape.exceptions import AccountsError
+from ape.logging import logger
 
 OUTPUT_FORMAT = "__TEST__{}__"
 
@@ -293,3 +295,13 @@ def test_prompt_choice(runner, opt):
     result = runner.invoke(cmd, [], input=f"{opt}\n")
     assert "Select one of the following:" in result.output
     assert "__expected_foo" in result.output
+
+
+def test_verbosity_option(runner):
+    @click.command()
+    @verbosity_option()
+    def cmd():
+        click.echo(logger.level)
+
+    result = runner.invoke(cmd, ["--verbosity", "ERROR"])
+    assert "40" in result.output

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -309,8 +309,8 @@ def test_verbosity_option(runner):
     def cmd():
         click.echo(f"__expected_{logger.level}")
 
-    result = runner.invoke(cmd, ["--verbosity", "ERROR"])
-    assert "__expected_40" in result.output
+    result = runner.invoke(cmd, ["--verbosity", logger.level])
+    assert f"__expected_{logger.level}" in result.output
 
 
 def test_account_prompt_name():

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -315,9 +315,9 @@ def test_verbosity_option(runner):
 
 def test_account_prompt_name():
     """
-    It is very important for this class to have the name field,
-    even though it is not used. That is because some click
-    internal expect this property to exist (without being documented).
+    It is very important for this class to have the `name` attribute,
+    even though it is not used. That is because some click internals
+    expect this property to exist, and we skip the super() constructor.
     """
     option = AccountAliasPromptChoice()
     assert option.name == "account"

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -4,6 +4,7 @@ import click
 import pytest
 
 from ape.cli import (
+    AccountAliasPromptChoice,
     NetworkBoundCommand,
     PromptChoice,
     account_option,
@@ -283,10 +284,15 @@ def test_prompt_choice(runner, opt):
     def choice_callback(ctx, param, value):
         return param.type.get_user_selected_choice()
 
+    choice = PromptChoice(["foo", "bar"])
+    assert hasattr(choice, "name")
+    choice = PromptChoice(["foo", "bar"], name="choice")
+    assert choice.name == "choice"
+
     @click.command()
     @click.option(
         "--choice",
-        type=PromptChoice(["foo", "bar"]),
+        type=choice,
         callback=choice_callback,
     )
     def cmd(choice):
@@ -301,7 +307,19 @@ def test_verbosity_option(runner):
     @click.command()
     @verbosity_option()
     def cmd():
-        click.echo(logger.level)
+        click.echo(f"__expected_{logger.level}")
 
     result = runner.invoke(cmd, ["--verbosity", "ERROR"])
-    assert "40" in result.output
+    assert "__expected_40" in result.output
+
+
+def test_account_prompt_name():
+    """
+    It is very important for this class to have the name field,
+    even though it is not used. That is because some click
+    internal expect this property to exist (without being documented).
+    """
+    option = AccountAliasPromptChoice()
+    assert option.name == "account"
+    option = AccountAliasPromptChoice(name="account_z")
+    assert option.name == "account_z"

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -34,6 +34,12 @@ def test_run(ape_cli, runner, project):
 
 
 @skip_projects_except("script")
+def test_run_with_verbosity(ape_cli, runner, project):
+    result = runner.invoke(ape_cli, ["run", "click", "--verbosity", "DEBUG"])
+    assert result.exit_code == 0, result.output
+
+
+@skip_projects_except("script")
 def test_run_subdirectories(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["run"])
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
### What I did

* feat: now instead of `from ape.cli.options import verbosity_options`, you can do `from ape.cli import verbosity_option`.
* feat: automatically add `--verbosity` option to `main` and `cli` based scripts
* fix: `AttributeError` from certain custom option classes not having an attribute named `.name`
* feat: Allow `verbosity_option()` to work without passing in the logger as an argument
* feat: Will accept integer values for `--verbosity`

**needed for silverback https://github.com/SilverBackLtd/silverback/pull/9**

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
