### PR TITLE
feat: decode bytes32 symbols in traces [APE-1368]

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -788,7 +788,7 @@ class Ethereum(EcosystemAPI):
 
             if isinstance(symbol, str):
                 return symbol.strip()
-            
+
             # bytes32 symbol appears in ds-token
             if isinstance(symbol, bytes):
                 try:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -792,7 +792,7 @@ class Ethereum(EcosystemAPI):
             # bytes32 symbol appears in ds-token
             if isinstance(symbol, bytes):
                 try:
-                    return symbol.rstrip(b'\x00').decode()
+                    return symbol.rstrip(b"\x00").decode()
                 except UnicodeDecodeError:
                     return str(symbol)
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -786,8 +786,15 @@ class Ethereum(EcosystemAPI):
             except ContractError:
                 symbol = None
 
-            if symbol and str(symbol).strip():
-                return str(symbol).strip()
+            if isinstance(symbol, str):
+                return symbol.strip()
+            
+            # bytes32 symbol appears in ds-token
+            if isinstance(symbol, bytes):
+                try:
+                    return symbol.rstrip(b'\x00').decode()
+                except UnicodeDecodeError:
+                    return str(symbol)
 
         name = contract_type.name.strip() if contract_type.name else None
         return name or self._get_contract_id_from_address(address)


### PR DESCRIPTION
### What I did

improve the display of symbols for tokens that use a `bytes32` symbol in `ReceiptAPI.show_trace()`

one major example being MKR, tracked back to [ds-token](https://github.com/dapphub/ds-token/commit/08412f94a62529d7853c1e817c9406a4d0735d4a).

### How I did it

different handling for the returned `str` and `bytes` value, while keeping the fallback to contract type name.

### How to verify it

before
```python
VoteDelegate.free(wad=200000204806431039674) [121538 gas]
├── b'IOU\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0
│   0\x00\x00\x00\x00\x00\x00'.pull(src=tx.origin, wad=2000000000000000000) [30756 gas]
├── DSChief.free(wad=2000000000000000000) [59556 gas]
│   ├── b'IOU\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0
│   │   0\x00\x00\x00\x00\x00\x00\x00'.burn(guy=VoteDelegate, wad=2000000000000000000) [8353 gas]
│   └── b'MKR\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0
│       0\x00\x00\x00\x00\x00\x00\x00'.push(dst=VoteDelegate, wad=2000000000000000000) [32670 gas]
└── b'MKR\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0
    0\x00\x00\x00\x00\x00\x00'.push(dst=tx.origin, wad=2000000000000000000) [20696 gas]
```

after
```python
VoteDelegate.free(wad=2000000000000000000) [121538 gas]
├── IOU.pull(src=tx.origin, wad=2000000000000000000) [30756 gas]
├── DSChief.free(wad=2000000000000000000) [59556 gas]
│   ├── IOU.burn(guy=VoteDelegate, wad=2000000000000000000) [8353 gas]
│   └── MKR.push(dst=VoteDelegate, wad=2000000000000000000) [32670 gas]
└── MKR.push(dst=tx.origin, wad=2000000000000000000) [20696 gas]
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
