### PR TITLE
test: caplog fixes [APE-1396]

### DIFF
--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Dict, Union
 
 import pytest
@@ -24,12 +23,11 @@ def test_integer_deployment_addresses(networks):
 )
 def test_bad_value_in_deployments(ecosystems, networks, err_part, caplog, plugin_manager):
     deployments = _create_deployments()
-    with caplog.at_level(logging.WARNING):
-        all_ecosystems = dict(plugin_manager.ecosystems)
-        ecosystem_dict = {e: all_ecosystems[e] for e in ecosystems if e in all_ecosystems}
-        DeploymentConfigCollection(deployments, ecosystem_dict, networks)
-        assert len(caplog.records) > 0, "Nothing was logged"
-        assert f"Invalid {err_part}" in caplog.records[0].message
+    all_ecosystems = dict(plugin_manager.ecosystems)
+    ecosystem_dict = {e: all_ecosystems[e] for e in ecosystems if e in all_ecosystems}
+    DeploymentConfigCollection(deployments, ecosystem_dict, networks)
+    assert len(caplog.records) > 0, "Nothing was logged"
+    assert f"Invalid {err_part}" in caplog.records[0].message
 
 
 def _create_deployments(ecosystem_name: str = "ethereum", network_name: str = "local") -> Dict:

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -1,4 +1,3 @@
-import logging
 import time
 
 import pandas as pd
@@ -88,13 +87,11 @@ def test_column_validation(eth_tester_provider, caplog):
     expected = "Unrecognized field(s) 'numbr', must be one of 'number, timestamp'."
     assert exc_info.value.args[-1] == expected
 
-    with caplog.at_level(logging.WARNING):
-        validate_and_expand_columns(["numbr", "timestamp"], Model)
+    validate_and_expand_columns(["numbr", "timestamp"], Model)
 
     assert expected in caplog.records[-1].msg
 
-    with caplog.at_level(logging.WARNING):
-        validate_and_expand_columns(["number", "timestamp", "number"], Model)
+    validate_and_expand_columns(["number", "timestamp", "number"], Model)
 
     assert "Duplicate fields in ['number', 'timestamp', 'number']" in caplog.records[-1].msg
 

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -281,14 +281,15 @@ def test_compile_only_dependency(ape_cli, runner, project, clean_cache, caplog):
     # Trigger actual dependency compilation
     dependency = project.dependencies["dependency-in-project-only"]["local"]
     _ = dependency.DependencyInProjectOnly
+
+    # Pop the log record off here so we can check the tail again below.
     log_record = caplog.records.pop()
     assert expected_log_message in log_record.message
 
     # It should not need to compile again.
     _ = dependency.DependencyInProjectOnly
     if caplog.records:
-        log_record = caplog.records.pop()
-        assert expected_log_message not in log_record.message, "Compiled twice!"
+        assert expected_log_message not in caplog.records[-1].message, "Compiled twice!"
 
     # Force a re-compile and trigger the dependency to compile via CLI
     result = runner.invoke(


### PR DESCRIPTION
### What I did

we were getting some intermittent failures in tests because of caplog.
i think i found the reason why but dont know 100%

### How I did it

* removed a call `records.pop()` that was potentially causing issues
* removed unneeded calls to `at_level()` which could potentially hide some INFO based logs on other test s

### How to verify it

im hoping just all passing CI both now and in the future can help identify this as a success.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
