### PR TITLE
fix: an indefinite compile issue [APE-1450]

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -36,7 +36,8 @@ def build_docs(path: Path) -> Path:
     try:
         subprocess.check_call(["sphinx-build", "docs", str(path)])
     except subprocess.SubprocessError as err:
-        raise ApeDocsBuildError(f"Command 'sphinx-build docs {path}' failed.") from err
+        message = f"Command 'sphinx-build docs {path}' failed.\nErr:{err}"
+        raise ApeDocsBuildError(message) from err
 
     return path
 

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -122,8 +122,8 @@ class CompilerManager(BaseManager):
                 and not any(x in [p.name for p in path.parents] for x in (".cache", ".build"))
             ]
 
-            for path in paths_to_compile:
-                source_id = get_relative_path(path, contracts_folder)
+            source_ids = [get_relative_path(p, contracts_folder) for p in paths_to_compile]
+            for source_id in source_ids:
                 logger.info(f"Compiling '{source_id}'.")
 
             compiled_contracts = self.registered_compilers[extension].compile(
@@ -155,11 +155,25 @@ class CompilerManager(BaseManager):
                     raise CompilerError(error_message)
 
                 elif contract_name in built_names:
-                    error_message = (
-                        f"{ContractType.__name__} collision between "
-                        f"with contract named '{contract_name}'."
+                    # Ensure we are not colliding.
+                    existing_artifact = (
+                        self.project_manager.local_project._cache_folder / f"{contract_name}.json"
                     )
-                    raise CompilerError(error_message)
+
+                    try:
+                        existing_contract = ContractType.parse_file(existing_artifact)
+                    except Exception:
+                        existing_artifact.unlink()
+
+                    else:
+                        path = self.project_manager.lookup_path(existing_contract.source_id)
+                        if path and existing_contract.source_id != contract_type.source_id:
+                            error_message = f"{ContractType.__name__} collision '{contract_name}'."
+                            raise CompilerError(error_message)
+
+                        elif not path:
+                            # Artifact remaining from deleted contract, can delete.
+                            existing_artifact.unlink()
 
                 contract_types_dict[contract_name] = contract_type
 

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -100,6 +100,8 @@ class CompilerManager(BaseManager):
         contracts_folder = self.config_manager.contracts_folder
         contract_types_dict: Dict[str, ContractType] = {}
         built_paths = [p for p in self.project_manager.local_project._cache_folder.glob("*.json")]
+        built_names = [p.stem for p in built_paths if p.stem != "__local__"]
+
         for extension in extensions:
             path_patterns_to_ignore = self.config_manager.compiler.ignore_files
             ignore_path_lists = [contracts_folder.rglob(p) for p in path_patterns_to_ignore]
@@ -149,6 +151,13 @@ class CompilerManager(BaseManager):
                         f"{ContractType.__name__} collision between sources "
                         f"'{contract_type.source_id}' and "
                         f"'{already_added_contract_type.source_id}'."
+                    )
+                    raise CompilerError(error_message)
+
+                elif contract_name in built_names:
+                    error_message = (
+                        f"{ContractType.__name__} collision between "
+                        f"with contract named '{contract_name}'."
                     )
                     raise CompilerError(error_message)
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -512,3 +512,23 @@ def mock_explorer(mocker):
     explorer = mocker.MagicMock()
     explorer.name = "mock"  # Needed for network data serialization.
     return explorer
+
+
+@pytest.fixture
+def mock_compiler(mocker):
+    mock = mocker.MagicMock()
+    mock.ext = ".__mock__"
+
+    def mock_compile(paths, *args, **kwargs):
+        result = []
+        for path in paths:
+            if path.suffix == mock.ext:
+                name = path.stem
+                code = HexBytes(123).hex()
+                contract_type = ContractType(contractName=name, abi=[], deploymentBytecode=code)
+                result.append(contract_type)
+
+        return result
+
+    mock.compile.side_effect = mock_compile
+    return mock

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -75,12 +75,17 @@ def test_flatten_contract(compilers, project_with_contract):
 def test_contract_type_collision(compilers, project_with_contract, mock_compiler):
     existing_compilers = compilers._registered_compilers_cache[project_with_contract.path]
     all_compilers = {**existing_compilers, mock_compiler.ext: mock_compiler}
-    compilers._registered_compilers_cache[project_with_contract.path] = all_compilers
 
-    # Make contracts of type .__mock__ with the same names.
-    contract_name = next(iter(project_with_contract.contracts))
-    new_contract = project_with_contract.path / f"{contract_name}{mock_compiler.ext}"
-    new_contract.write_text("foobar")
+    try:
+        compilers._registered_compilers_cache[project_with_contract.path] = all_compilers
 
-    with pytest.raises(CompilerError, match="ContractType collision.*"):
-        compilers.compile([new_contract])
+        # Make contracts of type .__mock__ with the same names.
+        contract_name = next(iter(project_with_contract.contracts))
+        new_contract = project_with_contract.path / f"{contract_name}{mock_compiler.ext}"
+        new_contract.write_text("foobar")
+
+        with pytest.raises(CompilerError, match="ContractType collision.*"):
+            compilers.compile([new_contract])
+
+    finally:
+        compilers._registered_compilers_cache[project_with_contract.path] = existing_compilers


### PR DESCRIPTION
### What I did

issue where contract type collision error would not raise when adding contract with same name after compiling,
and in cases where deleted contracts remained, new contracts with the same name would indefinitely re-compile

i think this fixes #1594 (APE-1277) but may need some testing from the user who opened the issue

fixes: #1594 
Fixes: APE-1277

### How I did it

Check already built names for collisions as well

### How to verify it

1. compile a project with contract Test.vy
2. add a new contract Test.sol
3. compile again
4. **Notice things compile indefinitely and never properly cache** (maybe fixes: #1594  ?) without this PR and with this PR, you get the expected error


### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
