### PR TITLE
feat: detect solady push0 minimal proxies [APE-1123]

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -82,6 +82,7 @@ class ProxyType(IntEnum):
     OpenZeppelin = 7  # openzeppelin upgradeability proxy
     Delegate = 8  # eip-897 delegate proxy
     ZeroAge = 9  # a more-minimal proxy
+    Push0 = 10  # solady push0 minimal proxy
 
 
 class ProxyInfo(ProxyInfoAPI):
@@ -245,6 +246,7 @@ class Ethereum(EcosystemAPI):
             ProxyType.Vyper: r"366000600037611000600036600073(.{40})5af4602c57600080fd5b6110006000f3",  # noqa: E501
             ProxyType.Clones: r"36603057343d52307f830d2d700a97af574b186c80d40429385d24241565b08a7c559ba283a964d9b160203da23d3df35b3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e605b57fd5bf3",  # noqa: E501
             ProxyType.ZeroAge: r"3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e602a57fd5bf3",
+            ProxyType.Push0: r"5f5f365f5f37365f73(.{40})5af43d5f5f3e6029573d5ffd5b3d5ff3",
         }
         for type, pattern in patterns.items():
             match = re.match(pattern, code)

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -82,7 +82,7 @@ class ProxyType(IntEnum):
     OpenZeppelin = 7  # openzeppelin upgradeability proxy
     Delegate = 8  # eip-897 delegate proxy
     ZeroAge = 9  # a more-minimal proxy
-    Push0 = 10  # solady push0 minimal proxy
+    SoladyPush0 = 10  # solady push0 minimal proxy
 
 
 class ProxyInfo(ProxyInfoAPI):
@@ -246,7 +246,7 @@ class Ethereum(EcosystemAPI):
             ProxyType.Vyper: r"366000600037611000600036600073(.{40})5af4602c57600080fd5b6110006000f3",  # noqa: E501
             ProxyType.Clones: r"36603057343d52307f830d2d700a97af574b186c80d40429385d24241565b08a7c559ba283a964d9b160203da23d3df35b3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e605b57fd5bf3",  # noqa: E501
             ProxyType.ZeroAge: r"3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e602a57fd5bf3",
-            ProxyType.Push0: r"5f5f365f5f37365f73(.{40})5af43d5f5f3e6029573d5ffd5b3d5ff3",
+            ProxyType.SoladyPush0: r"5f5f365f5f37365f73(.{40})5af43d5f5f3e6029573d5ffd5b3d5ff3",
         }
         for type, pattern in patterns.items():
             match = re.match(pattern, code)


### PR DESCRIPTION
### What I did

add support for autodetecting [solady push0 minimal proxies](https://github.com/Vectorized/solady/blob/8c751db06e614e26e6acb9b385b463feef5e3a9f/src/utils/LibClone.sol#L168).

a deployer for them can be found [here](https://etherscan.io/address/0x4de3505c938d1e6af47c0ff94ba4baf9163d7b81#code) and an example instance can be found [here](https://etherscan.io/address/0x39a0f5da85b4a08686b6e931860e5192deb685f0#code)

originally found [here](https://twitter.com/optimizoor/status/1646418810717736962).

### How I did it

added a pattern to the existing proxy info detector.

### How to verify it

```python
>>> chain.contracts.get_proxy_info('0x39a0F5da85b4a08686B6E931860E5192DeB685f0')
ProxyInfoAPI(target='0x0000000000006396FF2a80c067f99B3d2Ab4Df24')
```

### Checklist

- [x] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
