### PR TITLE
fix: log decoding issues and missing events [APE-1289]

### DIFF
--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -269,11 +269,9 @@ class ContractLog(BaseContractLog):
 
     @validator("contract_address", pre=True)
     def validate_address(cls, value):
-        from ape import convert
+        return cls.conversion_manager.convert(value, AddressType)
 
-        return convert(value, AddressType)
-
-    # NOTE: This class has an overrided `__getattr__` method, but `block` is a reserved keyword
+    # NOTE: This class has an overridden `__getattr__` method, but `block` is a reserved keyword
     #       in most smart contract languages, so it is safe to use. Purposely avoid adding
     #       `.datetime` and `.timestamp` in case they are used as event arg names.
     @cached_property
@@ -299,8 +297,7 @@ class ContractLog(BaseContractLog):
         """
 
         try:
-            normal_attribute = self.__getattribute__(item)
-            return normal_attribute
+            return self.__getattribute__(item)
         except AttributeError:
             pass
 

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -262,7 +262,11 @@ class ContractLog(BaseContractLog):
 
     @validator("block_number", "log_index", "transaction_index", pre=True)
     def validate_hex_ints(cls, value):
-        if not isinstance(value, int):
+        if value is None:
+            # Should only happen for optionals.
+            return value
+
+        elif not isinstance(value, int):
             return to_int(value)
 
         return value

--- a/src/ape/utils/abi.py
+++ b/src/ape/utils/abi.py
@@ -3,10 +3,12 @@ from dataclasses import make_dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from eth_abi import decode, grammar
+from eth_abi.exceptions import DecodingError, InsufficientDataBytes
 from eth_utils import decode_hex
 from ethpm_types import HexBytes
 from ethpm_types.abi import ABIType, ConstructorABI, EventABI, EventABIType, MethodABI
 
+from ape.logging import logger
 from ape.types import AddressType
 
 ARRAY_PATTERN = re.compile(r"[(*\w,? )]*\[\d*]")
@@ -344,21 +346,43 @@ class LogInputABICollection:
     def event_name(self):
         return self.abi.name
 
-    def decode(self, topics: List[str], data: str) -> Dict:
+    def decode(self, topics: List[str], data: str, use_hex_on_fail: bool = False) -> Dict:
         decoded = {}
         for abi, topic_value in zip(self.topic_abi_types, topics[1:]):
             # reference types as indexed arguments are written as a hash
             # https://docs.soliditylang.org/en/v0.8.15/contracts.html#events
             abi_type = "bytes32" if is_dynamic_sized_type(abi.type) else abi.canonical_type
-            value = decode([abi_type], decode_hex(topic_value))[0]
-            decoded[abi.name] = self.decode_value(abi_type, value)
+            hex_value = decode_hex(topic_value)
+
+            try:
+                value = decode([abi_type], hex_value)[0]
+            except InsufficientDataBytes as err:
+                logger.warn_from_exception(err, f"Failed to decode log data '{self.event_name}'.")
+                if use_hex_on_fail:
+                    decoded[abi.name] = hex_value
+                else:
+                    raise DecodingError(str(err)) from err
+
+            else:
+                decoded[abi.name] = self.decode_value(abi_type, value)
 
         data_abi_types = [abi.canonical_type for abi in self.data_abi_types]
         hex_data = decode_hex(data) if isinstance(data, str) else data
-        data_values = decode(data_abi_types, hex_data)
 
-        for abi, value in zip(self.data_abi_types, data_values):
-            decoded[abi.name] = self.decode_value(abi.canonical_type, value)
+        try:
+            data_values = decode(data_abi_types, hex_data)
+        except InsufficientDataBytes as err:
+            logger.warn_from_exception(err, f"Failed to decode log data '{self.event_name}'.")
+            if use_hex_on_fail:
+                for abi in self.data_abi_types:
+                    # Set each to the full data, so it's at least there.
+                    decoded[abi.name] = hex_data
+            else:
+                raise DecodingError(str(err)) from err
+
+        else:
+            for abi, value in zip(self.data_abi_types, data_values):
+                decoded[abi.name] = self.decode_value(abi.canonical_type, value)
 
         return decoded
 

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -270,32 +270,63 @@ class Receipt(ReceiptAPI):
                 for address, contract in contract_types.items()
             }
 
+            def get_default_log(
+                _log: Dict, logs: ContractLogContainer, name: Optional[str] = None
+            ) -> ContractLog:
+                # For when we fail to decode.
+                if not name:
+                    name = "UnknownLog"
+                    index = _log.get("logIndex")
+                    if index is not None:
+                        name = f"{name}_WithIndex_{index}"
+
+                return ContractLog(
+                    block_hash=self.block.hash,
+                    block_number=self.block_number,
+                    event_arguments={"__root__": _log["data"]},
+                    event_name=f"<{name}>",
+                    log_index=logs[-1].log_index + 1 if logs else 0,
+                    transaction_hash=self.txn_hash,
+                    transaction_index=logs[-1].transaction_index if logs else None,
+                )
+
             decoded_logs: ContractLogContainer = ContractLogContainer()
             for log in self.logs:
-                contract_address = log["address"]
-                if (
-                    not (contract_address := log.get("address"))
-                    or contract_address not in selectors
-                ):
-                    continue
+                if contract_address := log.get("address"):
+                    if contract_address in selectors and (topics := log.get("topics")):
+                        selector = encode_hex(topics[0])
+                        if selector in selectors[contract_address]:
+                            event_abi = selectors[contract_address][selector]
+                            decoded_logs.extend(
+                                self.provider.network.ecosystem.decode_logs([log], event_abi)
+                            )
 
-                if not (topics := log.get("topics")):
-                    continue
+                        elif library_log := self._decode_ds_note(log):
+                            decoded_logs.append(library_log)
 
-                selector = encode_hex(topics[0])
-                if selector in selectors[contract_address]:
-                    event_abi = selectors[contract_address][selector]
-                    decoded_logs.extend(
-                        self.provider.network.ecosystem.decode_logs([log], event_abi)
-                    )
+                        else:
+                            name = f"UnknownLogWithSelector_{selector}"
+                            obj = get_default_log(log, decoded_logs, name=name)
+                            decoded_logs.append(obj)
 
-                else:
-                    # Likely a library log
-                    if library_log := self._decode_ds_note(log):
+                    elif library_log := self._decode_ds_note(log):
                         decoded_logs.append(library_log)
 
-                        # Log found - no need to keep searching.
-                        break
+                    else:
+                        name = f"UnknownLogAtAddress_{contract_address}"
+                        index = log.get("logIndex")
+                        if index is not None:
+                            name = f"{name}_AndLogIndex_{index}"
+
+                        obj = get_default_log(log, decoded_logs, name=name)
+                        decoded_logs.append(obj)
+
+                elif library_log := self._decode_ds_note(log):
+                    decoded_logs.append(library_log)
+
+                else:
+                    obj = get_default_log(log, decoded_logs)
+                    decoded_logs.append(obj)
 
             return decoded_logs
 

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -305,6 +305,7 @@ class Receipt(ReceiptAPI):
                             decoded_logs.append(library_log)
 
                         else:
+                            # Search for selector in other spots:
                             name = f"UnknownLogWithSelector_{selector}"
                             obj = get_default_log(log, decoded_logs, name=name)
                             decoded_logs.append(obj)

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -283,14 +283,11 @@ class Receipt(ReceiptAPI):
                     continue
 
                 selector = encode_hex(topics[0])
-                if contract_address in selectors and selector in selectors[contract_address]:
+                if selector in selectors[contract_address]:
                     event_abi = selectors[contract_address][selector]
                     decoded_logs.extend(
                         self.provider.network.ecosystem.decode_logs([log], event_abi)
                     )
-
-                    # Log found - no need to keep searching.
-                    break
 
                 else:
                     # Likely a library log

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -304,21 +304,20 @@ def test_filter_events_with_same_abi(
     filtering. This test verifies we filter by contract address as well as ABI.
     """
 
