### PR TITLE
fix: better warning for attribute error [APE-1139]

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -10,6 +10,7 @@ from packaging.version import InvalidVersion, Version
 from pydantic import ValidationError
 from yaml import safe_dump
 
+from ape.exceptions import ApeAttributeError
 from ape.logging import logger
 from ape.utils import (
     BaseInterfaceModel,
@@ -332,13 +333,13 @@ class DependencyAPI(BaseInterfaceModel):
         try:
             container = self.get(contract_name)
         except Exception as err:
-            raise AttributeError(
+            raise ApeAttributeError(
                 f"Dependency project '{self.name}' has no contract "
                 f"or attribute '{contract_name}'.\n{err}"
             ) from err
 
         if not container:
-            raise AttributeError(
+            raise ApeAttributeError(
                 f"Dependency project '{self.name}' has no contract '{contract_name}'."
             )
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -13,6 +13,7 @@ from ape.api import AccountAPI, Address, ReceiptAPI, TransactionAPI
 from ape.api.address import BaseAddress
 from ape.api.query import ContractEventQuery, extract_fields
 from ape.exceptions import (
+    ApeAttributeError,
     ArgumentsLengthError,
     ChainError,
     ContractError,
@@ -856,7 +857,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
             }
         except Exception as err:
             # NOTE: Must raise AttributeError for __attr__ method or will seg fault
-            raise AttributeError(str(err)) from err
+            raise ApeAttributeError(str(err)) from err
 
     @cached_property
     def _mutable_methods_(self) -> Dict[str, ContractTransactionHandler]:
@@ -875,7 +876,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
             }
         except Exception as err:
             # NOTE: Must raise AttributeError for __attr__ method or will seg fault
-            raise AttributeError(str(err)) from err
+            raise ApeAttributeError(str(err)) from err
 
     def call_view_method(self, method_name: str, *args, **kwargs) -> Any:
         """
@@ -908,7 +909,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
         else:
             # Didn't find anything that matches
             name = self.contract_type.name or self.__class__.__name__
-            raise AttributeError(f"'{name}' has no attribute '{method_name}'.")
+            raise ApeAttributeError(f"'{name}' has no attribute '{method_name}'.")
 
     def invoke_transaction(self, method_name: str, *args, **kwargs) -> ReceiptAPI:
         """
@@ -943,7 +944,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
         else:
             # Didn't find anything that matches
             name = self.contract_type.name or self.__class__.__name__
-            raise AttributeError(f"'{name}' has no attribute '{method_name}'.")
+            raise ApeAttributeError(f"'{name}' has no attribute '{method_name}'.")
 
     def get_event_by_signature(self, signature: str) -> ContractEvent:
         """
@@ -1014,7 +1015,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
             }
         except Exception as err:
             # NOTE: Must raise AttributeError for __attr__ method or will seg fault
-            raise AttributeError(str(err)) from err
+            raise ApeAttributeError(str(err)) from err
 
     @cached_property
     def _errors_(self) -> Dict[str, List[Type[CustomError]]]:
@@ -1054,7 +1055,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
 
         except Exception as err:
             # NOTE: Must raise AttributeError for __attr__ method or will seg fault
-            raise AttributeError(str(err)) from err
+            raise ApeAttributeError(str(err)) from err
 
     def _create_custom_error_type(self, abi: ErrorABI) -> Type[CustomError]:
         def exec_body(namespace):
@@ -1115,7 +1116,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
             # Didn't find anything that matches
             # NOTE: `__getattr__` *must* raise `AttributeError`
             name = self.contract_type.name or self.__class__.__name__
-            raise AttributeError(f"'{name}' has no attribute '{attr_name}'.")
+            raise ApeAttributeError(f"'{name}' has no attribute '{attr_name}'.")
 
         elif (
             int(attr_name in self._view_methods_)
@@ -1126,7 +1127,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
         ):
             # ABI should not contain a mix of events, mutable and view methods that match
             # NOTE: `__getattr__` *must* raise `AttributeError`
-            raise AttributeError(f"{self.__class__.__name__} has corrupted ABI.")
+            raise ApeAttributeError(f"{self.__class__.__name__} has corrupted ABI.")
 
         if attr_name in self._view_methods_:
             return self._view_methods_[attr_name]
@@ -1137,7 +1138,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
         elif attr_name in self._events_:
             evt_options = self._events_[attr_name]
             if len(evt_options) > 1:
-                raise AttributeError(
+                raise ApeAttributeError(
                     f"Multiple events named '{attr_name}' in '{self.contract_type.name}'.\n"
                     f"Use '{self.get_event_by_signature.__name__}' look-up."
                 )
@@ -1147,7 +1148,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
         elif attr_name in self._errors_:
             err_options = self._errors_[attr_name]
             if len(err_options) > 1:
-                raise AttributeError(
+                raise ApeAttributeError(
                     f"Multiple errors named '{attr_name}' in '{self.contract_type.name}'.\n"
                     f"Use '{self.get_error_by_signature.__name__}' look-up."
                 )
@@ -1155,7 +1156,9 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
             return err_options[0]
 
         else:
-            raise AttributeError(f"No attribute '{attr_name}' found in contract '{self.address}'.")
+            raise ApeAttributeError(
+                f"No attribute '{attr_name}' found in contract '{self.address}'."
+            )
 
 
 class ContractContainer(ContractTypeWrapper):

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -349,6 +349,12 @@ class ProjectError(ApeException):
     """
 
 
+class ApeAttributeError(ProjectError, AttributeError):
+    """
+    Raised when trying to access items via ``.`` access.
+    """
+
+
 class UnknownVersionError(ProjectError):
     """
     Raised when trying to install an unknown version of a package.

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -5,7 +5,7 @@ from ethpm_types import ContractType
 from ethpm_types.source import Content
 
 from ape.api import CompilerAPI
-from ape.exceptions import CompilerError, ContractLogicError
+from ape.exceptions import ApeAttributeError, CompilerError, ContractLogicError
 from ape.logging import logger
 from ape.utils import get_relative_path
 
@@ -39,7 +39,7 @@ class CompilerManager(BaseManager):
 
         compiler = self.get_compiler(name)
         if not compiler:
-            raise AttributeError(f"No attribute or compiler named '{name}'.")
+            raise ApeAttributeError(f"No attribute or compiler named '{name}'.")
 
         return compiler
 

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -4,7 +4,7 @@ import yaml
 
 from ape.api import EcosystemAPI, ProviderAPI, ProviderContextManager
 from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI
-from ape.exceptions import NetworkError
+from ape.exceptions import ApeAttributeError, NetworkError
 from ape.logging import logger
 
 from .base import BaseManager
@@ -259,7 +259,7 @@ class NetworkManager(BaseManager):
         """
 
         if attr_name not in self.ecosystems:
-            raise AttributeError(f"{self.__class__.__name__} has no attribute '{attr_name}'.")
+            raise ApeAttributeError(f"{self.__class__.__name__} has no attribute '{attr_name}'.")
 
         return self.ecosystems[attr_name]
 

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -509,19 +509,19 @@ class ProjectManager(BaseManager):
 
             message = (
                 f"{message} However, there is a source file named '{attr_name}', "
-                "Did you mean to reference a contract name from this source file?"
+                "did you mean to reference a contract name from this source file?"
             )
             file_check_appended = True
             break
 
-        if not file_check_appended:
-            # Possibly, the user does not have compiler plugins installed or working.
-            missing_exts = self.extensions_with_missing_compilers([])
-            if missing_exts:
-                message = (
-                    f"{message} Could it be from one of the missing compilers for extensions: "
-                    + f'{", ".join(sorted(missing_exts))}?'
-                )
+        # Possibly, the user does not have compiler plugins installed or working.
+        missing_exts = self.extensions_with_missing_compilers([])
+        if missing_exts:
+            start = "Else, could" if file_check_appended else "Could"
+            message = (
+                f"{message} {start} it be from one of the missing compilers for extensions: "
+                + f'{", ".join(sorted(missing_exts))}?'
+            )
 
         raise ApeAttributeError(message)
 

--- a/src/ape/plugins/__init__.py
+++ b/src/ape/plugins/__init__.py
@@ -5,6 +5,7 @@ import subprocess
 from typing import Any, Callable, Generator, Iterator, List, Optional, Tuple, Type, cast
 
 from ape.__modules__ import __modules__
+from ape.exceptions import ApeAttributeError
 from ape.logging import logger
 
 from .account import AccountPlugin
@@ -155,7 +156,7 @@ class PluginManager:
 
     def __getattr__(self, attr_name: str) -> Iterator[Tuple[str, Tuple]]:
         if not hasattr(plugin_manager.hook, attr_name):
-            raise AttributeError(f"{self.__class__.__name__} has no attribute '{attr_name}'.")
+            raise ApeAttributeError(f"{self.__class__.__name__} has no attribute '{attr_name}'.")
 
         # Do this to get access to the package name
         hook_fn = getattr(plugin_manager.hook, attr_name)

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -21,6 +21,7 @@ from ethpm_types.source import Closure
 from pydantic import BaseModel, root_validator, validator
 from web3.types import FilterParams
 
+from ape.exceptions import ApeAttributeError
 from ape.types.address import AddressType, RawAddress
 from ape.types.signatures import MessageSignature, SignableMessage, TransactionSignature
 from ape.types.trace import CallTreeNode, ControlFlow, GasReport, SourceTraceback, TraceFrame
@@ -279,7 +280,7 @@ class ContractLog(BaseContractLog):
             pass
 
         if item not in self.event_arguments:
-            raise AttributeError(f"{self.__class__.__name__} has no attribute '{item}'.")
+            raise ApeAttributeError(f"{self.__class__.__name__} has no attribute '{item}'.")
 
         return self.event_arguments[item]
 

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -27,9 +27,11 @@ def test_missing_compilers_with_source_files(project_with_source_files_contract)
 def test_missing_compilers_error_message(project_with_source_files_contract, sender):
     missing_exts = project_with_source_files_contract.extensions_with_missing_compilers()
     expected = (
-        "ProjectManager has no attribute or contract named 'ContractA'. "
-        "Could it be from one of the missing compilers for extensions: "
-        f'{", ".join(sorted(missing_exts))}?'
+        r"ProjectManager has no attribute or contract named 'ContractA'\. "
+        r"However, there is a source file named 'ContractA', "
+        r"did you mean to reference a contract name from this source file\? "
+        r"Else, could it be from one of the missing compilers for extensions: "
+        rf'{", ".join(sorted(missing_exts))}\?'
     )
     with pytest.raises(AttributeError, match=expected):
         project_with_source_files_contract.ContractA.deploy(

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -376,8 +376,11 @@ def test_contracts_folder(project, config):
 
 def test_getattr_contract_not_exists(project):
     expected = (
-        r"ProjectManager has no attribute or contract named 'ThisIsNotAContractThatExists'. "
-        r"Could it be from one of the missing compilers for extensions:.*"
+        r"ProjectManager has no attribute or contract named "
+        r"'ThisIsNotAContractThatExists'. However, there is a source "
+        r"file named 'ThisIsNotAContractThatExists', did you mean to "
+        r"reference a contract name from this source file\? "
+        r"Else, could it be from one of the missing compilers for extensions:.*\?"
     )
     project.contracts_folder.mkdir(exist_ok=True)
     contract = project.contracts_folder / "ThisIsNotAContractThatExists.foo"


### PR DESCRIPTION
### What I did

I spent too long being stuck, so I added an extra warning after I figured it out.
Also made the error a lot prettier by using our base class as well as attribute error

It looks like this now:

```
(yoko) ➜  ape-playground git:(proxy) ✗ ape run beacon

  File "/HOMEApeProjects/ape-playground/scripts/beacon.py", line 9, in main
    contract = ape.project.file.deploy(sender=account)

ERROR: (ApeAttributeError) ProjectManager has no attribute or contract named 'file'. However, there is a source file named 'file', Did you mean to reference a contract name from this source file?
```

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
