### PR TITLE
feat!: change CompileAPI to ecosystem based compilers [APE-1322]

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,7 +95,7 @@ jobs:
             pip install .[test]
 
         - name: Run Tests
-          run: pytest -m "not fuzzing" -s --cov=src -n auto --dist loadscope
+          run: ape test -m "not fuzzing" -s --cov=src --dist loadscope
 
     fuzzing:
         runs-on: ubuntu-latest
@@ -117,4 +117,4 @@ jobs:
             pip install .[test]
 
         - name: Run Tests
-          run: pytest -m "fuzzing" --no-cov -s
+          run: ape test -m "fuzzing" --no-cov -s

--- a/src/ape/api/compiler.py
+++ b/src/ape/api/compiler.py
@@ -30,6 +30,11 @@ class CompilerAPI(BaseInterfaceModel):
     def name(self) -> str:
         ...
 
+    @property
+    @abstractmethod
+    def extension(self) -> str:
+        ...
+
     @abstractmethod
     def get_versions(self, all_paths: List[Path]) -> Set[str]:
         """

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -153,7 +153,8 @@ class ProjectAPI(BaseInterfaceModel):
 
     @property
     def _cache_folder(self) -> Path:
-        folder = self.contracts_folder.parent / ".build"
+        current_ecosystem = self.network_manager.network.ecosystem.name
+        folder = self.contracts_folder.parent / ".build" / current_ecosystem
         # NOTE: If we use the cache folder, we expect it to exist
         folder.mkdir(exist_ok=True, parents=True)
         return folder

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -125,8 +125,8 @@ class BaseProject(ProjectAPI):
             return files
 
         compilers = self.compiler_manager.registered_compilers
-        for extension in compilers:
-            ext = extension.replace(".", "\\.")
+        for compiler in compilers.values():
+            ext = compiler.extension.replace(".", "\\.")
             pattern = rf"[\w|-]+{ext}"
             ext_files = get_all_files_in_directory(self.contracts_folder, pattern=pattern)
             files.extend(ext_files)

--- a/src/ape/plugins/compiler.py
+++ b/src/ape/plugins/compiler.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Type
+from typing import Type
 
 from ape.api import CompilerAPI
 
@@ -13,7 +13,7 @@ class CompilerPlugin(PluginType):
     """
 
     @hookspec
-    def register_compiler(self) -> Tuple[Tuple[str], Type[CompilerAPI]]:  # type: ignore[empty-body]
+    def register_compiler(self) -> Type[CompilerAPI]:  # type: ignore[empty-body]
         """
         A hook for returning the set of file extensions the plugin handles
         and the compiler class that can be used to compile them.
@@ -22,8 +22,8 @@ class CompilerPlugin(PluginType):
 
             @plugins.register(plugins.CompilerPlugin)
             def register_compiler():
-                return (".json",), InterfaceCompiler
+                return InterfaceCompiler
 
         Returns:
-            Tuple[Tuple[str], Type[:class:`~ape.api.CompilerAPI`]]
+            Type[:class:`~ape.api.CompilerAPI`]
         """

--- a/src/ape/pytest/coverage.py
+++ b/src/ape/pytest/coverage.py
@@ -49,10 +49,11 @@ class CoverageData(ManagerAccessMixin):
         for src in self.sources:
             source_cov = project_coverage.include(src)
             ext = Path(src.source_id).suffix
-            if ext not in self.compiler_manager.registered_compilers:
+            if ext not in self.compiler_manager.supported_extensions:
                 continue
 
-            compiler = self.compiler_manager.registered_compilers[ext]
+            compiler = self.compiler_manager.get_compiler(ext)
+            assert compiler is not None
             try:
                 compiler.init_coverage_profile(source_cov, src)
             except NotImplementedError:

--- a/src/ape/types/trace.py
+++ b/src/ape/types/trace.py
@@ -503,10 +503,11 @@ class SourceTraceback(BaseModel):
             return cls.parse_obj([])
 
         ext = f".{source_id.split('.')[-1]}"
-        if ext not in accessor.compiler_manager.registered_compilers:
+        if ext not in accessor.compiler_manager.supported_extensions:
             return cls.parse_obj([])
 
-        compiler = accessor.compiler_manager.registered_compilers[ext]
+        compiler = accessor.compiler_manager.get_compiler(ext)
+        assert compiler is not None
         try:
             return compiler.trace_source(contract_type, trace, HexBytes(data))
         except NotImplementedError:

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -4,14 +4,19 @@ from typing import Dict, Set
 import click
 from ethpm_types import ContractType
 
