### PR TITLE
fix: does not add  fixture when it's a doctest [APE-1231]

### DIFF
--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -134,6 +134,7 @@ class PytestApeRunner(ManagerAccessMixin):
         if (
             self.config_wrapper.isolation is False
             or "_function_isolation" in item.fixturenames  # prevent double injection
+            or isinstance(item, pytest.DoctestItem)  # doctests don't have fixturenames
         ):
             # isolation is disabled via cmdline option
             return


### PR DESCRIPTION
### What I did

- `pytest_runtest_setup` will skip doctests now too

### How I did it

if `item` is `pytest.DoctestItem`, do not inject anything

### How to verify it

add doctests to some functions in the code, ensure pytest includes them when collecting the tests

### Checklist

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
