### PR TITLE
fix: issue where couldn't specify multiple versions when installing plugins [APE-1345]

### DIFF
--- a/tests/integration/cli/test_plugins.py
+++ b/tests/integration/cli/test_plugins.py
@@ -5,6 +5,7 @@ import pytest
 from tests.integration.cli.utils import github_xfail
 
 TEST_PLUGIN_NAME = "tokens"
+TEST_PLUGIN_NAME_2 = "optimism"
 
 
 class PluginsList(list):
@@ -138,6 +139,12 @@ def test_upgrade(ape_plugins_runner, installed_plugin):
 def test_upgrade_failure(ape_plugins_runner):
     result = ape_plugins_runner.invoke(["install", "NOT_EXISTS", "--upgrade"])
     assert result.exit_code == 1
+
+
+@github_xfail()
+def test_install_multiple_in_one_str(ape_plugins_runner):
+    result = ape_plugins_runner.invoke(["install", f"{TEST_PLUGIN_NAME} {TEST_PLUGIN_NAME_2}"])
+    assert result.exit_code == 0
 
 
 @github_xfail()


### PR DESCRIPTION
### What I did

when using the github action, the versions are all strung together, so this PR makes it parse that correctly.


### How I did it

split(" ")

### How to verify it

```sh
ape plugins install "tokens==0.6.1 polygon"
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
