### PR TITLE
feat!: rewrite poll methods with new API [APE-1411]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         "pluggy>=1.3,<2",
         "pydantic>=1.10.8,<3",
         "PyGithub>=1.59,<2",
-        "pytest>=6.0,<7.4.3",
+        "pytest>=6.0,<8.0",
         "python-dateutil>=2.8.2,<3",
         "PyYAML>=5.0,<7",
         "requests>=2.28.1,<3",

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         "pluggy>=1.3,<2",
         "pydantic>=1.10.8,<3",
         "PyGithub>=1.59,<2",
-        "pytest>=6.0,<8.0",
+        "pytest>=6.0,<7.4.3",
         "python-dateutil>=2.8.2,<3",
         "PyYAML>=5.0,<7",
         "requests>=2.28.1,<3",

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1477,7 +1477,7 @@ class Web3Provider(ProviderAPI, ABC):
                 start_time = time.time()
                 while confirmed_block is None:
                     if time.time() - start_time > timeout:
-                        raise RuntimeError(
+                        raise ProviderError(
                             f"Timed out waiting for block {confirmed_block_number} to be available."
                         )
                     logger.warning(f"Block {confirmed_block_number} not found. Waiting 1 seconds.")

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1512,18 +1512,16 @@ class Web3Provider(ProviderAPI, ABC):
         for block in self.poll_blocks(stop_block, required_confirmations, new_block_timeout):
             if block.number is None:
                 raise ValueError("Block number cannot be None")
-
-            log_filter = {
+            log_params: Dict[str, int | AddressType | List[Union[str, List[str]]]] = {
                 "fromBlock": block.number,
                 "toBlock": block.number,
             }
-
             if address is not None:
-                log_filter["address"] = address
+                log_params["address"] = address
             if topics is not None:
-                log_filter["topics"] = topics
-
-            for log in self.web3.eth.get_logs(log_filter):
+                log_params["topics"] = topics
+            log_params_obj = LogFilter(**log_params).dict()
+            for log in self.web3.eth.get_logs(log_params_obj):
                 yield ContractLog.parse_obj(log)
 
     def block_ranges(self, start=0, stop=None, page=None):

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1466,9 +1466,9 @@ class Web3Provider(ProviderAPI, ABC):
         # Pretend we _did_ yield the last confirmed item, for logic's sake.
         fake_last_block = self.get_block(self.web3.eth.block_number - required_confirmations)
         # NOTE: type warning ignored due to pydantic compat issue
-        last = YieldAction(  # type: ignore
+        last = YieldAction(
             number=fake_last_block.number, hash=fake_last_block.hash, time=time.time()
-        )
+        )  # type: ignore
 
         # A helper method for various points of ensuring we didn't timeout.
         def assert_chain_activity():
@@ -1536,7 +1536,9 @@ class Web3Provider(ProviderAPI, ABC):
                     return
 
                 # Set the last action, used for checking timeouts and re-orgs.
-                last = YieldAction(number=block.number, hash=block.hash, time=time.time())  # type: ignore
+                last = YieldAction(
+                    number=block.number, hash=block.hash, time=time.time()
+                )  # type: ignore
 
     def poll_logs(
         self,

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -630,6 +630,35 @@ class ProviderAPI(BaseInterfaceModel):
         """
 
     @raises_not_implemented
+    def poll_blocks(  # type: ignore[empty-body]
+        self,
+        stop_block: Optional[int] = None,
+        required_confirmations: Optional[int] = None,
+        new_block_timeout: Optional[int] = None,
+    ) -> Iterator[BlockAPI]: # type: ignore[empty-body]
+        """
+        Poll new blocks.
+        **NOTE**: When a chain reorganization occurs, this method logs an error and
+        yields the missed blocks, even if they were previously yielded with different
+        block numbers.
+        **NOTE**: This is a daemon method; it does not terminate unless an exception occurs
+        or a ``stop`` is given.
+        Args:
+            start_block (Optional[int]): The block number to start with. Defaults to the pending
+              block number.
+            stop_block (Optional[int]): Optionally set a future block number to stop at.
+              Defaults to never-ending.
+            required_confirmations (Optional[int]): The amount of confirmations to wait
+              before yielding the block. The more confirmations, the less likely a reorg will occur.
+              Defaults to the network's configured required confirmations.
+            new_block_timeout (Optional[float]): The amount of time to wait for a new block before
+              timing out. Defaults to 10 seconds for local networks or ``50 * block_time`` for live
+              networks.
+        Returns:
+            Iterator[:class:`~ape.api.providers.BlockAPI`]
+        """
+
+    @raises_not_implemented
     def get_call_tree(self, txn_hash: str) -> CallTreeNode:  # type: ignore[empty-body]
         """
         Create a tree structure of calls for a transaction.
@@ -1357,6 +1386,76 @@ class Web3Provider(ProviderAPI, ABC):
                     block_number,
                     stop_block,
                 )
+
+    def poll_blocks(self, stop_block: Optional[int] = None, required_confirmations: Optional[int] = None, new_block_timeout: Optional[int] = None) -> Iterator[BlockAPI]:
+        filter = self.web3.eth.filter("latest")
+        network_name = self.network.name
+        block_time = self.network.block_time
+        timeout = (
+            (
+                10.0
+                if network_name == LOCAL_NETWORK_NAME or network_name.endswith("-fork")
+                else 50 * block_time
+            )
+            if new_block_timeout is None
+            else new_block_timeout
+        )
+
+        if required_confirmations is None:
+            required_confirmations = self.network_confirmations
+
+        last_yielded_height = None
+
+        while True:
+            if stop_block is not None and last_yielded_height is not None and last_yielded_height >= stop_block:
+                break
+            changes = self.web3.eth.get_filter_changes(filter.filter_id)
+            for new_block_hash in changes:
+                block = self.web3.eth.get_block(new_block_hash)
+                confirmed_block_number = block.number - required_confirmations
+                if last_yielded_height and confirmed_block_number < last_yielded_height:
+                    num_blocks_behind = last_yielded_height - confirmed_block_number
+                    if num_blocks_behind > required_confirmations:
+                        logger.error(f"{num_blocks_behind} Block reorganization detected. Try adjusting the required network confirmations")
+                    else:
+                        logger.warning(f"{num_blocks_behind} Block reorganization detected. Reorg is within the required network confirmations")
+                        last_yielded_height = confirmed_block_number
+                        continue
+                confirmed_block = self.web3.eth.get_block(confirmed_block_number)
+                start_time = time.time()
+                while confirmed_block is None:
+                    if time.time() - start_time > timeout:
+                        raise RuntimeError(
+                            f"Timed out waiting for block {confirmed_block_number} to be available."
+                        )
+                    logger.warning(
+                        f"Block {confirmed_block_number} not found. Waiting 1 seconds."
+                    )
+                    time.sleep(1)
+                    confirmed_block = self.web3.eth.get_block(confirmed_block_number)
+                if last_yielded_height and confirmed_block.number < last_yielded_height:
+                    num_blocks_behind = last_yielded_height - confirmed_block.number
+                    logger.error(f"{num_blocks_behind} Block reorganization detected. Try adjusting the required network confirmations")
+                last_yielded_height = confirmed_block.number
+                yield confirmed_block
+
+    def poll_logs(
+            self,
+            stop_block: Optional[int] = None,
+            address: Optional[AddressType] = None,
+            topics: Optional[List[Union[str, List[str]]]] = None,
+            required_confirmations: Optional[int] = None,
+            new_block_timeout: Optional[int] = None) -> Iterator[ContractLog]:
+        required_confirmations = (
+            required_confirmations or self.provider.network.required_confirmations
+        )
+        for block in self.poll_blocks(stop_block, required_confirmations, new_block_timeout):
+            yield from self.web3.eth.get_logs({
+                "fromBlock": block.number,
+                "toBlock": block.number,
+                "address": address,
+                "topics": topics
+            })
 
     def block_ranges(self, start=0, stop=None, page=None):
         if stop is None:

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1481,12 +1481,12 @@ class Web3Provider(ProviderAPI, ABC):
             # The next block we want is simply 1 after the last.
             next_block = last.number + 1
 
-            # Use an "adjused" head, based on the required confirmations.
             head = self.get_block("latest")
 
             try:
                 if head.number is None or head.hash is None:
                     raise ProviderError("Head block has no number or hash.")
+                # Use an "adjused" head, based on the required confirmations.
                 adjusted_head = self.get_block(head.number - required_confirmations)
                 if adjusted_head.number is None or adjusted_head.hash is None:
                     raise ProviderError("Adjusted head block has no number or hash.")

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1549,7 +1549,7 @@ class Web3Provider(ProviderAPI, ABC):
         for block in self.poll_blocks(stop_block, required_confirmations, new_block_timeout):
             if block.number is None:
                 raise ValueError("Block number cannot be None")
-            log_params: Dict[str, int | AddressType | List[Union[str, List[str]]]] = {
+            log_params: Dict[str, int | AddressType | List[EventABI] | List[AddressType] | List[Union[str, EventABI, AddressType, List[str]]]] = {
                 "start_block": block.number,
                 "stop_block": block.number,
                 "events": events,

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1485,6 +1485,7 @@ class Web3Provider(ProviderAPI, ABC):
                 adjusted_head = self.get_block(head.number - required_confirmations)
             except Exception:
                 # TODO: I did encounter this sometimes in a re-org, needs better handling
+                assert_chain_activity()
                 continue
 
             if adjusted_head.number == last.number and adjusted_head.hash == last.hash:

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1510,14 +1510,20 @@ class Web3Provider(ProviderAPI, ABC):
             required_confirmations or self.provider.network.required_confirmations
         )
         for block in self.poll_blocks(stop_block, required_confirmations, new_block_timeout):
-            for log in self.web3.eth.get_logs(
-                {
-                    "fromBlock": block.number,
-                    "toBlock": block.number,
-                    "address": address,
-                    "topics": topics,
-                }
-            ):
+            if block.number is None:
+                raise ValueError("Block number cannot be None")
+
+            log_filter = {
+                "fromBlock": block.number,
+                "toBlock": block.number,
+            }
+
+            if address is not None:
+                log_filter["address"] = address
+            if topics is not None:
+                log_filter["topics"] = topics
+
+            for log in self.web3.eth.get_logs(log_filter):
                 yield ContractLog.parse_obj(log)
 
     def block_ranges(self, start=0, stop=None, page=None):

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -644,7 +644,7 @@ class ProviderAPI(BaseInterfaceModel):
         block numbers.
 
         **NOTE**: This is a daemon method; it does not terminate unless an exception occurs
-        or a ``stop`` is given.
+        or a ``stop_block`` is given.
 
         Args:
             start_block (Optional[int]): The block number to start with. Defaults to the pending

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -635,7 +635,7 @@ class ProviderAPI(BaseInterfaceModel):
         stop_block: Optional[int] = None,
         required_confirmations: Optional[int] = None,
         new_block_timeout: Optional[int] = None,
-    ) -> Iterator[BlockAPI]:  # type: ignore[empty-body]
+    ) -> Iterator[BlockAPI]:
         """
         Poll new blocks.
 
@@ -670,7 +670,7 @@ class ProviderAPI(BaseInterfaceModel):
         topics: Optional[List[Union[str, List[str]]]] = None,
         required_confirmations: Optional[int] = None,
         new_block_timeout: Optional[int] = None,
-    ) -> Iterator[ContractLog]:  # type: ignore[empty-body]
+    ) -> Iterator[ContractLog]:
         """
         Poll new blocks. Optionally set a start block to include historical blocks.
 
@@ -684,6 +684,10 @@ class ProviderAPI(BaseInterfaceModel):
         Args:
             stop_block (Optional[int]): Optionally set a future block number to stop at.
               Defaults to never-ending.
+            address (Optional[str]): The address of the contract to filter logs by.
+              Defaults to all addresses.
+            topics (Optional[List[Union[str, List[str]]]]): The topics to filter logs by.
+              Defaults to all topics.
             required_confirmations (Optional[int]): The amount of confirmations to wait
               before yielding the block. The more confirmations, the less likely a reorg will occur.
               Defaults to the network's configured required confirmations.
@@ -1480,7 +1484,7 @@ class Web3Provider(ProviderAPI, ABC):
                         raise ProviderError(
                             f"Timed out waiting for block {confirmed_block_number} to be available."
                         )
-                    logger.warning(f"Block {confirmed_block_number} not found. Waiting 1 seconds.")
+                    logger.warning(f"Block {confirmed_block_number} not found. Waiting 1 second.")
                     time.sleep(1)
                     confirmed_block = self.web3.eth.get_block(confirmed_block_number)
                 if last_yielded_height and confirmed_block.number < last_yielded_height:

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1535,9 +1535,9 @@ class Web3Provider(ProviderAPI, ABC):
         required_confirmations: Optional[int] = None,
         new_block_timeout: Optional[int] = None,
     ) -> Iterator[ContractLog]:
-        required_confirmations = (
-            required_confirmations or self.provider.network.required_confirmations
-        )
+        if required_confirmations is None:
+            required_confirmations = self.network.required_confirmations
+
         for block in self.poll_blocks(stop_block, required_confirmations, new_block_timeout):
             if block.number is None:
                 raise ValueError("Block number cannot be None")

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1443,7 +1443,7 @@ class Web3Provider(ProviderAPI, ABC):
         block_time = self.network.block_time
         wait_time = block_time / 2
 
-        # The timeout occurs when there is chain activity
+        # The timeout occurs when there is no chain activity
         # after a certain time.
         timeout = (
             (10.0 if self.network.is_dev else 50 * block_time)

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -701,7 +701,7 @@ class ContractEvent(ManagerAccessMixin):
         # NOTE: Now we process the rest
         yield from self.provider.poll_logs(
             stop_block=stop_block,
-            address=self.contract.address,
+            address=self.contract.contract_type.address,
             required_confirmations=required_confirmations,
             new_block_timeout=new_block_timeout,
         )

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -699,6 +699,14 @@ class ContractEvent(ManagerAccessMixin):
             start_block = height + 1
 
         # NOTE: Now we process the rest
+        yield from self.provider.poll_logs(
+            stop_block=stop_block,
+            address=self.contract.address,
+            required_confirmations=required_confirmations,
+            new_block_timeout=new_block_timeout,
+        )
+
+        # NOTE: Now we process the rest
         for new_block in self.chain_manager.blocks.poll_blocks(
             start_block=start_block,
             stop_block=stop_block,

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -700,7 +700,7 @@ class ContractEvent(ManagerAccessMixin):
         # NOTE: Now we process the rest
         yield from self.provider.poll_logs(
             stop_block=stop_block,
-            address=self.contract.contract_type.address,
+            address=self.contract.address,
             required_confirmations=required_confirmations,
             new_block_timeout=new_block_timeout,
         )

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -703,6 +703,7 @@ class ContractEvent(ManagerAccessMixin):
             address=self.contract.address,
             required_confirmations=required_confirmations,
             new_block_timeout=new_block_timeout,
+            events=[self.abi],
         )
 
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -374,7 +374,7 @@ class ContractEvent(ManagerAccessMixin):
 
     def __init__(
         self,
-        contract: "ContractTypeWrapper",
+        contract: "ContractContainer",
         abi: EventABI,
         cached_logs: Optional[List[ContractLog]] = None,
     ) -> None:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -374,7 +374,7 @@ class ContractEvent(ManagerAccessMixin):
 
     def __init__(
         self,
-        contract: "ContractContainer",
+        contract: Union["ContractInstance", "ContractContainer"],
         abi: EventABI,
         cached_logs: Optional[List[ContractLog]] = None,
     ) -> None:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -706,19 +706,6 @@ class ContractEvent(ManagerAccessMixin):
             new_block_timeout=new_block_timeout,
         )
 
