### PR TITLE
fix: warning from authenticating to Github in deprecated way [APE-1258]

### DIFF
--- a/src/ape/utils/github.py
+++ b/src/ape/utils/github.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Dict, Optional, Set
 
 from github import Github, UnknownObjectException
+from github.Auth import Token as GithubToken
 from github.GitRelease import GitRelease
 from github.Organization import Organization
 from github.Repository import Repository as GithubRepository
@@ -67,7 +68,8 @@ class GithubClient:
 
     def __init__(self):
         token = os.environ[self.TOKEN_KEY] if self.TOKEN_KEY in os.environ else None
-        self._client = Github(login_or_token=token, user_agent=USER_AGENT)
+        auth = GithubToken(token)
+        self._client = Github(auth=auth, user_agent=USER_AGENT)
 
     @cached_property
     def ape_org(self) -> Organization:

--- a/src/ape/utils/github.py
+++ b/src/ape/utils/github.py
@@ -68,7 +68,7 @@ class GithubClient:
 
     def __init__(self):
         token = os.environ[self.TOKEN_KEY] if self.TOKEN_KEY in os.environ else None
-        auth = GithubToken(token)
+        auth = GithubToken(token) if token else None
         self._client = Github(auth=auth, user_agent=USER_AGENT)
 
     @cached_property


### PR DESCRIPTION
### What I did

change kwarg we use to auth to gh so it stops being mad

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
