### PR TITLE
fix: sort providers in `ape networks list` [APE-1442]

### DIFF
--- a/src/ape_networks/_cli.py
+++ b/src/ape_networks/_cli.py
@@ -78,6 +78,7 @@ def _list(cli_ctx, output_format, ecosystem_filter, network_filter, provider_fil
 
                 if providers:
                     network_tree = make_sub_tree(network, ecosystem_tree.add)
+                    providers = sorted(providers, key=lambda p: p["name"])
                     for provider in providers:
                         make_sub_tree(provider, network_tree.add)
 

--- a/tests/integration/cli/test_networks.py
+++ b/tests/integration/cli/test_networks.py
@@ -8,6 +8,7 @@ ethereum  (default)
 ├── goerli
 │   └── geth  (default)
 ├── local  (default)
+│   ├── geth
 │   └── test  (default)
 ├── mainnet
 │   └── test  (default)


### PR DESCRIPTION
### What I did

this was a miss from https://github.com/ApeWorX/ape/pull/1690 when you have multiple providers installed

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
