### PR TITLE
fix: don't compile `contracts/.build` [APE-1358]

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -236,7 +236,7 @@ class DependencyAPI(BaseInterfaceModel):
     **NOTE**: This must be the name of a directory in the project.
     """
 
-    exclude: List[str] = ["package.json", "package-lock.json"]
+    exclude: List[str] = ["package.json", "package-lock.json", ".build/*.json"]
     """
     A list of glob-patterns for excluding files in dependency projects.
     """

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -236,7 +236,7 @@ class DependencyAPI(BaseInterfaceModel):
     **NOTE**: This must be the name of a directory in the project.
     """
 
-    exclude: List[str] = ["package.json", "package-lock.json", ".build/*.json"]
+    exclude: List[str] = ["package.json", "package-lock.json", "**/.build/**/*.json"]
     """
     A list of glob-patterns for excluding files in dependency projects.
     """

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -118,7 +118,7 @@ class CompilerManager(BaseManager):
                 and path not in paths_to_ignore
                 and path not in built_paths
                 and path.suffix == extension
-                and ".cache" not in [p.name for p in path.parents]
+                and not any(x in [p.name for p in path.parents] for x in (".cache", ".build"))
             ]
 
             for path in paths_to_compile:

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -27,7 +27,6 @@ class InterfaceCompiler(CompilerAPI):
         filepaths.sort()  # Sort to assist in reproducing consistent results.
         contract_types: List[ContractType] = []
         contract_type_data: Dict
-
         for path in filepaths:
             data = json.loads(path.read_text())
             source_path = (

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -27,6 +27,7 @@ class InterfaceCompiler(CompilerAPI):
         filepaths.sort()  # Sort to assist in reproducing consistent results.
         contract_types: List[ContractType] = []
         contract_type_data: Dict
+
         for path in filepaths:
             data = json.loads(path.read_text())
             source_path = (

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -628,7 +628,7 @@ def test_contracts_get_multiple(vyper_contract_instance, solidity_contract_insta
 def test_contracts_get_multiple_no_addresses(chain, caplog):
     contract_map = chain.contracts.get_multiple([])
     assert not contract_map
-    assert caplog.records[-1].levelname == "WARNING"
+    assert "WARNING" in caplog.records[-1].levelname
     assert "No addresses provided." in caplog.records[-1].message
 
 

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -89,6 +89,10 @@ def test_compile(ape_cli, runner, project, clean_cache):
     assert all(f.stem in result.output for f in expected_files)
     assert not any(f.stem in result.output for f in unexpected_files)
 
+    # Copy in .build to show that those file won't compile.
+    # (Anything in a .build is ignored, even if in a contracts folder to prevent accidents).
+    shutil.copytree(project.path / ".build", project.contracts_folder / ".build")
+
     result = runner.invoke(ape_cli, ["compile"], catch_exceptions=False)
     assert result.exit_code == 0, result.output
     # First time it compiles, it caches


### PR DESCRIPTION
### What I did

somehow a good friend of mine ended up with their .build folder within their contracts folder, maybe from an odd usage of using_project (TBD).

anyway, there is not reason to ever compile such things so i added it to the ignore list.

### How I did it

same we do for .cache

### How to verify it

tbd

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
