### PR TITLE
refactor: BaseModel getattr logic sharing [APE-1415]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ exclude =
 	docs
 	build
 	.eggs
+	tests/integration/cli/projects
 per-file-ignores =
     # Need signal handler before imports
     src/ape/__init__.py: E402

--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -40,7 +40,7 @@ class PluginConfig(BaseSettings):
         return cls(**update(default_values, overrides))
 
     def __getattr__(self, attr_name: str) -> Any:
-        # allow hyphens in plugin config files
+        # Allow hyphens in plugin config files.
         attr_name = attr_name.replace("-", "_")
         return super().__getattribute__(attr_name)
 

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -25,6 +25,7 @@ from ape.types import AddressType, AutoGasLimit, CallTreeNode, ContractLog, GasL
 from ape.utils import (
     DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT,
     BaseInterfaceModel,
+    ExtraModelAttributes,
     ManagerAccessMixin,
     abstractmethod,
     cached_property,
@@ -221,45 +222,13 @@ class EcosystemAPI(BaseInterfaceModel):
         if len(self.networks) == 0:
             raise NetworkError("Must define at least one network in ecosystem")
 
-    def __getitem__(self, network_name: str) -> "NetworkAPI":
-        """
-        Get a network by name.
-
-        Raises:
-            :class:`~ape.exceptions.NetworkNotFoundError`:
-              When there is no network with the given name.
-
-        Args:
-            network_name (str): The name of the network to retrieve.
-
-        Returns:
-            :class:`~ape.api.networks.NetworkAPI`
-        """
-        return self.get_network(network_name)
-
-    def __getattr__(self, network_name: str) -> "NetworkAPI":
-        """
-        Get a network by name using ``.`` access.
-
-        Usage example::
-
-            from ape import networks
-            mainnet = networks.ecosystem.mainnet
-
-        Raises:
-            :class:`~ape.exceptions.NetworkNotFoundError`:
-              When there is no network with the given name.
-
-        Args:
-            network_name (str): The name of the network to retrieve.
-
-        Returns:
-            :class:`~ape.api.networks.NetworkAPI`
-        """
-        try:
-            return self.get_network(network_name.replace("_", "-"))
-        except NetworkNotFoundError:
-            return self.__getattribute__(network_name)
+    def __ape_extra_attributes__(self) -> Iterator[ExtraModelAttributes]:
+        yield ExtraModelAttributes(
+            name="networks",
+            attributes=self.networks,
+            include_getattr=True,
+            include_getitem=True,
+        )
 
     def add_network(self, network_name: str, network: "NetworkAPI"):
         """

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -27,7 +27,13 @@ from ape.types import (
     TraceFrame,
     TransactionSignature,
 )
-from ape.utils import BaseInterfaceModel, abstractmethod, cached_property, raises_not_implemented
+from ape.utils import (
+    BaseInterfaceModel,
+    ExtraModelAttributes,
+    abstractmethod,
+    cached_property,
+    raises_not_implemented,
+)
 
 if TYPE_CHECKING:
     from ape.api.providers import BlockAPI
@@ -261,8 +267,8 @@ class ReceiptAPI(BaseInterfaceModel):
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {self.txn_hash}>"
 
-    def __getattr__(self, item: str) -> Any:
-        return getattr(self.transaction, item)
+    def __ape_extra_attributes__(self) -> Iterator[ExtraModelAttributes]:
+        yield ExtraModelAttributes(name="transaction", attributes=self.transaction)
 
     @validator("transaction", pre=True)
     def confirm_transaction(cls, value):

--- a/src/ape/utils/__init__.py
+++ b/src/ape/utils/__init__.py
@@ -13,6 +13,7 @@ from ape.utils.abi import (
 from ape.utils.basemodel import (
     BaseInterface,
     BaseInterfaceModel,
+    ExtraModelAttributes,
     ManagerAccessMixin,
     injected_before_use,
 )
@@ -75,6 +76,7 @@ __all__ = [
     "EMPTY_BYTES32",
     "expand_environment_variables",
     "extract_nested_value",
+    "ExtraModelAttributes",
     "get_relative_path",
     "gas_estimation_error_message",
     "get_package_version",

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -192,3 +192,8 @@ def test_track_coverage(deploy_receipt, mocker):
 
     assert mock_runner.track_coverage.call_count == 0
     ManagerAccessMixin._test_runner = original
+
+
+def test_access_from_tx(deploy_receipt):
+    actual = deploy_receipt.receiver
+    assert actual == ""


### PR DESCRIPTION
### What I did

So as I am working on some pydantic v2 refactor stuff for !0.7, I am noticing some other smaller refactors that would really make it a lot easier, stuff we can do now... stuff we are likely going to have to do anyway...

So this is one of those things.
Right now, we have some weird logic for __getattr__ and everyone is kinda wildwildwesting it but for the most part have to keep in mind the same gotchas. I am finding that v2 of pydantic has even more gotchas in this regard. So, we can isolated those to one place with this new system of allowing getattr / getitem overloads.

### How I did it

A new method in BaseModel `__ape_extra_attributes__` that returns an iterator of this new class containing the attributes, some metadata, and what parts to use it in. It also has a handy method for checking such attributes.
So the models that need custom __getattr__, e.g. events and projects and stuff, they yield some of these bad girls and off we go, no more needing to call `__getattribute__ and being all funky there.

Examples:

```python
    def __ape_extra_attributes__(self) -> Iterator[ExtraModelAttributes]:
        yield ExtraModelAttributes(
            name=self.name,
            attributes=self.contracts,
            include_getattr=True,
            include_getitem=True,
        )


    def __ape_extra_attributes__(self) -> Iterator[ExtraModelAttributes]:
        yield ExtraModelAttributes(
            name=self.event_name,
            attributes=self.event_arguments,
            include_getattr=True,
            include_getitem=True,
        )

```

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
