### PR TITLE
feat: `--include-dependencies` flag for `ape compile` command and setting [APE-682]

### DIFF
--- a/docs/commands/pm.rst
+++ b/docs/commands/pm.rst
@@ -1,0 +1,3 @@
+.. click:: ape_pm._cli:cli
+  :prog: pm
+  :nested: full

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@
 
    commands/accounts.rst
    commands/compile.rst
+   commands/pm.rst
    commands/console.rst
    commands/init.rst
    commands/networks.rst

--- a/docs/userguides/compile.md
+++ b/docs/userguides/compile.md
@@ -65,3 +65,21 @@ compiler:
 ```
 
 **NOTE**: You must include the defaults in the list when overriding if you wish to retain them.
+
+## Dependencies
+
+In Ape, compile plugins typically let you have dependencies.
+See [this guide](./dependencies.html) to learn more about configuring dependencies in Ape.
+
+To always compile dependencies in Ape during the `ape compile` command, use the CLI flag `--include-dependencies`:
+
+```shell
+ape compile --include-dependencies
+```
+
+Alternatively, configure it to always happen:
+
+```yaml
+compile:
+  use_dependencies: true
+```

--- a/docs/userguides/compile.md
+++ b/docs/userguides/compile.md
@@ -68,7 +68,7 @@ compiler:
 
 ## Dependencies
 
-In Ape, compile plugins typically let you have dependencies.
+In Ape, compiler plugins typically let you have dependencies.
 See [this guide](./dependencies.html) to learn more about configuring dependencies in Ape.
 
 To always compile dependencies in Ape during the `ape compile` command, use the CLI flag `--include-dependencies`:

--- a/docs/userguides/dependencies.md
+++ b/docs/userguides/dependencies.md
@@ -212,7 +212,7 @@ Now, in your solidity files, import `OpenZeppelin` sources via:
 import "@openzeppelin/token/ERC721/ERC721.sol";
 ```
 
-### Accessing Dependency Types
+### Compiling Dependencies
 
 Sometimes, you may need to access types (such as contract types) from dependencies.
 You can achieve this using the project manager:
@@ -220,8 +220,22 @@ You can achieve this using the project manager:
 ```python
 from ape import accounts, project
 
+# NOTE: This will compile the dependency
 dependency_contract = project.dependencies["my_dependency"]["1.0.0"].DependencyContractType
 my_account = accounts.load("alias")
 deployed_contract = my_account.deploy(dependency_contract, "argument")
 print(deployed_contract.address)
+```
+
+If you would like to always compile dependencies during `ape compile` rather than only have them get compiled upon asking for contract types, you can use the config option `include_dependencies` from the `compile` config:
+
+```yaml
+compile:
+  include_dependencies: true
+```
+
+Alternatively, use the `--include-dependencies` CLI flag:
+
+```shell
+ape compile --include-dependencies
 ```

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -412,11 +412,6 @@ class DependencyAPI(BaseInterfaceModel):
                 if "evm_version" in settings:
                     compiler_data["evm_version"] = settings["evm_version"]
 
-                for key, setting in self.config_override.items():
-                    if key.strip().lower() == compiler.name.strip().lower():
-                        compiler_data = {**compiler_data, **setting}
-                        break
-
                 if compiler_data:
                     config_data[name] = compiler_data
 
@@ -450,6 +445,7 @@ class DependencyAPI(BaseInterfaceModel):
             if dependencies_config:
                 config_data["dependencies"] = dependencies_config
 
+            config_data = {**config_data, **self.config_override}
             if config_data:
                 target_config_file.unlink(missing_ok=True)
                 with open(target_config_file, "w") as cf:

--- a/src/ape_compile/__init__.py
+++ b/src/ape_compile/__init__.py
@@ -1,24 +1,8 @@
 from ape import plugins
-from ape.api import ConfigEnum, PluginConfig
-
-
-class EvmVersion(ConfigEnum):
-    constantinople = "constantinople"
-    istanbul = "istanbul"
-    paris = "paris"
-    shanghai = "shanghai"
+from ape.api import PluginConfig
 
 
 class Config(PluginConfig):
