### PR TITLE
fix: issue with HTML favicon when running in CI [APE-1165]

### DIFF
--- a/src/ape/types/coverage.py
+++ b/src/ape/types/coverage.py
@@ -848,7 +848,8 @@ class CoverageReport(BaseModel):
                 favicon.write_bytes(docs_favicon.read_bytes())
             else:
                 # Try downloading from the internet. This may happen if running
-                # ape in an isolated file system or a temporary directory.
+                # ape in an isolated file system or a temporary directory,
+                # such as CI/CD tests for Ape.
                 try:
                     url = "https://github.com/ApeWorX/ape/blob/main/docs/favicon.ico"
                     response = requests.get(url)
@@ -856,7 +857,6 @@ class CoverageReport(BaseModel):
                     favicon.write_bytes(response.content)
                 except Exception as err:
                     # Don't let this stop us from generating the report.
-                    # Although, this shouldn't happen.
                     logger.debug(f"Failed finding favicon for coverage HTML. {err}")
 
             css = html_path / "styles.css"


### PR DESCRIPTION
### What I did

found a small issue with favicon when running coverage in CI and including HTML.
the favicon just wouldnt exst, it wouldnt cause any issues or anything so this a non-emergency, but just something the tests in `ape-vyper` caught

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
