### PR TITLE
fix: move functions_incremented outside loop [APE-1184]

### DIFF
--- a/src/ape/pytest/coverage.py
+++ b/src/ape/pytest/coverage.py
@@ -82,6 +82,7 @@ class CoverageData(ManagerAccessMixin):
             return set(), []
 
         handled_pcs = set()
+        functions_incremented: List[str] = []
         for pc in pcs:
             if pc < 0:
                 continue
@@ -91,7 +92,6 @@ class CoverageData(ManagerAccessMixin):
                 continue
 
             for contract in source_coverage.contracts:
-                functions_incremented: List[str] = []
                 for function in contract.functions:
                     statements_hit = []
                     for statement in function.statements:


### PR DESCRIPTION
### What I did
Moved the `functions_incremented` variable outside of the for loop because it wasn't being accessed properly and giving a error: `UnboundLocalError: cannot access local variable 'functions_incremented' where it is not associated with a value`
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
