### PR TITLE
fix: does not add  fixture when it's a doctest [APE-1236]

### DIFF
--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -134,6 +134,7 @@ class PytestApeRunner(ManagerAccessMixin):
         if (
             self.config_wrapper.isolation is False
             or "_function_isolation" in item.fixturenames  # prevent double injection
+            or isinstance(item, pytest.DoctestItem)  # doctests don't have fixturenames
         ):
             # isolation is disabled via cmdline option
             return

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -135,7 +135,6 @@ class PytestApeRunner(ManagerAccessMixin):
             self.config_wrapper.isolation is False
             or isinstance(item, pytest.DoctestItem)  # doctests don't have fixturenames
             or "_function_isolation" in item.fixturenames  # prevent double injection
-            or isinstance(item, pytest.DoctestItem)  # doctests don't have fixturenames
         ):
             # isolation is disabled via cmdline option
             return

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -133,8 +133,8 @@ class PytestApeRunner(ManagerAccessMixin):
         """
         if (
             self.config_wrapper.isolation is False
-            or "_function_isolation" in item.fixturenames  # prevent double injection
             or isinstance(item, pytest.DoctestItem)  # doctests don't have fixturenames
+            or "_function_isolation" in item.fixturenames  # prevent double injection
         ):
             # isolation is disabled via cmdline option
             return


### PR DESCRIPTION
### What I did

My previously merged PR wouldn't have fixed the issue because the check for fixturenames was performed before the check if the item is a DoctestItem.

Previous PR: https://github.com/ApeWorX/ape/pull/1567

TLDR; of the issue in previous PR:

![image](https://github.com/ApeWorX/ape/assets/13678461/1b7d10ae-ddbf-47c7-8f52-dd7a004c0e3e)


### How I did it

made the order correct. First check if it's a DoctestItem, if not, then continue with the other check.
