### PR TITLE
fix: also handle non empty padding err

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union, cast
 
 from eth_abi import decode, encode
-from eth_abi.exceptions import InsufficientDataBytes
+from eth_abi.exceptions import InsufficientDataBytes, NonEmptyPaddingBytes
 from eth_typing import Hash32
 from eth_utils import (
     encode_hex,
@@ -439,8 +439,8 @@ class Ethereum(EcosystemAPI):
 
         try:
             vm_return_values = decode(output_types_str_ls, raw_data)
-        except InsufficientDataBytes as err:
-            raise DecodingError() from err
+        except (InsufficientDataBytes, NonEmptyPaddingBytes) as err:
+            raise DecodingError(str(err)) from err
 
         if not vm_return_values:
             return vm_return_values
@@ -836,7 +836,7 @@ class Ethereum(EcosystemAPI):
                     if not call.failed
                     else None
                 )
-            except (DecodingError, InsufficientDataBytes):
+            except DecodingError:
                 if return_value_bytes == HexBytes("0x"):
                     # Empty result, but it failed decoding because of its length.
                     return_values = ("",)

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -6,6 +6,7 @@ from ethpm_types import HexBytes
 from ethpm_types.abi import ABIType, MethodABI
 
 from ape.api.networks import LOCAL_NETWORK_NAME
+from ape.exceptions import DecodingError
 from ape.types import AddressType
 from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
 from ape_ethereum.ecosystem import BLUEPRINT_HEADER, Block
@@ -253,3 +254,25 @@ def test_encode_blueprint_contract(ethereum, vyper_contract_type):
         + ct_bytes
     )
     assert actual.data == HexBytes(expected)
+
+
+def test_decode_return_data_non_empty_padding_bytes(ethereum):
+    raw_data = HexBytes(
+        "0x08c379a000000000000000000000000000000000000000000000000000000000000000200"
+        "000000000000000000000000000000000000000000000000000000000000012696e73756666"
+        "696369656e742066756e64730000000000000000000000000000"
+    )
+    abi = MethodABI.parse_obj(
+        {
+            "type": "function",
+            "name": "transfer",
+            "stateMutability": "nonpayable",
+            "inputs": [
+                {"name": "receiver", "type": "address"},
+                {"name": "amount", "type": "uint256"},
+            ],
+            "outputs": [{"name": "", "type": "bool"}],
+        }
+    )
+    with pytest.raises(DecodingError):
+        ethereum.decode_returndata(abi, raw_data)


### PR DESCRIPTION
### What I did

a simple PR that adds another exception from eth-abi to decoding error

### How I did it

adds to the exception to the handler

### How to verify it

yearn-vaults-v3 now works again with the latest Anvil node update

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
