### PR TITLE
feat: pyproject.toml approach for mdformat

### DIFF
--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,1 +1,0 @@
-number = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     rev: 0.7.14
     hooks:
     -   id: mdformat
-        additional_dependencies: [mdformat-gfm, mdformat-frontmatter]
+        additional_dependencies: [mdformat-gfm, mdformat-frontmatter, mdformat-pyproject]
 
 default_language_version:
     python: python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,6 @@ force_grid_wrap = 0
 include_trailing_comma = true
 multi_line_output = 3
 use_parentheses = true
+
+[tool.mdformat]
+number = true

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ extras_require = {
         "mdformat>=0.7.16",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
+        "mdformat-pyproject>=0.0.1",  # Allows configuring in pyproject.toml
     ],
     "doc": [
         "myst-parser>=1.0.0,<2",  # Parse markdown docs


### PR DESCRIPTION
### What I did

This is kinda fresh and it may be a little hacky, but I'd like to use this approach to cut down the need of a whole config file that does almost nothing.

The reason we have to use a plugin is because `mdformat` is on the fence about supporting this out-of-the-box because of there are non-python projects that use `mdformat` and they prefer delegating to their plugin system (sound familiar?) 

So someone made this plugin and it seems to work and we only have 1 setting. 

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