-    receipt = contract_with_call_depth.emitLogWithSameInterfaceFromMultipleContracts(sender=owner)
-    events = receipt.events
+    tx = contract_with_call_depth.emitLogWithSameInterfaceFromMultipleContracts(sender=owner)
 
-    assert contract_with_call_depth.OneOfMany(addr=owner.address) in events
-    assert middle_contract.OneOfMany(addr=contract_with_call_depth.address) in events
-    assert leaf_contract.OneOfMany(addr=contract_with_call_depth.address) in events
+    assert contract_with_call_depth.OneOfMany(addr=owner.address) in tx.events
+    assert middle_contract.OneOfMany(addr=contract_with_call_depth.address) in tx.events
+    assert leaf_contract.OneOfMany(addr=contract_with_call_depth.address) in tx.events
 
     # Ensure each contract's event appears only once
-    result_a = receipt.events.filter(contract_with_call_depth.OneOfMany)
+    result_a = tx.events.filter(contract_with_call_depth.OneOfMany)
     assert result_a == [contract_with_call_depth.OneOfMany(addr=owner.address)]
 
-    result_b = receipt.events.filter(middle_contract.OneOfMany)
+    result_b = tx.events.filter(middle_contract.OneOfMany)
     assert result_b == [middle_contract.OneOfMany(addr=contract_with_call_depth.address)]
 
