### PR TITLE
refactor!: accept any msg type via `AccountAPI.sign_message` [APE-1305]

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterator, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Type, Union
 
 import click
 from eip712.messages import SignableMessage as EIP712SignableMessage
@@ -54,18 +54,21 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         return None
 
     @abstractmethod
-    def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
+    def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
         """
         Sign a message.
 
         Args:
-          msg (:class:`~ape.types.signatures.SignableMessage`): The message to sign.
+          msg (Any): The message to sign. Account plugins can handle various types of messages.
+            For example, :class:`~ape.accounts.LocalAccount` can handle
+            :class:`~ape.types.signatures.SignableMessage`
             See these
             `docs <https://eth-account.readthedocs.io/en/stable/eth_account.html#eth_account.messages.SignableMessage>`__  # noqa: E501
             for more type information on this type.
+          **signer_options: Additional kwargs given to the signer to modify the signing operation.
 
         Returns:
-          :class:`~ape.types.signatures.MessageSignature` (optional): The signed message.
+            :class:`~ape.types.signatures.MessageSignature` (optional): The signed message.
         """
 
     @abstractmethod
@@ -494,7 +497,7 @@ class ImpersonatedAccount(AccountAPI):
     def address(self) -> AddressType:
         return self.raw_address
 
-    def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
+    def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
         raise NotImplementedError("This account cannot sign messages")
 
     def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -68,7 +68,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
           **signer_options: Additional kwargs given to the signer to modify the signing operation.
 
         Returns:
-            :class:`~ape.types.signatures.MessageSignature` (optional): The signed message.
+            :class:`~ape.types.signatures.MessageSignature` (optional): The signature corresponding to the message.
         """
 
     @abstractmethod

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -6,6 +6,7 @@ from eip712.messages import EIP712Message
 from eip712.messages import SignableMessage as EIP712SignableMessage
 from eth_account import Account
 from eth_account.messages import encode_defunct
+from hexbytes import HexBytes
 
 from ape.api.address import BaseAddress
 from ape.api.transactions import ReceiptAPI, TransactionAPI
@@ -263,7 +264,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
 
     def check_signature(
         self,
-        data: Union[SignableMessage, TransactionAPI, str, EIP712Message],
+        data: Union[SignableMessage, TransactionAPI, str, EIP712Message, int],
         signature: Optional[MessageSignature] = None,  # TransactionAPI doesn't need it
     ) -> bool:
         """
@@ -280,6 +281,8 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         """
         if isinstance(data, str):
             data = encode_defunct(text=data)
+        elif isinstance(data, int):
+            data = encode_defunct(hexstr=HexBytes(data).hex())
         if isinstance(data, EIP712Message):
             data = data.signable_message
         if isinstance(data, (SignableMessage, EIP712SignableMessage)):

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -67,11 +67,11 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
             :class:`~ape.types.signatures.SignableMessage`, str, int, and bytes.
             See these
             `docs <https://eth-account.readthedocs.io/en/stable/eth_account.html#eth_account.messages.SignableMessage>`__  # noqa: E501
-            for more type information on this type.
+            for more type information on the ``SignableMessage`` type.
           **signer_options: Additional kwargs given to the signer to modify the signing operation.
 
         Returns:
-            :class:`~ape.types.signatures.MessageSignature` (optional): The signature corresponding to the message.
+          :class:`~ape.types.signatures.MessageSignature` (optional): The signature corresponding to the message.
         """
 
     @abstractmethod

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -2,7 +2,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Type, Union
 
 import click
-from eip712.messages import EIP712Message, SignableMessage as EIP712SignableMessage
+from eip712.messages import EIP712Message
+from eip712.messages import SignableMessage as EIP712SignableMessage
 from eth_account import Account
 from eth_account.messages import encode_defunct
 

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -283,7 +283,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
             data = encode_defunct(text=data)
         elif isinstance(data, int):
             data = encode_defunct(hexstr=HexBytes(data).hex())
-        if isinstance(data, EIP712Message):
+        elif isinstance(data, EIP712Message):
             data = data.signable_message
         if isinstance(data, (SignableMessage, EIP712SignableMessage)):
             if signature:

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -63,8 +63,8 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
 
         Args:
           msg (Any): The message to sign. Account plugins can handle various types of messages.
