### PR TITLE
fix: false-positives bug when making mock-log assertions [APE-1352]

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -447,21 +447,12 @@ class ReceiptAPI(BaseInterfaceModel):
         since this is not available from the receipt object.
         """
 
-        call_tree = self.call_tree
-        if not call_tree:
+        if not (call_tree := self.call_tree) or not (method_abi := self.method_called):
             return None
 
-        method_abi = self.method_called
-        if not method_abi:
-            return None
-
-        if isinstance(call_tree.outputs, str):
+        if isinstance(call_tree.outputs, (str, HexBytes, int)):
             output = self.provider.network.ecosystem.decode_returndata(
                 method_abi, HexBytes(call_tree.outputs)
-            )
-        elif isinstance(call_tree.outputs, HexBytes):
-            output = self.provider.network.ecosystem.decode_returndata(
-                method_abi, call_tree.outputs
             )
         else:
             # Already enriched.

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -367,7 +367,7 @@ class MockContractLog(BaseContractLog):
         for name, value in self.event_arguments.items():
             # Make sure `value` is not `None` (user explicitly set it `None`)
             # NOTE: `other.event_arguments[name]` will raise `IndexError` only if ABIs don't match
-            if value and value != other.event_arguments[name]:
+            if value is not None and value != other.event_arguments[name]:
                 return False
 
         return True

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -279,6 +279,18 @@ def test_contract_decode_logs_no_abi(owner, contract_instance):
     assert events == [contract_instance.NumberChange(newNum=1)]
 
 
+def test_contract_decode_logs_falsy_check(owner, vyper_contract_instance):
+    """
+    Verifies a bug fix where false-y values differing were ignored.
+    """
+
+    receipt = vyper_contract_instance.setNumber(1, sender=owner)
+    events = list(receipt.decode_logs())  # no abi
+
+    with pytest.raises(AssertionError):
+        assert events == [vyper_contract_instance.NumberChange(newNum=0)]
+
+
 def test_contract_log_container(owner, contract_instance):
     receipt = contract_instance.setNumber(1, sender=owner)
     events = receipt.events.filter(contract_instance.NumberChange, newNum=1)

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -284,11 +284,9 @@ def test_contract_decode_logs_falsy_check(owner, vyper_contract_instance):
     Verifies a bug fix where false-y values differing were ignored.
     """
 
-    receipt = vyper_contract_instance.setNumber(1, sender=owner)
-    events = list(receipt.decode_logs())  # no abi
-
+    tx = vyper_contract_instance.setNumber(1, sender=owner)
     with pytest.raises(AssertionError):
-        assert events == [vyper_contract_instance.NumberChange(newNum=0)]
+        assert tx.events == [vyper_contract_instance.NumberChange(newNum=0)]
 
 
 def test_contract_log_container(owner, contract_instance):


### PR DESCRIPTION
### What I did

Because of a check that ignored all fasley values, log-assertion checks would have false-positives, meaning your tests pass when they shouldn't! dun dun dunnn.

### How I did it

check that `is not None` instead of falsey.

### How to verify it

This passes on main branch believe it or not:

```python
tx = c.setNumber(1, sender=owner)
assert tx.events == [c.NumberChange(newNum=0)]  # actual value was 1 but Ape didn't care
```

however with these changes, it correctly fails.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
