### PR TITLE
feat: `ape pm compile` for all dependencies and prevent failing on first dependency during compile [APE-1143]

### DIFF
--- a/docs/userguides/dependencies.md
+++ b/docs/userguides/dependencies.md
@@ -148,6 +148,18 @@ ape pm compile OpenZeppelin --version 4.6.0 --force
 **NOTE**: You only need to specify a version if you have more than one version of a dependency installed.
 Otherwise, you just give it the name.
 
+To compile all dependencies in your local project, run the command with no arguments while in your project:
+
+```shell
+ape pm compile
+```
+
+Alternatively, you can compile dependencies along with your project's contracts by using the `--include-dependencies` flag in `ape-compile`:
+
+```shell
+ape compile --include-dependencies
+```
+
 ## Misc
 
 The following guidelines are applicable to **ALL** dependency types.

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -87,7 +87,11 @@ def cli(cli_ctx, file_paths: Set[Path], use_cache: bool, display_size: bool, inc
     if include_dependencies:
         for versions in cli_ctx.project_manager.dependencies.values():
             for dependency in versions.values():
-                dependency.compile(use_cache=use_cache)
+                try:
+                    dependency.compile(use_cache=use_cache)
+                except Exception as err:
+                    # Log error and try to compile the remaining dependencies.
+                    cli_ctx.logger.error(err)
 
     if display_size:
         _display_byte_code_sizes(cli_ctx, contract_types)

--- a/tests/integration/cli/test_pm.py
+++ b/tests/integration/cli/test_pm.py
@@ -92,6 +92,13 @@ def test_compile_package_not_exists(ape_cli, runner):
 
 @skip_projects_except("with-contracts")
 def test_compile(ape_cli, runner, project):
+    result = runner.invoke(ape_cli, ["pm", "compile"])
+    assert result.exit_code == 0, result.output
+    assert f"Package '__FooDep__' compiled." in result.output
+
+
+@skip_projects_except("with-contracts")
+def test_compile_dependency(ape_cli, runner, project):
     name = "__FooDep__"
     result = runner.invoke(ape_cli, ["pm", "compile", name])
     assert result.exit_code == 0, result.output

--- a/tests/integration/cli/test_pm.py
+++ b/tests/integration/cli/test_pm.py
@@ -94,7 +94,7 @@ def test_compile_package_not_exists(ape_cli, runner):
 def test_compile(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["pm", "compile"])
     assert result.exit_code == 0, result.output
-    assert f"Package '__FooDep__' compiled." in result.output
+    assert "Package '__FooDep__' compiled." in result.output
 
 
 @skip_projects_except("with-contracts")


### PR DESCRIPTION
### What I did

2 fixes that should have been in #1504 

* `ape pm compile` with no args to compile all dependencies in the project, matching `ape pm install` with no args.
* when encountering an error during compiling a dependencies, (which is likely, and will happen if you use chainlink), it will log the error and carry on compiling the rest instead of failing out entirely there.
* ^ this same change for `ape compile --include-dependencies` (should have been part of #1506)

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
