### PR TITLE
fix: pytest trace shows wrong lineno [APE-1388]

### DIFF
--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -693,7 +693,10 @@ def _get_custom_python_traceback(
             continue
 
         depth = exec_item.depth
-        lineno = exec_item.begin_lineno
+
+        # NOTE: Use the last lineno executed as "the line number".
+        lineno = exec_item.begin_lineno if exec_item.end_lineno is None else exec_item.end_lineno
+
         if lineno is None:
             idx -= 1
             continue

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -164,10 +164,10 @@ class LogFilter(BaseModel):
         from ape import convert
         from ape.utils.abi import LogInputABICollection, is_dynamic_sized_type
 
-        event = getattr(event, "abi", event)
+        event_abi: EventABI = getattr(event, "abi", event)  # type: ignore[assignment]
         search_topics = search_topics or {}
-        topic_filter: List[Optional[HexStr]] = [encode_hex(keccak(text=event.selector))]
-        abi_inputs = LogInputABICollection(event)
+        topic_filter: List[Optional[HexStr]] = [encode_hex(keccak(text=event_abi.selector))]
+        abi_inputs = LogInputABICollection(event_abi)
 
         def encode_topic_value(abi_type, value):
             if isinstance(value, (list, tuple)):
@@ -190,7 +190,7 @@ class LogFilter(BaseModel):
         invalid_topics = set(search_topics) - set(topic_names)
         if invalid_topics:
             raise ValueError(
-                f"{event.name} defines {', '.join(topic_names)} as indexed topics, "
+                f"{event_abi.name} defines {', '.join(topic_names)} as indexed topics, "
                 f"but you provided {', '.join(invalid_topics)}"
             )
 
@@ -200,7 +200,7 @@ class LogFilter(BaseModel):
 
         return cls(
             addresses=addresses or [],
-            events=[event],
+            events=[event_abi],
             topic_filter=topic_filter,
             start_block=start_block,
             stop_block=stop_block,


### PR DESCRIPTION
### What I did

Noticed we were not alway showing the last line in pytest exception repr.
Using `end_lineno` instead of `begin_lineno` fixed that.

### How I did it


### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
