### PR TITLE
Move polls

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterator, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Type, Union
 
 import click
 from eip712.messages import SignableMessage as EIP712SignableMessage
@@ -54,18 +54,21 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         return None
 
     @abstractmethod
-    def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
+    def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
         """
         Sign a message.
 
         Args:
-          msg (:class:`~ape.types.signatures.SignableMessage`): The message to sign.
+          msg (Any): The message to sign. Account plugins can handle various types of messages.
+            For example, :class:`~ape.accounts.LocalAccount` can handle
+            :class:`~ape.types.signatures.SignableMessage`
             See these
             `docs <https://eth-account.readthedocs.io/en/stable/eth_account.html#eth_account.messages.SignableMessage>`__  # noqa: E501
             for more type information on this type.
+          **signer_options: Additional kwargs given to the signer to modify the signing operation.
 
         Returns:
-          :class:`~ape.types.signatures.MessageSignature` (optional): The signed message.
+            :class:`~ape.types.signatures.MessageSignature` (optional): The signed message.
         """
 
     @abstractmethod
@@ -494,7 +497,7 @@ class ImpersonatedAccount(AccountAPI):
     def address(self) -> AddressType:
         return self.raw_address
 
-    def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
+    def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
         raise NotImplementedError("This account cannot sign messages")
 
     def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -68,7 +68,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
           **signer_options: Additional kwargs given to the signer to modify the signing operation.
 
         Returns:
-            :class:`~ape.types.signatures.MessageSignature` (optional): The signed message.
+            :class:`~ape.types.signatures.MessageSignature` (optional): The signature corresponding to the message.
         """
 
     @abstractmethod

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -2,7 +2,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Type, Union
 
 import click
-from eip712.messages import EIP712Message, SignableMessage as EIP712SignableMessage
+from eip712.messages import EIP712Message
+from eip712.messages import SignableMessage as EIP712SignableMessage
 from eth_account import Account
 from eth_account.messages import encode_defunct
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -597,12 +597,12 @@ class ProviderAPI(BaseInterfaceModel):
         """
 
     @raises_not_implemented
-    def poll_blocks(
+    def poll_blocks(  # type: ignore[empty-body]
         self,
         stop_block: Optional[int] = None,
         required_confirmations: Optional[int] = None,
         new_block_timeout: Optional[int] = None,
-    ) -> Iterator[BlockAPI]:  # type: ignore[empty-body]
+    ) -> Iterator[BlockAPI]:
         """
         Poll new blocks.
 
@@ -1631,7 +1631,7 @@ class Web3Provider(ProviderAPI, ABC):
 
     @property
     def height(self) -> int:
-        return self.head.number
+        return self.head.number or 0
 
     def range_blocks(
         self,

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -29,7 +29,7 @@ from web3.types import RPCEndpoint, TxParams
 
 from ape.api.config import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI
-from ape.api.query import BlockTransactionQuery, ContractEventQuery
+from ape.api.query import BlockQuery, BlockTransactionQuery, ContractEventQuery
 from ape.api.transactions import ReceiptAPI, TransactionAPI
 from ape.exceptions import (
     ApeException,

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -29,9 +29,8 @@ from web3.types import RPCEndpoint, TxParams
 
 from ape.api.config import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI
-from ape.api.query import BlockTransactionQuery
+from ape.api.query import BlockTransactionQuery, ContractEventQuery
 from ape.api.transactions import ReceiptAPI, TransactionAPI
-from ape.contracts.base import ContractInstance, ContractTypeWrapper
 from ape.exceptions import (
     ApeException,
     APINotImplementedError,
@@ -1816,7 +1815,7 @@ class Web3Provider(ProviderAPI, ABC):
 
     def range_contract_events(
         self,
-        contract: ContractInstance,
+        contract: "ContractInstance",
         start_or_stop: int,
         stop: Optional[int] = None,
         search_topics: Optional[Dict[str, Any]] = None,
@@ -1882,7 +1881,7 @@ class Web3Provider(ProviderAPI, ABC):
 
     def poll_logs(
         self,
-        contract: ContractTypeWrapper,
+        contract: "ContractTypeWrapper",
         stop_block: Optional[int] = None,
         required_confirmations: Optional[int] = None,
         new_block_timeout: Optional[int] = None,

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1811,7 +1811,7 @@ class Web3Provider(ProviderAPI, ABC):
 
     def range_contract_events(
         self,
-        contract: "ContractInstance",
+        contract: "ContractInstance", # noqa: F821
         start_or_stop: int,
         stop: Optional[int] = None,
         search_topics: Optional[Dict[str, Any]] = None,
@@ -1876,7 +1876,7 @@ class Web3Provider(ProviderAPI, ABC):
 
     def poll_logs(
         self,
-        contract: "ContractTypeWrapper",
+        contract: "ContractTypeWrapper", # noqa: F821
         stop_block: Optional[int] = None,
         required_confirmations: Optional[int] = None,
         new_block_timeout: Optional[int] = None,

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -602,7 +602,7 @@ class ProviderAPI(BaseInterfaceModel):
         stop_block: Optional[int] = None,
         required_confirmations: Optional[int] = None,
         new_block_timeout: Optional[int] = None,
-    ) -> Iterator[BlockAPI]: # type: ignore[empty-body]
+    ) -> Iterator[BlockAPI]:  # type: ignore[empty-body]
         """
         Poll new blocks.
 
