### PR TITLE
docs: clarify doc message [APE-1224]

### DIFF
--- a/src/ape_cache/query.py
+++ b/src/ape_cache/query.py
@@ -129,7 +129,7 @@ class CacheQueryProvider(QueryAPI):
 
         if not database_file.is_file():
             # NOTE: Raising `info` here hints user that they can initialize the cache db
-            logger.info("Cache database has not been initialized")
+            logger.info("`ape-cache` database has not been initialized")
             self.database_bypass = True
             return None
 


### PR DESCRIPTION
### What I did

when using the ape logger in projects that contain multiple cache databases, the context is suddenly missing.
This PR very simply adds missing context

### How I did it

mention `ape-cache` 

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
