### PR TITLE
fix: improve error when polling for blocks on local networks [APE-1176]

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -312,7 +312,17 @@ class BlockContainer(BaseManager):
         def _try_timeout():
             if time.time() - time_since_last > timeout:
                 time_waited = round(time.time() - time_since_last, 4)
-                raise ChainError(f"Timed out waiting for new block (time_waited={time_waited}).")
+                message = f"Timed out waiting for new block (time_waited={time_waited})."
+                if (
+                    self.provider.network.name == LOCAL_NETWORK_NAME
+                    or self.provider.network.name.endswith("-fork")
+                ):
+                    message += (
+                        " If using a local network, try configuring mining to mine on an interval "
+                        "or adjusting the block time."
+                    )
+
+                raise ChainError(message)
 
         while True:
             confirmable_block_number = self.height - required_confirmations


### PR DESCRIPTION
### What I did

when using a local net and poll blocks times out waiting for a new block, encourage user to adjust mining settings on node.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
