### PR TITLE
docs: remove gitcoin link from funding [APE-1360]

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,1 @@
 github: ApeWorX
-custom:
-- https://gitcoin.co/grants/5958/ape-maintanence-fund


### PR DESCRIPTION
Link was non-functional