-from ape.cli import ape_cli_context, contract_file_paths_argument
+from ape.cli import (
+    NetworkBoundCommand,
+    ape_cli_context,
+    contract_file_paths_argument,
+    network_option,
+)
 
 
 def _include_dependencies_callback(ctx, param, value):
     return value or ctx.obj.config_manager.get_config("compile").include_dependencies
 
 
-@click.command(short_help="Compile select contract source files")
+@click.command(short_help="Compile select contract source files", cls=NetworkBoundCommand)
 @contract_file_paths_argument()
 @click.option(
     "-f",
@@ -37,7 +42,15 @@ def _include_dependencies_callback(ctx, param, value):
     callback=_include_dependencies_callback,
 )
 @ape_cli_context()
-def cli(cli_ctx, file_paths: Set[Path], use_cache: bool, display_size: bool, include_dependencies):
+@network_option()
+def cli(
+    cli_ctx,
+    file_paths: Set[Path],
+    use_cache: bool,
+    display_size: bool,
+    include_dependencies: bool,
+    network: str,
+):
     """
     Compiles the manifest for this project and saves the results
     back to the manifest.

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -152,6 +152,7 @@ class EthereumConfig(PluginConfig):
     sepolia_fork: NetworkConfig = _create_local_config()
     local: NetworkConfig = _create_local_config(default_provider="test")
     default_network: str = LOCAL_NETWORK_NAME
+    compilers: Dict[str, Dict[str, Any]] = {"ethpm": {}}
 
 
 class Block(BlockAPI):

--- a/src/ape_pm/__init__.py
+++ b/src/ape_pm/__init__.py
@@ -5,4 +5,4 @@ from .compiler import InterfaceCompiler
 
 @plugins.register(plugins.CompilerPlugin)
 def register_compiler():
-    return (".json",), InterfaceCompiler
+    return InterfaceCompiler

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -16,6 +16,10 @@ class InterfaceCompiler(CompilerAPI):
     def name(self) -> str:
         return "ethpm"
 
+    @property
+    def extension(self) -> str:
+        return ".json"
+
     def get_versions(self, all_paths: List[Path]) -> Set[str]:
         # NOTE: This bypasses the serialization of this compiler into the package manifest's
         #       ``compilers`` field. You should not do this with a real compiler plugin.

--- a/src/ape_test/_cli.py
+++ b/src/ape_test/_cli.py
@@ -11,7 +11,7 @@ import pytest
 from watchdog import events  # type: ignore
 from watchdog.observers import Observer  # type: ignore
 
-from ape.cli import ape_cli_context
+from ape.cli import NetworkBoundCommand, ape_cli_context, network_option
 from ape.utils import ManagerAccessMixin, cached_property
 
 # Copied from https://github.com/olzhasar/pytest-watcher/blob/master/pytest_watcher/watcher.py
@@ -44,7 +44,7 @@ class EventHandler(events.FileSystemEventHandler, ManagerAccessMixin):
 
     @cached_property
     def _extensions_to_watch(self) -> List[str]:
-        return [".py", *self.compiler_manager.registered_compilers.keys()]
+        return [".py", *self.compiler_manager.supported_extensions]
 
     def _is_path_watched(self, filepath: str) -> bool:
         """
@@ -78,8 +78,10 @@ def _run_main_loop(delay: float, pytest_args: Sequence[str]) -> None:
     add_help_option=False,  # NOTE: This allows pass-through to pytest's help
     short_help="Launches pytest and runs the tests for a project",
     context_settings=dict(ignore_unknown_options=True),
+    cls=NetworkBoundCommand,
 )
 @ape_cli_context()
+@network_option()
 @click.option(
     "-w",
     "--watch",
@@ -104,7 +106,7 @@ def _run_main_loop(delay: float, pytest_args: Sequence[str]) -> None:
     help="Delay between polling cycles for `ape test --watch`. Defaults to 0.5 seconds.",
 )
 @click.argument("pytest_args", nargs=-1, type=click.UNPROCESSED)
-def cli(cli_ctx, watch, watch_folders, watch_delay, pytest_args):
+def cli(cli_ctx, watch, watch_folders, watch_delay, pytest_args, network):
     if watch:
         event_handler = EventHandler()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from click.testing import CliRunner
 
 import ape
 from ape.exceptions import APINotImplementedError, UnknownSnapshotError
+from ape.logging import logger
 from ape.managers.config import CONFIG_FILE_NAME
 from ape.types import AddressType
 from ape.utils import ZERO_ADDRESS
