### PR TITLE
feat: added option to load contracts using `ABIs`

### DIFF
--- a/docs/userguides/contracts.md
+++ b/docs/userguides/contracts.md
@@ -98,6 +98,21 @@ from ape import Contract
 contract = Contract("v2.registry.ychad.eth")
 ```
 
+## From ABIs
+
+You can load contracts using their ABIs:
+
+```python
+from ape import Contract
+
+address = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45"
+abi = '[{"inputs":[{"internalType":"contract MultiWrapper"...]
+
+contract = Contract(address, abi=abi)
+```
+
+This will create the Contract instance from the given ABI. 
+
 ## From Previous Deployment
 
 Ape keeps track of your deployments for you so you can always refer back to a version that you deployed previously.

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -669,3 +669,18 @@ def test_get_contract_receipt(chain, vyper_contract_instance):
     chain.mine()
     receipt = chain.contracts.get_creation_receipt(address)
     assert receipt.contract_address == address
+
+
+def test_load_solidity_contract_from_abi():
+    # USDC contract
+    abi = '[{"constant":false,"inputs":[{"name":"newImplementation","type":"address"}],"name":"upgradeTo","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"newImplementation","type":"address"},{"name":"data","type":"bytes"}],"name":"upgradeToAndCall","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"constant":true,"inputs":[],"name":"implementation","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"newAdmin","type":"address"}],"name":"changeAdmin","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"admin","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"inputs":[{"name":"_implementation","type":"address"}],"payable":false,"stateMutability":"nonpayable","type":"constructor"},{"payable":true,"stateMutability":"payable","type":"fallback"},{"anonymous":false,"inputs":[{"indexed":false,"name":"previousAdmin","type":"address"},{"indexed":false,"name":"newAdmin","type":"address"}],"name":"AdminChanged","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"implementation","type":"address"}],"name":"Upgraded","type":"event"}]'
+    address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+
+    contract = ape.Contract(address, abi=abi)
+
+    assert isinstance(contract, ContractInstance)
+    assert contract.address == address
+
+
+def test_load_vyper_contract_from_abi():
+    pass


### PR DESCRIPTION
### What I did

Added the option to load contracts using `ABIs`.
#### Example
```py

contract = Contract(address, abi=abi)
```


fixes: #1615

### How I did it

Added the option to pass `abi` in the `instance_at` method of `ape.managers.chain.ContractCache` Class.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->
1. Clone this revision & install it using pip. Or use poetry to run a virtual enviroment.
- Sample `pyproject.toml` for poetry
```bash
[tool.poetry]
name = "load_contracts_from_abi"
version = "0.1.0"
description = ""
authors = ["Your Name <you@example.com>"]
readme = "README.md"
packages = [{include = "load_contracts_from_abi"}]

[tool.poetry.dependencies]
python = ">=3.10,<3.11"
eth-ape = "*"
ape-alchemy = "^0.6.2"
ape-solidity= "^0.6.7"
ape-foundry = "^0.6.14"
ape-etherscan = "*"
```
2. Run `poetry install && poetry shell`
3. Run `pip install -e <path/to/this/revision>`
4. Run this code below
```py
#!/usr/bin/python3
from ape import Contract


def main():

     abi = '[{"inputs":[{"internalType":"contract MultiWrapper","name":"_multiWrapper"
