### PR TITLE
fix: persistent fork issue when calling `networks.fork()` [APE-938]

### DIFF
--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -96,9 +96,11 @@ class NetworkManager(BaseManager):
         provider_settings = provider_settings or {}
 
         if provider_name:
-            return forked_network.use_provider(provider_name, provider_settings)
+            return forked_network.use_provider(
+                provider_name, provider_settings, disconnect_after=True
+            )
 
-        return forked_network.use_default_provider(provider_settings)
+        return forked_network.use_default_provider(provider_settings, disconnect_after=True)
 
     @property
     def ecosystem_names(self) -> Set[str]:
@@ -441,6 +443,7 @@ class NetworkManager(BaseManager):
         self,
         network_choice: Optional[str] = None,
         provider_settings: Optional[Dict] = None,
+        disconnect_after: bool = False,
     ) -> ProviderContextManager:
         """
         Parse a network choice into a context manager for managing a temporary
@@ -465,7 +468,7 @@ class NetworkManager(BaseManager):
         provider = self.get_provider_from_choice(
             network_choice=network_choice, provider_settings=provider_settings
         )
-        return ProviderContextManager(provider=provider)
+        return ProviderContextManager(provider=provider, disconnect_after=disconnect_after)
 
     @property
     def default_ecosystem(self) -> EcosystemAPI:


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1433
Fixes: APE-938

### How I did it

When using the `fork()` function, disconnect.
Otherwise, do as normal.

### How to verify it

```python
In [2]: provider
Out[2]: <alchemy chain_id=1>

In [3]: provider.name
Out[3]: 'alchemy'

In [4]: provider.is_connected
Out[4]: True

In [5]: with networks.fork("hardhat"):
   ...:     print("test")
   ...: 
INFO: Starting 'Hardhat node' process.
INFO: Stopping 'Hardhat node' process.
test

In [6]: provider.is_connected
Out[6]: True

In [7]: with networks.fork("hardhat"):
   ...:     print(provider.name)
   ...:     print(provider.is_connected)
   ...: 
INFO: Starting 'Hardhat node' process.
INFO: Stopping 'Hardhat node' process.
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
