### PR TITLE
feat: sort networks in `list` command [APE-1439]

### DIFF
--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -541,7 +541,7 @@ class NetworkManager(BaseManager):
             )
 
         try:
-            return yaml.dump(data, sort_keys=False)
+            return yaml.dump(data, sort_keys=True)
         except ValueError as err:
             try:
                 data_str = json.dumps(data)

--- a/src/ape_networks/_cli.py
+++ b/src/ape_networks/_cli.py
@@ -47,7 +47,8 @@ def _lazy_get(name: str) -> _LazySequence:
 def _list(cli_ctx, output_format, ecosystem_filter, network_filter, provider_filter):
     if output_format == OutputFormat.TREE:
         default_suffix = "[dim default]  (default)"
-        ecosystems = cli_ctx.network_manager.network_data["ecosystems"]
+        ecosystems = {e["name"]: e for e in cli_ctx.network_manager.network_data["ecosystems"]}
+        ecosystems = {n: ecosystems[n] for n in sorted(ecosystems)}
 
         def make_sub_tree(data: Dict, create_tree: Callable) -> Tree:
             name = f"[bold green]{data['name']}"
@@ -57,17 +58,18 @@ def _list(cli_ctx, output_format, ecosystem_filter, network_filter, provider_fil
             sub_tree = create_tree(name)
             return sub_tree
 
-        for ecosystem in ecosystems:
+        for ecosystem_name, ecosystem in ecosystems.items():
             if ecosystem_filter and ecosystem["name"] not in ecosystem_filter:
                 continue
 
             ecosystem_tree = make_sub_tree(ecosystem, Tree)
-            _networks = ecosystem["networks"]
+            _networks = {n["name"]: n for n in ecosystem["networks"]}
+            _networks = {n: _networks[n] for n in sorted(_networks)}
             if network_filter:
-                _networks = [n for n in _networks if n["name"] in network_filter]
+                _networks = {n: v for n, v in _networks.items() if n in network_filter}
 
-            for network in _networks:
-                if network_filter and network["name"] not in network_filter:
+            for network_name, network in _networks.items():
+                if network_filter and network_name not in network_filter:
                     continue
 
                 providers = network["providers"]

--- a/tests/integration/cli/test_networks.py
+++ b/tests/integration/cli/test_networks.py
@@ -5,55 +5,53 @@ from .utils import run_once, skip_projects_except
 
 _DEFAULT_NETWORKS_TREE = """
 ethereum  (default)
-├── mainnet
-│   └── geth  (default)
 ├── goerli
 │   └── geth  (default)
-├── sepolia
-│   └── geth  (default)
-└── local  (default)
-    ├── geth
-    └── test  (default)
+├── local  (default)
+│   └── test  (default)
+├── mainnet
+│   └── test  (default)
+└── sepolia
+    └── geth  (default)
 """
 _DEFAULT_NETWORKS_YAML = """
 ecosystems:
-- name: ethereum
-  isDefault: true
+- isDefault: true
+  name: ethereum
   networks:
-  - name: mainnet
-    providers:
-    - name: geth
-      isDefault: true
-  - name: mainnet-fork
-    providers: []
   - name: goerli
     providers:
-    - name: geth
-      isDefault: true
+    - isDefault: true
+      name: geth
   - name: goerli-fork
+    providers: []
+  - isDefault: true
+    name: local
+    providers:
+    - name: geth
+    - isDefault: true
+      name: test
+  - name: mainnet
+    providers:
+    - isDefault: true
+      name: geth
+  - name: mainnet-fork
     providers: []
   - name: sepolia
     providers:
-    - name: geth
-      isDefault: true
+    - isDefault: true
+      name: geth
   - name: sepolia-fork
     providers: []
-  - name: local
-    isDefault: true
-    providers:
-    - name: geth
-    - name: test
-      isDefault: true
 """
 _GETH_NETWORKS_TREE = """
 ethereum  (default)
-├── mainnet
-│   └── geth  (default)
 ├── goerli
 │   └── geth  (default)
-└── local  (default)
-    ├── geth  (default)
-    └── test
+├── local  (default)
+│   └── geth  (default)
+└── mainnet
+    └── geth  (default)
 """
 _TEST_PROVIDER_TREE_OUTPUT = """
 ethereum  (default)
@@ -91,7 +89,11 @@ def assert_rich_text(actual: str, expected: str):
 @run_once
 def test_list(ape_cli, runner):
     result = runner.invoke(ape_cli, ["networks", "list"])
-    assert_rich_text(result.output, _DEFAULT_NETWORKS_TREE)
+
+    # Grab ethereum
+    actual = "ethereum  (default)\n" + "".join(result.output.split("ethereum  (default)\n")[-1])
+
+    assert_rich_text(actual, _DEFAULT_NETWORKS_TREE)
 
 
 @run_once
@@ -115,25 +117,37 @@ def test_geth(ape_cli, runner, networks, project):
     assert (
         networks.provider.network.default_provider == "geth"
     ), "Setup failed - default provider didn't apply from config"
-    assert_rich_text(result.output, _GETH_NETWORKS_TREE)
+
+    # Grab ethereum
+    actual = "ethereum  (default)\n" + "".join(result.output.split("ethereum  (default)\n")[-1])
+
+    assert_rich_text(actual, _GETH_NETWORKS_TREE)
 
     # Assert that URI still exists for local network
     # (was bug where one network's URI disappeared when setting different network's URI)
     geth_provider = networks.get_provider_from_choice(f"ethereum:{LOCAL_NETWORK_NAME}:geth")
-    actual = geth_provider.uri
-    assert actual == GETH_URI
+    actual_uri = geth_provider.uri
+    assert actual_uri == GETH_URI
 
 
 @run_once
 def test_filter_networks(ape_cli, runner, networks):
     result = runner.invoke(ape_cli, ["networks", "list", "--network", "goerli"])
-    assert_rich_text(result.output, _GOERLI_NETWORK_TREE_OUTPUT)
+
+    # Grab ethereum
+    actual = "ethereum  (default)\n" + "".join(result.output.split("ethereum  (default)\n")[-1])
+
+    assert_rich_text(actual, _GOERLI_NETWORK_TREE_OUTPUT)
 
 
 @run_once
 def test_filter_providers(ape_cli, runner, networks):
     result = runner.invoke(ape_cli, ["networks", "list", "--provider", "test"])
-    assert_rich_text(result.output, _TEST_PROVIDER_TREE_OUTPUT)
+
+    # Grab ethereum
+    actual = "ethereum  (default)\n" + "".join(result.output.split("ethereum  (default)\n")[-1])
+
+    assert_rich_text(actual, _TEST_PROVIDER_TREE_OUTPUT)
 
 
 @run_once


### PR DESCRIPTION
### What I did

It is frustrating using `ape networks list` when you have lots of networks because the order is inconsistent. Every time I am looking for `polygon-zkevm`, it is in a different spot etc.

This sorts it

### How I did it

sorting

### How to verify it

output is sorted

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
