### PR TITLE
refactor: move web3 loggers and fix test failures [APE-1404]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
       - id: black
         name: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
+requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0,<8"]
 
 [tool.mypy]
 exclude = ["build/", "dist/", "docs/", "tests/integration/cli/projects/"]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require = {
         "hypothesis-jsonschema==0.19.0",  # JSON Schema fuzzer extension
     ],
     "lint": [
-        "black>=23.7.0,<24",  # Auto-formatter and linter
+        "black>=23.9.1,<24",  # Auto-formatter and linter
         "mypy>=1.5.1,<2",  # Static type analyzer
         "types-PyYAML",  # Needed due to mypy typeshed
         "types-requests",  # Needed due to mypy typeshed

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -723,6 +723,11 @@ class Web3Provider(ProviderAPI, ABC):
     _web3: Optional[Web3] = None
     _client_version: Optional[str] = None
 
+    def __init__(self, *args, **kwargs):
+        logger.create_logger("web3.RequestManager")
+        logger.create_logger("web3.providers.HTTPProvider")
+        super().__init__(*args, **kwargs)
+
     @property
     def web3(self) -> Web3:
         """

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import Any, Dict, Iterator, List, Optional, Set, Type, Union
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Type, Union
 
 from ethpm_types.abi import EventABI, MethodABI
 from pydantic import BaseModel, NonNegativeInt, PositiveInt, root_validator
@@ -53,7 +53,9 @@ def _all_columns(Model: Type[BaseInterfaceModel]) -> Set[str]:
     return columns
 
 
-def validate_and_expand_columns(columns: List[str], Model: Type[BaseInterfaceModel]) -> List[str]:
+def validate_and_expand_columns(
+    columns: Sequence[str], Model: Type[BaseInterfaceModel]
+) -> List[str]:
     if len(columns) == 1 and columns[0] == "*":
         # NOTE: By default, only pull explicit fields
         #       (because they are cheap to pull, but properties might not be)

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -12,7 +12,7 @@ from ape.cli.choices import (
 )
 from ape.cli.utils import Abort
 from ape.exceptions import ContractError
-from ape.logging import DEFAULT_LOG_LEVEL, CliLogger, LogLevel, logger
+from ape.logging import DEFAULT_LOG_LEVEL, ApeLogger, LogLevel, logger
 from ape.managers.base import ManagerAccessMixin
 
 _VERBOSITY_VALUES = ("--verbosity", "-v")
@@ -47,7 +47,7 @@ class ApeCliContextObject(ManagerAccessMixin):
         raise Abort(msg)
 
 
-def verbosity_option(cli_logger: Optional[CliLogger] = None, default: str = DEFAULT_LOG_LEVEL):
+def verbosity_option(cli_logger: Optional[ApeLogger] = None, default: str = DEFAULT_LOG_LEVEL):
     """A decorator that adds a `--verbosity, -v` option to the decorated
     command.
     """
@@ -57,7 +57,7 @@ def verbosity_option(cli_logger: Optional[CliLogger] = None, default: str = DEFA
 
 
 def _create_verbosity_kwargs(
-    _logger: Optional[CliLogger] = None, default: str = DEFAULT_LOG_LEVEL
+    _logger: Optional[ApeLogger] = None, default: str = DEFAULT_LOG_LEVEL
 ) -> Dict:
     cli_logger = _logger or logger
 

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -102,7 +102,7 @@ class ClickHandler(logging.Handler):
             self.handleError(record)
 
 
-class CliLogger:
+class ApeLogger:
     _mentioned_verbosity_option = False
     _extra_loggers: Dict[str, logging.Logger] = {}
 
@@ -121,7 +121,7 @@ class CliLogger:
         self.fmt = fmt
 
     @classmethod
-    def create(cls, fmt: Optional[str] = None) -> "CliLogger":
+    def create(cls, fmt: Optional[str] = None) -> "ApeLogger":
         fmt = fmt or DEFAULT_LOG_FORMAT
         _logger = get_logger("ape", fmt=fmt)
         return cls(_logger, fmt)
@@ -258,7 +258,10 @@ def _get_level(level: Optional[Union[str, int]] = None) -> str:
     return level
 
 
-logger = CliLogger.create()
+logger = ApeLogger.create()
+
+# TODO: Can remove this type alias after 0.7
+CliLogger = ApeLogger
 
 
-__all__ = ["DEFAULT_LOG_LEVEL", "logger", "LogLevel"]
+__all__ = ["DEFAULT_LOG_LEVEL", "logger", "LogLevel", "ApeLogger"]

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1318,15 +1318,6 @@ class ContractCache(BaseManager):
         if not deployments:
             return []
 
-        if isinstance(deployments[0], str):
-            # TODO: Remove this migration logic >= version 0.6.0
-            logger.debug("Migrating 'deployments_map.json'.")
-            deployments = [{"address": a} for a in deployments]
-            self._deployments = {
-                **self._deployments,
-                contract_type.name: deployments,
-            }
-
         instances: List[ContractInstance] = []
         for deployment in deployments:
             address = deployment["address"]

--- a/src/ape_networks/_cli.py
+++ b/src/ape_networks/_cli.py
@@ -85,8 +85,8 @@ def run(cli_ctx, network):
     Start a node process
     """
 
-    # Ignore web3 logs
-    cli_ctx.logger._clear_extra_loggers()
+    # Ignore extra loggers, such as web3 loggers.
+    cli_ctx.logger._extra_loggers = {}
 
     network_ctx = cli_ctx.network_manager.parse_network_choice(network)
     provider = network_ctx._provider

--- a/src/ape_networks/_cli.py
+++ b/src/ape_networks/_cli.py
@@ -86,7 +86,7 @@ def run(cli_ctx, network):
     """
 
     # Ignore web3 logs
-    cli_ctx.logger._clear_web3_loggers()
+    cli_ctx.logger._clear_extra_loggers()
 
     network_ctx = cli_ctx.network_manager.parse_network_choice(network)
     provider = network_ctx._provider

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -42,7 +42,7 @@ def plugins_argument():
     """
 
     def load_from_file(ctx, file_path: Path) -> List[PluginInstallRequest]:
-        if file_path.is_file() and file_path.name != CONFIG_FILE_NAME:
+        if file_path.is_dir() and (file_path / CONFIG_FILE_NAME).is_file():
             file_path = file_path / CONFIG_FILE_NAME
 
         if file_path.is_file():

--- a/src/ape_plugins/utils.py
+++ b/src/ape_plugins/utils.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Tuple
 from pydantic import root_validator
 
 from ape.__modules__ import __modules__
-from ape.logging import CliLogger
+from ape.logging import ApeLogger
 from ape.plugins import clean_plugin_name
 from ape.utils import BaseInterfaceModel, cached_property, get_package_version, github_client
 
@@ -194,7 +194,7 @@ class PluginInstallRequest(BaseInterfaceModel):
 
 
 class ModifyPluginResultHandler:
-    def __init__(self, logger: CliLogger, plugin: PluginInstallRequest):
+    def __init__(self, logger: ApeLogger, plugin: PluginInstallRequest):
         self._logger = logger
         self._plugin = plugin
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import Callable, Dict, Optional
+from typing import Dict, Optional
 
 import pytest
 import yaml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -396,6 +396,7 @@ def ape_caplog(caplog):
     class ApeCaplog:
         def __init__(self):
             self.messages_at_start = list(caplog.messages)
+            self.set_levels()
 
         def __getattr__(self, name: str) -> Any:
             return getattr(caplog, name)
@@ -424,6 +425,11 @@ def ape_caplog(caplog):
             """
             return caplog.messages[-1] if len(caplog.messages) else ""
 
+        @classmethod
+        def set_levels(cls):
+            logger.set_level(LogLevel.INFO)
+            caplog.set_level(LogLevel.WARNING)
+
         def assert_last_log(self, message: str):
             assert message in self.head, self.fail_message
 
@@ -446,11 +452,10 @@ def ape_caplog(caplog):
                 time.sleep(delay)
 
                 # Reset levels in case they got switched.
+                self.set_levels()
                 logger.set_level(LogLevel.INFO)
                 caplog.set_level(LogLevel.WARNING)
 
             pytest.fail(self.fail_message)
 
-    logger.set_level(LogLevel.INFO)
-    caplog.set_level(LogLevel.WARNING)
     return ApeCaplog()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -401,12 +401,19 @@ def ape_caplog(caplog):
 
         @property
         def fail_message(self) -> str:
-            logs_before_message = (
-                f"Failed to detect logs. "
-                f"However, we did have logs before the operation: "
-                f"{', '.join(self.messages_at_start)}"
-            )
-            return logs_before_message if self.messages_at_start else "failed to detect log"
+            if caplog.messages:
+                last_message = caplog.messages[-1]
+                return f"Actual last message: {last_message}"
+
+            elif self.messages_at_start:
+                return (
+                    f"Failed to detect logs. "
+                    f"However, we did have logs before the operation: "
+                    f"{', '.join(self.messages_at_start)}"
+                )
+
+            else:
+                return "No logs found!"
 
         @property
         def head(self) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from click.testing import CliRunner
 
 import ape
 from ape.exceptions import APINotImplementedError, UnknownSnapshotError
+from ape.logging import LogLevel, logger
 from ape.managers.config import CONFIG_FILE_NAME
 from ape.types import AddressType
 from ape.utils import ZERO_ADDRESS
@@ -387,3 +388,10 @@ def skip_if_plugin_installed(*plugin_names: str):
 @pytest.fixture
 def zero_address():
     return ZERO_ADDRESS
+
+
+@pytest.fixture
+def ape_caplog(caplog):
+    logger.set_level(LogLevel.INFO)
+    caplog.set_level(LogLevel.WARNING)
+    return caplog

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -387,33 +387,3 @@ def skip_if_plugin_installed(*plugin_names: str):
 @pytest.fixture
 def zero_address():
     return ZERO_ADDRESS
-
-
-@pytest.fixture
-def assert_log(caplog):
-    """
-    A utility for asserting logs occurred.
-    It will attempt the operation more than once to verify the log.
-    """
-
-    class CheckState:
-        TIMES: int = 3
-        times_tried: int = 0
-        success: bool = False
-
-    state = CheckState()
-
-    def fn(op: Callable, expected: str):
-        result = None
-        while state.times_tried < state.TIMES:
-            result = op()
-            if len(caplog.records) > 0 and expected in caplog.records[-1].message:
-                state.success = True
-                break
-            else:
-                state.times_tried += 1
-
-        assert state.success, f"Log '{expected}' not found."
-        return result
-
-    return fn

--- a/tests/functional/test_block_container.py
+++ b/tests/functional/test_block_container.py
@@ -132,7 +132,7 @@ def test_poll_blocks_reorg(chain_that_mined_5, eth_tester_provider, owner, PollD
         "Try adjusting the required network confirmations."
     )
     assert caplog.records, "Didn't detect re-org"
-    assert expected_error in caplog.records[-1].message
+    assert expected_error in caplog.messages[-1]
 
     # Show that there are duplicate blocks
     block_numbers: List[int] = [blocks.get().number for _ in range(6)]

--- a/tests/functional/test_block_container.py
+++ b/tests/functional/test_block_container.py
@@ -100,7 +100,7 @@ def test_poll_blocks(chain_that_mined_5, eth_tester_provider, owner, PollDaemon)
     assert second == third - 1
 
 
-def test_poll_blocks_reorg(chain_that_mined_5, eth_tester_provider, owner, PollDaemon, caplog):
+def test_poll_blocks_reorg(chain_that_mined_5, eth_tester_provider, owner, PollDaemon, ape_caplog):
     blocks: Queue = Queue(maxsize=6)
     poller = chain_that_mined_5.blocks.poll_blocks()
 
@@ -131,8 +131,8 @@ def test_poll_blocks_reorg(chain_that_mined_5, eth_tester_provider, owner, PollD
         "Chain has reorganized since returning the last block. "
         "Try adjusting the required network confirmations."
     )
-    assert caplog.records, "Didn't detect re-org"
-    assert expected_error in caplog.messages[-1]
+    assert ape_caplog.records, "Didn't detect re-org"
+    ape_caplog.assert_last_log(expected_error)
 
     # Show that there are duplicate blocks
     block_numbers: List[int] = [blocks.get().number for _ in range(6)]

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -21,13 +21,15 @@ def test_integer_deployment_addresses(networks):
     "ecosystems,networks,err_part",
     [(["ERRORS"], ["mainnet"], "ecosystem"), (["ethereum"], ["ERRORS"], "network")],
 )
-def test_bad_value_in_deployments(ecosystems, networks, err_part, caplog, plugin_manager):
+def test_bad_value_in_deployments(ecosystems, networks, err_part, assert_log, plugin_manager):
     deployments = _create_deployments()
     all_ecosystems = dict(plugin_manager.ecosystems)
     ecosystem_dict = {e: all_ecosystems[e] for e in ecosystems if e in all_ecosystems}
     DeploymentConfigCollection(deployments, ecosystem_dict, networks)
-    assert len(caplog.records) > 0, "Nothing was logged"
-    assert f"Invalid {err_part}" in caplog.records[0].message
+    assert_log(
+        lambda: DeploymentConfigCollection(deployments, ecosystem_dict, networks),
+        f"Invalid {err_part}",
+    )
 
 
 def _create_deployments(ecosystem_name: str = "ethereum", network_name: str = "local") -> Dict:

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -26,7 +26,7 @@ def test_bad_value_in_deployments(ecosystems, networks, err_part, caplog, plugin
     all_ecosystems = dict(plugin_manager.ecosystems)
     ecosystem_dict = {e: all_ecosystems[e] for e in ecosystems if e in all_ecosystems}
     DeploymentConfigCollection(deployments, ecosystem_dict, networks)
-    assert f"Invalid {err_part}" in caplog.records[-1].message
+    assert f"Invalid {err_part}" in caplog.messages[-1]
 
 
 def _create_deployments(ecosystem_name: str = "ethereum", network_name: str = "local") -> Dict:

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -26,7 +26,10 @@ def test_bad_value_in_deployments(ecosystems, networks, err_part, ape_caplog, pl
     all_ecosystems = dict(plugin_manager.ecosystems)
     ecosystem_dict = {e: all_ecosystems[e] for e in ecosystems if e in all_ecosystems}
     DeploymentConfigCollection(deployments, ecosystem_dict, networks)
-    ape_caplog.assert_last_log(f"Invalid {err_part}")
+    ape_caplog.assert_last_log_with_retries(
+        lambda: DeploymentConfigCollection(deployments, ecosystem_dict, networks),
+        f"Invalid {err_part}",
+    )
 
 
 def _create_deployments(ecosystem_name: str = "ethereum", network_name: str = "local") -> Dict:

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -21,12 +21,12 @@ def test_integer_deployment_addresses(networks):
     "ecosystems,networks,err_part",
     [(["ERRORS"], ["mainnet"], "ecosystem"), (["ethereum"], ["ERRORS"], "network")],
 )
-def test_bad_value_in_deployments(ecosystems, networks, err_part, caplog, plugin_manager):
+def test_bad_value_in_deployments(ecosystems, networks, err_part, ape_caplog, plugin_manager):
     deployments = _create_deployments()
     all_ecosystems = dict(plugin_manager.ecosystems)
     ecosystem_dict = {e: all_ecosystems[e] for e in ecosystems if e in all_ecosystems}
     DeploymentConfigCollection(deployments, ecosystem_dict, networks)
-    assert f"Invalid {err_part}" in caplog.messages[-1]
+    assert f"Invalid {err_part}" in ape_caplog.messages[-1]
 
 
 def _create_deployments(ecosystem_name: str = "ethereum", network_name: str = "local") -> Dict:

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -21,15 +21,12 @@ def test_integer_deployment_addresses(networks):
     "ecosystems,networks,err_part",
     [(["ERRORS"], ["mainnet"], "ecosystem"), (["ethereum"], ["ERRORS"], "network")],
 )
-def test_bad_value_in_deployments(ecosystems, networks, err_part, assert_log, plugin_manager):
+def test_bad_value_in_deployments(ecosystems, networks, err_part, caplog, plugin_manager):
     deployments = _create_deployments()
     all_ecosystems = dict(plugin_manager.ecosystems)
     ecosystem_dict = {e: all_ecosystems[e] for e in ecosystems if e in all_ecosystems}
     DeploymentConfigCollection(deployments, ecosystem_dict, networks)
-    assert_log(
-        lambda: DeploymentConfigCollection(deployments, ecosystem_dict, networks),
-        f"Invalid {err_part}",
-    )
+    assert f"Invalid {err_part}" in caplog.records[-1].message
 
 
 def _create_deployments(ecosystem_name: str = "ethereum", network_name: str = "local") -> Dict:

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -26,7 +26,7 @@ def test_bad_value_in_deployments(ecosystems, networks, err_part, ape_caplog, pl
     all_ecosystems = dict(plugin_manager.ecosystems)
     ecosystem_dict = {e: all_ecosystems[e] for e in ecosystems if e in all_ecosystems}
     DeploymentConfigCollection(deployments, ecosystem_dict, networks)
-    assert f"Invalid {err_part}" in ape_caplog.messages[-1]
+    ape_caplog.assert_last_log(f"Invalid {err_part}")
 
 
 def _create_deployments(ecosystem_name: str = "ethereum", network_name: str = "local") -> Dict:

--- a/tests/functional/test_contracts_cache.py
+++ b/tests/functional/test_contracts_cache.py
@@ -209,17 +209,6 @@ def test_get_deployments_live(
     assert address_from_api_1 == deployed_contract_1.address
 
 
-def test_get_deployments_live_migration(
-    chain, owner, contract_0, dummy_live_network, ape_caplog, use_debug
-):
-    contract = owner.deploy(contract_0, required_confirmations=0)
-    old_style_map = {"ethereum": {"goerli": {"ApeContract0": [contract.address]}}}
-    chain.contracts._write_deployments_mapping(old_style_map)
-    actual = chain.contracts.get_deployments(contract_0)
-    assert actual == [contract]
-    assert ape_caplog.messages[-1] == "Migrating 'deployments_map.json'."
-
-
 def test_get_multiple_deployments_live(
     chain, owner, contract_0, contract_1, remove_disk_writes_deployments, dummy_live_network
 ):

--- a/tests/functional/test_contracts_cache.py
+++ b/tests/functional/test_contracts_cache.py
@@ -65,7 +65,7 @@ def test_instance_at_uses_given_contract_type_when_retrieval_fails(mocker, chain
     chain.contracts.get.side_effect = fn
 
     actual = chain.contracts.instance_at(new_address, contract_type=expected_contract_type)
-    assert expected_fail_message in caplog.records[-1].message
+    assert expected_fail_message in caplog.messages[-1]
     assert actual.contract_type == expected_contract_type
 
 
@@ -217,7 +217,7 @@ def test_get_deployments_live_migration(
     chain.contracts._write_deployments_mapping(old_style_map)
     actual = chain.contracts.get_deployments(contract_0)
     assert actual == [contract]
-    assert caplog.records[-1].message == "Migrating 'deployments_map.json'."
+    assert caplog.messages[-1] == "Migrating 'deployments_map.json'."
 
 
 def test_get_multiple_deployments_live(
@@ -283,7 +283,7 @@ def test_get_multiple_no_addresses(chain, caplog):
     contract_map = chain.contracts.get_multiple([])
     assert not contract_map
     assert "WARNING" in caplog.records[-1].levelname
-    assert "No addresses provided." in caplog.records[-1].message
+    assert "No addresses provided." in caplog.messages[-1]
 
 
 def test_get_all_include_non_contract_address(vyper_contract_instance, chain, owner):

--- a/tests/functional/test_contracts_cache.py
+++ b/tests/functional/test_contracts_cache.py
@@ -46,7 +46,7 @@ def test_instance_at_when_given_name_as_contract_type(chain, contract_instance):
 
 
 @explorer_test
-def test_instance_at_uses_given_contract_type_when_retrieval_fails(mocker, chain, caplog):
+def test_instance_at_uses_given_contract_type_when_retrieval_fails(mocker, chain, ape_caplog):
     # The manager always attempts retrieval so that default contact types can
     # get cached. However, sometimes an explorer plugin may fail. If given a contract-type
     # in that situation, we can use it and not fail and log the error instead.
@@ -65,7 +65,7 @@ def test_instance_at_uses_given_contract_type_when_retrieval_fails(mocker, chain
     chain.contracts.get.side_effect = fn
 
     actual = chain.contracts.instance_at(new_address, contract_type=expected_contract_type)
-    assert expected_fail_message in caplog.messages[-1]
+    ape_caplog.assert_last_log(expected_fail_message)
     assert actual.contract_type == expected_contract_type
 
 

--- a/tests/functional/test_contracts_cache.py
+++ b/tests/functional/test_contracts_cache.py
@@ -210,14 +210,14 @@ def test_get_deployments_live(
 
 
 def test_get_deployments_live_migration(
-    chain, owner, contract_0, dummy_live_network, caplog, use_debug
+    chain, owner, contract_0, dummy_live_network, ape_caplog, use_debug
 ):
     contract = owner.deploy(contract_0, required_confirmations=0)
     old_style_map = {"ethereum": {"goerli": {"ApeContract0": [contract.address]}}}
     chain.contracts._write_deployments_mapping(old_style_map)
     actual = chain.contracts.get_deployments(contract_0)
     assert actual == [contract]
-    assert caplog.messages[-1] == "Migrating 'deployments_map.json'."
+    assert ape_caplog.messages[-1] == "Migrating 'deployments_map.json'."
 
 
 def test_get_multiple_deployments_live(

--- a/tests/functional/test_contracts_cache.py
+++ b/tests/functional/test_contracts_cache.py
@@ -46,7 +46,7 @@ def test_instance_at_when_given_name_as_contract_type(chain, contract_instance):
 
 
 @explorer_test
-def test_instance_at_uses_given_contract_type_when_retrieval_fails(mocker, chain, caplog):
+def test_instance_at_uses_given_contract_type_when_retrieval_fails(mocker, chain, assert_log):
     # The manager always attempts retrieval so that default contact types can
     # get cached. However, sometimes an explorer plugin may fail. If given a contract-type
     # in that situation, we can use it and not fail and log the error instead.
@@ -64,9 +64,11 @@ def test_instance_at_uses_given_contract_type_when_retrieval_fails(mocker, chain
     chain.contracts.get = mocker.MagicMock()
     chain.contracts.get.side_effect = fn
 
-    actual = chain.contracts.instance_at(new_address, contract_type=expected_contract_type)
+    actual = assert_log(
+        lambda: chain.contracts.instance_at(new_address, contract_type=expected_contract_type),
+        expected_fail_message,
+    )
     assert actual.contract_type == expected_contract_type
-    assert caplog.records[-1].message == expected_fail_message
 
 
 @explorer_test

--- a/tests/functional/test_contracts_cache.py
+++ b/tests/functional/test_contracts_cache.py
@@ -46,7 +46,7 @@ def test_instance_at_when_given_name_as_contract_type(chain, contract_instance):
 
 
 @explorer_test
-def test_instance_at_uses_given_contract_type_when_retrieval_fails(mocker, chain, assert_log):
+def test_instance_at_uses_given_contract_type_when_retrieval_fails(mocker, chain, caplog):
     # The manager always attempts retrieval so that default contact types can
     # get cached. However, sometimes an explorer plugin may fail. If given a contract-type
     # in that situation, we can use it and not fail and log the error instead.
@@ -64,10 +64,8 @@ def test_instance_at_uses_given_contract_type_when_retrieval_fails(mocker, chain
     chain.contracts.get = mocker.MagicMock()
     chain.contracts.get.side_effect = fn
 
-    actual = assert_log(
-        lambda: chain.contracts.instance_at(new_address, contract_type=expected_contract_type),
-        expected_fail_message,
-    )
+    actual = chain.contracts.instance_at(new_address, contract_type=expected_contract_type)
+    assert expected_fail_message in caplog.records[-1].message
     assert actual.contract_type == expected_contract_type
 
 

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -205,26 +205,26 @@ def test_block_times(ethereum):
     assert ethereum.goerli.block_time == 15
 
 
-def test_ecosystems_when_default_network_not_exists(temp_config, caplog, networks):
+def test_ecosystems_when_default_network_not_exists(temp_config, ape_caplog, networks):
     bad_network = "NOT_EXISTS"
     config = {"ethereum": {"default_network": bad_network}}
     with temp_config(config):
         assert networks.ecosystems
 
-    err = caplog.messages[-1]
+    err = ape_caplog.messages[-1]
     assert err == (
         f"Failed setting default network: "
         f"'{bad_network}' is not a valid network for ecosystem 'ethereum'."
     )
 
 
-def test_ecosystems_when_default_provider_not_exists(temp_config, caplog, networks):
+def test_ecosystems_when_default_provider_not_exists(temp_config, ape_caplog, networks):
     bad_provider = "NOT_EXISTS"
     config = {"ethereum": {"goerli": {"default_provider": bad_provider}}}
     with temp_config(config):
         assert networks.ecosystems
 
-    err = caplog.messages[-1]
+    err = ape_caplog.messages[-1]
     assert err == (
         f"Failed setting default provider: "
         f"Provider '{bad_provider}' not found in network 'ethereum:goerli'."

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -211,7 +211,7 @@ def test_ecosystems_when_default_network_not_exists(temp_config, caplog, network
     with temp_config(config):
         assert networks.ecosystems
 
-    err = caplog.records[-1].message
+    err = caplog.messages[-1]
     assert err == (
         f"Failed setting default network: "
         f"'{bad_network}' is not a valid network for ecosystem 'ethereum'."
@@ -224,7 +224,7 @@ def test_ecosystems_when_default_provider_not_exists(temp_config, caplog, networ
     with temp_config(config):
         assert networks.ecosystems
 
-    err = caplog.records[-1].message
+    err = caplog.messages[-1]
     assert err == (
         f"Failed setting default provider: "
         f"Provider '{bad_provider}' not found in network 'ethereum:goerli'."

--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -211,8 +211,7 @@ def test_ecosystems_when_default_network_not_exists(temp_config, ape_caplog, net
     with temp_config(config):
         assert networks.ecosystems
 
-    err = ape_caplog.messages[-1]
-    assert err == (
+    assert ape_caplog.head == (
         f"Failed setting default network: "
         f"'{bad_network}' is not a valid network for ecosystem 'ethereum'."
     )
@@ -224,8 +223,7 @@ def test_ecosystems_when_default_provider_not_exists(temp_config, ape_caplog, ne
     with temp_config(config):
         assert networks.ecosystems
 
-    err = ape_caplog.messages[-1]
-    assert err == (
+    assert ape_caplog.head == (
         f"Failed setting default provider: "
         f"Provider '{bad_provider}' not found in network 'ethereum:goerli'."
     )

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -88,11 +88,9 @@ def test_column_validation(eth_tester_provider, caplog):
     assert exc_info.value.args[-1] == expected
 
     validate_and_expand_columns(["numbr", "timestamp"], Model)
-
     assert expected in caplog.records[-1].msg
 
     validate_and_expand_columns(["number", "timestamp", "number"], Model)
-
     assert "Duplicate fields in ['number', 'timestamp', 'number']" in caplog.records[-1].msg
 
 

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -80,18 +80,18 @@ def test_column_expansion():
     assert columns == list(Model.__fields__)
 
 
-def test_column_validation(eth_tester_provider, assert_log):
+def test_column_validation(eth_tester_provider, caplog):
     with pytest.raises(ValueError) as exc_info:
         validate_and_expand_columns(["numbr"], Model)
 
     expected = "Unrecognized field(s) 'numbr', must be one of 'number, timestamp'."
     assert exc_info.value.args[-1] == expected
 
-    assert_log(lambda: validate_and_expand_columns(["numbr", "timestamp"], Model), expected)
-    assert_log(
-        lambda: validate_and_expand_columns(["number", "timestamp", "number"], Model),
-        "Duplicate fields in ['number', 'timestamp', 'number']",
-    )
+    validate_and_expand_columns(["numbr", "timestamp"], Model)
+    assert expected in caplog.records[-1].message
+
+    validate_and_expand_columns(["number", "timestamp", "number"], Model)
+    assert "Duplicate fields in ['number', 'timestamp', 'number']" in caplog.records[-1].message
 
 
 def test_specify_engine(chain, eth_tester_provider):

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -80,18 +80,18 @@ def test_column_expansion():
     assert columns == list(Model.__fields__)
 
 
-def test_column_validation(eth_tester_provider, caplog):
+def test_column_validation(eth_tester_provider, assert_log):
     with pytest.raises(ValueError) as exc_info:
         validate_and_expand_columns(["numbr"], Model)
 
     expected = "Unrecognized field(s) 'numbr', must be one of 'number, timestamp'."
     assert exc_info.value.args[-1] == expected
 
-    validate_and_expand_columns(["numbr", "timestamp"], Model)
-    assert expected in caplog.records[-1].msg
-
-    validate_and_expand_columns(["number", "timestamp", "number"], Model)
-    assert "Duplicate fields in ['number', 'timestamp', 'number']" in caplog.records[-1].msg
+    assert_log(lambda: validate_and_expand_columns(["numbr", "timestamp"], Model), expected)
+    assert_log(
+        lambda: validate_and_expand_columns(["number", "timestamp", "number"], Model),
+        "Duplicate fields in ['number', 'timestamp', 'number']",
+    )
 
 
 def test_specify_engine(chain, eth_tester_provider):

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -87,8 +87,9 @@ def test_column_validation(eth_tester_provider, ape_caplog):
     expected = "Unrecognized field(s) 'numbr', must be one of 'number, timestamp'."
     assert exc_info.value.args[-1] == expected
 
-    validate_and_expand_columns(["numbr", "timestamp"], Model)
-    ape_caplog.assert_last_log(expected)
+    ape_caplog.assert_last_log_with_retries(
+        lambda: validate_and_expand_columns(["numbr", "timestamp"], Model), expected
+    )
 
     validate_and_expand_columns(["number", "timestamp", "number"], Model)
     assert "Duplicate fields in ['number', 'timestamp', 'number']" in ape_caplog.messages[-1]

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -88,10 +88,10 @@ def test_column_validation(eth_tester_provider, caplog):
     assert exc_info.value.args[-1] == expected
 
     validate_and_expand_columns(["numbr", "timestamp"], Model)
-    assert expected in caplog.records[-1].message
+    assert expected in caplog.messages[-1]
 
     validate_and_expand_columns(["number", "timestamp", "number"], Model)
-    assert "Duplicate fields in ['number', 'timestamp', 'number']" in caplog.records[-1].message
+    assert "Duplicate fields in ['number', 'timestamp', 'number']" in caplog.messages[-1]
 
 
 def test_specify_engine(chain, eth_tester_provider):

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -80,7 +80,7 @@ def test_column_expansion():
     assert columns == list(Model.__fields__)
 
 
-def test_column_validation(eth_tester_provider, caplog):
+def test_column_validation(eth_tester_provider, ape_caplog):
     with pytest.raises(ValueError) as exc_info:
         validate_and_expand_columns(["numbr"], Model)
 
@@ -88,10 +88,10 @@ def test_column_validation(eth_tester_provider, caplog):
     assert exc_info.value.args[-1] == expected
 
     validate_and_expand_columns(["numbr", "timestamp"], Model)
-    assert expected in caplog.messages[-1]
+    assert expected in ape_caplog.messages[-1]
 
     validate_and_expand_columns(["number", "timestamp", "number"], Model)
-    assert "Duplicate fields in ['number', 'timestamp', 'number']" in caplog.messages[-1]
+    assert "Duplicate fields in ['number', 'timestamp', 'number']" in ape_caplog.messages[-1]
 
 
 def test_specify_engine(chain, eth_tester_provider):

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -88,7 +88,7 @@ def test_column_validation(eth_tester_provider, ape_caplog):
     assert exc_info.value.args[-1] == expected
 
     validate_and_expand_columns(["numbr", "timestamp"], Model)
-    assert expected in ape_caplog.messages[-1]
+    ape_caplog.assert_last_log(expected)
 
     validate_and_expand_columns(["number", "timestamp", "number"], Model)
     assert "Duplicate fields in ['number', 'timestamp', 'number']" in ape_caplog.messages[-1]

--- a/tests/functional/utils/test_abi.py
+++ b/tests/functional/utils/test_abi.py
@@ -69,10 +69,7 @@ def test_decoding_with_strict(collection, topics, log_data_missing_trailing_zero
     the user and still proceed to decode the log.
     """
     actual = collection.decode(topics, log_data_missing_trailing_zeroes)
-    assert (
-        "However, we are able to get a value using decode(strict=False)"
-        in caplog.records[-1].message
-    )
+    assert "However, we are able to get a value using decode(strict=False)" in caplog.messages[-1]
     expected = {
         "name": "Launchnodes",
         "nodeOperatorId": 30,

--- a/tests/functional/utils/test_abi.py
+++ b/tests/functional/utils/test_abi.py
@@ -69,9 +69,7 @@ def test_decoding_with_strict(collection, topics, log_data_missing_trailing_zero
     the user and still proceed to decode the log.
     """
     actual = collection.decode(topics, log_data_missing_trailing_zeroes)
-    assert (
-        "However, we are able to get a value using decode(strict=False)" in ape_caplog.messages[-1]
-    )
+    ape_caplog.assert_last_log("However, we are able to get a value using decode(strict=False)")
     expected = {
         "name": "Launchnodes",
         "nodeOperatorId": 30,

--- a/tests/functional/utils/test_abi.py
+++ b/tests/functional/utils/test_abi.py
@@ -62,13 +62,16 @@ def log_data_missing_trailing_zeroes():
     )
 
 
-def test_decoding_with_strict(collection, topics, log_data_missing_trailing_zeroes, caplog):
+def test_decoding_with_strict(collection, topics, log_data_missing_trailing_zeroes, assert_log):
     """
     This test is for a time where Alchemy gave us log data when it was missing trailing zeroes.
     When using strict=False, it was able to properly decode. In this case, in Ape, we warn
     the user and still proceed to decode the log.
     """
-    actual = collection.decode(topics, log_data_missing_trailing_zeroes)
+    actual = assert_log(
+        lambda: collection.decode(topics, log_data_missing_trailing_zeroes),
+        "However, we are able to get a value using decode(strict=False)",
+    )
     expected = {
         "name": "Launchnodes",
         "nodeOperatorId": 30,
@@ -76,7 +79,3 @@ def test_decoding_with_strict(collection, topics, log_data_missing_trailing_zero
         "stakingLimit": 0,
     }
     assert actual == expected
-    assert (
-        "However, we are able to get a value using decode(strict=False)"
-        in caplog.records[-1].message
-    )

--- a/tests/functional/utils/test_abi.py
+++ b/tests/functional/utils/test_abi.py
@@ -68,8 +68,10 @@ def test_decoding_with_strict(collection, topics, log_data_missing_trailing_zero
     When using strict=False, it was able to properly decode. In this case, in Ape, we warn
     the user and still proceed to decode the log.
     """
-    actual = collection.decode(topics, log_data_missing_trailing_zeroes)
-    ape_caplog.assert_last_log("However, we are able to get a value using decode(strict=False)")
+    actual = ape_caplog.assert_last_log_with_retries(
+        lambda: collection.decode(topics, log_data_missing_trailing_zeroes),
+        "However, we are able to get a value using decode(strict=False)",
+    )
     expected = {
         "name": "Launchnodes",
         "nodeOperatorId": 30,

--- a/tests/functional/utils/test_abi.py
+++ b/tests/functional/utils/test_abi.py
@@ -62,14 +62,16 @@ def log_data_missing_trailing_zeroes():
     )
 
 
-def test_decoding_with_strict(collection, topics, log_data_missing_trailing_zeroes, caplog):
+def test_decoding_with_strict(collection, topics, log_data_missing_trailing_zeroes, ape_caplog):
     """
     This test is for a time where Alchemy gave us log data when it was missing trailing zeroes.
     When using strict=False, it was able to properly decode. In this case, in Ape, we warn
     the user and still proceed to decode the log.
     """
     actual = collection.decode(topics, log_data_missing_trailing_zeroes)
-    assert "However, we are able to get a value using decode(strict=False)" in caplog.messages[-1]
+    assert (
+        "However, we are able to get a value using decode(strict=False)" in ape_caplog.messages[-1]
+    )
     expected = {
         "name": "Launchnodes",
         "nodeOperatorId": 30,

--- a/tests/functional/utils/test_abi.py
+++ b/tests/functional/utils/test_abi.py
@@ -62,15 +62,16 @@ def log_data_missing_trailing_zeroes():
     )
 
 
-def test_decoding_with_strict(collection, topics, log_data_missing_trailing_zeroes, assert_log):
+def test_decoding_with_strict(collection, topics, log_data_missing_trailing_zeroes, caplog):
     """
     This test is for a time where Alchemy gave us log data when it was missing trailing zeroes.
     When using strict=False, it was able to properly decode. In this case, in Ape, we warn
     the user and still proceed to decode the log.
     """
-    actual = assert_log(
-        lambda: collection.decode(topics, log_data_missing_trailing_zeroes),
-        "However, we are able to get a value using decode(strict=False)",
+    actual = collection.decode(topics, log_data_missing_trailing_zeroes)
+    assert (
+        "However, we are able to get a value using decode(strict=False)"
+        in caplog.records[-1].message
     )
     expected = {
         "name": "Launchnodes",

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -283,13 +283,20 @@ def test_compile_only_dependency(ape_cli, runner, project, clean_cache, caplog):
     _ = dependency.DependencyInProjectOnly
 
     # Pop the log record off here so we can check the tail again below.
-    log_record = caplog.records.pop()
-    assert expected_log_message in log_record.message
+    length_before = len(caplog.records)
+    assert expected_log_message in caplog.records[-1].message
 
     # It should not need to compile again.
     _ = dependency.DependencyInProjectOnly
     if caplog.records:
-        assert expected_log_message not in caplog.records[-1].message, "Compiled twice!"
+        if expected_log_message in caplog.records[-1].message:
+            length_after = len(caplog.records)
+            # The only way it should be the same log is if there
+            # were not additional logs.
+            assert length_after == length_before
+
+        else:
+            pytest.fail("Compiled twice!")
 
     # Force a re-compile and trigger the dependency to compile via CLI
     result = runner.invoke(

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -284,12 +284,12 @@ def test_compile_only_dependency(ape_cli, runner, project, clean_cache, caplog):
 
     # Pop the log record off here so we can check the tail again below.
     length_before = len(caplog.records)
-    assert expected_log_message in caplog.records[-1].message
+    assert expected_log_message in caplog.messages[-1]
 
     # It should not need to compile again.
     _ = dependency.DependencyInProjectOnly
     if caplog.records:
-        if expected_log_message in caplog.records[-1].message:
+        if expected_log_message in caplog.messages[-1]:
             length_after = len(caplog.records)
             # The only way it should be the same log is if there
             # were not additional logs.

--- a/tests/integration/cli/test_plugins.py
+++ b/tests/integration/cli/test_plugins.py
@@ -148,13 +148,12 @@ def test_install_multiple_in_one_str(ape_plugins_runner):
 
 
 @github_xfail()
-def test_install_from_config_file(ape_cli, runner, temp_config, caplog):
+def test_install_from_config_file(ape_cli, runner, temp_config):
     plugins_config = {"plugins": [{"name": TEST_PLUGIN_NAME}]}
     with temp_config(plugins_config):
         result = runner.invoke(ape_cli, ["plugins", "install", "."], catch_exceptions=False)
         assert result.exit_code == 0, result.output
-
-    assert TEST_PLUGIN_NAME in caplog.records[-1].message
+        assert TEST_PLUGIN_NAME in result.stdout
 
 
 @github_xfail()

--- a/tests/integration/cli/test_plugins.py
+++ b/tests/integration/cli/test_plugins.py
@@ -158,7 +158,7 @@ def test_install_from_config_file(ape_cli, runner, temp_config, caplog):
 
 
 @github_xfail()
-def test_uninstall(ape_cli, runner, installed_plugin, caplog):
+def test_uninstall(ape_cli, runner, installed_plugin):
     result = runner.invoke(
         ape_cli, ["plugins", "uninstall", TEST_PLUGIN_NAME, "--yes"], catch_exceptions=False
     )


### PR DESCRIPTION
### What I did

* Moves web3 loggers to web3 provider
* Fixes a type on a query validation method (was receiving tuples here even tho it says list, but really any sequence should work)
* Soft-rename (non-breaking) of the logger class
* Issue with plugin installs when given dir, only noticed in a xfail test
* create a testing assert log fixtures for our tests here so operations can be retried, this should mitigate the xdist related issues with caplog hopefully
* 
### How to verify it

gimme a passing build on merge to main

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