@@ -319,8 +320,11 @@ def skip_if_plugin_installed(*plugin_names: str):
         for name in names:
             # Compilers
             if name in ("solidity", "vyper"):
-                compiler = ape.compilers.get_compiler(name)
-                if compiler:
+                try:
+                    ape.compilers.get_compiler(name)
+                except ValueError:
+                    logger.debug(f"Compiler not found: {name}")
+                else:
 
                     def test_skip_from_compiler():
                         pytest.mark.skip(msg_f.format(name))

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -239,8 +239,9 @@ def project_with_contract(temp_config):
 def project_with_source_files_contract(temp_config):
     bases_source_dir = BASE_SOURCES_DIRECTORY
     project_source_dir = APE_PROJECT_FOLDER
+    data = {"ethereum": {"compilers": ["ethpm"]}}
 
-    with temp_config() as project:
+    with temp_config(data) as project:
         copy_tree(str(project_source_dir), str(project.path))
         copy_tree(str(bases_source_dir), f"{project.path}/contracts/")
         yield project

--- a/tests/functional/data/projects/ApeProject/ape-config.yaml
+++ b/tests/functional/data/projects/ApeProject/ape-config.yaml
@@ -1,1 +1,5 @@
 contracts_folder: ./contracts
+
+ethereum:
+  compilers:
+    - ethpm

--- a/tests/integration/cli/projects/empty-config/ape-config.yaml
+++ b/tests/integration/cli/projects/empty-config/ape-config.yaml
@@ -1,1 +1,4 @@
 # Empty config
+ethereum:
+  compilers:
+    - ethpm

--- a/tests/integration/cli/projects/geth/ape-config.yaml
+++ b/tests/integration/cli/projects/geth/ape-config.yaml
@@ -1,6 +1,8 @@
 ethereum:
   local:
     default_provider: geth
+  compilers:
+    - ethpm
 
 # Change the default URI for one of the networks to
 # ensure that the default values of the other networks

--- a/tests/integration/cli/projects/only-dependencies/ape-config.yaml
+++ b/tests/integration/cli/projects/only-dependencies/ape-config.yaml
@@ -7,3 +7,7 @@ compile:
   # NOTE: this should say `include_dependencies: false` below.
   # (it gets replaced with `true` in a test temporarily)
   include_dependencies: false
+
+ethereum:
+  compilers:
+    - ethpm

--- a/tests/integration/cli/projects/test/ape-config.yaml
+++ b/tests/integration/cli/projects/test/ape-config.yaml
@@ -1,3 +1,7 @@
 test:
   # `false` because running pytest within pytest.
   disconnect_providers_after: false
+
+ethereum:
+  compilers:
+    - ethpm

--- a/tests/integration/cli/projects/with-contracts/ape-config.yaml
+++ b/tests/integration/cli/projects/with-contracts/ape-config.yaml
@@ -12,3 +12,7 @@ compile:
   exclude:
     - exclude_dir/*
     - Excl*.json
+
+ethereum:
+  compilers:
+    - ethpm

--- a/tests/integration/cli/projects/with-dependencies/ape-config.yaml
+++ b/tests/integration/cli/projects/with-dependencies/ape-config.yaml
@@ -15,3 +15,7 @@ dependencies:
 
   - name: renamed-contracts-folder-specified-in-config
     local: ./renamed_contracts_folder_specified_in_config
+
+ethereum:
+  compilers:
+    - ethpm

--- a/tests/integration/cli/projects/with-dependencies/containing_sub_dependencies/ape-config.yaml
+++ b/tests/integration/cli/projects/with-dependencies/containing_sub_dependencies/ape-config.yaml
@@ -1,3 +1,7 @@
 dependencies:
   - name: sub-dependency
     local: ./sub_dependency
+
+ethereum:
+  compilers:
+    - ethpm

--- a/tests/integration/cli/projects/with-dependencies/renamed_contracts_folder_specified_in_config/ape-config.yaml
+++ b/tests/integration/cli/projects/with-dependencies/renamed_contracts_folder_specified_in_config/ape-config.yaml
@@ -1,1 +1,5 @@
 contracts_folder: my_contracts
+
+ethereum:
+  compilers:
+    - ethpm


### PR DESCRIPTION
### What I did

Changed CompilerAPI so that we can select which compilers to be used in compilation process, so same extensions can be used as plugin as long as you dont use them at the same time for ecosystem configurations. .build/ folder now generates summary per ecosystem.

fixes: #

### How to verify it

Run tests.

### Checklist

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
