### PR TITLE
fix: GitHub client retry on rate limiting [APE-1198]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ setup(
         "SQLAlchemy>=1.4.35",
         "tqdm>=4.62.3,<5.0",
         "traitlets>=5.3.0",
+        "urllib3>=1.26.16,<2",
         "watchdog>=3.0,<4",
         # ** Dependencies maintained by Ethereum Foundation **
         "eth-abi>=4.1.0,<5",

--- a/src/ape/utils/github.py
+++ b/src/ape/utils/github.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import subprocess
 import tempfile
-from urllib3.util.retry import Retry
 import zipfile
 from io import BytesIO
 from pathlib import Path
@@ -13,6 +12,7 @@ from github.Auth import Token as GithubToken
 from github.GitRelease import GitRelease
 from github.Organization import Organization
 from github.Repository import Repository as GithubRepository
+from urllib3.util.retry import Retry
 
 from ape.exceptions import CompilerError, ProjectError, UnknownVersionError
 from ape.logging import logger

--- a/src/ape/utils/github.py
+++ b/src/ape/utils/github.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+from urllib3.util.retry import Retry
 import zipfile
 from io import BytesIO
 from pathlib import Path
@@ -21,11 +22,10 @@ from ape.utils.misc import USER_AGENT, cached_property, stream_response
 class GitProcessWrapper:
     @cached_property
     def git(self) -> str:
-        git_cmd_path = shutil.which("git")
-        if not git_cmd_path:
-            raise ProjectError("`git` not installed.")
+        if path := shutil.which("git"):
+            return path
 
-        return git_cmd_path
+        raise ProjectError("`git` not installed.")
 
     def clone(self, url: str, target_path: Optional[Path] = None, branch: Optional[str] = None):
         command = [self.git, "-c", "advice.detachedHead=false", "clone", url]
@@ -69,14 +69,15 @@ class GithubClient:
     def __init__(self):
         token = os.environ[self.TOKEN_KEY] if self.TOKEN_KEY in os.environ else None
         auth = GithubToken(token) if token else None
-        self._client = Github(auth=auth, user_agent=USER_AGENT)
+        retry = Retry(total=10, backoff_factor=1.0, status_forcelist=[403])
+        self._client = Github(auth=auth, user_agent=USER_AGENT, retry=retry)
 
     @cached_property
     def ape_org(self) -> Organization:
         """
         The ``ApeWorX`` organization on ``Github`` (https://github.com/ApeWorX).
         """
-        return self._client.get_organization("ApeWorX")
+        return self.get_organization("ApeWorX")
 
     @cached_property
     def available_plugins(self) -> Set[str]:
@@ -152,6 +153,9 @@ class GithubClient:
 
         else:
             return self._repo_cache[repo_path]
+
+    def get_organization(self, name: str) -> Organization:
+        return self._client.get_organization(name)
 
     def clone_repo(
         self,


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1545
Fixes: APE-1198

### How I did it

Utilize the retry arg with a special object

### How to verify it

First, unset your token:

```sh
unset GITHUB_ACCESS_TOKEN
```

Now, run some bad code:

```python
In [1]: from ape.utils.github import GithubClient

In [2]: client = GithubClient()

In [3]: for i in range(100):
   ...:     client.get_organization("ApeWorX")
```

You will notice that without this PR, you will get a rate limiting error like the one mentioned in the issue.
But with this PR, it will work, however it will takes ages to complete without your GITHUB_ACCESS_TOKEN, however it will still work.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
