### PR TITLE
feat: improved contract receipt related logic

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -131,8 +131,7 @@ class TransactionAPI(BaseInterfaceModel):
     @property
     def receipt(self) -> Optional["ReceiptAPI"]:
         """
-        This transaction's associated published receipt,
-        if it exists.
+        This transaction's associated published receipt, if it exists.
         """
 
         try:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -591,9 +591,19 @@ class ContractEvent(ManagerAccessMixin):
         stop_block = None
 
         if stop is None:
-            start_block = self.chain_manager.contracts.get_creation_receipt(
-                self.contract.address
-            ).block_number
+            contract = None
+            try:
+                contract = self.chain_manager.contracts.instance_at(self.contract.address)
+            except Exception:
+                pass
+
+            if contract:
+                start_block = contract.receipt.block_number
+            else:
+                start_block = self.chain_manager.contracts.get_creation_receipt(
+                    self.contract.address
+                ).block_number
+
             stop_block = start_or_stop
         elif start_or_stop is not None and stop is not None:
             start_block = start_or_stop

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -585,14 +585,13 @@ class ContractEvent(ManagerAccessMixin):
         """
 
         if not hasattr(self.contract, "address"):
-            yield from []
             return
 
         start_block = None
         stop_block = None
 
         if stop is None:
-            start_block = self.chain_manager.get_contract_receipt(
+            start_block = self.chain_manager.contracts.get_creation_receipt(
                 self.contract.address
             ).block_number
             stop_block = start_or_stop
@@ -845,7 +844,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
                 return receipt
 
         # Brute force find the receipt.
-        receipt = self.chain_manager.get_contract_receipt(self.address)
+        receipt = self.chain_manager.contracts.get_creation_receipt(self.address)
         self._cached_receipt = receipt
         return receipt
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1657,18 +1657,38 @@ class ChainManager(BaseManager):
         return self.chain_manager.history[transaction_hash]
 
     def get_contract_receipt(
-        self, start_block: int = 0, stop_block: Optional[int] = None
+        self, address: AddressType, start_block: int = 0, stop_block: Optional[int] = None
     ) -> ReceiptAPI:
         """
         Get the receipt responsible for the initial creation of the contract.
 
         Args:
-            start_block (int): Optionally provide a start block to lessen the
-              search.
-            stop_block (Optional[int]): Optionally provider a stop block to
-              lessen the search.
+            address (``AddressType``): The address of the contract.
+            start_block (int): The block to start looking from.
+            stop_block (Optional[int]): The block to stop looking at.
 
         Returns:
             :class:`~ape.apt.transactions.ReceiptAPI`
         """
-        feat / get - code - block - id
+        if stop_block is None and (stop := self.blocks.head.number):
+            stop_block = stop
+        elif stop_block is None:
+            raise ChainError("Chain missing blocks.")
+
+        mid_block = (stop_block - start_block) // 2 + start_block
+        # NOTE: biased towards mid_block == start_block
+
+        if start_block == mid_block:
+            for tx in self.blocks[mid_block].transactions:
+                if (receipt := tx.receipt) and receipt.contract_address == address:
+                    return receipt
+
+            return self.get_contract_receipt(
+                address, start_block=mid_block + 1, stop_block=stop_block
+            )
+
+        elif self.provider.get_code(address, block_id=mid_block):
+            return self.get_contract_receipt(address, start_block=start_block, stop_block=mid_block)
+
+        else:
+            raise ChainError(f"Failed to find a contract-creation receipt for '{address}'.")

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1671,17 +1671,4 @@ class ChainManager(BaseManager):
         Returns:
             :class:`~ape.apt.transactions.ReceiptAPI`
         """
-        if stop_block is None:
-            stop_block = self.blocks.head.number
-
-        mid_block = (stop_block - start_block) // 2 + start_block
-        # NOTE: biased towards mid_block == start_block
-
-        if start_block == mid_block:
-            for tx in self.chain_manager.blocks[mid_block].transactions:
-                if tx.receipt.contract_address == self.address:
-                    return tx.receipt
-
-
-
-        raise  # cannot find receipt
+        feat / get - code - block - id

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1333,6 +1333,43 @@ class ContractCache(BaseManager):
         with self._deployments_mapping_cache.open("w") as fp:
             json.dump(deployments_map, fp, sort_keys=True, indent=2, default=sorted)
 
