### PR TITLE
fix: pygithub breaking change [APE-1276]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         "pandas>=1.3.0,<2",
         "pluggy>=0.12,<2",
         "pydantic>=1.10.8,<2",
-        "PyGithub>=1.54,<2",
+        "PyGithub>=1.59,<2",
         "pytest>=6.0,<8.0",
         "python-dateutil>=2.8.2,<3",
         "PyYAML>=5.0,<7",


### PR DESCRIPTION
### What I did

fixes this error on ape load

```python
ModuleNotFoundError: No module named 'github.auth'
```

ape required pygithub>=1.54, while in fact auth module [was added](https://github.com/PyGithub/PyGithub/blob/main/doc/changes.rst#version-1590-june-22-2023
) to pygithub in 1.59.

### How I did it

bump version

### How to verify it

try a fresh install from the repo and then run any ape command

### Checklist

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