-        # NOTE: Now we process the rest
-        for new_block in self.chain_manager.blocks.poll_blocks(
-            start_block=start_block,
-            stop_block=stop_block,
-            required_confirmations=required_confirmations,
-            new_block_timeout=new_block_timeout,
-        ):
-            if new_block.number is None:
-                continue
-
-            # Get all events in the new block.
-            yield from self.range(new_block.number, stop=new_block.number + 1)
-
 
 class ContractTypeWrapper(ManagerAccessMixin):
     contract_type: ContractType

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -688,9 +688,8 @@ class ContractEvent(ManagerAccessMixin):
             Iterator[:class:`~ape.types.ContractLog`]
         """
 
-        required_confirmations = (
-            required_confirmations or self.provider.network.required_confirmations
-        )
+        if required_confirmations is None:
+            required_confirmations = self.provider.network.required_confirmations
 
         # NOTE: We process historical blocks separately here to minimize rpc calls
         height = max(self.chain_manager.blocks.height - required_confirmations, 0)

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -276,7 +276,6 @@ class BlockContainer(BaseManager):
         if stop_block is not None and stop_block <= self.chain_manager.blocks.height:
             raise ValueError("'stop' argument must be in the future.")
 
-
         # Get number of last block with the necessary amount of confirmations.
         block = None
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1,5 +1,4 @@
 import json
-import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from functools import partial
@@ -24,7 +23,6 @@ from ape.api.query import (
 from ape.contracts import ContractContainer, ContractInstance
 from ape.exceptions import (
     APINotImplementedError,
-    BlockNotFoundError,
     ChainError,
     ContractNotFoundError,
     ConversionError,
@@ -271,18 +269,6 @@ class BlockContainer(BaseManager):
         Returns:
             Iterator[:class:`~ape.api.providers.BlockAPI`]
         """
