### PR TITLE
fix: more source traceback improvements [APE-1335]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.2.1,<0.3",
         "ethpm-types>=0.5.3,<0.6",
-        "evm-trace>=0.1.0a22",
+        "evm-trace>=0.1.0a23",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -100,8 +100,7 @@ class BaseAddress(BaseInterface):
         elif "sender" not in kwargs and self.account_manager.default_sender is not None:
             return self.account_manager.default_sender.call(txn, **kwargs)
 
-        receipt = self.provider.send_transaction(txn)
-        return receipt
+        return self.provider.send_transaction(txn)
 
     @property
     def nonce(self) -> int:

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -100,7 +100,8 @@ class BaseAddress(BaseInterface):
         elif "sender" not in kwargs and self.account_manager.default_sender is not None:
             return self.account_manager.default_sender.call(txn, **kwargs)
 
-        return self.provider.send_transaction(txn)
+        receipt = self.provider.send_transaction(txn)
+        return receipt
 
     @property
     def nonce(self) -> int:

--- a/src/ape/api/compiler.py
+++ b/src/ape/api/compiler.py
@@ -6,7 +6,6 @@ from ethpm_types import ContractType, HexBytes
 from ethpm_types.source import Content, ContractSource
 from evm_trace.geth import TraceFrame as EvmTraceFrame
 from evm_trace.geth import create_call_node_data
-from evm_trace.utils import to_address
 from semantic_version import Version  # type: ignore
 
 from ape.exceptions import APINotImplementedError, ContractLogicError

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1085,11 +1085,10 @@ class Web3Provider(ProviderAPI, ABC):
     ) -> bytes:
         account = self.account_manager.test_accounts[0]
         receipt = account.call(txn, **kwargs)
-        call_tree = receipt.call_tree
-        if not call_tree:
+        if not (call_tree := receipt.call_tree):
             return self._send_call(txn, **kwargs)
 
-        # Grab raw retrurndata before enrichment
+        # Grab raw returndata before enrichment
         returndata = call_tree.outputs
 
         if (track_gas or track_coverage) and show_gas and not show_trace:
@@ -1454,6 +1453,9 @@ class Web3Provider(ProviderAPI, ABC):
             ),
         )
 
+        # NOTE: Ensure to cache even the failed receipts.
+        self.chain_manager.history.append(receipt)
+
         if receipt.failed:
             txn_dict = receipt.transaction.dict()
             txn_params = cast(TxParams, txn_dict)
@@ -1467,7 +1469,6 @@ class Web3Provider(ProviderAPI, ABC):
                 raise vm_err from err
 
         logger.info(f"Confirmed {receipt.txn_hash} (total fees paid = {receipt.total_fees_paid})")