@@ -657,7 +657,6 @@ class ProviderAPI(BaseInterfaceModel):
                went wrong in the call.
         """
         return VirtualMachineError(base_err=exception, **kwargs)
-
 
 
 class TestProviderAPI(ProviderAPI):
@@ -1694,12 +1693,12 @@ class Web3Provider(ProviderAPI, ABC):
         blocks = self.query_manager.query(query, engine_to_use=engine_to_use)
         yield from cast(Iterator[BlockAPI], blocks)
 
-
     def poll_blocks(
-            self,
-            stop_block: Optional[int] = None,
-            required_confirmations: Optional[int] = None,
-            new_block_timeout: Optional[int] = None) -> Iterator[BlockAPI]:
+        self,
+        stop_block: Optional[int] = None,
+        required_confirmations: Optional[int] = None,
+        new_block_timeout: Optional[int] = None,
+    ) -> Iterator[BlockAPI]:
         network_name = self.network.name
         block_time = self.provider.network.block_time
         timeout = (
@@ -1731,10 +1730,7 @@ class Web3Provider(ProviderAPI, ABC):
             if time.time() - time_since_last > timeout:
                 time_waited = round(time.time() - time_since_last, 4)
                 message = f"Timed out waiting for new block (time_waited={time_waited})."
-                if (
-                    self.network.name == LOCAL_NETWORK_NAME
-                    or self.network.name.endswith("-fork")
-                ):
+                if self.network.name == LOCAL_NETWORK_NAME or self.network.name.endswith("-fork"):
                     message += (
                         " If using a local network, try configuring mining to mine on an interval "
                         "or adjusting the block time."
@@ -1878,7 +1874,6 @@ class Web3Provider(ProviderAPI, ABC):
         )
         yield from self.query_manager.query(contract_event_query)  # type: ignore
 
-
     def poll_logs(
         self,
         contract: "ContractTypeWrapper",
@@ -1886,10 +1881,7 @@ class Web3Provider(ProviderAPI, ABC):
         required_confirmations: Optional[int] = None,
         new_block_timeout: Optional[int] = None,
     ) -> Iterator[ContractLog]:
-
-        required_confirmations = (
-            required_confirmations or self.network.required_confirmations
-        )
+        required_confirmations = required_confirmations or self.network.required_confirmations
 
         height = max(self.chain_manager.blocks.height - required_confirmations, 0)
 
@@ -1906,8 +1898,9 @@ class Web3Provider(ProviderAPI, ABC):
                 continue
 
             # Get all events in the new block.
-            yield from self.range_contract_events(contract, new_block.number, stop=new_block.number + 1)
-
+            yield from self.range_contract_events(
+                contract, new_block.number, stop=new_block.number + 1
+            )
 
 
 class UpstreamProvider(ProviderAPI):

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -138,7 +138,8 @@ class KeyfileAccount(AccountAPI):
                 r=to_bytes(signed_msg.r),
                 s=to_bytes(signed_msg.s),
             )
-        raise TypeError(f"Can't sign message of type {type(msg)}")
+        logger.warning("Unsupported message type, (type=%r, msg=%r)", type(msg), msg)
+        return None
 
     def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:
         user_approves = self.__autosign or click.confirm(f"{txn}\n\nSign: ")

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -122,6 +122,7 @@ class KeyfileAccount(AccountAPI):
 
     def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
         if isinstance(msg, str):
+            # Convert to SignableMessage for handling below
             msg = encode_defunct(text=msg)
         if isinstance(msg, SignableMessage):
             user_approves = self.__autosign or click.confirm(f"{msg}\n\nSign: ")

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Iterator, Optional
 
 import click
+from eip712.messages import EIP712Message
 from eth_account import Account as EthAccount
 from eth_account.messages import encode_defunct
 from eth_utils import to_bytes
@@ -122,8 +123,11 @@ class KeyfileAccount(AccountAPI):
 
     def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
         if isinstance(msg, str):
-            # Convert to SignableMessage for handling below
+            # Convert str to SignableMessage for handling below
             msg = encode_defunct(text=msg)
+        elif isinstance(msg, EIP712Message):
+            # Convert EIP712Message to SignableMessage for handling below
+            msg = msg.signable_message
         if isinstance(msg, SignableMessage):
             user_approves = self.__autosign or click.confirm(f"{msg}\n\nSign: ")
             if not user_approves:

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -1,7 +1,7 @@
-from typing import Iterator, List, Optional
+from typing import Any, Iterator, List, Optional
 
 from eth_account import Account as EthAccount
-from eth_account.messages import SignableMessage
+from eth_account.messages import SignableMessage, encode_defunct
 from eth_utils import to_bytes
 
 from ape.api import TestAccountAPI, TestAccountContainerAPI, TransactionAPI
@@ -101,13 +101,16 @@ class TestAccount(TestAccountAPI):
     def address(self) -> AddressType:
         return self.network_manager.ethereum.decode_address(self.address_str)
 
-    def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
-        signed_msg = EthAccount.sign_message(msg, self.private_key)
-        return MessageSignature(
-            v=signed_msg.v,
-            r=to_bytes(signed_msg.r),
-            s=to_bytes(signed_msg.s),
-        )
+    def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
+        if isinstance(msg, str):
+            msg = encode_defunct(text=msg)
+        if isinstance(msg, SignableMessage):
+            signed_msg = EthAccount.sign_message(msg, self.private_key)
+            return MessageSignature(
+                v=signed_msg.v,
+                r=to_bytes(signed_msg.r),
+                s=to_bytes(signed_msg.s),
+            )
 
     def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:
         # Signs anything that's given to it

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -111,6 +111,7 @@ class TestAccount(TestAccountAPI):
                 r=to_bytes(signed_msg.r),
                 s=to_bytes(signed_msg.s),
             )
+        return None
 
     def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:
         # Signs anything that's given to it

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -50,6 +50,12 @@ def test_sign_message(signer):
     assert signer.check_signature(message, signature)
 
 
+def test_sign_message_unsupported_type_returns_none(signer):
+    message = 1234
+    signature = signer.sign_message(message)
+    assert signature is None
+
+
 def test_recover_signer(signer):
     message = encode_defunct(text="Hello Apes!")
     signature = signer.sign_message(message)


### PR DESCRIPTION
### What I did

Moves the logic for polling events and blocks into the Provider API. These new methods no longer also query historical data, they are only used for gathering events/blocks as they come in.

### How I did it

Moved the logic over, and made it so the necessary contract data for polling events comes in as an argument.
Also removed the querying of historical data, calling these new functions now will only pull future events. The `range_*` methods in the provider implementation can still be used to query for historical data, and if useful this could be added to the ProvidersAPI interface.

### How to verify it

Queried for new contract events manually

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [X] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
