### PR TITLE
chore: upgrade watchdog

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ setup(
         "SQLAlchemy>=1.4.35",
         "tqdm>=4.62.3,<5.0",
         "traitlets>=5.3.0",
-        "watchdog>=2.1.9,<3.0",
+        "watchdog>=3.0,<4",
         # ** Dependencies maintained by Ethereum Foundation **
         "eth-abi>=4.0.0,<5",
         "eth-account>=0.8,<0.9",


### PR DESCRIPTION
### What I did

this helps me with work with an environment using dependencies that are incompatible with watchdog 2's dependencies.


### How I did it

upgrade to watchdog3 , no changes were needed

### How to verify it

all options still work.

```sh
ape test --watch --watch-folders "tests" --watch-folders contracts --watch-delay 0.8
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
