### PR TITLE
fix: better URL sanitization in `ape-geth` connection [APE-1233]

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[release]
+        pip install -e .[release]
 
     - name: Build
       run: python setup.py sdist bdist_wheel

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[release]
+        pip install .[release]
 
     - name: Build
       run: python setup.py sdist bdist_wheel

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -252,7 +252,10 @@ class BaseGethProvider(Web3Provider, ABC):
 
     @property
     def _clean_uri(self) -> str:
-        return str(URL(self.uri).with_user(None).with_password(None))
+        url = URL(self.uri).with_user(None).with_password(None)
+        # If there is a path, hide it but show that you are hiding it.
+        # Use string interpolation to prevent URL-character encoding.
+        return f"{url.with_path('')}/[hidden]" if url.path else f"{url}"
 
     @property
     def ipc_path(self) -> Path:


### PR DESCRIPTION
### What I did

Noticed that if your URL contains API keys, they would not get sanitized properly.
I think the only way we can really do this in such a generic way to just always sanitize the path when they exist.

### How I did it

Check if there is a path.
If there is, do `with_path("")` and put `[hidden]` at the end of the URL.
(I borrowed this from some AWS logs I happened to see).
Otherwise, keep as normal, so `[hidden]` is only appended when actually hiding the path.

### How to verify it

This was my log before (except im not actually pasting my API key, but it was where `apikeythatwasnotactuallyhidden` is):

```
INFO: Starting 'Hardhat node' process.
INFO: Connecting to existing Geth node at  https://eth-mainnet.g.alchemy.com/v2/apikeythatwasnotactuallyhidden.
```

This is in it now, so the whole path is just `[hidden]` now.

```
INFO: Starting 'Hardhat node' process.
INFO: Connecting to existing Geth node at  https://eth-mainnet.g.alchemy.com/[hidden].
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