+    def get_creation_receipt(
+        self, address: AddressType, start_block: int = 0, stop_block: Optional[int] = None
+    ) -> ReceiptAPI:
+        """
+        Get the receipt responsible for the initial creation of the contract.
+
+        Args:
+            address (``AddressType``): The address of the contract.
+            start_block (int): The block to start looking from.
+            stop_block (Optional[int]): The block to stop looking at.
+
+        Returns:
+            :class:`~ape.apt.transactions.ReceiptAPI`
+        """
+        if stop_block is None and (stop := self.chain_manager.blocks.head.number):
+            stop_block = stop
+        elif stop_block is None:
+            raise ChainError("Chain missing blocks.")
+
+        mid_block = (stop_block - start_block) // 2 + start_block
+        # NOTE: biased towards mid_block == start_block
+
+        if start_block == mid_block:
+            for tx in self.chain_manager.blocks[mid_block].transactions:
+                if (receipt := tx.receipt) and receipt.contract_address == address:
+                    return receipt
+
+            return self.get_creation_receipt(
+                address, start_block=mid_block + 1, stop_block=stop_block
+            )
+
+        elif self.provider.get_code(address, block_id=mid_block):
+            return self.get_creation_receipt(address, start_block=start_block, stop_block=mid_block)
+
+        else:
+            raise ChainError(f"Failed to find a contract-creation receipt for '{address}'.")
+
 
 class ReportManager(BaseManager):
     """
@@ -1655,40 +1692,3 @@ class ChainManager(BaseManager):
             :class:`~ape.apt.transactions.ReceiptAPI`
         """
         return self.chain_manager.history[transaction_hash]
-
-    def get_contract_receipt(
-        self, address: AddressType, start_block: int = 0, stop_block: Optional[int] = None
-    ) -> ReceiptAPI:
-        """
-        Get the receipt responsible for the initial creation of the contract.
-
-        Args:
-            address (``AddressType``): The address of the contract.
-            start_block (int): The block to start looking from.
-            stop_block (Optional[int]): The block to stop looking at.
-
-        Returns:
-            :class:`~ape.apt.transactions.ReceiptAPI`
-        """
-        if stop_block is None and (stop := self.blocks.head.number):
-            stop_block = stop
-        elif stop_block is None:
-            raise ChainError("Chain missing blocks.")
-
-        mid_block = (stop_block - start_block) // 2 + start_block
-        # NOTE: biased towards mid_block == start_block
-
-        if start_block == mid_block:
-            for tx in self.blocks[mid_block].transactions:
-                if (receipt := tx.receipt) and receipt.contract_address == address:
-                    return receipt
-
-            return self.get_contract_receipt(
-                address, start_block=mid_block + 1, stop_block=stop_block
-            )
-
-        elif self.provider.get_code(address, block_id=mid_block):
-            return self.get_contract_receipt(address, start_block=start_block, stop_block=mid_block)
-
-        else:
-            raise ChainError(f"Failed to find a contract-creation receipt for '{address}'.")

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1645,4 +1645,43 @@ class ChainManager(BaseManager):
         return self.provider.set_balance(account, amount)
 
     def get_receipt(self, transaction_hash: str) -> ReceiptAPI:
+        """
+        Get a transaction receipt from the chain.
+
+        Args:
+            transaction_hash (str): The hash of the transaction.
+
+        Returns:
+            :class:`~ape.apt.transactions.ReceiptAPI`
+        """
         return self.chain_manager.history[transaction_hash]
+
+    def get_contract_receipt(
+        self, start_block: int = 0, stop_block: Optional[int] = None
+    ) -> ReceiptAPI:
+        """
+        Get the receipt responsible for the initial creation of the contract.
+
+        Args:
+            start_block (int): Optionally provide a start block to lessen the
+              search.
+            stop_block (Optional[int]): Optionally provider a stop block to
+              lessen the search.
+
+        Returns:
+            :class:`~ape.apt.transactions.ReceiptAPI`
+        """
+        if stop_block is None:
+            stop_block = self.blocks.head.number
+
+        mid_block = (stop_block - start_block) // 2 + start_block
+        # NOTE: biased towards mid_block == start_block
+
+        if start_block == mid_block:
+            for tx in self.chain_manager.blocks[mid_block].transactions:
+                if tx.receipt.contract_address == self.address:
+                    return tx.receipt
+
+
+
+        raise  # cannot find receipt

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1360,12 +1360,20 @@ class ContractCache(BaseManager):
                 if (receipt := tx.receipt) and receipt.contract_address == address:
                     return receipt
 
-            return self.get_creation_receipt(
-                address, start_block=mid_block + 1, stop_block=stop_block
-            )
+            if mid_block + 1 <= stop_block:
+                return self.get_creation_receipt(
+                    address, start_block=mid_block + 1, stop_block=stop_block
+                )
+            else:
+                raise ChainError(f"Failed to find a contract-creation receipt for '{address}'.")
 
         elif self.provider.get_code(address, block_id=mid_block):
             return self.get_creation_receipt(address, start_block=start_block, stop_block=mid_block)
+
+        elif start_block + 1 <= mid_block:
+            return self.get_creation_receipt(
+                address, start_block=start_block + 1, stop_block=stop_block
+            )
 
         else:
             raise ChainError(f"Failed to find a contract-creation receipt for '{address}'.")

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -12,7 +12,7 @@ from ethpm_types.utils import AnyUrl
 from ape.api import DependencyAPI, ProjectAPI
 from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.contracts import ContractContainer, ContractInstance, ContractNamespace
