### PR TITLE
chore: fix return type of `ContractContainer.__getattr__` [APE-1166]

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -1190,7 +1190,7 @@ class ContractContainer(ContractTypeWrapper):
     def __repr__(self) -> str:
         return f"<{self.contract_type.name}>"
 
-    def __getattr__(self, name: str) -> Union[ContractEvent, Type[CustomError]]:
+    def __getattr__(self, name: str) -> Any:
         """
         Access a contract error or event type via its ABI name using ``.`` access.
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -1198,7 +1198,8 @@ class ContractContainer(ContractTypeWrapper):
             name (str): The name of the event or error.
 
         Returns:
-            :class:`~ape.types.ContractEvent` or a subclass of :class:`~ape.exceptions.CustomError`.
+            :class:`~ape.types.ContractEvent` or a subclass of :class:`~ape.exceptions.CustomError`
+            or any real attribute of the class.
         """
 
         try:

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -1,6 +1,6 @@
 import shutil
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Type, Union
+from typing import Any, Dict, Iterable, List, Optional, Type, Union
 
 from ethpm_types import ContractInstance as EthPMContractInstance
 from ethpm_types import ContractType, PackageManifest, PackageMeta, Source
@@ -411,7 +411,7 @@ class ProjectManager(BaseManager):
 
         return self.local_project.contracts
 
-    def __getattr__(self, attr_name: str) -> Union[ContractContainer, ContractNamespace]:
+    def __getattr__(self, attr_name: str) -> Any:
         """
         Get a contract container from an existing contract type in
         the local project using ``.`` access.
@@ -433,7 +433,8 @@ class ProjectManager(BaseManager):
             attr_name (str): The name of the contract in the project.
 
         Returns:
-            :class:`~ape.contracts.ContractContainer`
+            :class:`~ape.contracts.ContractContainer`,
+            a :class:`~ape.contracts.ContractNamespace`, or any attribute.
         """
 
         result = self._get_attr(attr_name)


### PR DESCRIPTION
### What I did

i found this while working on other stuff

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
