### PR TITLE
fix: show full network name in `ContractTypeNotFoundError` [APE-1259]

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -638,11 +638,7 @@ class ProviderContextManager(ManagerAccessMixin):
         if not provider.is_connected:
             return None
 
-        return (
-            f"{provider.network.ecosystem.name}:"
-            f"{provider.network.name}:{provider.name}-"
-            f"{provider.chain_id}"
-        )
+        return f"{provider.network_choice}:-{provider.chain_id}"
 
 
 class NetworkAPI(BaseInterfaceModel):
@@ -694,8 +690,7 @@ class NetworkAPI(BaseInterfaceModel):
             # Only happens on local networks
             chain_id = None
 
-        network_key = f"{self.ecosystem.name}:{self.name}"
-        content = f"{network_key} chain_id={self.chain_id}" if chain_id is not None else network_key
+        content = f"{self.choice} chain_id={self.chain_id}" if chain_id is not None else self.choice
         return f"<{content}>"
 
     @property
@@ -925,6 +920,10 @@ class NetworkAPI(BaseInterfaceModel):
 
         return None
 
+    @property
+    def choice(self) -> str:
+        return f"{self.ecosystem.name}:{self.name}"
+
     def set_default_provider(self, provider_name: str):
         """
         Change the default provider.
@@ -939,10 +938,7 @@ class NetworkAPI(BaseInterfaceModel):
         if provider_name in self.providers:
             self._default_provider = provider_name
         else:
-            raise NetworkError(
-                f"Provider '{provider_name}' not found in network "
-                f"'{self.ecosystem.name}:{self.name}'."
-            )
+            raise NetworkError(f"Provider '{provider_name}' not found in network '{self.choice}'.")
 
     def use_default_provider(
         self, provider_settings: Optional[Dict] = None

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -211,6 +211,13 @@ class ProviderAPI(BaseInterfaceModel):
             :class:`~ape.types.ContractCode`: The contract bytecode.
         """
 
+    @property
+    def network_choice(self) -> str:
+        """
+        The connected network choice string.
+        """
+        return f"{self.network.choice}:{self.name}"
+
     @raises_not_implemented
     def get_storage_at(self, address: AddressType, slot: int) -> bytes:  # type: ignore[empty-body]
         """
@@ -722,8 +729,7 @@ class Web3Provider(ProviderAPI, ABC):
             # Use the less-accurate approach (OK for testing).
             logger.debug(
                 "Failed using `web3.eth.fee_history` for network "
-                f"'{self.network.ecosystem.name}:{self.network.name}:{self.name}'. "
-                f"Error: {exc}"
+                f"'{self.network_choice}'. Error: {exc}"
             )
             return self._get_last_base_fee()
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -969,7 +969,7 @@ class ContractCache(BaseManager):
         if not contract_type:
             # Create error message from custom exception cls.
             err = ContractNotFoundError(
-                address, self.provider.network.explorer is not None, self.provider.name
+                address, self.provider.network.explorer is not None, self.provider.network_choice
             )
             # Must raise IndexError.
             raise IndexError(str(err))
@@ -1185,7 +1185,7 @@ class ContractCache(BaseManager):
             raise ContractNotFoundError(
                 contract_address,
                 self.provider.network.explorer is not None,
-                self.provider.name,
+                self.provider.network_choice,
             )
 
         elif not isinstance(contract_type, ContractType):

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -397,7 +397,7 @@ def test_instance_at_contract_type_not_found(chain):
     new_address = "0x4a986a6dca6dbF99Bc3D17F8d71aFB0D60E740F9"
     expected = (
         rf"Failed to get contract type for address '{new_address}'. "
-        r"Current provider 'test' has no associated explorer plugin. "
+        r"Current provider 'ethereum:local:test' has no associated explorer plugin. "
         "Try installing an explorer plugin using .*ape plugins install etherscan.*, "
         r"or using a network with explorer support\."
     )
@@ -409,7 +409,7 @@ def test_contracts_getitem_contract_not_found(chain):
     new_address = "0x4a986a6dca6dbF99Bc3D17F8d71aFB0D60E740F9"
     expected = (
         rf"Failed to get contract type for address '{new_address}'. "
-        r"Current provider 'test' has no associated explorer plugin. "
+        r"Current provider 'ethereum:local:test' has no associated explorer plugin. "
         "Try installing an explorer plugin using .*ape plugins install etherscan.*, "
         r"or using a network with explorer support\."
     )


### PR DESCRIPTION
### What I did

Show network and ecosystem in error message when contract type not found.

fixes: #1577
Fixes: Ape-1247

Otherwise it is confusing when you think you are on a fork when you are actually on local.

### How I did it

Make shared network choice and use all over, including in that error, without being a breaking change for the error

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
