### PR TITLE
refactor: move transaction convert methods to conversion manager [APE-1416]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ exclude =
 	docs
 	build
 	.eggs
+	tests/integration/cli/projects
 per-file-ignores =
     # Need signal handler before imports
     src/ape/__init__.py: E402

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -5,7 +5,6 @@ from ethpm_types import HexBytes
 from ape.exceptions import ConversionError
 from ape.types import AddressType, ContractCode
 from ape.utils import BaseInterface, abstractmethod, cached_property
-from ape.utils.abi import _convert_kwargs
 
 if TYPE_CHECKING:
     from ape.api.transactions import ReceiptAPI, TransactionAPI
@@ -167,7 +166,7 @@ class BaseAddress(BaseInterface):
         return self.chain_manager.history[self.address]
 
     def as_transaction(self, **kwargs) -> "TransactionAPI":
-        converted_kwargs = _convert_kwargs(kwargs, self.conversion_manager.convert)
+        converted_kwargs = self.conversion_manager.convert_method_kwargs(kwargs)
         return self.provider.network.ecosystem.create_transaction(
             receiver=self.address, **converted_kwargs
         )

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -115,7 +115,7 @@ class EcosystemAPI(BaseInterfaceModel):
         or Starknet's ``Declare`` transaction type.
 
         Args:
-            contract (``ContractType``): The type of contract to create a blueprint for.
+            contract_type (``ContractType``): The type of contract to create a blueprint for.
               This is the type of contract that will get created by factory contracts.
             *args: Calldata, if applicable.
             **kwargs: Transaction specifications, such as ``value``.

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -686,7 +686,7 @@ class NetworkAPI(BaseInterfaceModel):
         return cls(
             name="adhoc",
             ecosystem=ethereum,
-            data_folder=data_folder,
+            data_folder=Path(data_folder),
             request_header=request_header,
             _default_provider="geth",
         )

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from ethpm_types import Checksum, ContractType, PackageManifest, Source
 from ethpm_types.manifest import PackageName
-from ethpm_types.utils import AnyUrl, compute_checksum
+from ethpm_types.utils import Algorithm, AnyUrl, compute_checksum
 from packaging.version import InvalidVersion, Version
 from pydantic import ValidationError
 