-            For example, :class:`~ape.accounts.LocalAccount` can handle
-            :class:`~ape.types.signatures.SignableMessage`
+            For example, :class:`~ape_accounts.accouns.KeyfileAccount` can handle
+            :class:`~ape.types.signatures.SignableMessage`, str, int, and bytes.
             See these
             `docs <https://eth-account.readthedocs.io/en/stable/eth_account.html#eth_account.messages.SignableMessage>`__  # noqa: E501
             for more type information on this type.

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -158,22 +158,20 @@ class KeyfileAccount(AccountAPI):
         self.keyfile_path.unlink()
 
     def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
-        if not isinstance(msg, (SignableMessage, EIP712Message, str, int, bytes)):
-            logger.warning("Unsupported message type, (type=%r, msg=%r)", type(msg), msg)
-            return None
-
         user_approves = False
 
         if isinstance(msg, str):
-            # Convert str to SignableMessage for handling below
             user_approves = self.__autosign or click.confirm(f"Message: {msg}\n\nSign: ")
             msg = encode_defunct(text=msg)
         elif isinstance(msg, int):
             user_approves = self.__autosign or click.confirm(f"Message: {msg}\n\nSign: ")
             msg = encode_defunct(hexstr=HexBytes(msg).hex())
+        elif isinstance(msg, bytes):
+            user_approves = self.__autosign or click.confirm(f"Message: {msg.hex()}\n\nSign: ")
+            msg = encode_defunct(primitive=msg)
         elif isinstance(msg, EIP712Message):
             # Display message data to user
-            display_msg = "Signing Message\n"
+            display_msg = f"Signing EIP712 Message\n"
 
             # Domain Data
             display_msg += "Domain\n"
@@ -197,7 +195,12 @@ class KeyfileAccount(AccountAPI):
 
             # Convert EIP712Message to SignableMessage for handling below
             msg = msg.signable_message
-        elif isinstance(msg, SignableMessage):
+        else:
+            logger.warning("Unsupported message type, (type=%r, msg=%r)", type(msg), msg)
+            return None
+
+        # msg should be a SignableMessage at this point
+        if isinstance(msg, SignableMessage):
             user_approves = self.__autosign or click.confirm(f"{msg}\n\nSign: ")
 
         if not user_approves:

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -158,7 +158,7 @@ class KeyfileAccount(AccountAPI):
         self.keyfile_path.unlink()
 
     def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
-        if not isinstance(msg, (SignableMessage, EIP712Message, str, int)):
+        if not isinstance(msg, (SignableMessage, EIP712Message, str, int, bytes)):
             logger.warning("Unsupported message type, (type=%r, msg=%r)", type(msg), msg)
             return None
 
@@ -197,6 +197,8 @@ class KeyfileAccount(AccountAPI):
 
             # Convert EIP712Message to SignableMessage for handling below
             msg = msg.signable_message
+        elif isinstance(msg, SignableMessage):
+            user_approves = self.__autosign or click.confirm(f"{msg}\n\nSign: ")
 
         if not user_approves:
             return None

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -174,7 +174,8 @@ class KeyfileAccount(AccountAPI):
                 r=to_bytes(signed_msg.r),
                 s=to_bytes(signed_msg.s),
             )
-        raise TypeError(f"Can't sign message of type {type(msg)}")
+        logger.warning("Unsupported message type, (type=%r, msg=%r)", type(msg), msg)
+        return None
 
     def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:
         user_approves = self.__autosign or click.confirm(f"{txn}\n\nSign: ")

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -171,7 +171,7 @@ class KeyfileAccount(AccountAPI):
             msg = encode_defunct(primitive=msg)
         elif isinstance(msg, EIP712Message):
             # Display message data to user
-            display_msg = f"Signing EIP712 Message\n"
+            display_msg = "Signing EIP712 Message\n"
 
             # Domain Data
             display_msg += "Domain\n"

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -162,11 +162,36 @@ class KeyfileAccount(AccountAPI):
             logger.warning("Unsupported message type, (type=%r, msg=%r)", type(msg), msg)
             return None
 
-        user_approves = self.__autosign or click.confirm(f"Message: {msg}\n\nSign: ")
+        user_approves = False
+
         if isinstance(msg, str):
             # Convert str to SignableMessage for handling below
