### PR TITLE
fix: issue where subclass receipts were not recognized in transaction error

### DIFF
--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -650,8 +650,9 @@ class CustomError(ContractLogicError):
 
 
 def _get_ape_traceback(txn: FailedTxn) -> Optional["SourceTraceback"]:
-    is_receipt = "ReceiptAPI" in [t.__name__ for t in txn.__class__.__bases__]
-    receipt: "ReceiptAPI" = txn if is_receipt else txn.receipt  # type: ignore
+    from ape.api.transactions import ReceiptAPI
+
+    receipt: "ReceiptAPI" = txn if isinstance(txn, ReceiptAPI) else txn.receipt  # type: ignore
     if not receipt:
         return None
 

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -44,7 +44,7 @@ def test_create_dynamic_fee_kwargs(ethereum, fee_kwargs):
         assert txn.max_fee == int(100e9)
 
 
-def test_txn_hash(owner, eth_tester_provider, ethereum):
+def test_txn_hash_and_receipt(owner, eth_tester_provider, ethereum):
     txn = ethereum.create_transaction()
     txn = owner.prepare_transaction(txn)
     txn = owner.sign_transaction(txn)
@@ -52,6 +52,10 @@ def test_txn_hash(owner, eth_tester_provider, ethereum):
 
     actual = txn.txn_hash.hex()
     receipt = eth_tester_provider.send_transaction(txn)
+
+    # Show that we can access the receipt from the transaction.
+    assert txn.receipt == receipt
+
     expected = receipt.txn_hash
 
     assert actual == expected
@@ -82,3 +86,8 @@ def test_txn_str_when_data_is_bytes(ethereum):
     txn = ethereum.create_transaction(data=HexBytes("0x123"))
     actual = str(txn)
     assert isinstance(actual, str)
+
+
+def test_transaction_with_none_receipt(ethereum):
+    txn = ethereum.create_transaction(data=HexBytes("0x123"))
+    assert txn.receipt is None


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1687 
Fixes: APE-1431

### How I did it

Use `isinstance()` instead of weird base class check

### How to verify it

ape-arbitrum works now
ape-arbitrum has a subclassed Receipt, so it ran into this bug.
Poor ape-arbitrum lately!

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