,"type":"address"},{"internalType":"contract IOracle[]","name":"existingOracles"
,"type":"address[]"},{"internalType":"enum OffchainOracle.OracleType[]","name":"oracleTypes"
,"type":"uint8[]"},{"internalType":"contract IERC20[]","name":"existingConnectors"
,"type":"address[]"},{"internalType":"contract IERC20","name":"wBase","type":"address"}]
,"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":false
,"internalType":"contract IERC20","name":"connector","type":"address"}],"name":"ConnectorAdded"
,"type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"contract
IERC20","name":"connector","type":"address"}],"name":"ConnectorRemoved","type":"event"}
,{"anonymous":false,"inputs":[{"indexed":false,"internalType":"contract MultiWrapper"
,"name":"multiWrapper","type":"address"}],"name":"MultiWrapperUpdated","type":"event"}
,{"anonymous":false,"inputs":[{"indexed":false,"internalType":"contract IOracle"
,"name":"oracle","type":"address"},{"indexed":false,"internalType":"enum OffchainOracle.OracleType"
,"name":"oracleType","type":"uint8"}],"name":"OracleAdded","type":"event"},{"anonymous":false
,"inputs":[{"indexed":false,"internalType":"contract IOracle","name":"oracle","type":"address"}
,{"indexed":false,"internalType":"enum OffchainOracle.OracleType","name":"oracleType"
,"type":"uint8"}],"name":"OracleRemoved","type":"event"},{"anonymous":false,"inputs":[{"indexed":true
,"internalType":"address","name":"previousOwner","type":"address"},{"indexed":true
,"internalType":"address","name":"newOwner","type":"address"}],"name":"OwnershipTransferred"
,"type":"event"},{"inputs":[{"internalType":"contract IERC20","name":"connector"
,"type":"address"}],"name":"addConnector","outputs":[],"stateMutability":"nonpayable"
,"type":"function"},{"inputs":[{"internalType":"contract IOracle","name":"oracle"
,"type":"address"},{"internalType":"enum OffchainOracle.OracleType","name":"oracleKind"
,"type":"uint8"}],"name":"addOracle","outputs":[],"stateMutability":"nonpayable"
,"type":"function"},{"inputs":[],"name":"connectors","outputs":[{"internalType":"contract
IERC20[]","name":"allConnectors","type":"address[]"}],"stateMutability":"view","type":"function"}
,{"inputs":[{"internalType":"contract IERC20","name":"srcToken","type":"address"}
,{"internalType":"contract IERC20","name":"dstToken","type":"address"},{"internalType":"bool"
,"name":"useWrappers","type":"bool"}],"name":"getRate","outputs":[{"internalType":"uint256"
,"name":"weightedRate","type":"uint256"}],"stateMutability":"view","type":"function"}
,{"inputs":[{"internalType":"contract IERC20","name":"srcToken","type":"address"}
,{"internalType":"bool","name":"useSrcWrappers","type":"bool"}],"name":"getRateToEth"
,"outputs":[{"internalType":"uint256","name":"weightedRate","type":"uint256"}],"stateMutability":"view"
,"type":"function"},{"inputs":[],"name":"multiWrapper","outputs":[{"internalType":"contract
MultiWrapper","name":"","type":"address"}],"stateMutability":"view","type":"function"}
,{"inputs":[],"name":"oracles","outputs":[{"internalType":"contract IOracle[]","name":"allOracles"
,"type":"address[]"},{"internalType":"enum OffchainOracle.OracleType[]","name":"oracleTypes"
,"type":"uint8[]"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"owner"
,"outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view"
,"type":"function"},{"inputs":[{"internalType":"contract IERC20","name":"connector"
,"type":"address"}],"name":"removeConnector","outputs":[],"stateMutability":"nonpayable"
,"type":"function"},{"inputs":[{"internalType":"contract IOracle","name":"oracle"
,"type":"address"},{"internalType":"enum OffchainOracle.OracleType","name":"oracleKind"
,"type":"uint8"}],"name":"removeOracle","outputs":[],"stateMutability":"nonpayable"
,"type":"function"},{"inputs":[],"name":"renounceOwnership","outputs":[],"stateMutability":"nonpayable"
,"type":"function"},{"inputs":[{"internalType":"contract MultiWrapper","name":"_multiWrapper"
,"type":"address"}],"name":"setMultiWrapper","outputs":[],"stateMutability":"nonpayable"
,"type":"function"},{"inputs":[{"internalType":"address","name":"newOwner","type":"address"}]
,"name":"transferOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"}]' 
    address = "0x07D91f5fb9Bf7798734C3f606dB065549F6893bb"
    contract = Contract(address, abi=abi)

    assert contract.address == address
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