@@ -210,7 +210,7 @@ class ProjectAPI(BaseInterfaceModel):
 
             source_dict[key] = Source(
                 checksum=Checksum(
-                    algorithm="md5",
+                    algorithm=Algorithm.MD5,
                     hash=compute_checksum(source_path.read_bytes()),
                 ),
                 urls=[],

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -104,7 +104,7 @@ class BlockAPI(BaseInterfaceModel):
     @validator("hash", "parent_hash", pre=True)
     def validate_hexbytes(cls, value):
         # NOTE: pydantic treats these values as bytes and throws an error
-        if value and not isinstance(value, HexBytes):
+        if value and not isinstance(value, bytes):
             return HexBytes(value)
 
         return value

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -94,7 +94,7 @@ def extract_fields(item, columns):
 
 
 class _BaseQuery(BaseModel):
-    columns: List[str]
+    columns: Sequence[str]
 
     # TODO: Support "*" from getting the EcosystemAPI fields
 

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -118,7 +118,7 @@ class TransactionAPI(BaseInterfaceModel):
         to submit the transaction.
         """
         if self.max_fee is None:
-            raise TransactionError("Max fee must not be null.")
+            raise TransactionError("`self.max_fee` must not be None.")
 
         return self.value + self.max_fee
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -113,7 +113,7 @@ class BlockContainer(BaseManager):
 
     def query(
         self,
-        *columns: List[str],
+        *columns: str,
         start_block: int = 0,
         stop_block: Optional[int] = None,
         step: int = 1,
@@ -130,7 +130,7 @@ class BlockContainer(BaseManager):
               than the chain length.
 
         Args:
-            columns (List[str]): columns in the DataFrame to return
+            *columns (str): columns in the DataFrame to return
             start_block (int): The first block, by number, to include in the
               query. Defaults to 0.
             stop_block (Optional[int]): The last block, by number, to include
@@ -438,12 +438,12 @@ class AccountHistory(BaseInterfaceModel):
             start_nonce = receipt.nonce + 1  # start next loop on the next item
 
         if start_nonce != stop_nonce:
-            # NOTE: there is no more sessional history, so just return query engine iterator
+            # NOTE: there is no more session history, so just return query engine iterator
             yield from iter(self[start_nonce : stop_nonce + 1])  # noqa: E203
 
     def query(
         self,
-        *columns: List[str],
+        *columns: str,
         start_nonce: int = 0,
         stop_nonce: Optional[int] = None,
         engine_to_use: Optional[str] = None,
@@ -459,7 +459,7 @@ class AccountHistory(BaseInterfaceModel):
               than the account's current nonce.
 
         Args:
-            columns (List[str]): columns in the DataFrame to return
+            *columns (str): columns in the DataFrame to return
             start_nonce (int): The first transaction, by nonce, to include in the
               query. Defaults to 0.
             stop_nonce (Optional[int]): The last transaction, by nonce, to include

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -36,7 +36,7 @@ class DeploymentConfigCollection(BaseModel):
         root_data = data.get("__root__", data)
         valid_ecosystems = root_data.pop("valid_ecosystems", {})
         valid_networks = root_data.pop("valid_networks", {})
-        valid_data = {}
+        valid_data: Dict = {}
         for ecosystem_name, networks in root_data.items():
             if ecosystem_name not in valid_ecosystems:
                 logger.warning(f"Invalid ecosystem '{ecosystem_name}' in deployments config.")

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -14,7 +14,7 @@ from eth_utils import (
 )
 from ethpm_types import ConstructorABI, EventABI, HexBytes, MethodABI
 
-from ape.api import ConverterAPI
+from ape.api import ConverterAPI, TransactionAPI
 from ape.api.address import BaseAddress
 from ape.exceptions import ConversionError
 from ape.types import AddressType
@@ -372,8 +372,6 @@ class ConversionManager(BaseManager):
         return self.convert(pre_processed_args, tuple)
 
     def convert_method_kwargs(self, kwargs) -> Dict:
-        from ape.api.transactions import TransactionAPI
-
         fields = TransactionAPI.__fields__
 
         kwargs_to_convert = {k: v for k, v in kwargs.items() if k == "sender" or k in fields}

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Any, Dict, List, Tuple, Type, Union
+from typing import Any, Dict, List, Sequence, Tuple, Type, Union
 
 from dateutil.parser import parse  # type: ignore
 from eth_utils import (
@@ -12,7 +12,7 @@ from eth_utils import (
     to_hex,
     to_int,
 )
-from ethpm_types import HexBytes
+from ethpm_types import ConstructorABI, EventABI, HexBytes, MethodABI
 
 from ape.api import ConverterAPI
 from ape.api.address import BaseAddress
@@ -291,11 +291,7 @@ class ConversionManager(BaseManager):
             bool: ``True`` when we consider the given value to be the given type.
         """
 
-        if type is AddressType:
-            return is_checksum_address(value)
-
-        else:
-            return isinstance(value, type)
+        return is_checksum_address(value) if type is AddressType else isinstance(value, type)
 
     def convert(self, value: Any, type: Union[Type, Tuple, List]) -> Any:
         """
@@ -356,3 +352,33 @@ class ConversionManager(BaseManager):
                 raise ConversionError(message) from err
 
         raise ConversionError(f"No conversion registered to handle '{value}'.")
+
+    def convert_method_args(
+        self,
+        abi: Union[MethodABI, ConstructorABI, EventABI],
+        arguments: Sequence[Any],
+    ):
+        input_types = [i.canonical_type for i in abi.inputs]
+        pre_processed_args = []
+        for ipt, argument in zip(input_types, arguments):
+            # Handle primitive-addresses separately since they may not occur
+            # on the tuple-conversion if they are integers or bytes.
+            if str(ipt) == "address":
+                converted_value = self.convert(argument, AddressType)
+                pre_processed_args.append(converted_value)
+            else:
+                pre_processed_args.append(argument)
+
+        return self.convert(pre_processed_args, tuple)
+
+    def convert_method_kwargs(self, kwargs) -> Dict:
+        from ape.api.transactions import TransactionAPI
+
+        fields = TransactionAPI.__fields__
+
+        kwargs_to_convert = {k: v for k, v in kwargs.items() if k == "sender" or k in fields}
+        converted_fields = {
+            k: self.convert(v, AddressType if k == "sender" else fields[k].type_)
+            for k, v in kwargs_to_convert.items()
+        }
+        return {**kwargs, **converted_fields}

--- a/src/ape/managers/project/dependency.py
+++ b/src/ape/managers/project/dependency.py
@@ -287,7 +287,7 @@ class LocalDependency(DependencyAPI):
     """
 
     local: str
-    version = "local"
+    version: str = "local"
 
     @root_validator()
     def validate_contracts_folder(cls, value):

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -1,13 +1,13 @@
 import shutil
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Type, Union
+from typing import Any, Dict, Iterable, List, Optional, Type, Union, cast
 
 from ethpm_types import ContractInstance as EthPMContractInstance
 from ethpm_types import ContractType, PackageManifest, PackageMeta, Source
 from ethpm_types.contract_type import BIP122_URI
 from ethpm_types.manifest import PackageName
 from ethpm_types.source import Compiler, ContractSource
-from ethpm_types.utils import AnyUrl
+from ethpm_types.utils import AnyUrl, Hex
 
 from ape.api import DependencyAPI, ProjectAPI
 from ape.api.networks import LOCAL_NETWORK_NAME
@@ -196,7 +196,7 @@ class ProjectManager(BaseManager):
                 filtered_contract_types = [
                     ct for ct in contract_types if ct.source_id in source_ids
                 ]
-                contract_type_names = [ct.name for ct in filtered_contract_types]
+                contract_type_names = [ct.name for ct in filtered_contract_types if ct.name]
                 compiler_list.append(
                     Compiler(
                         name=compiler.name,
@@ -703,6 +703,9 @@ class ProjectManager(BaseManager):
             raise ProjectError("Can only publish deployments on a live network.")
 
         contract_name = contract.contract_type.name
+        if not (contract_name := contract.contract_type.name):
+            raise ProjectError("Contract name required when publishing.")
+
         try:
             receipt = contract.receipt
         except ChainError as err:
@@ -721,10 +724,10 @@ class ProjectManager(BaseManager):
 
         block_hash = block_hash_bytes.hex()
         artifact = EthPMContractInstance(
-            address=contract.address,
+            address=cast(Hex, contract.address),
             block=block_hash,
             contractType=contract_name,
-            transaction=contract.txn_hash,
+            transaction=cast(Hex, contract.txn_hash),
             runtimeBytecode=contract.contract_type.runtime_bytecode,
         )
 

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -230,7 +230,7 @@ class ApeProject(BaseProject):
 
 
 class BrownieProject(BaseProject):
-    config_file_name = "brownie-config.yaml"
+    config_file_name: str = "brownie-config.yaml"
 
     @property
     def brownie_config_path(self) -> Path:

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Union, cast
 
 from eth_abi.abi import encode
 from eth_abi.packed import encode_packed
-from eth_typing import HexStr
-from eth_utils import encode_hex, keccak
+from eth_typing import Hash32, HexStr
+from eth_utils import encode_hex, keccak, to_hex
 from ethpm_types import (
     ABI,
     Bytecode,
@@ -88,7 +88,7 @@ and otherwise you can provide a numeric value.
 """
 
 
-TopicFilter = List[Union[Optional[HexStr], List[Optional[HexStr]]]]
+TopicFilter = Sequence[Union[Optional[HexStr], List[Optional[HexStr]]]]
 
 
 @dataclass
@@ -142,11 +142,13 @@ class LogFilter(BaseModel):
         return convert(value, AddressType)
 
     def dict(self, client=None):
+        _Hash32 = Union[Hash32, HexBytes, HexStr]
+        topics = cast(Sequence[Optional[Union[_Hash32, Sequence[_Hash32]]]], self.topic_filter)
         return FilterParams(
             address=self.addresses,
-            fromBlock=hex(self.start_block),  # type: ignore
-            toBlock=hex(self.stop_block),  # type: ignore
-            topics=self.topic_filter,  # type: ignore
+            fromBlock=to_hex(self.start_block),
+            toBlock=to_hex(self.stop_block),
+            topics=topics,
         )
 
     @classmethod

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -9,10 +9,7 @@ from ape.types import AddressType
 
 
 def _left_pad_bytes(val: bytes, num_bytes: int) -> bytes:
-    if len(val) < num_bytes:
-        return b"\x00" * (num_bytes - len(val)) + val
-
-    return val
+    return b"\x00" * (num_bytes - len(val)) + val if len(val) < num_bytes else val
 
 
 @dataclass(frozen=True)

--- a/src/ape/utils/abi.py
+++ b/src/ape/utils/abi.py
@@ -9,7 +9,6 @@ from ethpm_types import HexBytes
 from ethpm_types.abi import ABIType, ConstructorABI, EventABI, EventABIType, MethodABI
 
 from ape.logging import logger
-from ape.types import AddressType
 
 ARRAY_PATTERN = re.compile(r"[(*\w,? )]*\[\d*]")
 
@@ -440,31 +439,3 @@ class LogInputABICollection:
         #  ecosystem API through the calling function.
 
         return value
-
-
-def _convert_args(arguments, converter, abi: Union[MethodABI, ConstructorABI]) -> Tuple:
-    input_types = [i.canonical_type for i in abi.inputs]
-    pre_processed_args = []
-    for ipt, argument in zip(input_types, arguments):
-        # Handle primitive-addresses separately since they may not occur
-        # on the tuple-conversion if they are integers or bytes.
-        if str(ipt) == "address":
-            converted_value = converter(argument, AddressType)
-            pre_processed_args.append(converted_value)
-        else:
-            pre_processed_args.append(argument)
-
-    return converter(pre_processed_args, tuple)
-
-
-def _convert_kwargs(kwargs, converter) -> Dict:
-    from ape.api.transactions import TransactionAPI
-
-    fields = TransactionAPI.__fields__
-
-    kwargs_to_convert = {k: v for k, v in kwargs.items() if k == "sender" or k in fields}
-    converted_fields = {
-        k: converter(v, AddressType if k == "sender" else fields[k].type_)
-        for k, v in kwargs_to_convert.items()
-    }
-    return {**kwargs, **converted_fields}

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, ClassVar, List, Optional, cast
 
 from ethpm_types import BaseModel
 
@@ -88,10 +88,10 @@ class ManagerAccessMixin:
         Returns:
             :class:`~ape.api.providers.ProviderAPI`
         """
-        if self.network_manager.active_provider is None:
-            raise ProviderNotConnectedError()
+        if provider := self.network_manager.active_provider:
+            return provider
 
-        return self.network_manager.active_provider
+        raise ProviderNotConnectedError()
 
 
 class BaseInterface(ManagerAccessMixin, ABC):
@@ -123,27 +123,3 @@ class BaseInterfaceModel(BaseInterface, BaseModel):
         """
         # Filter out protected/private members
         return [member for member in super().__dir__() if not member.startswith("_")]
-
-    def dict(self, *args, **kwargs) -> Dict:
-        if "by_alias" not in kwargs:
-            kwargs["by_alias"] = True
-
-        if "exclude_none" not in kwargs:
-            kwargs["exclude_none"] = True
-
-        return super().dict(*args, **kwargs)
-
-    def json(self, *args, **kwargs) -> str:
-        if "separators" not in kwargs:
-            kwargs["separators"] = (",", ":")
-
-        if "sort_keys" not in kwargs:
-            kwargs["sort_keys"] = True
-
-        if "by_alias" not in kwargs:
-            kwargs["by_alias"] = True
-
-        if "exclude_none" not in kwargs:
-            kwargs["exclude_none"] = True
-
-        return super().json(*args, **kwargs)

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -5,7 +5,7 @@ from asyncio import gather
 from datetime import datetime
 from functools import cached_property, lru_cache, singledispatchmethod, wraps
 from pathlib import Path
-from typing import Any, Callable, Coroutine, Dict, List, Mapping, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, Mapping, Optional, cast
 
 import requests
 import yaml
@@ -17,11 +17,14 @@ from tqdm.auto import tqdm  # type: ignore
 
 from ape.exceptions import APINotImplementedError, ProviderNotConnectedError
 from ape.logging import logger
-from ape.types import AddressType
 from ape.utils.os import expand_environment_variables
 
+if TYPE_CHECKING:
+    from ape.types import AddressType
+
+
 EMPTY_BYTES32 = HexBytes("0x0000000000000000000000000000000000000000000000000000000000000000")
-ZERO_ADDRESS: AddressType = cast(AddressType, "0x0000000000000000000000000000000000000000")
+ZERO_ADDRESS: "AddressType" = cast("AddressType", "0x0000000000000000000000000000000000000000")
 DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT = 120
 DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT = 20
 DEFAULT_LIVE_NETWORK_BASE_FEE_MULTIPLIER = 1.4

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -50,7 +50,6 @@ from ape.utils import (
     returns_array,
     to_int,
 )
-from ape.utils.abi import _convert_kwargs
 from ape.utils.misc import DEFAULT_MAX_RETRIES_TX
 from ape_ethereum.proxies import (
     IMPLEMENTATION_ABI,
@@ -237,7 +236,7 @@ class Ethereum(EcosystemAPI):
         deploy_bytecode = HexBytes(
             return_data_size + len_bytes + return_instructions + blueprint_bytecode
         )
-        converted_kwargs = _convert_kwargs(kwargs, self.conversion_manager.convert)
+        converted_kwargs = self.conversion_manager.convert_method_kwargs(kwargs)
         return self.encode_deployment(
             deploy_bytecode, contract_type.constructor, **converted_kwargs
         )

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -90,7 +90,7 @@ class NetworkConfig(PluginConfig):
     block_time: int = 0
     transaction_acceptance_timeout: int = DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT
     default_transaction_type: TransactionType = TransactionType.DYNAMIC
-    max_receipt_retries = DEFAULT_MAX_RETRIES_TX
+    max_receipt_retries: int = DEFAULT_MAX_RETRIES_TX
 
     gas_limit: GasLimit = "auto"
     """
@@ -263,11 +263,10 @@ class Ethereum(EcosystemAPI):
             ProxyType.SplitsCWIA: r"36602f57343d527f9e4ac34f21c619cefc926c8bd93b54bf5a39c7ab2127a895af1cc0691d7e3dff60203da13d3df35b3d3d3d3d363d3d3761.{4}606736393661.{4}013d73(.{40})5af43d3d93803e606557fd5bf3.*",  # noqa: E501
             ProxyType.SoladyPush0: r"^5f5f365f5f37365f73(.{40})5af43d5f5f3e6029573d5ffd5b3d5ff3",
         }
-        for type, pattern in patterns.items():
-            match = re.match(pattern, code)
-            if match:
+        for type_, pattern in patterns.items():
+            if match := re.match(pattern, code):
                 target = self.conversion_manager.convert(match.group(1), AddressType)
-                return ProxyInfo(type=type, target=target)
+                return ProxyInfo(type=type_, target=target)
 
         sequence_pattern = r"363d3d373d3d3d363d30545af43d82803e903d91601857fd5bf3"
         if re.match(sequence_pattern, code):
@@ -349,7 +348,7 @@ class Ethereum(EcosystemAPI):
                 break
 
         if txn_hash:
-            txn_hash = txn_hash.hex() if isinstance(txn_hash, HexBytes) else txn_hash
+            txn_hash = txn_hash.hex() if isinstance(txn_hash, bytes) else txn_hash
 
         data_bytes = data.get("data", b"")
         if data_bytes and isinstance(data_bytes, str):
@@ -358,8 +357,12 @@ class Ethereum(EcosystemAPI):
         elif "input" in data and isinstance(data["input"], str):
             data["input"] = HexBytes(data["input"])
 
+        block_number = data.get("block_number") or data.get("blockNumber")
+        if block_number is None:
+            raise ValueError("Missing block number.")
+
         receipt = Receipt(
-            block_number=data.get("block_number") or data.get("blockNumber"),
+            block_number=block_number,
             contract_address=data.get("contract_address") or data.get("contractAddress"),
             gas_limit=data.get("gas", data.get("gas_limit", data.get("gasLimit"))) or 0,
             gas_price=data.get("gas_price", data.get("gasPrice")) or 0,
@@ -490,7 +493,7 @@ class Ethereum(EcosystemAPI):
         return tuple(output_values)
 
     def _enrich_value(self, value: Any, **kwargs) -> Any:
-        if isinstance(value, HexBytes):
+        if isinstance(value, bytes):
             try:
                 string_value = value.strip(b"\x00").decode("utf8")
                 return f'"{string_value}"'
@@ -553,13 +556,14 @@ class Ethereum(EcosystemAPI):
         self, deployment_bytecode: HexBytes, abi: ConstructorABI, *args, **kwargs
     ) -> BaseTransaction:
         txn = self.create_transaction(**kwargs)
-        txn.data = deployment_bytecode
+        data = HexBytes(deployment_bytecode)
 
         # Encode args, if there are any
         if abi and args:
-            txn.data += self.encode_calldata(abi, *args)
+            data = HexBytes(data + self.encode_calldata(abi, *args))
 
-        return txn  # type: ignore
+        txn.data = data
+        return cast(BaseTransaction, txn)
 
     def encode_transaction(
         self,
@@ -572,9 +576,9 @@ class Ethereum(EcosystemAPI):
 
         # Add method ID
         txn.data = self.get_method_selector(abi)
-        txn.data += self.encode_calldata(abi, *args)
+        txn.data = HexBytes(txn.data + self.encode_calldata(abi, *args))
 
-        return txn  # type: ignore
+        return cast(BaseTransaction, txn)
 
     def create_transaction(self, **kwargs) -> TransactionAPI:
         """
@@ -836,10 +840,8 @@ class Ethereum(EcosystemAPI):
         **kwargs,
     ) -> CallTreeNode:
         calldata = call.inputs
-        if isinstance(calldata, str):
+        if isinstance(calldata, (str, bytes, int)):
             calldata_arg = HexBytes(calldata)
-        elif isinstance(calldata, HexBytes):
-            calldata_arg = calldata
         else:
             # Not sure if we can get here.
             # Mostly for mypy's sake.
@@ -872,10 +874,10 @@ class Ethereum(EcosystemAPI):
             return call
 
         default_return_value = "<?>"
-        if isinstance(call.outputs, str) and is_0x_prefixed(call.outputs):
+        if (isinstance(call.outputs, str) and is_0x_prefixed(call.outputs)) or isinstance(
+            call.outputs, (int, bytes)
+        ):
             return_value_bytes = HexBytes(call.outputs)
-        elif isinstance(call.outputs, HexBytes):
-            return_value_bytes = call.outputs
         else:
             return_value_bytes = None
 
@@ -917,9 +919,9 @@ class Ethereum(EcosystemAPI):
         return self._python_type_for_abi_type(abi_type)
 
 
-def parse_type(type: Dict[str, Any]) -> Union[str, Tuple, List]:
-    if "tuple" not in type["type"]:
-        return type["type"]
+def parse_type(type_: Dict[str, Any]) -> Union[str, Tuple, List]:
+    if "tuple" not in type_["type"]:
+        return type_["type"]
 
-    result = tuple([parse_type(c) for c in type["components"]])
-    return [result] if is_array(type["type"]) else result
+    result = tuple([parse_type(c) for c in type_["components"]])
+    return [result] if is_array(type_["type"]) else result

--- a/src/ape_ethereum/proxies.py
+++ b/src/ape_ethereum/proxies.py
@@ -1,7 +1,9 @@
 from enum import IntEnum, auto
+from typing import cast
 
 from ethpm_types import ContractType, MethodABI
 from ethpm_types.abi import ABIType
+from ethpm_types.utils import Hex
 from lazyasd import LazyObject  # type: ignore
 
 from ape.api.networks import ProxyInfoAPI
@@ -90,7 +92,7 @@ IMPLEMENTATION_ABI = MethodABI(
 
 def _make_minimal_proxy(address: str = MINIMAL_PROXY_TARGET_PLACEHOLDER) -> ContractContainer:
     address = address.replace("0x", "")
-    code = MINIMAL_PROXY_BYTES.replace(MINIMAL_PROXY_TARGET_PLACEHOLDER, address)
+    code = cast(Hex, MINIMAL_PROXY_BYTES.replace(MINIMAL_PROXY_TARGET_PLACEHOLDER, address))
     bytecode = {"bytecode": code}
     contract_type = ContractType(abi=[], deploymentBytecode=bytecode)
     return ContractContainer(contract_type=contract_type)

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -107,10 +107,7 @@ class DynamicFeeTransaction(BaseTransaction):
 
     @validator("type", allow_reuse=True)
     def check_type(cls, value):
-        if isinstance(value, TransactionType):
-            return value.value
-
-        return value
+        return value.value if isinstance(value, TransactionType) else value
 
 
 class AccessListTransaction(BaseTransaction):

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -246,8 +246,8 @@ class BaseGethProvider(Web3Provider, ABC):
     _client_version: Optional[str] = None
 
     # optimal values for geth
-    block_page_size = 5000
-    concurrency = 16
+    block_page_size: int = 5000
+    concurrency: int = 16
 
     name: str = "geth"
 
@@ -450,10 +450,10 @@ class GethDev(BaseGethProvider, TestProviderAPI, SubprocessProvider):
 
     def connect(self):
         self._set_web3()
-        if not self.is_connected:
-            self.start()
-        else:
+        if self.is_connected:
             self._complete_connect()
+        else:
+            self.start()
 
     def start(self, timeout: int = 20):
         test_config = self.config_manager.get_config("test").dict()

--- a/src/ape_test/__init__.py
+++ b/src/ape_test/__init__.py
@@ -6,9 +6,8 @@ from ape import plugins
 from ape.api import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.utils import DEFAULT_HD_PATH, DEFAULT_NUMBER_OF_TEST_ACCOUNTS, DEFAULT_TEST_MNEMONIC
-
-from .accounts import TestAccount, TestAccountContainer
-from .provider import EthTesterProviderConfig, LocalProvider
+from ape_test.accounts import TestAccount, TestAccountContainer
+from ape_test.provider import EthTesterProviderConfig, LocalProvider
 
 
 class GasExclusion(PluginConfig):
@@ -79,7 +78,7 @@ class CoverageConfig(PluginConfig):
     the ``--coverage`` flag.
     """
 
-    reports = CoverageReportsConfig()
+    reports: CoverageReportsConfig = CoverageReportsConfig()
     """
     Enable reports.
     """

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -109,16 +109,16 @@ class LocalProvider(TestProviderAPI, Web3Provider):
 
     @property
     def chain_id(self) -> int:
+        if self.cached_chain_id:
+            return self.cached_chain_id
+
         try:
-            if self.cached_chain_id:
-                return self.cached_chain_id
-
             result = self._make_request("eth_chainId", [])
-            self.cached_chain_id = result
-            return result
-
         except ProviderNotConnectedError:
-            return self.provider_settings.get("chain_id", self.config.provider.chain_id)
+            result = self.provider_settings.get("chain_id", self.config.provider.chain_id)
+
+        self.cached_chain_id = result
+        return result
 
     @property
     def gas_price(self) -> int:

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -2,7 +2,7 @@ import threading
 import time
 from distutils.dir_util import copy_tree
 from pathlib import Path
-from typing import Optional
+from typing import Optional, cast
 
 import pytest
 from ethpm_types import ContractType, HexBytes
@@ -30,7 +30,7 @@ def get_contract_type():
 
 
 ALIAS_2 = "__FUNCTIONAL_TESTS_ALIAS_2__"
-TEST_ADDRESS = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+TEST_ADDRESS = cast(AddressType, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
 BASE_PROJECTS_DIRECTORY = (Path(__file__).parent / "data" / "projects").absolute()
 PROJECT_WITH_LONG_CONTRACTS_FOLDER = BASE_PROJECTS_DIRECTORY / "LongContractsFolder"
 APE_PROJECT_FOLDER = BASE_PROJECTS_DIRECTORY / "ApeProject"
@@ -378,7 +378,7 @@ def assert_log_values(contract_instance):
         address: Optional[AddressType] = None,
     ):
         assert log.contract_address == address or contract_instance.address
-        assert isinstance(log.b, HexBytes)
+        assert isinstance(log.b, bytes)
         expected_previous_number = number - 1 if previous_number is None else previous_number
         assert log.prevNum == expected_previous_number, "Event param 'prevNum' has unexpected value"
         assert log.newNum == number, "Event param 'newNum' has unexpected value"

--- a/tests/functional/conversion/test_encode_structs.py
+++ b/tests/functional/conversion/test_encode_structs.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple
+from typing import Dict, Tuple, cast
 
 import pytest
 from ethpm_types import HexBytes
@@ -48,7 +48,7 @@ EXPECTED = HexBytes(
     "0000000000000000000000000000000000000000000000000000000000000001"
     "000000000000000000000000d9b7fdb3fc0a0aa3a507dcf0976bc23d49a9c7a3"
 )
-ADDRESS = "0xD9b7fdb3FC0A0Aa3A507dCf0976bc23D49a9C7A3"
+ADDRESS = cast(AddressType, "0xD9b7fdb3FC0A0Aa3A507dCf0976bc23D49a9C7A3")
 DATA_BY_TYPE_KEY = {
     "tuple": (1, HexBytes("0x02"), True, ADDRESS),
     "dict": {"a": 1, "b": HexBytes("0x02"), "c": True, "d": ADDRESS},

--- a/tests/functional/geth/conftest.py
+++ b/tests/functional/geth/conftest.py
@@ -66,7 +66,7 @@ def mock_geth(geth_provider, mock_web3):
         network=geth_provider.network,
         provider_settings={},
         data_folder=Path("."),
-        request_header="",
+        request_header={},
     )
     original_web3 = provider._web3
     provider._web3 = mock_web3

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -293,18 +293,16 @@ def test_autosign_transactions(runner, keyfile_account, receiver):
         assert keyfile_account.transfer(receiver, "1 gwei")
 
 
-def test_impersonate_not_implemented(accounts):
-    test_address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+def test_impersonate_not_implemented(accounts, address):
     expected_err_msg = (
         "Your provider does not support impersonating accounts:\n"
-        f"No account with address '{test_address}'."
+        f"No account with address '{address}'."
     )
     with pytest.raises(IndexError, match=expected_err_msg):
-        _ = accounts[test_address]
+        _ = accounts[address]
 
 
-def test_impersonated_account_ignores_signature_check_on_txn(accounts):
-    address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+def test_impersonated_account_ignores_signature_check_on_txn(accounts, address):
     account = ImpersonatedAccount(raw_address=address)
 
     # Impersonate hack, since no providers in core actually support it.

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -3,6 +3,7 @@ from typing import Dict, Union
 import pytest
 
 from ape.api import PluginConfig
+from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.managers.config import CONFIG_FILE_NAME, DeploymentConfigCollection, merge_configs
 from ape.types import GasLimit
 from ape_ethereum.ecosystem import NetworkConfig
@@ -10,11 +11,16 @@ from tests.functional.conftest import PROJECT_WITH_LONG_CONTRACTS_FOLDER
 
 
 def test_integer_deployment_addresses(networks):
-    deployments_data = _create_deployments()
-    config = DeploymentConfigCollection(
-        deployments_data, {"ethereum": networks.ethereum}, ["local"]
+    data = {
+        **_create_deployments(),
+        "valid_ecosystems": {"ethereum": networks.ethereum},
+        "valid_networks": [LOCAL_NETWORK_NAME],
+    }
+    config = DeploymentConfigCollection(__root__=data)
+    assert (
+        config.root["ethereum"]["local"][0]["address"]
+        == "0x0c25212c557d00024b7Ca3df3238683A35541354"
     )
-    assert config["ethereum"]["local"][0]["address"] == "0x0c25212c557d00024b7Ca3df3238683A35541354"
 
 
 @pytest.mark.parametrize(
@@ -25,9 +31,9 @@ def test_bad_value_in_deployments(ecosystems, networks, err_part, ape_caplog, pl
     deployments = _create_deployments()
     all_ecosystems = dict(plugin_manager.ecosystems)
     ecosystem_dict = {e: all_ecosystems[e] for e in ecosystems if e in all_ecosystems}
-    DeploymentConfigCollection(deployments, ecosystem_dict, networks)
+    data = {**deployments, "valid_ecosystems": ecosystem_dict, "valid_networks": networks}
     ape_caplog.assert_last_log_with_retries(
-        lambda: DeploymentConfigCollection(deployments, ecosystem_dict, networks),
+        lambda: DeploymentConfigCollection(__root__=data),
         f"Invalid {err_part}",
     )
 

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -18,7 +18,7 @@ def test_integer_deployment_addresses(networks):
     }
     config = DeploymentConfigCollection(__root__=data)
     assert (
-        config.root["ethereum"]["local"][0]["address"]
+        config.__root__["ethereum"]["local"][0]["address"]
         == "0x0c25212c557d00024b7Ca3df3238683A35541354"
     )
 

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -14,7 +14,7 @@ from ape.types import ContractLog
 @pytest.fixture
 def assert_log_values(owner, chain):
     def _assert_log_values(log: ContractLog, number: int, previous_number: Optional[int] = None):
-        assert isinstance(log.b, HexBytes)
+        assert isinstance(log.b, bytes)
         expected_previous_number = number - 1 if previous_number is None else previous_number
         assert log.prevNum == expected_previous_number, "Event param 'prevNum' has unexpected value"
         assert log.newNum == number, "Event param 'newNum' has unexpected value"

--- a/tests/functional/test_coverage.py
+++ b/tests/functional/test_coverage.py
@@ -75,7 +75,7 @@ def coverage_project(source_contract, second_source_contract):
 
 @pytest.fixture
 def coverage_report(coverage_project):
-    return CoverageReport(source_folders=[Path.cwd()], projects=[coverage_project], timestamp=None)
+    return CoverageReport(source_folders=[Path.cwd()], projects=[coverage_project], timestamp=0)
 
 
 class TestFunctionCoverage:

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -54,7 +54,7 @@ def test_encode_address(ethereum):
     assert actual == raw_address
 
 
-def test_encode_calldata(ethereum):
+def test_encode_calldata(ethereum, address):
     abi = MethodABI(
         type="function",
         name="callMe",
@@ -65,7 +65,6 @@ def test_encode_calldata(ethereum):
             ABIType(name="d", type="bytes4[]"),
         ],
     )
-    address = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
     byte_array = ["0x456", "0x678"]
     values = ("0x123", address, HexBytes(55), byte_array)
 

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -1,5 +1,6 @@
 import shutil
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pytest
 import yaml
@@ -183,7 +184,10 @@ def test_meta(temp_config, project):
         assert project.meta.license == "MIT"
         assert project.meta.description == "test"
         assert project.meta.keywords == ["testing"]
-        assert str(project.meta.links["apeworx.io"]).startswith("https://apeworx.io")
+
+        actual_url = urlparse(project.meta.links["apeworx.io"])
+        assert actual_url.hostname == "apeworx.io"
+        assert actual_url.scheme == "https"
 
 
 def test_brownie_project_configure(config, base_projects_directory):

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -183,7 +183,7 @@ def test_meta(temp_config, project):
         assert project.meta.license == "MIT"
         assert project.meta.description == "test"
         assert project.meta.keywords == ["testing"]
-        assert "https://apeworx.io" in project.meta.links["apeworx.io"]
+        assert str(project.meta.links["apeworx.io"]).startswith("https://apeworx.io")
 
 
 def test_brownie_project_configure(config, base_projects_directory):
@@ -193,7 +193,7 @@ def test_brownie_project_configure(config, base_projects_directory):
         # Left from previous run
         expected_config_file.unlink()
 
-    project = BrownieProject(path=project_path, contracts_folder="contracts")
+    project = BrownieProject(path=project_path, contracts_folder=Path("contracts"))
     project.process_config_file()
     assert expected_config_file.is_file()
 

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import pytest
 from eth_utils import to_hex
 from ethpm_types.abi import EventABI
@@ -11,7 +13,7 @@ BLOCK_NUMBER = 323423
 EVENT_NAME = "MyEvent"
 LOG_INDEX = 7
 TXN_INDEX = 2
-RAW_LOG = {
+RAW_LOG: Dict = {
     "block_hash": BLOCK_HASH,
     "block_number": BLOCK_NUMBER,
     "contract_address": ZERO_ADDRESS,


### PR DESCRIPTION
### What I did

Moves `_convert_args` and `_convert_kwargs` to the `ConversionManager`.

Reasoning: The `ConversionManager` is just dying for my tasks and these methods are awkwardly placed and they require passing the conversion manager around anyway, so it jus makes sense to have them be in the ConversionManager

Also, does other small typing related changes to help make the diff for Pydantic v2 much smaller.

### How I did it

moved the methods

### How to verify it

things still work

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