-    result_c = receipt.events.filter(leaf_contract.OneOfMany)
+    result_c = tx.events.filter(leaf_contract.OneOfMany)
     assert result_c == [leaf_contract.OneOfMany(addr=contract_with_call_depth.address)]
 
 

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -305,10 +305,11 @@ def test_filter_events_with_same_abi(
     """
 
     receipt = contract_with_call_depth.emitLogWithSameInterfaceFromMultipleContracts(sender=owner)
+    events = receipt.events
 
-    assert contract_with_call_depth.OneOfMany(addr=owner.address) in receipt.events
-    assert middle_contract.OneOfMany(addr=contract_with_call_depth.address) in receipt.events
-    assert leaf_contract.OneOfMany(addr=contract_with_call_depth.address) in receipt.events
+    assert contract_with_call_depth.OneOfMany(addr=owner.address) in events
+    assert middle_contract.OneOfMany(addr=contract_with_call_depth.address) in events
+    assert leaf_contract.OneOfMany(addr=contract_with_call_depth.address) in events
 
     # Ensure each contract's event appears only once
     result_a = receipt.events.filter(contract_with_call_depth.OneOfMany)

--- a/tests/functional/utils/test_abi.py
+++ b/tests/functional/utils/test_abi.py
@@ -1,0 +1,82 @@
+import pytest
+from ethpm_types import HexBytes
+from ethpm_types.abi import EventABI, EventABIType
+
+from ape.utils.abi import LogInputABICollection
+
+
+@pytest.fixture
+def event_abi():
+    return EventABI(
+        type="event",
+        name="NodeOperatorAdded",
+        inputs=[
+            EventABIType(
+                name="nodeOperatorId",
+                type="uint256",
+                components=None,
+                internalType=None,
+                indexed=False,
+            ),
+            EventABIType(
+                name="name", type="string", components=None, internalType=None, indexed=False
+            ),
+            EventABIType(
+                name="rewardAddress",
+                type="address",
+                components=None,
+                internalType=None,
+                indexed=False,
+            ),
+            EventABIType(
+                name="stakingLimit",
+                type="uint64",
+                components=None,
+                internalType=None,
+                indexed=False,
+            ),
+        ],
+        anonymous=False,
+    )
+
+
+@pytest.fixture
+def collection(event_abi):
+    return LogInputABICollection(event_abi)
+
+
+@pytest.fixture
+def topics():
+    return ["0xc52ec0ad7872dae440d886040390c13677df7bf3cca136d8d81e5e5e7dd62ff1"]
+
+
+@pytest.fixture
+def log_data_missing_trailing_zeroes():
+    return HexBytes(
+        "0x000000000000000000000000000000000000000000000000000000000000001e"
+        "000000000000000000000000000000000000000000000000000000000000008000"
+        "00000000000000000000005a8b929edbf3ce44526465dd2087ec7efb59a5610000"
+        "000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000b4c61756e"
+        "63686e6f646573"
+    )
+
+
+def test_decoding_with_strict(collection, topics, log_data_missing_trailing_zeroes, caplog):
+    """
+    This test is for a time where Alchemy gave us log data when it was missing trailing zeroes.
+    When using strict=False, it was able to properly decode. In this case, in Ape, we warn
+    the user and still proceed to decode the log.
+    """
+    actual = collection.decode(topics, log_data_missing_trailing_zeroes)
+    expected = {
+        "name": "Launchnodes",
+        "nodeOperatorId": 30,
+        "rewardAddress": "0x5a8b929edbf3ce44526465dd2087ec7efb59a561",
+        "stakingLimit": 0,
+    }
+    assert actual == expected
+    assert (
+        "However, we are able to get a value using decode(strict=False)"
+        in caplog.records[-1].message
+    )


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1604 
Fixes: APE-1289

### How I did it

* Made it so the events that did not decode would still show up as raw.
So `NodeOperatorAdded` is not still decoding for the tx, going to figure out why exactly before taking this PR out of draft.
So far, all this does and adhere to the advice and still show the events on the tx when they fail to decode.

### How to verify it

You should now see events where the event arguments didnt decode right - they are at least on the receipt now and everything else about them works, including the event name and such...
also the warning makes more sense.

Only thing left:

- [x] figure out why node operator added events isnt decoding

btw, am using some events with strings in it and that didnt cause any bug yet.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