-    evm_version: EvmVersion = EvmVersion.shanghai
-    """
-    A base EVM version for compiler plugins to look to
-    when their own is missing. **NOTE**: Typically, compiler
-    plugins define their own, and not every compiler is EVM compatible.
-    This is only used as a global setting for the compilers that
-    are EVM compatible.
-    """
-
     include_dependencies: bool = False
     """
     Set to ``True`` to compile dependencies during ``ape compile``.
@@ -29,9 +13,6 @@ class Config(PluginConfig):
     contract types always compiled during ``ape compile``, and these projects
     should configure ``include_dependencies`` to be ``True``.
     """
-
-    def validate_config(self):
-        self.evm_version = EvmVersion[self.evm_version]
 
 
 @plugins.register(plugins.Config)

--- a/src/ape_compile/__init__.py
+++ b/src/ape_compile/__init__.py
@@ -1,8 +1,16 @@
+from typing import Any, Optional
+
+from pydantic import Field, validator
+
 from ape import plugins
 from ape.api import PluginConfig
+from ape.logging import logger
 
 
 class Config(PluginConfig):
+    # TODO: Remove in 0.7
+    evm_version: Optional[Any] = Field(None, exclude=True, repr=False)
+
     include_dependencies: bool = False
     """
     Set to ``True`` to compile dependencies during ``ape compile``.
@@ -13,6 +21,16 @@ class Config(PluginConfig):
     contract types always compiled during ``ape compile``, and these projects
     should configure ``include_dependencies`` to be ``True``.
     """
+
+    @validator("evm_version")
+    def warn_deprecate(cls, value):
+        if value:
+            logger.warning(
+                "`evm_version` config is deprecated. "
+                "Please set in respective compiler plugin config."
+            )
+
+        return None
 
 
 @plugins.register(plugins.Config)

--- a/src/ape_compile/__init__.py
+++ b/src/ape_compile/__init__.py
@@ -5,10 +5,30 @@ from ape.api import ConfigEnum, PluginConfig
 class EvmVersion(ConfigEnum):
     constantinople = "constantinople"
     istanbul = "istanbul"
+    paris = "paris"
+    shanghai = "shanghai"
 
 
 class Config(PluginConfig):
-    evm_version: EvmVersion = EvmVersion.istanbul
+    evm_version: EvmVersion = EvmVersion.shanghai
+    """
+    A base EVM version for compiler plugins to look to
+    when their own is missing. **NOTE**: Typically, compiler
+    plugins define their own, and not every compiler is EVM compatible.
+    This is only used as a global setting for the compilers that
+    are EVM compatible.
+    """
+
+    include_dependencies: bool = False
+    """
+    Set to ``True`` to compile dependencies during ``ape compile``.
+    Generally, dependencies are not compiled during ``ape compile``
+    This is because dependencies may not compile in Ape on their own,
+    but you can still reference them in your project's contracts' imports.
+    Some projects may be more dependency-based and wish to have the
+    contract types always compiled during ``ape compile``, and these projects
+    should configure ``include_dependencies`` to be ``True``.
+    """
 
     def validate_config(self):
         self.evm_version = EvmVersion[self.evm_version]

--- a/tests/integration/cli/projects/only-dependencies/ape-config.yaml
+++ b/tests/integration/cli/projects/only-dependencies/ape-config.yaml
@@ -2,3 +2,8 @@ dependencies:
   - name: dependency-in-project-only
     local: ./dependency_in_project_only
     contracts_folder: sources
+
+compile:
+  # NOTE: this should say `include_dependencies: false` below.
+  # (it gets replaced with `true` in a test temporarily)
+  include_dependencies: false


### PR DESCRIPTION
### What I did

fixes: #1326 
Fixes: APE-682

* Adds a new CLI flag for `--include-dependencies` so you compile dependencies during `ape compile` if you choose
* Allow config:

```yaml
compile:
  include_dependencies: true
```

to always do this

* Allow skipping cache for dependency compiling via `dep.compile(use_cache=False)`
* Pass along `use_cache` value so `--force` works with `--include-dependencies` to still compile dependencies even when their contract types are already filled out. This is great for compiling with new settings!


### How I did it

* new config
* new click option
* callback in click option looks at config when it is not set
* during compile command, if the value is true, loop through the project's dependencies and call compile and pass along the use_cache value
* handle use_cache in dep.compile

### How to verify it

you can compile dependencies using `ape compile`

btw this works great with some other PRs i just opened

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
