### PR TITLE
chore: bump evm-trace dep [APE-1237]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.2.1,<0.3",
         "ethpm-types>=0.5.3,<0.6",
-        "evm-trace==0.1.0a21",
+        "evm-trace==0.1.0a22",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -133,8 +133,8 @@ class PytestApeRunner(ManagerAccessMixin):
         """
         if (
             self.config_wrapper.isolation is False
-            or "_function_isolation" in item.fixturenames  # prevent double injection
             or isinstance(item, pytest.DoctestItem)  # doctests don't have fixturenames
+            or "_function_isolation" in item.fixturenames  # prevent double injection
         ):
             # isolation is disabled via cmdline option
             return


### PR DESCRIPTION
### What I did

Running into local mypy resolution conflict (I am using mypy 1.4.1) but because of some eth-ape deps I need to downgrade to mypy < 1. This is the conflict:

```
Because eth-ape (0.6.15.dev3+g553d08ab8) @ git+https://github.com/ApeWorX/ape.git@553d08ab801101faca292a05d509f8f932d44c1b depends on both evm-trace (0.1.0a21) and evm-trace (0.1.0a21), evm-trace is required.
And because evm-trace (0.1.0a21) depends on py-evm (0.7.0a2), py-evm is required.
And because py-evm (0.7.0a2) depends on mypy-extensions (>=0.4.1,<1.0.0)
 and mypy (1.4.1) depends on mypy-extensions (>=1.0.0), mypy is forbidden.
So, because no versions of mypy match >1.4.1,<2.0.0
 and api depends on mypy (^1.4.1), version solving failed.
```

If we bump evm-trace, mypy will be able to resolve properly.

### How I did it

Bumped emv-trace in setup.py

### How to verify it

Try and add eth-ape as a dep to a project that depends on mypy > 1

### Checklist

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
