### PR TITLE
chore: bump ethpmtypes [APE-1454]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
         "web3[tester]>=6.7.0,<7",
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.2.1,<0.3",
-        "ethpm-types>=0.5.6,<0.6",
+        "ethpm-types>=0.5.8,<0.6",
         "evm-trace>=0.1.0a23",
     ],
     entry_points={


### PR DESCRIPTION
### What I did

bump to 0.5.8 because 0.5.7 has a bug that affects core.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
