### PR TITLE
feat(query): add timestamp to ContractLog [APE-1391]

### DIFF
--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -295,6 +295,10 @@ class ContractLog(BaseContractLog):
         return self.chain_manager.blocks[self.block_number]
 
     @property
+    def timestamp(self) -> int:
+        return self.block.timestamp
+
+    @property
     def _event_args_str(self) -> str:
         return " ".join(f"{key}={val}" for key, val in self.event_arguments.items())
 

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -296,6 +296,11 @@ class ContractLog(BaseContractLog):
 
     @property
     def timestamp(self) -> int:
+        """
+        The UNIX timestamp of when the event was emitted.
+
+        NOTE: This performs a block lookup.
+        """
         return self.block.timestamp
 
     @property

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -102,6 +102,7 @@ def test_decode_logs(owner, contract_instance, assert_log_values):
         logs = receipt.decode_logs(event_type)
         assert len(logs) == 1
         assert_log_values(logs[0], num)
+        assert receipt.timestamp == logs[0].timestamp
 
     assert_receipt_logs(receipt_0, 1)
     assert_receipt_logs(receipt_1, 2)


### PR DESCRIPTION
### What I did

Adds the `.timestamp` property to `ContractLog`, allowing users to pull the raw timestamp when querying events

fixes: #1612

### How I did it

This should be safe to add as both Solidity and Vyper use `timestamp` as a reserved keyword, thus it would not appear as an event arg name

### How to verify it

Validate my intution is true re: reserved keyword

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
