### PR TITLE
fix: correct return type of `abort()` function [APE-1242]

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[release]
+        pip install -e .[release]
 
     - name: Build
       run: python setup.py sdist bdist_wheel

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[release]
+        pip install .[release]
 
     - name: Build
       run: python setup.py sdist bdist_wheel

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, NoReturn, Optional, Union
 
 import click
 from ethpm_types import ContractType
@@ -30,7 +30,7 @@ class ApeCliContextObject(ManagerAccessMixin):
         self.config_manager.load()
 
     @staticmethod
-    def abort(msg: str, base_error: Optional[Exception] = None):
+    def abort(msg: str, base_error: Optional[Exception] = None) -> NoReturn:
         """
         End execution of the current command invocation.
 

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -135,14 +135,13 @@ def _import(cli_ctx, alias, import_from_mnemonic, custom_hd_path):
             account = EthAccount.from_mnemonic(mnemonic=mnemonic, account_path=custom_hd_path)
         except Exception as error:
             cli_ctx.abort(f"Seed phrase can't be imported: {error}")
-            return
+
     else:
         key = click.prompt("Enter Private Key", hide_input=True)
         try:
             account = EthAccount.from_key(to_bytes(hexstr=key))
         except Exception as error:
             cli_ctx.abort(f"Key can't be imported: {error}")
-            return
 
     passphrase = click.prompt(
         "Create Passphrase to encrypt account",

--- a/src/ape_pm/_cli.py
+++ b/src/ape_pm/_cli.py
@@ -204,10 +204,7 @@ def compile(cli_ctx, name, version, force):
             break
 
     if not version_found:
-        # Return only needed for mypy
-        return cli_ctx.abort(
-            f"Version '{version}' for dependency '{name}' not found. Is it installed?"
-        )
+        cli_ctx.abort(f"Version '{version}' for dependency '{name}' not found. Is it installed?")
 
     dependency = versions[version_found]
 


### PR DESCRIPTION
### What I did

type checkers were reading this as a return type of `None` when it is actually `NoReturn`, this fixes various hacks we had to do.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
