### PR TITLE
fix: actually install ape [APE-1217]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,11 @@ FROM python:${PYTHON_VERSION} as builder
 WORKDIR /wheels
 
 COPY ./recommended-plugins.txt ./recommended-plugins.txt
+COPY . .
 
 RUN pip install --upgrade pip \
     && pip install wheel \
-    && pip wheel -r ./recommended-plugins.txt --wheel-dir=/wheels
+    && pip wheel .[recommended-plugins] --wheel-dir=/wheels
 
 FROM python:${PYTHON_VERSION}-slim
 


### PR DESCRIPTION
### What I did

changed dockerfile so that it actually installs ape instead of installing it as a dependency of the recommended plugins text file.

### How I did it

updated dockerfile
### How to verify it

build it
### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
