### PR TITLE
fix: conversion error

### DIFF
--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -30,7 +30,7 @@ class HexConverter(ConverterAPI):
     """
 
     def is_convertible(self, value: Any) -> bool:
-        return isinstance(value, str) and is_hex(value)
+        return isinstance(value, str) and is_hex(value) and is_0x_prefixed(value)
 
     def convert(self, value: str) -> bytes:
         """
@@ -59,10 +59,15 @@ class HexIntConverter(ConverterAPI):
         )
 
     def convert(self, value: Any) -> int:
-        if isinstance(value, bytes) or (isinstance(value, str) and is_0x_prefixed(value)):
-            return to_int(HexBytes(value))
-        else:
-            return int(value)
+        return to_int(HexBytes(value))
+
+
+class StringIntConverter(ConverterAPI):
+    def is_convertible(self, value: Any) -> bool:
+        return isinstance(value, str) and not is_0x_prefixed(value) and value.isnumeric()
+
+    def convert(self, value: str) -> int:
+        return int(value)
 
 
 class AddressAPIConverter(ConverterAPI):
@@ -250,7 +255,7 @@ class ConversionManager(BaseManager):
                 IntAddressConverter(),
             ],
             bytes: [HexConverter()],
-            int: [TimestampConverter(), HexIntConverter()],
+            int: [TimestampConverter(), HexIntConverter(), StringIntConverter()],
             Decimal: [],
             list: [ListTupleConverter()],
             tuple: [ListTupleConverter()],

--- a/tests/functional/conversion/test_hex.py
+++ b/tests/functional/conversion/test_hex.py
@@ -1,6 +1,8 @@
 import pytest
 
 from ape import chain
+from ape.exceptions import ConversionError
+from ape.managers.converters import HexConverter, HexIntConverter
 
 
 def test_hex_str():
@@ -14,5 +16,9 @@ def test_hex_str():
 
 def test_missing_prefix():
     hex_value = "A100"
-    with pytest.raises(ValueError):
+
+    assert not HexConverter().is_convertible(hex_value)
+    assert not HexIntConverter().is_convertible(hex_value)
+
+    with pytest.raises(ConversionError):
         chain.conversion_manager.convert(hex_value, int)


### PR DESCRIPTION
### What I did

* Was intermittently getting a failing test in the new conversion work from https://github.com/ApeWorX/ape/pull/1481
* Noticed `HexIntConverter` was also handling base-10
* Made a new class for base-10 int strings
* Handle errors so it is always a `ConversionError` and show the conversion class (helped debug)
* HexIntConverter now does not work with base 10 at all, uses the other converterer now
* 

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
