### PR TITLE
docs: fix version selector [APE-1163]

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import List
 
 import requests
+from semantic_version import Version  # type: ignore
 
 sys.path.insert(0, os.path.abspath(".."))
 
@@ -103,7 +104,9 @@ def get_versions() -> List[str]:
     pattern = re.compile(r"v\d+.?\d?.?\d?$")
     data = response.json()
     tree = data.get("tree", [])
-    return list({x["path"] for x in tree if x["type"] == "tree" and pattern.match(x["path"])})
+    versions = list({x["path"] for x in tree if x["type"] == "tree" and pattern.match(x["path"])})
+    sorted_version_objs = sorted([Version(v.lstrip("v")) for v in versions])
+    return [f"v{x}" for x in sorted_version_objs]
 
 
 html_context = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,7 @@ def get_versions() -> List[str]:
     api_url = "https://api.github.com/repos/ApeWorx/ape/git/trees/gh-pages?recursive=1"
     response = requests.get(api_url)
     response.raise_for_status()
-    pattern = re.compile(r"v\d+.?\d?.?\d?$")
+    pattern = re.compile(r"v\d+.?\d+.?\d+$")
     data = response.json()
     tree = data.get("tree", [])
     versions = list({x["path"] for x in tree if x["type"] == "tree" and pattern.match(x["path"])})

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,7 +105,7 @@ def get_versions() -> List[str]:
     data = response.json()
     tree = data.get("tree", [])
     versions = list({x["path"] for x in tree if x["type"] == "tree" and pattern.match(x["path"])})
-    sorted_version_objs = sorted([Version(v.lstrip("v")) for v in versions])
+    sorted_version_objs = sorted([Version(v.lstrip("v")) for v in versions], reverse=True)
     return [f"v{x}" for x in sorted_version_objs]
 
 


### PR DESCRIPTION
### What I did

noticed the version selector was not really working and it is just broken in general.
this is because it builds the docs before committing to the gh-pages, so it doesnt know all the versions to build, each version had a different list in its list of versions - got weird...

### How I did it

use the web as the source of truth, so you get em all
one issue tho is locally you wont have access to those versions in your _build unless you have built them before

### How to verify it

```
cd docs
```

```python
from conf import get_versions
get_versions()
```

```sh
cd ..
python build_docs.py
python -m http.server --directory "docs/_build/" --bind 127.0.0.1 1337
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