-from ape.exceptions import ApeAttributeError, APINotImplementedError, ProjectError
+from ape.exceptions import ApeAttributeError, APINotImplementedError, ChainError, ProjectError
 from ape.logging import logger
 from ape.managers.base import BaseManager
 from ape.managers.project.types import ApeProject, BrownieProject
@@ -730,9 +730,12 @@ class ProjectManager(BaseManager):
             raise ProjectError("Can only publish deployments on a live network.")
 
         contract_name = contract.contract_type.name
-        receipt = contract.receipt
-        if not receipt:
-            raise ProjectError(f"Contract '{contract_name}' transaction receipt is unknown.")
+        try:
+            receipt = contract.receipt
+        except ChainError as err:
+            raise ProjectError(
+                f"Contract '{contract_name}' transaction receipt is unknown."
+            ) from err
 
         block_number = receipt.block_number
         block_hash_bytes = self.provider.get_block(block_number).hash

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -630,9 +630,9 @@ def test_cache_non_checksum_address(chain, vyper_contract_instance):
 
 def test_get_contract_receipt(chain, vyper_contract_instance):
     address = vyper_contract_instance.address
-    receipt = chain.get_contract_receipt(address)
+    receipt = chain.contracts.get_creation_receipt(address)
     assert receipt.contract_address == address
 
     chain.mine()
-    receipt = chain.get_contract_receipt(address)
+    receipt = chain.contracts.get_creation_receipt(address)
     assert receipt.contract_address == address

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -626,3 +626,13 @@ def test_cache_non_checksum_address(chain, vyper_contract_instance):
     lowered_address = vyper_contract_instance.address.lower()
     chain.contracts[lowered_address] = vyper_contract_instance.contract_type
     assert chain.contracts[vyper_contract_instance.address] == vyper_contract_instance.contract_type
+
+
+def test_get_contract_receipt(chain, vyper_contract_instance):
+    address = vyper_contract_instance.address
+    receipt = chain.get_contract_receipt(address)
+    assert receipt.contract_address == address
+
+    chain.mine()
+    receipt = chain.get_contract_receipt(address)
+    assert receipt.contract_address == address

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -524,6 +524,16 @@ def test_receipt(contract_instance, owner):
     assert receipt.sender == owner
 
 
+def test_receipt_when_needs_brute_force(vyper_contract_instance, owner):
+    # Force it to use the brute-force approach.
+    vyper_contract_instance._cached_receipt = None
+    vyper_contract_instance.txn_hash = None
+
+    actual = vyper_contract_instance.receipt.contract_address
+    expected = vyper_contract_instance.address
+    assert actual == expected
+
+
 def test_from_receipt_when_receipt_not_deploy(contract_instance, owner):
     receipt = contract_instance.setNumber(555, sender=owner)
     expected_err = (

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -62,13 +62,14 @@ def test_transaction_contract_event_query(contract_instance, owner, eth_tester_p
     assert df_events.event_name[0] == "FooHappened"
 
 
-def test_transaction_contract_event_query_starts_query_at_deploy_tx(contract_instance, owner, eth_tester_provider):
+def test_transaction_contract_event_query_starts_query_at_deploy_tx(
+    contract_instance, owner, eth_tester_provider
+):
     contract_instance.fooAndBar(sender=owner)
     time.sleep(0.1)
     df_events = contract_instance.FooHappened.query("*")
     assert isinstance(df_events, pd.DataFrame)
     assert df_events.event_name[0] == "FooHappened"
-
 
 
 class Model(BaseInterfaceModel):

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -62,6 +62,15 @@ def test_transaction_contract_event_query(contract_instance, owner, eth_tester_p
     assert df_events.event_name[0] == "FooHappened"
 
 
+def test_transaction_contract_event_query_starts_query_at_deploy_tx(contract_instance, owner, eth_tester_provider):
+    contract_instance.fooAndBar(sender=owner)
+    time.sleep(0.1)
+    df_events = contract_instance.FooHappened.query("*")
+    assert isinstance(df_events, pd.DataFrame)
+    assert df_events.event_name[0] == "FooHappened"
+
+
+
 class Model(BaseInterfaceModel):
     number: int
     timestamp: int


### PR DESCRIPTION
### What I did

**Please** review + merge #1547 first! this PR depends on those changes so it has all the same changes but i will rebase after and the diff will look nicer. I am leaving it in draft until that is done

* Adds `chain.get_contract_receipt()` method to help get receipts for contracts.
* Changes `receipt` on `ContractInstance` to no longer be optional. If it does not have it, it will call the new method to get it.
* fixes: #1062  Changes the default `start_block` to use the start block of the contract's receipt when not given for event queries

### How I did it

@fubuloubu wrote the start of the algo, i fixed the bug in it, pasted in it, made mypy happy, added some tests, wired it up in some places that make it work nicely in the bg.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