-        network_name = self.provider.network.name
-        block_time = self.provider.network.block_time
-        timeout = (
-            (
-                10.0
-                if network_name == LOCAL_NETWORK_NAME or network_name.endswith("-fork")
-                else 50 * block_time
-            )
-            if new_block_timeout is None
-            else new_block_timeout
-        )
-
         if required_confirmations is None:
             required_confirmations = self.network_confirmations
 
@@ -300,9 +286,9 @@ class BlockContainer(BaseManager):
         yield from self.provider.poll_blocks(
             stop_block=stop_block,
             required_confirmations=required_confirmations,
-            new_block_timeout=new_block_timeout)
+            new_block_timeout=new_block_timeout,
+        )
 
-        
     def _get_block(self, block_id: BlockID) -> BlockAPI:
         return self.provider.get_block(block_id)
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -245,7 +245,7 @@ class BlockContainer(BaseManager):
         block numbers.
 
         **NOTE**: This is a daemon method; it does not terminate unless an exception occurs
-        or a ``stop`` is given.
+        or a ``stop_block`` is given.
 
         Usage example::
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -269,6 +269,7 @@ class BlockContainer(BaseManager):
         Returns:
             Iterator[:class:`~ape.api.providers.BlockAPI`]
         """
+
         if required_confirmations is None:
             required_confirmations = self.network_confirmations
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -275,9 +275,6 @@ class BlockContainer(BaseManager):
         if stop_block is not None and stop_block <= self.chain_manager.blocks.height:
             raise ValueError("'stop' argument must be in the future.")
 
-        # Get number of last block with the necessary amount of confirmations.
-        block = None
-
         if start_block is not None:
             # Front-load historical blocks.
             for block in self.range(start_block, self.height - required_confirmations + 1):

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -160,7 +160,7 @@ class LogFilter(BaseModel):
         return FilterParams(
             address=self.addresses,
             fromBlock=to_hex(self.start_block),
-            toBlock=to_hex(self.stop_block),
+            toBlock=to_hex(self.stop_block or self.start_block),
             topics=topics,
         )
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -11,7 +11,7 @@ import ape
 from ape.api import TransactionAPI
 from ape.contracts import ContractContainer, ContractInstance
 from ape.contracts.base import ContractCallHandler
-from ape.exceptions import ChainError, ContractLogicError
+from ape.exceptions import ChainError, ContractLogicError, ProviderError
 from ape.logging import LogLevel
 from ape.logging import logger as _logger
 from ape.types import AddressType, ContractLog
@@ -435,7 +435,7 @@ class PollDaemonThread(threading.Thread):
 
             try:
                 self._handler(next(self._poller))
-            except ChainError:
+            except (ChainError, ProviderError):
                 # Check if can stop once more before exiting
                 if self._do_stop():
                     return

--- a/tests/functional/test_block_container.py
+++ b/tests/functional/test_block_container.py
@@ -147,3 +147,30 @@ def test_poll_blocks_timeout(
     with pytest.raises(ProviderError, match=r"Timed out waiting for next block."):
         with PollDaemon("blocks", poller, lambda x: None, lambda: False):
             time.sleep(1.5)
+
+def test_poll_blocks_reorg_with_timeout(
+    vyper_contract_instance, chain_that_mined_5, eth_tester_provider, owner, PollDaemon, ape_caplog
+):
+    blocks: Queue = Queue(maxsize=6)
+    poller = chain_that_mined_5.blocks.poll_blocks(new_block_timeout=1)
+
+    with pytest.raises(ProviderError, match=r"Timed out waiting for next block."):
+        with PollDaemon("blocks", poller, blocks.put, blocks.full):
+            # Sleep first to ensure listening before mining.
+            time.sleep(1)
+
+            snapshot = chain_that_mined_5.snapshot()
+            chain_that_mined_5.mine(2)
+
+            # Wait to allow blocks before re-org to get yielded
+            time.sleep(5)
+
+            # Simulate re-org by reverting to the snapshot
+            chain_that_mined_5.restore(snapshot)
+
+            # Allow it time to trigger realizing there was a re-org
+            time.sleep(1)
+            chain_that_mined_5.mine(2)
+            time.sleep(1)
+
+            chain_that_mined_5.mine(3)

--- a/tests/functional/test_block_container.py
+++ b/tests/functional/test_block_container.py
@@ -175,7 +175,8 @@ def test_poll_blocks_reorg_with_timeout(
             time.sleep(1)
 
             chain_that_mined_5.mine(3)
-            
+
+
 def test_poll_blocks_future(chain_that_mined_5, eth_tester_provider, owner, PollDaemon):
     blocks: Queue = Queue(maxsize=3)
     poller = chain_that_mined_5.blocks.poll_blocks(

--- a/tests/functional/test_block_container.py
+++ b/tests/functional/test_block_container.py
@@ -148,6 +148,7 @@ def test_poll_blocks_timeout(
         with PollDaemon("blocks", poller, lambda x: None, lambda: False):
             time.sleep(1.5)
 
+
 def test_poll_blocks_reorg_with_timeout(
     vyper_contract_instance, chain_that_mined_5, eth_tester_provider, owner, PollDaemon, ape_caplog
 ):

--- a/tests/functional/test_block_container.py
+++ b/tests/functional/test_block_container.py
@@ -5,7 +5,7 @@ from typing import List
 import pytest
 from ethpm_types import HexBytes
 
-from ape.exceptions import ChainError
+from ape.exceptions import ChainError, ProviderError
 
 
 def test_iterate_blocks(chain_that_mined_5):
@@ -144,6 +144,6 @@ def test_poll_blocks_timeout(
 ):
     poller = chain_that_mined_5.blocks.poll_blocks(new_block_timeout=1)
 
-    with pytest.raises(ChainError, match=r"Timed out waiting for new block \(time_waited=1.\d+\)."):
+    with pytest.raises(ProviderError, match=r"Timed out waiting for next block."):
         with PollDaemon("blocks", poller, lambda x: None, lambda: False):
             time.sleep(1.5)

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -7,7 +7,7 @@ from eth_utils import to_hex
 from ethpm_types import ContractType, HexBytes
 
 from ape.api import ReceiptAPI
-from ape.exceptions import ChainError
+from ape.exceptions import ProviderError
 from ape.types import ContractLog
 
 
@@ -234,11 +234,11 @@ def test_poll_logs_timeout(vyper_contract_instance, eth_tester_provider, owner, 
     new_block_timeout = 1
     poller = vyper_contract_instance.NumberChange.poll_logs(new_block_timeout=new_block_timeout)
 
-    with pytest.raises(ChainError) as err:
+    with pytest.raises(ProviderError) as err:
         with PollDaemon("logs", poller, lambda x: None, lambda: False):
             time.sleep(1.5)
 
-    assert "Timed out waiting for new block (time_waited=1" in str(err.value)
+    assert "Timed out waiting for next block" in str(err.value)
 
 
 def test_contract_two_events_with_same_name(


### PR DESCRIPTION
### What I did

Implemented new poll_blocks and poll_events methods in the ProviderAPI

fixes: #1669 

### How I did it

Used the new Web3.py filter objects for polling of new blocks and events. The event polling uses the block polling for confirmations so as to not repeat that logic in both functions.

### How to verify it


### Checklist

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
