### PR TITLE
test: type check fail from tests [APE-1125]

### DIFF
--- a/tests/functional/utils/test_github.py
+++ b/tests/functional/utils/test_github.py
@@ -83,7 +83,7 @@ class TestGithubClient:
         # it will try again without the `v`.
         def side_effect(version):
             if version.startswith("v"):
-                raise UnknownObjectException("", {}, {})
+                raise UnknownObjectException(400, {}, {})
 
             return mock_release
 
@@ -98,7 +98,7 @@ class TestGithubClient:
         # it will try again with the `v`.
         def side_effect(version):
             if not version.startswith("v"):
-                raise UnknownObjectException("", {}, {})
+                raise UnknownObjectException(400, {}, {})
 
             return mock_release
 


### PR DESCRIPTION
### What I did

an upgrade in pygithub caused this but it is not a big deal because only happen in tests.
only type checking in the tests failed, no other issues detecting

### How I did it

change how we make an exception class in tests

### How to verify it

type check works again

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
