### PR TITLE
test: fix pytest collection warnings that appear when tests fail [APE-1146]

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -318,7 +318,12 @@ def skip_if_plugin_installed(*plugin_names: str):
             if name in ("solidity", "vyper"):
                 compiler = ape.compilers.get_compiler(name)
                 if compiler:
-                    return pytest.mark.skip(msg_f.format(name))
+
+                    def test_skip_from_compiler():
+                        pytest.mark.skip(msg_f.format(name))
+
+                    # NOTE: By returning a function, we avoid a collection warning.
+                    return test_skip_from_compiler
 
             # Converters
             elif name in ("ens",):
@@ -326,8 +331,11 @@ def skip_if_plugin_installed(*plugin_names: str):
                     type(n).__name__ for n in ape.chain.conversion_manager._converters[AddressType]
                 ]
                 if any(x.startswith(name.upper()) for x in address_converters):
-                    return pytest.mark.skip(msg_f.format(name))
 
+                    def test_skip_from_converter():
+                        pytest.mark.skip(msg_f.format(name))
+
+                    return test_skip_from_converter
         # noop
         return fn
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -12,6 +12,9 @@ from ape.utils.testing import DEFAULT_NUMBER_OF_TEST_ACCOUNTS
 from ape_ethereum.ecosystem import ProxyType
 from ape_test.accounts import TestAccount
 
+# NOTE: Even though `__test__` is set to `False` on the class,
+# it must be set here as well for it to properly work for some reason.
+TestAccount.__test__ = False
 MISSING_VALUE_TRANSFER_ERR_MSG = "Must provide 'VALUE' or use 'send_everything=True"
 
 APE_TEST_PATH = "ape_test.accounts.TestAccount"

--- a/tests/integration/cli/projects/test/tests/test_fixtures.py
+++ b/tests/integration/cli/projects/test/tests/test_fixtures.py
@@ -3,6 +3,10 @@ from ape.managers.chain import ChainManager
 from ape.managers.networks import NetworkManager
 from ape.managers.project import ProjectManager
 
+# Even though it is set on the class, it needs to be set _in the test_
+# for some reason.
+TestAccountManager.__test__ = False
+
 
 def test_accounts(accounts):
     assert isinstance(accounts, TestAccountManager)


### PR DESCRIPTION
### What I did

finally fixes a few warnings that were appearing when tests failed

### How I did it

for some reason have to set `__test__ = False` _in the test_... setting it in the class alone is not enough.
for another one, have to return a function starting with `test_` even if it is skip

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