-        self.chain_manager.history.append(receipt)
         return receipt
 
     def _create_call_tree_node(

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -547,9 +547,8 @@ class ReceiptAPI(BaseInterfaceModel):
             return
 
         tracker = self._test_runner.coverage_tracker
-        if self.provider.supports_tracing:
-            traceback = self.source_traceback
-            if traceback is not None and len(traceback) > 0 and self._test_runner is not None:
+        if self.provider.supports_tracing and (traceback := self.source_traceback):
+            if len(traceback) > 0:
                 tracker.cover(traceback)
 
         elif method := self.method_called:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1714,5 +1714,5 @@ class ChainManager(BaseManager):
         receipt = self.chain_manager.history[transaction_hash]
         if not isinstance(receipt, ReceiptAPI):
             raise ChainError(f"No receipt found with hash '{transaction_hash}'.")
-        
+
         return receipt

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1711,4 +1711,8 @@ class ChainManager(BaseManager):
         Returns:
             :class:`~ape.apt.transactions.ReceiptAPI`
         """
-        return self.chain_manager.history[transaction_hash]
+        receipt = self.chain_manager.history[transaction_hash]
+        if not isinstance(receipt, ReceiptAPI):
+            raise ChainError(f"No receipt found with hash '{transaction_hash}'.")
+        
+        return receipt

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -347,8 +347,12 @@ class ConversionManager(BaseManager):
             try:
                 return converter.convert(value)
             except Exception as err:
-                raise ConversionError(
-                    f"Failed to convert '{value}' using '{converter.__class__.__name__}'."
-                ) from err
+                try:
+                    error_value = f" '{value}' "
+                except Exception:
+                    error_value = " "
+
+                message = f"Failed to convert{error_value}using '{converter.__class__.__name__}'."
+                raise ConversionError(message) from err
 
         raise ConversionError(f"No conversion registered to handle '{value}'.")

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -771,11 +771,10 @@ class ProjectManager(BaseManager):
         destination.write_text(artifact.json())
 
     def _create_contract_source(self, contract_type: ContractType) -> Optional[ContractSource]:
-        if not contract_type.source_id:
+        if not (source_id := contract_type.source_id):
             return None
 
-        src = self._lookup_source(contract_type.source_id)
-        if not src:
+        if not (src := self._lookup_source(source_id)):
             return None
 
         try:

--- a/src/ape/pytest/coverage.py
+++ b/src/ape/pytest/coverage.py
@@ -76,7 +76,6 @@ class CoverageData(ManagerAccessMixin):
         self, src_path: Path, pcs: Iterable[int], inc_fn_hits: bool = True
     ) -> Tuple[Set[int], List[str]]:
         source_id = str(get_relative_path(src_path.absolute(), self.base_path))
-
         if source_id not in self.report.sources:
             # The source is not tracked for coverage.
             return set(), []
@@ -87,8 +86,7 @@ class CoverageData(ManagerAccessMixin):
             if pc < 0:
                 continue
 
-            source_coverage = self.report.get_source_coverage(source_id)
-            if not source_coverage:
+            if not (source_coverage := self.report.get_source_coverage(source_id)):
                 continue
 
             for contract in source_coverage.contracts:

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -184,17 +184,14 @@ class ReceiptCapture(ManagerAccessMixin):
         if not receipt:
             return
 
-        contract_address = receipt.receiver or receipt.contract_address
-        if not contract_address:
+        if not (contract_address := (receipt.receiver or receipt.contract_address)):
             return
 
-        contract_type = self.chain_manager.contracts.get(contract_address)
-        if not contract_type:
+        if not (contract_type := self.chain_manager.contracts.get(contract_address)):
             # Not an invoke-transaction or a known address
             return
 
-        source_id = contract_type.source_id or None
-        if not source_id:
+        if not (source_id := (contract_type.source_id or None)):
             # Not a local or known contract type.
             return
 

--- a/src/ape/utils/trace.py
+++ b/src/ape/utils/trace.py
@@ -278,9 +278,7 @@ def _parse_verbose_coverage(coverage: "CoverageReport", statement: bool = True) 
                             name = f"__{''.join(name_chars).replace('dev_', '')}__"
                             miss = (
                                 0
-                                if not any(
-                                    s.hit_count > 0 for s in fn.statements if s.tag == builtin
-                                )
+                                if any(s.hit_count > 0 for s in fn.statements if s.tag == builtin)
                                 else 1
                             )
                             rows.append(

--- a/src/ape/utils/trace.py
+++ b/src/ape/utils/trace.py
@@ -270,9 +270,12 @@ def _parse_verbose_coverage(coverage: "CoverageReport", statement: bool = True) 
                         # Create a row per unique type.
                         builtins = {x.tag for x in fn.statements if x.tag}
                         for builtin in builtins:
-                            name = (
-                                f"__{builtin.lower().strip().replace(' ', '_').replace(':', '')}__"
-                            )
+                            name_chars = [
+                                c
+                                for c in builtin.lower().strip().replace(" ", "_")
+                                if c.isalpha() or c == "_"
+                            ]
+                            name = f"__{''.join(name_chars).replace('dev_', '')}__"
                             miss = (
                                 0
                                 if not any(

--- a/src/ape/utils/trace.py
+++ b/src/ape/utils/trace.py
@@ -261,11 +261,6 @@ def _parse_verbose_coverage(coverage: "CoverageReport", statement: bool = True) 
                         # It is impossible to really track.
                         continue
 
-                    counts = [
-                        f"{fn.lines_valid}",
-                        f"{fn.miss_count}",
-                        f"{round(fn.line_rate * 100, 2)}%",
-                    ]
                     if fn.name == "__builtin__":
                         # Create a row per unique type.
                         builtins = {x.tag for x in fn.statements if x.tag}
@@ -287,12 +282,12 @@ def _parse_verbose_coverage(coverage: "CoverageReport", statement: bool = True) 
 
                     else:
                         row = (
-                            tuple(
-                                [
-                                    fn.name,
-                                    fn.full_name,
-                                    *counts,
-                                ]
+                            (
+                                fn.name,
+                                fn.full_name,
+                                f"{fn.lines_valid}",
+                                f"{fn.miss_count}",
+                                f"{round(fn.line_rate * 100, 2)}%",
                             )
                             if statement
                             else (fn.name, fn.full_name, "✓" if fn.hit_count > 0 else "x")

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -50,7 +50,18 @@ class KeyfileAccount(AccountAPI):
     __cached_key: Optional[HexBytes] = None
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} address={self.address} alias={self.alias}>"
+        # NOTE: Prevent errors from preventing repr from working.
+        try:
+            address_str = f" address={self.address} "
+        except Exception:
+            address_str = ""
+
+        try:
+            alias_str = f" alias={self.alias} "
+        except Exception:
+            alias_str = ""
+
+        return f"<{self.__class__.__name__}{address_str}{alias_str}>"
 
     @property
     def alias(self) -> str:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -209,10 +209,7 @@ class Ethereum(EcosystemAPI):
 
     @classmethod
     def decode_address(cls, raw_address: RawAddress) -> AddressType:
-        raw: Union[str, HexBytes] = (
-            HexBytes(raw_address) if isinstance(raw_address, int) else raw_address
-        )
-        return to_checksum_address(raw)
+        return to_checksum_address(HexBytes(raw_address)[-20:].rjust(20, b"\x00"))
 
     @classmethod
     def encode_address(cls, address: AddressType) -> RawAddress:

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -347,11 +347,10 @@ class BaseGethProvider(Web3Provider, ABC):
         self._client_version = None
 
     def get_transaction_trace(self, txn_hash: str) -> Iterator[TraceFrame]:
-        frames = self._stream_request(
+        struct_logs = self._stream_request(
             "debug_traceTransaction", [txn_hash, {"enableMemory": True}], "result.structLogs.item"
         )
-        for frame in frames:
-            yield self._create_trace_frame(EvmTraceFrame(**frame))
+        yield from create_trace_frames(struct_logs)
 
     def _get_transaction_trace_using_call_tracer(self, txn_hash: str) -> Dict:
         return self._make_request(

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -348,10 +348,10 @@ class BaseGethProvider(Web3Provider, ABC):
         self._client_version = None
 
     def get_transaction_trace(self, txn_hash: str) -> Iterator[TraceFrame]:
-        struct_logs = self._stream_request(
+        frames = self._stream_request(
             "debug_traceTransaction", [txn_hash, {"enableMemory": True}], "result.structLogs.item"
         )
-        for frame in create_trace_frames(struct_logs):
+        for frame in create_trace_frames(frames):
             yield self._create_trace_frame(frame)
 
     def _get_transaction_trace_using_call_tracer(self, txn_hash: str) -> Dict:

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -16,6 +16,7 @@ from ethpm_types import HexBytes
 from evm_trace import CallType, ParityTraceList
 from evm_trace import TraceFrame as EvmTraceFrame
 from evm_trace import (
+    create_trace_frames,
     get_calltree_from_geth_call_trace,
     get_calltree_from_geth_trace,
     get_calltree_from_parity_trace,

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -625,7 +625,7 @@ class GethDev(BaseGethProvider, TestProviderAPI, SubprocessProvider):
     def _trace_call(self, arguments: List[Any]) -> Tuple[Dict, Iterator[EvmTraceFrame]]:
         result = self._make_request("debug_traceCall", arguments)
         trace_data = result.get("structLogs", [])
-        return result, (EvmTraceFrame(**f) for f in trace_data)
+        return result, create_trace_frames(trace_data)
 
     def _eth_call(self, arguments: List) -> bytes:
         try:

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -351,7 +351,8 @@ class BaseGethProvider(Web3Provider, ABC):
         struct_logs = self._stream_request(
             "debug_traceTransaction", [txn_hash, {"enableMemory": True}], "result.structLogs.item"
         )
-        yield from create_trace_frames(struct_logs)
+        for frame in create_trace_frames(struct_logs):
+            yield self._create_trace_frame(frame)
 
     def _get_transaction_trace_using_call_tracer(self, txn_hash: str) -> Dict:
         return self._make_request(


### PR DESCRIPTION
### What I did

This helps in the case when a transaction fails before a dev message and a user gets confuses as like ape is not actually finding the dev message when actually the line it is failing on earlier. This PR shows the source traceback in that case.


before it was this:

```
/Users/jules/ApeProjects/yearn-vesting-escrow/tests/functional/VestingEscrowFactory/test_deploy_escrow.py:269: in test_vyper_donation
    with ape.reverts(dev_message="dev: lost donation"):
```

now it looks like this:

```
/Users/jules/ApeProjects/yearn-vesting-escrow/tests/functional/VestingEscrowFactory/test_deploy_escrow.py:269: in test_vyper_donation
    with ape.reverts(dev_message="dev: lost donation"):
E   AssertionError: Could not find the source of the revert.
E   Traceback (most recent call last)
E     File /Users/jules/ApeProjects/yearn-vesting-escrow/contracts/VestingEscrowFactory.vy, in deploy_vesting_contract
E     -->  92         vesting_start + vesting_duration,
E          93         cliff_length,
E          94         open_claim,
E          95     )
E          96     # skip transferFrom and approve and send directly to escrow
E          97     assert token.transferFrom(msg.sender, escrow, amount, default_return_value=True)  # dev: funding failed
```

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
