### PR TITLE
fix: convert value for create_transaction [APE-960]

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -616,7 +616,7 @@ class Ethereum(EcosystemAPI):
 
         if "value" in kwargs and not isinstance(kwargs["value"], int):
             kwargs["value"] = self.conversion_manager.convert(kwargs["value"], int)
-            
+
         return txn_class(**kwargs)
 
     def decode_logs(self, logs: List[Dict], *events: EventABI) -> Iterator["ContractLog"]:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -553,6 +553,9 @@ class Ethereum(EcosystemAPI):
         """
         Returns a transaction using the given constructor kwargs.
 
+        **NOTE**: This generally should not be called by the user since this API method is used as a
+        hook for Ecosystems to customize how transactions are created.
+
         Returns:
             :class:`~ape.api.transactions.TransactionAPI`
         """
@@ -610,6 +613,10 @@ class Ethereum(EcosystemAPI):
             kwargs["max_fee"] = kwargs.pop("max_fee_per_gas")
 
         kwargs["gas"] = kwargs.pop("gas_limit", kwargs.get("gas"))
+
+        if "value" in kwargs and not isinstance(kwargs["value"], int):
+            kwargs["value"] = self.conversion_manager.convert(kwargs["value"], int)
+            
         return txn_class(**kwargs)
 
     def decode_logs(self, logs: List[Dict], *events: EventABI) -> Iterator["ContractLog"]:


### PR DESCRIPTION
### What I did
Add check for "value" kwarg and convert it if it is not an `int` value in `create_transaction`.
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1441 

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it
It can be verified by running this in `ape console`:
`txn = networks.ecosystem.create_transaction(receiver="0x", value="1 wei", data=b"", type=convert(2, int))` 
<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
