### PR TITLE
fix: issue where revert infos were the same [APE-1210]

### DIFF
--- a/tests/functional/test_reverts_context_manager.py
+++ b/tests/functional/test_reverts_context_manager.py
@@ -10,14 +10,16 @@ def test_revert_info_context(owner, reverts_contract_instance):
     """
     Shows that the info context is properly maintained.
     """
-    with reverts() as info_0:
+
+    with reverts() as rev_0:
         reverts_contract_instance.revertStrings(0, sender=owner)
-        with reverts() as info_1:
+        with reverts() as rev_1:
             reverts_contract_instance.revertStrings(0, sender=owner)
 
-        assert info_1.value != info_0.value
+        err_1 = rev_1.value
 
-    assert info_0.value is not None
+    err_0 = rev_0.value
+    assert err_0 != err_1
 
 
 def test_no_args(owner, reverts_contract_instance):

--- a/tests/functional/test_reverts_context_manager.py
+++ b/tests/functional/test_reverts_context_manager.py
@@ -6,6 +6,20 @@ from ape.pytest.contextmanagers import RevertsContextManager as reverts
 from tests.conftest import geth_process_test
 
 
+def test_revert_info_context(owner, reverts_contract_instance):
+    """
+    Shows that the info context is properly maintained.
+    """
+    with reverts() as info_0:
+        reverts_contract_instance.revertStrings(0, sender=owner)
+        with reverts() as info_1:
+            reverts_contract_instance.revertStrings(0, sender=owner)
+
+        assert info_1.value != info_0.value
+
+    assert info_0.value is not None
+
+
 def test_no_args(owner, reverts_contract_instance):
     """
     Test catching transaction reverts without asserting on error messages.

--- a/tests/functional/test_reverts_context_manager.py
+++ b/tests/functional/test_reverts_context_manager.py
@@ -8,18 +8,15 @@ from tests.conftest import geth_process_test
 
 def test_revert_info_context(owner, reverts_contract_instance):
     """
-    Shows that the info context is properly maintained.
+    Shows no two revert info objects are the same instance.
     """
 
-    with reverts() as rev_0:
+    with reverts() as rev0:
         reverts_contract_instance.revertStrings(0, sender=owner)
-        with reverts() as rev_1:
-            reverts_contract_instance.revertStrings(0, sender=owner)
+    with reverts() as rev1:
+        reverts_contract_instance.revertStrings(0, sender=owner)
 
-        err_1 = rev_1.value
-
-    err_0 = rev_0.value
-    assert err_0 != err_1
+    assert rev0 != rev1
 
 
 def test_no_args(owner, reverts_contract_instance):

--- a/tests/functional/test_reverts_context_manager.py
+++ b/tests/functional/test_reverts_context_manager.py
@@ -11,12 +11,13 @@ def test_revert_info_context(owner, reverts_contract_instance):
     Shows no two revert info objects are the same instance.
     """
 
-    with reverts() as rev0:
+    rev = reverts()
+    with rev as rev0:
         reverts_contract_instance.revertStrings(0, sender=owner)
-    with reverts() as rev1:
-        reverts_contract_instance.revertStrings(0, sender=owner)
+    with rev as rev1:
+        reverts_contract_instance.revertStrings(1, sender=owner)
 
-    assert rev0 != rev1
+    assert rev0.value.revert_message != rev1.value.revert_message
 
 
 def test_no_args(owner, reverts_contract_instance):


### PR DESCRIPTION
### What I did

I am not sure if this is exactly related to the anomaly I am seeing, but this will at least guarantee that no 2 revert infos are the same.

### How I did it

Create a new RevertInfo object for each entered context

### How to verify it

can use reverts context still

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
