### PR TITLE
feat: support global `ape-config.yaml` files [APE-153]

### DIFF
--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -1,7 +1,14 @@
 # Configure Ape
 
-An `ape-config.yaml` file allows you to configure ape. This guide serves as an index of the settings you can include
-in an `ape-config.yaml` file.
+You can configure Ape using configuration files with the name `ape-config.yaml`.
+There are two locations you can place an `ape-config.yaml` file.
+
+1. In the root of your project
+2. In your `$HOME/.ape` directory (global)
+
+Project settings take precedent, but global settings allow you to configure preferences across all projects, such as your default mainnet provider (e.g. Alchemy versus running your own node).
+
+This guide serves as an index of the settings you can include in any `ape-config.yaml` file.
 
 ## Contracts Folder
 

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "click>=8.1.3,<9",
+        "click>=8.1.3,<8.1.4",
         "ijson>=3.1.4,<4",
         "importlib-metadata",
         "ipython>=8.5.0,<9",

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -147,8 +147,14 @@ class ConfigManager(BaseInterfaceModel):
         # The configs are popped off the dict for checking if all configs were processed.
 
         configs = {}
+        global_config_file = self.DATA_FOLDER / CONFIG_FILE_NAME
+        global_config = load_config(global_config_file) if global_config_file.is_file() else {}
         config_file = self.PROJECT_FOLDER / CONFIG_FILE_NAME
-        user_config = load_config(config_file) if config_file.is_file() else {}
+        user_config = {
+            **global_config,
+            **(load_config(config_file) if config_file.is_file() else {}),
+        }
+
         self.name = configs["name"] = user_config.pop("name", "")
         self.version = configs["version"] = user_config.pop("version", "")
         meta_dict = user_config.pop("meta", {})

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -150,6 +150,9 @@ class ConfigManager(BaseInterfaceModel):
         global_config_file = self.DATA_FOLDER / CONFIG_FILE_NAME
         global_config = load_config(global_config_file) if global_config_file.is_file() else {}
         config_file = self.PROJECT_FOLDER / CONFIG_FILE_NAME
+
+        # NOTE: It is critical that we read in global config values first
+        # so that project config values will override them as-needed.
         user_config = {
             **global_config,
             **(load_config(config_file) if config_file.is_file() else {}),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,8 @@ from ape.types import AddressType
 from ape.utils import ZERO_ADDRESS
 
 # NOTE: Ensure that we don't use local paths for these
-ape.config.DATA_FOLDER = Path(mkdtemp()).resolve()
+DATA_FOLDER = Path(mkdtemp()).resolve()
+ape.config.DATA_FOLDER = DATA_FOLDER
 PROJECT_FOLDER = Path(mkdtemp()).resolve()
 ape.config.PROJECT_FOLDER = PROJECT_FOLDER
 
@@ -51,7 +52,7 @@ def convert(chain):
 
 @pytest.fixture(scope="session")
 def data_folder(config):
-    return config.DATA_FOLDER
+    return DATA_FOLDER
 
 
 @pytest.fixture(scope="session")

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 import pytest
 
 from ape.api import PluginConfig
-from ape.managers.config import DeploymentConfigCollection
+from ape.managers.config import CONFIG_FILE_NAME, DeploymentConfigCollection
 from ape.types import GasLimit
 from ape_ethereum.ecosystem import NetworkConfig
 from tests.functional.conftest import PROJECT_WITH_LONG_CONTRACTS_FOLDER
@@ -150,3 +150,17 @@ def test_plugin_config_with_union_dicts(override_0, override_1):
     config = SubConfig.from_overrides({"bool_or_dict": override_0, "dict_or_bool": override_1})
     assert config.bool_or_dict == override_0
     assert config.dict_or_bool == override_1
+
+
+def test_global_config(data_folder, config):
+    config_file = data_folder / CONFIG_FILE_NAME
+    config_file.unlink(missing_ok=True)
+    config_file.touch()
+    config_content = """
+test:
+  number_of_accounts: 11
+""".strip()
+    config_file.write_text(config_content)
+    config.load(force_reload=True)
+    assert config.get_config("test").number_of_accounts == 11
+    config_file.unlink(missing_ok=True)


### PR DESCRIPTION
### What I did

was seriously impossible to use alchemy without hacking config files in places i shouldnt be, when working on silverback related work

fixes: #379 
Fixes: APE-153

### How I did it

read both places but read global first so it gets override by project settings
### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
