### PR TITLE
fix: issue where manifest was corrupted when changing branches [APE-1101]

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -116,7 +116,20 @@ class ProjectAPI(BaseInterfaceModel):
             manifest.contract_types = {}
 
         else:
-            manifest.contract_types = self.contracts
+            contracts: Dict[str, ContractType] = {}
+
+            # Exclude contracts with missing sources, else you'll get validation errors.
+            # This scenario happens if changing branches and you have some contracts on
+            # one branch and others on the next.
+            for name, contract in self.contracts.items():
+                source_id = contract.source_id
+                if not contract.source_id:
+                    continue
+
+                if source_id in (manifest.sources or {}):
+                    contracts[name] = contract
+
+            manifest.contract_types = contracts
 
         return manifest
 


### PR DESCRIPTION
### What I did

If you have 1 source file on one branch but not on the other, compiling would always be like "Corrupted, rebuilding manifest". because the source was always missing there but got previously compile and carried over in the `.build` folder.

now, that doesn't happen.

### How I did it

When looking at a cached manifest, don't put on the contract type JSONs if they are missing from the sources.

### How to verify it

Have 2 branches with different files in them, you should be able to compile without the manifest corrupted issue

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
