### PR TITLE
fix: unnecessary modification of build artifact

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -137,19 +137,22 @@ class ProjectAPI(BaseInterfaceModel):
 
     @property
     def contracts(self) -> Dict[str, ContractType]:
-        if self._contracts is None:
-            contracts = {}
-            for p in self._cache_folder.glob("*.json"):
-                if p == self.manifest_cachefile:
-                    continue
+        if self._contracts is not None:
+            return self._contracts
 
-                contract_name = p.stem
-                contract_type = ContractType.parse_file(p)
-                if contract_type.name is None:
-                    contract_type.name = contract_name
+        contracts = {}
+        for p in self._cache_folder.glob("*.json"):
+            if p == self.manifest_cachefile:
+                continue
 
-                contracts[contract_type.name] = contract_type
-            self._contracts = contracts
+            contract_name = p.stem
+            contract_type = ContractType.parse_file(p)
+            if contract_type.name is None:
+                contract_type.name = contract_name
+
+            contracts[contract_type.name] = contract_type
+
+        self._contracts = contracts
         return self._contracts
 
     @property

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -407,7 +407,7 @@ class ProjectManager(BaseManager):
         Returns:
             Dict[str, ``ContractType``]
         """
-        if self.local_project._cached_manifest is None:
+        if self.local_project.cached_manifest is None:
             return self.load_contracts()
 
         return self.local_project.contracts


### PR DESCRIPTION
### What I did

Fixes the bug mentioned in this comment: https://github.com/ApeWorX/ape/issues/1594#issuecomment-1673289476

### How I did it

Use `.cached_manifest` instead of `._cached_manifest`

### How to verify it

do both on main and this branch

1. run ape compile in a project with contracts
2. observe __local__.json modification time
3. open a console
4. type `project.contracts`
5. observe that modification time was updated unnecessarily on main but not on this branch

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