+            user_approves = self.__autosign or click.confirm(f"Message: {msg}\n\nSign: ")
             msg = encode_defunct(text=msg)
         elif isinstance(msg, EIP712Message):
+            # Display message data to user
+            display_msg = "Signing Message\n"
+
+            # Domain Data
+            display_msg += "Domain\n"
+            if msg._name_:
+                display_msg += f"\tName: {msg._name_}\n"
+            if msg._version_:
+                display_msg += f"\tVersion: {msg._version_}\n"
+            if msg._chainId_:
+                display_msg += f"\tChain ID: {msg._chainId_}\n"
+            if msg._verifyingContract_:
+                display_msg += f"\tContract: {msg._verifyingContract_}\n"
+            if msg._salt_:
+                display_msg += f"\tSalt: {msg._salt_}\n"
+
+            # Message Data
+            display_msg += "Message\n"
+            for field, value in msg._body_["message"].items():
+                display_msg += f"\t{field}: {value}\n"
+
+            user_approves = self.__autosign or click.confirm(f"{display_msg}\nSign: ")
+
             # Convert EIP712Message to SignableMessage for handling below
             msg = msg.signable_message
 

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -203,6 +203,7 @@ class KeyfileAccount(AccountAPI):
 
         if not user_approves:
             return None
+
         signed_msg = EthAccount.sign_message(msg, self.__key)
         return MessageSignature(
             v=signed_msg.v,

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -158,6 +158,7 @@ class KeyfileAccount(AccountAPI):
 
     def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
         if isinstance(msg, str):
+            # Convert to SignableMessage for handling below
             msg = encode_defunct(text=msg)
         if isinstance(msg, SignableMessage):
             user_approves = self.__autosign or click.confirm(f"{msg}\n\nSign: ")

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -158,7 +158,7 @@ class KeyfileAccount(AccountAPI):
         self.keyfile_path.unlink()
 
     def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
-        if not isinstance(msg, (SignableMessage, EIP712Message, str)):
+        if not isinstance(msg, (SignableMessage, EIP712Message, str, int)):
             logger.warning("Unsupported message type, (type=%r, msg=%r)", type(msg), msg)
             return None
 
@@ -168,6 +168,9 @@ class KeyfileAccount(AccountAPI):
             # Convert str to SignableMessage for handling below
             user_approves = self.__autosign or click.confirm(f"Message: {msg}\n\nSign: ")
             msg = encode_defunct(text=msg)
+        elif isinstance(msg, int):
+            user_approves = self.__autosign or click.confirm(f"Message: {msg}\n\nSign: ")
+            msg = encode_defunct(hexstr=HexBytes(msg).hex())
         elif isinstance(msg, EIP712Message):
             # Display message data to user
             display_msg = "Signing Message\n"

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -1,10 +1,11 @@
 import json
 from os import environ
 from pathlib import Path
-from typing import Dict, Iterator, Optional
+from typing import Any, Dict, Iterator, Optional
 
 import click
 from eth_account import Account as EthAccount
+from eth_account.messages import encode_defunct
 from eth_keys import keys  # type: ignore
 from eth_utils import to_bytes
 from ethpm_types import HexBytes
@@ -155,17 +156,20 @@ class KeyfileAccount(AccountAPI):
         self.__decrypt_keyfile(passphrase)
         self.keyfile_path.unlink()
 
-    def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
-        user_approves = self.__autosign or click.confirm(f"{msg}\n\nSign: ")
-        if not user_approves:
-            return None
-
-        signed_msg = EthAccount.sign_message(msg, self.__key)
-        return MessageSignature(
-            v=signed_msg.v,
-            r=to_bytes(signed_msg.r),
-            s=to_bytes(signed_msg.s),
-        )
+    def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
+        if isinstance(msg, str):
+            msg = encode_defunct(text=msg)
+        if isinstance(msg, SignableMessage):
+            user_approves = self.__autosign or click.confirm(f"{msg}\n\nSign: ")
+            if not user_approves:
+                return None
+            signed_msg = EthAccount.sign_message(msg, self.__key)
+            return MessageSignature(
+                v=signed_msg.v,
+                r=to_bytes(signed_msg.r),
+                s=to_bytes(signed_msg.s),
+            )
+        raise TypeError(f"Can't sign message of type {type(msg)}")
 
     def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:
         user_approves = self.__autosign or click.confirm(f"{txn}\n\nSign: ")

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -183,7 +183,7 @@ class KeyfileAccount(AccountAPI):
             if msg._verifyingContract_:
                 display_msg += f"\tContract: {msg._verifyingContract_}\n"
             if msg._salt_:
-                display_msg += f"\tSalt: {msg._salt_}\n"
+                display_msg += f"\tSalt: {msg._salt_.decode('utf-8')}\n"
 
             # Message Data
             display_msg += "Message\n"

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, Optional
 
 import click
+from eip712.messages import EIP712Message
 from eth_account import Account as EthAccount
 from eth_account.messages import encode_defunct
 from eth_keys import keys  # type: ignore
@@ -158,8 +159,11 @@ class KeyfileAccount(AccountAPI):
 
     def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
         if isinstance(msg, str):
-            # Convert to SignableMessage for handling below
+            # Convert str to SignableMessage for handling below
             msg = encode_defunct(text=msg)
+        elif isinstance(msg, EIP712Message):
+            # Convert EIP712Message to SignableMessage for handling below
+            msg = msg.signable_message
         if isinstance(msg, SignableMessage):
             user_approves = self.__autosign or click.confirm(f"{msg}\n\nSign: ")
             if not user_approves:

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -186,7 +186,7 @@ class KeyfileAccount(AccountAPI):
             if msg._verifyingContract_:
                 display_msg += f"\tContract: {msg._verifyingContract_}\n"
             if msg._salt_:
-                display_msg += f"\tSalt: {msg._salt_.decode('utf-8')}\n"
+                display_msg += f"\tSalt: 0x{msg._salt_.hex()}\n"
 
             # Message Data
             display_msg += "Message\n"

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -158,24 +158,26 @@ class KeyfileAccount(AccountAPI):
         self.keyfile_path.unlink()
 
     def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
+        if not isinstance(msg, (SignableMessage, EIP712Message, str)):
+            logger.warning("Unsupported message type, (type=%r, msg=%r)", type(msg), msg)
+            return None
+
+        user_approves = self.__autosign or click.confirm(f"Message: {msg}\n\nSign: ")
         if isinstance(msg, str):
             # Convert str to SignableMessage for handling below
             msg = encode_defunct(text=msg)
         elif isinstance(msg, EIP712Message):
             # Convert EIP712Message to SignableMessage for handling below
             msg = msg.signable_message
-        if isinstance(msg, SignableMessage):
-            user_approves = self.__autosign or click.confirm(f"{msg}\n\nSign: ")
-            if not user_approves:
-                return None
-            signed_msg = EthAccount.sign_message(msg, self.__key)
-            return MessageSignature(
-                v=signed_msg.v,
-                r=to_bytes(signed_msg.r),
-                s=to_bytes(signed_msg.s),
-            )
-        logger.warning("Unsupported message type, (type=%r, msg=%r)", type(msg), msg)
-        return None
+
+        if not user_approves:
+            return None
+        signed_msg = EthAccount.sign_message(msg, self.__key)
+        return MessageSignature(
+            v=signed_msg.v,
+            r=to_bytes(signed_msg.r),
+            s=to_bytes(signed_msg.s),
+        )
 
     def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:
         user_approves = self.__autosign or click.confirm(f"{txn}\n\nSign: ")

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -195,13 +195,11 @@ class KeyfileAccount(AccountAPI):
 
             # Convert EIP712Message to SignableMessage for handling below
             msg = msg.signable_message
+        elif isinstance(msg, SignableMessage):
+            user_approves = self.__autosign or click.confirm(f"{msg}\n\nSign: ")
         else:
             logger.warning("Unsupported message type, (type=%r, msg=%r)", type(msg), msg)
             return None
-
-        # msg should be a SignableMessage at this point
-        if isinstance(msg, SignableMessage):
-            user_approves = self.__autosign or click.confirm(f"{msg}\n\nSign: ")
 
         if not user_approves:
             return None

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -1,7 +1,7 @@
-from typing import Iterator, List, Optional
+from typing import Any, Iterator, List, Optional
 
 from eth_account import Account as EthAccount
-from eth_account.messages import SignableMessage
+from eth_account.messages import SignableMessage, encode_defunct
 from eth_utils import to_bytes
 
 from ape.api import TestAccountAPI, TestAccountContainerAPI, TransactionAPI
@@ -101,13 +101,16 @@ class TestAccount(TestAccountAPI):
     def address(self) -> AddressType:
         return self.network_manager.ethereum.decode_address(self.address_str)
 
-    def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
-        signed_msg = EthAccount.sign_message(msg, self.private_key)
-        return MessageSignature(
-            v=signed_msg.v,
-            r=to_bytes(signed_msg.r),
-            s=to_bytes(signed_msg.s),
-        )
+    def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
+        if isinstance(msg, str):
+            msg = encode_defunct(text=msg)
+        if isinstance(msg, SignableMessage):
+            signed_msg = EthAccount.sign_message(msg, self.private_key)
+            return MessageSignature(
+                v=signed_msg.v,
+                r=to_bytes(signed_msg.r),
+                s=to_bytes(signed_msg.s),
+            )
 
     def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:
         # Signs anything that's given to it

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -3,6 +3,7 @@ from typing import Any, Iterator, List, Optional
 from eth_account import Account as EthAccount
 from eth_account.messages import SignableMessage, encode_defunct
 from eth_utils import to_bytes
+from hexbytes import HexBytes
 
 from ape.api import TestAccountAPI, TestAccountContainerAPI, TransactionAPI
 from ape.types import AddressType, MessageSignature, TransactionSignature
@@ -102,8 +103,14 @@ class TestAccount(TestAccountAPI):
         return self.network_manager.ethereum.decode_address(self.address_str)
 
     def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
+        # Convert str and int to SignableMessage if needed
         if isinstance(msg, str):
             msg = encode_defunct(text=msg)
+        elif isinstance(msg, int):
+            msg = HexBytes(msg).hex()
+            msg = encode_defunct(hexstr=msg)
+
+        # Process SignableMessage
         if isinstance(msg, SignableMessage):
             signed_msg = EthAccount.sign_message(msg, self.private_key)
             return MessageSignature(

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -111,6 +111,7 @@ class TestAccount(TestAccountAPI):
                 r=to_bytes(signed_msg.r),
                 s=to_bytes(signed_msg.s),
             )
+        return None
 
     def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:
         # Signs anything that's given to it

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -53,6 +53,12 @@ def test_sign_message(signer, message):
     assert signer.check_signature(message, signature)
 
 
+def test_sign_message_unsupported_type_returns_none(signer):
+    message = 1234
+    signature = signer.sign_message(message)
+    assert signature is None
+
+
 def test_recover_signer(signer, message):
     signature = signer.sign_message(message)
     assert recover_signer(message, signature) == signer

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -53,6 +53,12 @@ def test_sign_message(signer, message):
     assert signer.check_signature(message, signature)
 
 
+def test_sign_string(signer):
+    message = "Hello Apes!"
+    signature = signer.sign_message(message)
+    assert signer.check_signature(message, signature)
+
+
 def test_sign_message_unsupported_type_returns_none(signer):
     message = 1234
     signature = signer.sign_message(message)

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -59,8 +59,14 @@ def test_sign_string(signer):
     assert signer.check_signature(message, signature)
 
 
+def test_sign_int(signer):
+    message = 4
+    signature = signer.sign_message(message)
+    assert signer.check_signature(message, signature)
+
+
 def test_sign_message_unsupported_type_returns_none(signer):
-    message = 1234
+    message = 1234.123
     signature = signer.sign_message(message)
     assert signature is None
 


### PR DESCRIPTION
### What I did

Refactor the definition of sign_message to accept Any. Signers implementing this class can raise when they receive a message type they can't handle.

Account plugins would each individual handle msg objects by type, including how they might display information from them for user feedback in terms of signing. This will improve UX because now we can display the text of a string message to sign (useful for displaying SIWE [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) authorizations), the complete object body and header for EIP-712 structured messages, and other future types of messages that might become necessary to support within Ape (EIP-4337?)


fixes: APE-1103

### How I did it

Change type signature of sign_message function, and update implementors to match the new definition.

### How to verify it

Run existing test suite

### Checklist

- [x] All changes are completed
- [ ] New test cases have been added
- [x] Documentation has been updated
