### PR TITLE
fix: hyphenated ecosystem names [APE-1437]

### DIFF
--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -227,6 +227,13 @@ class NetworkManager(BaseManager):
         """
 
         if attr_name not in self.ecosystems:
+            # First try alternating the hyphen and underscores.
+            attr_name_fix = (
+                attr_name.replace("_", "-") if "_" in attr_name else attr_name.replace("-", "_")
+            )
+            if attr_name_fix in self.ecosystems:
+                return self.ecosystems[attr_name_fix]
+
             raise ApeAttributeError(f"{self.__class__.__name__} has no attribute '{attr_name}'.")
 
         return self.ecosystems[attr_name]

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -189,3 +189,9 @@ def test_parse_network_choice_multiple_contexts(get_provider_with_unused_chain_i
             # Second context should already know about connected providers
             assert len(first_context.connected_providers) == expected_next_count
             assert len(second_context.connected_providers) == expected_next_count
+
+
+def test_getattr_ecosystem_with_hyphenated_name(networks, ethereum):
+    networks.ecosystems["hyphen-in-name"] = networks.ecosystems["ethereum"]
+    assert networks.hyphen_in_name  # Make sure does not raise AttributeError
+    del networks.ecosystems["hyphen-in-name"]


### PR DESCRIPTION
### What I did

Issue where couldnt use getattr for polygon zkevm ecosystem.

### How I did it

alternate hyphen with underscore as a last attempt

### How to verify it

`networks.polygon_zkevm` when you have `ape-polygon-zkevm` installed
### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
