### PR TITLE
feat: detect clones with immutable args [APE-1278]

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -233,7 +233,7 @@ class Ethereum(EcosystemAPI):
             ProxyType.Clones: r"36603057343d52307f830d2d700a97af574b186c80d40429385d24241565b08a7c559ba283a964d9b160203da23d3df35b3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e605b57fd5bf3",  # noqa: E501
             ProxyType.ZeroAge: r"3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e602a57fd5bf3",
             ProxyType.SoladyPush0: r"5f5f365f5f37365f73(.{40})5af43d5f5f3e6029573d5ffd5b3d5ff3",
-            ProxyType.ClonesWithImmutableArgs: r"3d3d3d3d363d3d3761007f603736393661007f013d73(.{40})5af43d3d93803e603557fd5bf3.*",
+            ProxyType.ClonesWithImmutableArgs: r"3d3d3d3d363d3d3761007f603736393661007f013d73(.{40})5af43d3d93803e603557fd5bf3.*",  # noqa: E501
         }
         for type, pattern in patterns.items():
             match = re.match(pattern, code)

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -233,6 +233,7 @@ class Ethereum(EcosystemAPI):
             ProxyType.Clones: r"36603057343d52307f830d2d700a97af574b186c80d40429385d24241565b08a7c559ba283a964d9b160203da23d3df35b3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e605b57fd5bf3",  # noqa: E501
             ProxyType.ZeroAge: r"3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e602a57fd5bf3",
             ProxyType.SoladyPush0: r"5f5f365f5f37365f73(.{40})5af43d5f5f3e6029573d5ffd5b3d5ff3",
+            ProxyType.ClonesWithImmutableArgs: r"3d3d3d3d363d3d3761007f603736393661007f013d73(.{40})5af43d3d93803e603557fd5bf3.*",
         }
         for type, pattern in patterns.items():
             match = re.match(pattern, code)

--- a/src/ape_ethereum/proxies.py
+++ b/src/ape_ethereum/proxies.py
@@ -24,6 +24,7 @@ class ProxyType(IntEnum):
     Delegate = 8  # eip-897 delegate proxy
     ZeroAge = 9  # a more-minimal proxy
     SoladyPush0 = 10  # solady push0 minimal proxy
+    ClonesWithImmutableArgs = 11  # https://github.com/wighawag/clones-with-immutable-args/blob/master/src/ClonesWithImmutableArgs.sol
 
 
 class ProxyInfo(ProxyInfoAPI):

--- a/src/ape_ethereum/proxies.py
+++ b/src/ape_ethereum/proxies.py
@@ -24,7 +24,7 @@ class ProxyType(IntEnum):
     Delegate = 8  # eip-897 delegate proxy
     ZeroAge = 9  # a more-minimal proxy
     SoladyPush0 = 10  # solady push0 minimal proxy
-    ClonesWithImmutableArgs = 11  # https://github.com/wighawag/clones-with-immutable-args/blob/master/src/ClonesWithImmutableArgs.sol
+    ClonesWithImmutableArgs = 11  # https://github.com/wighawag/clones-with-immutable-args/blob/master/src/ClonesWithImmutableArgs.sol  # noqa: E501
 
 
 class ProxyInfo(ProxyInfoAPI):


### PR DESCRIPTION
### What I did

detect a new proxy type [described here](https://github.com/wighawag/clones-with-immutable-args/blob/master/src/ClonesWithImmutableArgs.sol) and used in [ajna protocol](https://etherscan.io/address/0x5b14144DA6FD5e3B158d6dF7B6ED8345829aAB78#code).

### How I did it

using exiting way to add a proxy type

### How to verify it

```python
> chain.provider.network.ecosystem.get_proxy_info('0x5b14144DA6FD5e3B158d6dF7B6ED8345829aAB78')
ProxyInfo(target='0x05bB4F6362B02F17C1A3F2B047A8b23368269A21', type=<ProxyType.ClonesWithImmutableArgs: 11>)
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
