### PR TITLE
feat: better organize proxies and add solady cwia

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -228,13 +228,13 @@ class Ethereum(EcosystemAPI):
             return None
 
         patterns = {
-            ProxyType.Minimal: r"363d3d373d3d3d363d73(.{40})5af43d82803e903d91602b57fd5bf3",
-            ProxyType.Vyper: r"366000600037611000600036600073(.{40})5af4602c57600080fd5b6110006000f3",  # noqa: E501
-            ProxyType.Clones: r"36603057343d52307f830d2d700a97af574b186c80d40429385d24241565b08a7c559ba283a964d9b160203da23d3df35b3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e605b57fd5bf3",  # noqa: E501
-            ProxyType.ZeroAge: r"3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e602a57fd5bf3",
-            ProxyType.SoladyPush0: r"5f5f365f5f37365f73(.{40})5af43d5f5f3e6029573d5ffd5b3d5ff3",
-            ProxyType.ClonesWithImmutableArgs: r"3d3d3d3d363d3d3761007f603736393661007f013d73(.{40})5af43d3d93803e603557fd5bf3.*",  # noqa: E501
-            ProxyType.Create2ClonesWithImmutableArgs: r"3d3d3d3d363d3d376100476037363936610047013d73(.{40})5af43d3d93803e603557fd5bf3.*",  # noqa: E501
+            ProxyType.Minimal: r"^363d3d373d3d3d363d73(.{40})5af43d82803e903d91602b57fd5bf3",
+            ProxyType.ZeroAge: r"^3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e602a57fd5bf3",
+            ProxyType.Clones: r"^36603057343d52307f830d2d700a97af574b186c80d40429385d24241565b08a7c559ba283a964d9b160203da23d3df35b3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e605b57fd5bf3",  # noqa: E501
+            ProxyType.Vyper: r"^366000600037611000600036600073(.{40})5af4602c57600080fd5b6110006000f3",  # noqa: E501
+            ProxyType.CWIA: r"^3d3d3d3d363d3d3761.{4}603736393661.{4}013d73(.{40})5af43d3d93803e603557fd5bf3.*",  # noqa: E501
+            ProxyType.SoladyCWIA: r"36602c57343d527f9e4ac34f21c619cefc926c8bd93b54bf5a39c7ab2127a895af1cc0691d7e3dff593da1005b363d3d373d3d3d3d61.{4}806062363936013d73(.{40})5af43d3d93803e606057fd5bf3.*",  # noqa: E501
+            ProxyType.SoladyPush0: r"^5f5f365f5f37365f73(.{40})5af43d5f5f3e6029573d5ffd5b3d5ff3",
         }
         for type, pattern in patterns.items():
             match = re.match(pattern, code)

--- a/src/ape_ethereum/proxies.py
+++ b/src/ape_ethereum/proxies.py
@@ -13,19 +13,41 @@ MINIMAL_PROXY_BYTES = (
 
 
 class ProxyType(IntEnum):
+    # https://eips.ethereum.org/EIPS/eip-1167
     Minimal = 0  # eip-1167 minimal proxy contract
+
+    # https://eips.ethereum.org/EIPS/eip-1967
     Standard = 1  # eip-1967 standard proxy storage slots
     Beacon = 2  # eip-1967 beacon proxy
+
+    # https://eips.ethereum.org/EIPS/eip-1822
     UUPS = 3  # # eip-1822 universal upgradeable proxy standard
+
+    # https://github.com/vyperlang/vyper/blob/v0.2.8/vyper/functions/functions.py#L1428
     Vyper = 4  # vyper <0.2.9 create_forwarder_to
+
+    # https://github.com/0xSplits/splits-contracts/blob/main/contracts/libraries/Clones.sol
     Clones = 5  # 0xsplits clones
+
+    # https://github.com/safe-global/safe-contracts/blob/main/contracts/proxies/SafeProxy.sol
     GnosisSafe = 6
+
+    # https://github.com/OpenZeppelin/openzeppelin-labs/blob/master/initializer_contracts/contracts/UpgradeabilityProxy.sol
     OpenZeppelin = 7  # openzeppelin upgradeability proxy
+
+    # https://eips.ethereum.org/EIPS/eip-897
     Delegate = 8  # eip-897 delegate proxy
+
+    # https://medium.com/coinmonks/the-more-minimal-proxy-5756ae08ee48
     ZeroAge = 9  # a more-minimal proxy
-    SoladyPush0 = 10  # solady push0 minimal proxy
-    ClonesWithImmutableArgs = 11  # https://github.com/wighawag/clones-with-immutable-args/blob/master/src/ClonesWithImmutableArgs.sol  # noqa: E501
-    Create2ClonesWithImmutableArgs = 12  # https://github.com/emo-eth/create2-clones-with-immutable-args/blob/main/src/Create2ClonesWithImmutableArgs.sol  # noqa: E501
+
+    # https://github.com/wighawag/clones-with-immutable-args/blob/master/src/ClonesWithImmutableArgs.sol
+    # https://github.com/emo-eth/create2-clones-with-immutable-args/blob/main/src/Create2ClonesWithImmutableArgs.sol
+    CWIA = 10  # clones with immutable args
+
+    # https://github.com/Vectorized/solady/blob/main/src/utils/LibClone.sol
+    SoladyPush0 = 11  # solady push0 minimal proxy
+    SoladyCWIA = 12  # clones with immutable args with a receive method
 
 
 class ProxyInfo(ProxyInfoAPI):


### PR DESCRIPTION
### What I did

- add support for [solady's clones with immutable arguments](https://github.com/Vectorized/solady/blob/6c54795ef69838e233020e9ab29f3f6288efdf06/src/utils/LibClone.sol#L298) (CWIA) variant of minimal proxies
- better organize proxies, adding useful links to their implementations or specifications
- order code matching patterns by popularity on mainnet
- fix handling of extra data length bytes in CWIA proxies

### How I did it

to rank by popularity i [wrote a script](https://gist.github.com/banteg/f118d431fba39f66d948c5e8ffdc7e4d) that allows to regex search through the contract codes. these are the results.

| proxy type | count |
|--------|--------|
| eip-1167 | 13,265,959 | 
| 0xage | 9,824 | 
| 0xsplits clones | 2,804 | 
| vyper <0.2.9 | 481 | 
| clones with immutable args | 246 | 
| solady cwia | 75 | 
| solady push0 | 5 | 



</p>
</details> 


### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
