### PR TITLE
fix: handle nested structures in global config merge [APE-1218]

### DIFF
--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -323,7 +323,7 @@ class ConfigManager(BaseInterfaceModel):
 
 
 def merge_configs(base: Dict, secondary: Dict) -> Dict:
-    result = {}
+    result: Dict = {}
 
     # Short circuits
     if not base and not secondary:

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -153,10 +153,8 @@ class ConfigManager(BaseInterfaceModel):
 
         # NOTE: It is critical that we read in global config values first
         # so that project config values will override them as-needed.
-        user_config = {
-            **global_config,
-            **(load_config(config_file) if config_file.is_file() else {}),
-        }
+        project_config = load_config(config_file) if config_file.is_file() else {}
+        user_config = merge_configs(global_config, project_config)
 
         self.name = configs["name"] = user_config.pop("name", "")
         self.version = configs["version"] = user_config.pop("version", "")
@@ -322,3 +320,36 @@ class ConfigManager(BaseInterfaceModel):
             config_file = temp_project_path / CONFIG_FILE_NAME
             if clean_config and config_file.is_file():
                 config_file.unlink()
+
+
+def merge_configs(base: Dict, secondary: Dict) -> Dict:
+    result = {}
+
+    # Short circuits
+    if not base and not secondary:
+        return result
+    elif not base:
+        return secondary
+    elif not secondary:
+        return base
+
+    for key, value in base.items():
+        if key not in secondary:
+            result[key] = value
+
+        elif not isinstance(value, dict):
+            # Is a primitive value found in both configs.
+            # Must use the second one.
+            result[key] = secondary[key]
+
+        else:
+            # Merge the dictionaries.
+            sub = merge_configs(base[key], secondary[key])
+            result[key] = sub
+
+    # Add missed keys from secondary.
+    for key, value in secondary.items():
+        if key not in base:
+            result[key] = value
+
+    return result

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -188,7 +188,7 @@ def test_merge_configs():
 
     # Expected case `key only in global`: "mainnet"
     # Expected case `non-primitive override from project`: local -> default_provider, which
-    #  is `test` in global but `geth` in project; this it is `geth` in expected.
+    #  is `test` in global but `geth` in project; thus it is `geth` in expected.
     # Expected case `merge sub-dictionaries`: `ethereum` is being merged.
     # Expected case `add missing project keys`: `test` is added, so is `sepolia` (nested-example).
     expected = {

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 import pytest
 
 from ape.api import PluginConfig
-from ape.managers.config import CONFIG_FILE_NAME, DeploymentConfigCollection
+from ape.managers.config import CONFIG_FILE_NAME, DeploymentConfigCollection, merge_configs
 from ape.types import GasLimit
 from ape_ethereum.ecosystem import NetworkConfig
 from tests.functional.conftest import PROJECT_WITH_LONG_CONTRACTS_FOLDER
@@ -164,3 +164,17 @@ test:
     config.load(force_reload=True)
     assert config.get_config("test").number_of_accounts == 11
     config_file.unlink(missing_ok=True)
+
+
+def test_merge_configs():
+    global_config = {"ethereum": {"mainnet": {"default_provider": "geth"}}}
+    project_config = {"ethereum": {"local": {"default_provider": "geth"}}, "test": "foo"}
+    actual = merge_configs(global_config, project_config)
+    expected = {
+        "ethereum": {
+            "local": {"default_provider": "geth"},
+            "mainnet": {"default_provider": "geth"},
+        },
+        "test": "foo",
+    }
+    assert actual == expected


### PR DESCRIPTION
### What I did

Before, only top level keys worked, if you overrode one in a project, you had to override everything.
Now, it will merge the objects the best it can, thus global mainnet providers work a lot better as most projects still configure local Ethereum providers and that was causing conflicts / loss of config specs

### How I did it

carefully merge the objects

### How to verify it

can now config Ethereum in both places and have it merge and use both

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
