### PR TITLE
chore: add .python-version to generated .gitignore [APE-1182]

### DIFF
--- a/src/ape_init/_cli.py
+++ b/src/ape_init/_cli.py
@@ -46,6 +46,7 @@ def cli(cli_ctx, github):
 .env
 .venv
 .pytest_cache
+.python-version
 __pycache__
 """
             git_ignore_path.touch()


### PR DESCRIPTION
### What I did

one-liner to add `.python-version` to the `.gitignore` file of newly initialized ape projects. 

### Why I did it

[the bunny is right](https://twitter.com/bantg/status/1677475400048312320?s=20) about the convenience of declaring local virtualenv instances. more smol context on pyenv-virtualenv [here](https://realpython.com/effective-python-environment/#pyenv-virtualenv).

### How to verify it

inspect the `ape init`-generated `.gitignore` file

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
