### PR TITLE
fix: issue where project manager mistakenly thought an old contract was a `ContractNamespace` [APE-1111]

### DIFF
--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -484,7 +484,7 @@ class ProjectManager(BaseManager):
                 for ct in [
                     self._get_contract(ct.name)
                     for n, ct in self.contracts.items()
-                    if ct.name and n.split(".")[0] == attr_name
+                    if ct.name and "." in n and n.split(".")[0] == attr_name
                 ]
                 if ct
             ]

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -372,3 +372,15 @@ def test_contracts_folder(project, config):
     config.contracts_folder = None
     assert config.contracts_folder is None
     assert project.contracts_folder == expected
+
+
+def test_getattr_contract_not_exists(project):
+    expected = (
+        r"ProjectManager has no attribute or contract named 'ThisIsNotAContractThatExists'. "
+        r"Could it be from one of the missing compilers for extensions:.*"
+    )
+    project.contracts_folder.mkdir(exist_ok=True)
+    contract = project.contracts_folder / "ThisIsNotAContractThatExists.foo"
+    contract.touch()
+    with pytest.raises(AttributeError, match=expected):
+        _ = project.ThisIsNotAContractThatExists


### PR DESCRIPTION
### What I did

Here is how to repro the bug:

1. Use coverage branch for both ape and ape-vyper
2. Compile a project
3. Switch ape core off the coverage branch
4. Attempt to run a script using the contract container that got compiled
5. Notice it complains about not being able to call a `ContractNamepace`
6. HuhThatIsWeird.jpg
7. Ok, it works if switching back to correct branches but surely it is should not be confusing this with ContractNamespace
8. Look at the code- ah wasn't actually checking correctly

### How I did it

```python
"."
```

### How to verify it

Follow steps. Now you should see a more expected error.
`ape-vyper` fails to load so it complains the plugin is broken and that you are probably referencing something from it

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
