### PR TITLE
fix: allow None as access_list value [APE-1275]

### DIFF
--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -103,7 +103,7 @@ class DynamicFeeTransaction(BaseTransaction):
     max_priority_fee: Optional[int] = Field(None, alias="maxPriorityFeePerGas")
     max_fee: Optional[int] = Field(None, alias="maxFeePerGas")
     type: int = Field(TransactionType.DYNAMIC.value)
-    access_list: List[AccessList] = Field(default_factory=list, alias="accessList")
+    access_list: Optional[List[AccessList]] = Field(default_factory=list, alias="accessList")
 
     @validator("type", allow_reuse=True)
     def check_type(cls, value):
@@ -120,7 +120,7 @@ class AccessListTransaction(BaseTransaction):
 
     gas_price: Optional[int] = Field(None, alias="gasPrice")
     type: int = Field(TransactionType.ACCESS_LIST.value)
-    access_list: List[AccessList] = Field(default_factory=list, alias="accessList")
+    access_list: Optional[List[AccessList]] = Field(default_factory=list, alias="accessList")
 
     @validator("type", allow_reuse=True)
     def check_type(cls, value):


### PR DESCRIPTION
### What I did

this fixes transaction decoding for tenderly rpc

```python
ValidationError: 1 validation error for DynamicFeeTransaction
accessList
  none is not an allowed value (type=type_error.none.not_allowed)
```
if we inspect the raw response, we'll see
```python
'accessList': None,
'type': '0x2',
```

this [violates the spec](https://github.com/ethereum/execution-apis/blob/ebf99d80ef3f08b343515bea9b501406c0c25449/src/schemas/transaction.yaml#L86) on tenderly side but we better add a workaround. 

### How I did it

made `access_list` property optional for both eip-2930 and eip-1559 transactions.

### How to verify it

the issue only manifests itself when connected to tenderly rpc

`chain.blocks[-1].transactions`

### Checklist

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
