### PR TITLE
fix: specify encoding when calling `bytes` [APE-1186]

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -171,10 +171,10 @@ class TransactionAPI(BaseInterfaceModel):
         data = self.dict()
         if len(data["data"]) > 9:
             data["data"] = (
-                "0x" + bytes(data["data"][:3]).hex() + "..." + bytes(data["data"][-3:]).hex()
+                "0x" + bytes(data["data"][:3], encoding="utf8").hex() + "..." + bytes(data["data"][-3:], encoding="utf8").hex()
             )
         else:
-            data["data"] = "0x" + bytes(data["data"]).hex()
+            data["data"] = "0x" + bytes(data["data"], encoding="utf8").hex()
         params = "\n  ".join(f"{k}: {v}" for k, v in data.items())
         return f"{self.__class__.__name__}:\n  {params}"
 

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -170,14 +170,23 @@ class TransactionAPI(BaseInterfaceModel):
     def __str__(self) -> str:
         data = self.dict()
         if len(data["data"]) > 9:
-            data["data"] = (
-                "0x"
-                + bytes(data["data"][:3], encoding="utf8").hex()
-                + "..."
-                + bytes(data["data"][-3:], encoding="utf8").hex()
-            )
+            # only want to specify encoding if data["data"] is a string
+            if isinstance(data["data"], str):
+                data["data"] = (
+                    "0x"
+                    + bytes(data["data"][:3], encoding="utf8").hex()
+                    + "..."
+                    + bytes(data["data"][-3:], encoding="utf8").hex()
+                )
+            else:
+                data["data"] = (
+                    "0x" + bytes(data["data"][:3]).hex() + "..." + bytes(data["data"][-3:]).hex()
+                )
         else:
-            data["data"] = "0x" + bytes(data["data"], encoding="utf8").hex()
+            if isinstance(data["data"], str):
+                data["data"] = "0x" + bytes(data["data"], encoding="utf8").hex()
+            else:
+                data["data"] = "0x" + bytes(data["data"]).hex()
         params = "\n  ".join(f"{k}: {v}" for k, v in data.items())
         return f"{self.__class__.__name__}:\n  {params}"
 

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -171,7 +171,10 @@ class TransactionAPI(BaseInterfaceModel):
         data = self.dict()
         if len(data["data"]) > 9:
             data["data"] = (
-                "0x" + bytes(data["data"][:3], encoding="utf8").hex() + "..." + bytes(data["data"][-3:], encoding="utf8").hex()
+                "0x"
+                + bytes(data["data"][:3], encoding="utf8").hex()
+                + "..."
+                + bytes(data["data"][-3:], encoding="utf8").hex()
             )
         else:
             data["data"] = "0x" + bytes(data["data"], encoding="utf8").hex()

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -75,6 +75,10 @@ def test_transaction_dict_excludes_none_values():
 
 
 def test_txn_str_when_data_is_bytes(ethereum):
+    """
+    Tests against a condition that would cause transactions to
+    fail with string-encoding errors.
+    """
     txn = ethereum.create_transaction(data=HexBytes("0x123"))
     actual = str(txn)
     assert isinstance(actual, str)

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -72,3 +72,9 @@ def test_transaction_dict_excludes_none_values():
     txn.value = None  # type: ignore
     actual = txn.dict()
     assert "value" not in actual
+
+
+def test_txn_str_when_data_is_bytes(ethereum):
+    txn = ethereum.create_transaction(data=HexBytes("0x123"))
+    actual = str(txn)
+    assert isinstance(actual, str)


### PR DESCRIPTION
### What I did

Specify encoding as utf-8 when calling bytes

fixes: #1535

fixes: APE-1181

### How I did it

in this case we should always be dealing with utf8 strings

### How to verify it

I kept getting contract deployment failures like reported in the discord and in #1535 
with this fix I was able to deploy contracts successfully 

### Checklist

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
