### PR TITLE
fix: `ape plugins list` failed when no plugins installed. [APE-1425]

### DIFF
--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -218,6 +218,9 @@ def add_padding_to_strings(
         List[str]: A list of equal-length strings with padded spaces.
     """
 
+    if not str_list:
+        return []
+
     longest_item = len(max(str_list, key=len))
     spaced_items = []
 

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -340,9 +340,9 @@ def test_get_project_without_contracts_path(project):
 
 
 def test_get_project_with_contracts_path(project):
-    project_path = WITH_DEPS_PROJECT / "renamed_contracts_folder"
-    project = project.get_project(project_path, project_path / "sources")
-    assert project.contracts_folder == project_path / "sources"
+    project_path = WITH_DEPS_PROJECT / "renamed_contracts_folder_specified_in_config"
+    project = project.get_project(project_path, project_path / "my_contracts")
+    assert project.contracts_folder == project_path / "my_contracts"
 
 
 def test_get_project_figure_out_contracts_path(project):
@@ -351,6 +351,8 @@ def test_get_project_figure_out_contracts_path(project):
     to figure it out.
     """
     project_path = WITH_DEPS_PROJECT / "renamed_contracts_folder"
+    (project_path / "ape-config.yaml").unlink(missing_ok=True)  # Clean from prior.
+
     project = project.get_project(project_path)
     assert project.contracts_folder == project_path / "sources"
 

--- a/tests/functional/utils/test_misc.py
+++ b/tests/functional/utils/test_misc.py
@@ -27,11 +27,16 @@ def test_extract_nested_value_non_dict_in_middle_returns_none():
     assert not extract_nested_value(structure, "foo", "non_dict", "test")
 
 
-def test_add_spacing_to_strings():
+def test_add_padding_to_strings():
     string_list = ["foo", "address", "ethereum"]
     expected = ["foo         ", "address     ", "ethereum    "]
     actual = add_padding_to_strings(string_list, extra_spaces=4)
     assert actual == expected
+
+
+def test_add_padding_to_strings_empty_list():
+    actual = add_padding_to_strings([])
+    assert actual == []
 
 
 def test_raises_not_implemented():


### PR DESCRIPTION
### What I did

got an unhandled exception when attempting to list installed plugins when there werent any installed.

### How I did it

When given an empty list in the helper function, return empty list.

### How to verify it

* Ensure no plugins installed.
* Run `ape plugins list`

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
