### PR TITLE
fix: issue when switching providers when disconnecting [APE-1460]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-yaml
 
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 23.10.1
     hooks:
       - id: black
         name: black
@@ -21,7 +21,7 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.6.1
     hooks:
     -   id: mypy
         additional_dependencies: [

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ extras_require = {
         "hypothesis-jsonschema==0.19.0",  # JSON Schema fuzzer extension
     ],
     "lint": [
-        "black>=23.9.1,<24",  # Auto-formatter and linter
-        "mypy>=1.5.1,<2",  # Static type analyzer
+        "black>=23.10.1,<24",  # Auto-formatter and linter
+        "mypy>=1.6.1,<2",  # Static type analyzer
         "types-PyYAML",  # Needed due to mypy typeshed
         "types-requests",  # Needed due to mypy typeshed
         "types-setuptools",  # Needed due to mypy typeshed

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -879,17 +879,7 @@ class NetworkAPI(BaseInterfaceModel):
             provider_name = "geth"
 
         if provider_name in self.providers:
-            provider = self.providers[provider_name]()
-
-            if not provider.is_connected:
-                # Apply the settings before first connection process.
-                provider.provider_settings = provider_settings
-
-            elif provider.provider_settings != provider_settings:
-                # Handle new settings.
-                new_settings = {**provider.provider_settings, **provider_settings}
-                provider.update_settings(new_settings)
-
+            provider = self.providers[provider_name](provider_settings=provider_settings)
             if provider.connection_id in ProviderContextManager.connected_providers:
                 # Likely multi-chain testing or utilizing multiple on-going connections.
                 return ProviderContextManager.connected_providers[provider.connection_id]

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -1,7 +1,18 @@
 from functools import partial
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Collection,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 from eth_account import Account as EthAccount
 from eth_account._utils.legacy_transactions import (
@@ -430,7 +441,9 @@ class EcosystemAPI(BaseInterfaceModel):
 
         raise NetworkNotFoundError(network_name, ecosystem=self.name, options=self.networks)
 
-    def get_network_data(self, network_name: str) -> Dict:
+    def get_network_data(
+        self, network_name: str, provider_filter: Optional[Collection[str]] = None
+    ) -> Dict:
         """
         Get a dictionary of data about providers in the network.
 
@@ -439,6 +452,8 @@ class EcosystemAPI(BaseInterfaceModel):
 
         Args:
             network_name (str): The name of the network to get provider data from.
+            provider_filter (Optional[Collection[str]]): Optional filter the providers
+              by name.
 
         Returns:
             dict: A dictionary containing the providers in a network.
@@ -456,6 +471,9 @@ class EcosystemAPI(BaseInterfaceModel):
             data["explorer"] = str(network.explorer.name)
 
         for provider_name in network.providers:
+            if provider_filter and provider_name not in provider_filter:
+                continue
+
             provider_data: Dict = {"name": str(provider_name)}
 
             # Only add isDefault key when True

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -452,7 +452,7 @@ class EcosystemAPI(BaseInterfaceModel):
 
         Args:
             network_name (str): The name of the network to get provider data from.
-            provider_filter (Optional[Collection[str]]): Optional filter the providers
+            provider_filter (Optional[Collection[str]]): Optionally filter the providers
               by name.
 
         Returns:

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -861,16 +861,23 @@ class NetworkAPI(BaseInterfaceModel):
             provider_name = "geth"
 
         if provider_name in self.providers:
-            provider = self.providers[provider_name](provider_settings=provider_settings)
-
+            provider = self.providers[provider_name]()
             connection_id = provider.connection_id
+
             if not connection_id:
                 # Provider not yet connected
+                provider.provider_settings = provider_settings
                 return provider
 
-            if connection_id in ProviderContextManager.connected_providers:
-                return ProviderContextManager.connected_providers[connection_id]
+            elif connection_id in ProviderContextManager.connected_providers:
+                connected_provider = ProviderContextManager.connected_providers[connection_id]
+                new_settings = {**connected_provider.provider_settings, **provider_settings}
+                if connected_provider.provider_settings != provider_settings:
+                    connected_provider.update_settings(new_settings)
 
+                return connected_provider
+
+            provider.provider_settings = provider_settings
             return provider
 
         else:

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -196,8 +196,8 @@ class ProviderAPI(BaseInterfaceModel):
     @property
     def connection_id(self) -> Optional[str]:
         """
-        A connection ID to uniquely identify and manage multiple 
-        connections to providers, especially when working with multiple 
+        A connection ID to uniquely identify and manage multiple
+        connections to providers, especially when working with multiple
         providers of the same type, like multiple Geth --dev nodes.
         """
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -214,7 +214,7 @@ class ProviderAPI(BaseInterfaceModel):
 
         # NOTE: If other provider settings are different, ``.update_settings()``
         #    should be called.
-        return f"{self.network_choice}:-{chain_id}"
+        return f"{self.network_choice}:{chain_id}"
 
     @abstractmethod
     def update_settings(self, new_settings: dict):
@@ -1747,7 +1747,7 @@ class SubprocessProvider(ProviderAPI):
     @property
     def connection_id(self) -> Optional[str]:
         cmd_id = ",".join(self.build_command())
-        return f"{self.network_choice}:-{cmd_id}"
+        return f"{self.network_choice}:{cmd_id}"
 
     def _get_process_output_logger(self, name: str, path: Path):
         logger = getLogger(f"{self.name}_{name}_subprocessProviderLogger")

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -196,10 +196,9 @@ class ProviderAPI(BaseInterfaceModel):
     @property
     def connection_id(self) -> Optional[str]:
         """
-        A connection ID for this provider's connection used for managing
-        multiple connections to providers and identifying them, especially if
-        using multiple providers of the same type, such as multiple Geth --dev
-        nodes.
+        A connection ID to uniquely identify and manage multiple 
+        connections to providers, especially when working with multiple 
+        providers of the same type, like multiple Geth --dev nodes.
         """
 
         try:

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1744,6 +1744,11 @@ class SubprocessProvider(ProviderAPI):
     def _stderr_logger(self) -> Logger:
         return self._get_process_output_logger("stderr", self.stderr_logs_path)
 
+    @property
+    def connection_id(self) -> Optional[str]:
+        cmd_id = ",".join(self.build_command())
+        return f"{self.network_choice}:-{cmd_id}"
+
     def _get_process_output_logger(self, name: str, path: Path):
         logger = getLogger(f"{self.name}_{name}_subprocessProviderLogger")
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1568,7 +1568,8 @@ class Web3Provider(ProviderAPI, ABC):
             raw=evm_frame.dict(),
         )
 
-    def _make_request(self, endpoint: str, parameters: List) -> Any:
+    def _make_request(self, endpoint: str, parameters: Optional[List] = None) -> Any:
+        parameters = parameters or []
         coroutine = self.web3.provider.make_request(RPCEndpoint(endpoint), parameters)
         result = run_until_complete(coroutine)
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -128,7 +128,7 @@ class ProviderAPI(BaseInterfaceModel):
     network: NetworkAPI
     """A reference to the network this provider provides."""
 
-    provider_settings: dict
+    provider_settings: Dict = {}
     """The settings for the provider, as overrides to the configuration."""
 
     data_folder: Path

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -1,6 +1,6 @@
 import json
 from functools import cached_property
-from typing import Dict, Iterator, List, Optional, Set, Union
+from typing import Collection, Dict, Iterator, List, Optional, Set, Union
 
 import yaml
 
@@ -500,15 +500,33 @@ class NetworkManager(BaseManager):
         Returns:
             dict
         """
+        return self.get_network_data()
+
+    def get_network_data(
+        self,
+        ecosystem_filter: Optional[Collection[str]] = None,
+        network_filter: Optional[Collection[str]] = None,
+        provider_filter: Optional[Collection[str]] = None,
+    ):
         data: Dict = {"ecosystems": []}
 
         for ecosystem_name in self:
-            ecosystem_data = self._get_ecosystem_data(ecosystem_name)
+            if ecosystem_filter and ecosystem_name not in ecosystem_filter:
+                continue
+
+            ecosystem_data = self._get_ecosystem_data(
+                ecosystem_name, network_filter=network_filter, provider_filter=provider_filter
+            )
             data["ecosystems"].append(ecosystem_data)
 
         return data
 
-    def _get_ecosystem_data(self, ecosystem_name: str) -> Dict:
+    def _get_ecosystem_data(
+        self,
+        ecosystem_name: str,
+        network_filter: Optional[Collection[str]] = None,
+        provider_filter: Optional[Collection[str]] = None,
+    ) -> Dict:
         ecosystem = self[ecosystem_name]
         ecosystem_data: Dict = {"name": str(ecosystem_name)}
 
@@ -519,16 +537,21 @@ class NetworkManager(BaseManager):
         ecosystem_data["networks"] = []
 
         for network_name in getattr(self, ecosystem_name).networks:
-            network_data = ecosystem.get_network_data(network_name)
+            if network_filter and network_name not in network_filter:
+                continue
+
+            network_data = ecosystem.get_network_data(network_name, provider_filter=provider_filter)
             ecosystem_data["networks"].append(network_data)
 
         return ecosystem_data
 
     @property
+    # TODO: Remove in 0.7
     def networks_yaml(self) -> str:
         """
         Get a ``yaml`` ``str`` representing all the networks
         in all the ecosystems.
+        **NOTE**: Deprecated.
 
         View the result via CLI command ``ape networks list --format yaml``.
 

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -213,10 +213,10 @@ class BaseModel(_BaseModel):
 
             # The error message mentions the alternative mappings,
             # such as a contract-type map.
-            message = f"No attribute with name '{name}'."
+            message = f"'{repr(self)}' has no attribute '{name}'"
             if extras_checked:
                 extras_str = ", ".join(extras_checked)
-                message = f"{message} Also checked '{extras_str}'."
+                message = f"{message}. Also checked '{extras_str}'"
 
             raise ApeAttributeError(message)
 

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -57,7 +57,8 @@ class LocalProvider(TestProviderAPI, Web3Provider):
             mnemonic=self.config.mnemonic,
             num_accounts=self.config.number_of_accounts,
         )
-        endpoints = get_endpoints(chain_id)
+        endpoints = {**API_ENDPOINTS}
+        endpoints["eth"] = merge(endpoints["eth"], {"chainId": static_return(chain_id)})
         tester = EthereumTesterProvider(ethereum_tester=self._evm_backend, api_endpoints=endpoints)
         self._web3 = Web3(tester)
 
@@ -277,8 +278,3 @@ class LocalProvider(TestProviderAPI, Web3Provider):
 
         else:
             return VirtualMachineError(base_err=exception, **kwargs)
-
-
-def get_endpoints(chain_id: int):
-    eth_endpoints = merge(API_ENDPOINTS["eth"], {"chainId": static_return(chain_id)})
-    return merge(API_ENDPOINTS, {"eth": eth_endpoints})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,11 +204,9 @@ def ethereum(networks):
 
 @pytest.fixture(autouse=True)
 def eth_tester_provider(ethereum):
-    if not ape.networks.active_provider or ape.networks.provider.name != "test":
-        with ethereum.local.use_provider("test") as provider:
-            yield provider
-    else:
-        yield ape.networks.provider
+    # NOTE: Ensure it uses the default instance of eth-tester.
+    with ethereum.local.use_provider("test", provider_settings={"chain_id": 1337}) as provider:
+        yield provider
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from ape.exceptions import APINotImplementedError, UnknownSnapshotError
 from ape.logging import LogLevel, logger
 from ape.managers.config import CONFIG_FILE_NAME
 from ape.types import AddressType
-from ape.utils import ZERO_ADDRESS
+from ape.utils import DEFAULT_TEST_CHAIN_ID, ZERO_ADDRESS
 
 # NOTE: Ensure that we don't use local paths for these
 DATA_FOLDER = Path(mkdtemp()).resolve()
@@ -205,7 +205,9 @@ def ethereum(networks):
 @pytest.fixture(autouse=True)
 def eth_tester_provider(ethereum):
     # NOTE: Ensure it uses the default instance of eth-tester.
-    with ethereum.local.use_provider("test", provider_settings={"chain_id": 1337}) as provider:
+    with ethereum.local.use_provider(
+        "test", provider_settings={"chain_id": DEFAULT_TEST_CHAIN_ID}
+    ) as provider:
         yield provider
 
 

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -19,9 +19,9 @@ chain_id_factory = NewChainID()
 def get_provider_with_unused_chain_id(networks_connected_to_tester):
     networks = networks_connected_to_tester
 
-    def fn():
+    def fn(**more_settings):
         chain_id = chain_id_factory()
-        settings = {"chain_id": chain_id}
+        settings = {"chain_id": chain_id, **more_settings}
         choice = "ethereum:local:test"
         context = networks.parse_network_choice(choice, provider_settings=settings)
         return context
@@ -177,6 +177,15 @@ def test_parse_network_choice_new_chain_id(get_provider_with_unused_chain_id, ge
 
     for provider in context.connected_providers.values():
         assert provider._web3 is not None
+
+
+def test_disconnect_after(get_provider_with_unused_chain_id):
+    context = get_provider_with_unused_chain_id(disconnect_after=True)
+    with context as provider:
+        connection_id = provider.connection_id
+        assert connection_id in context.connected_providers
+
+    assert context not in context.connected_providers
 
 
 def test_parse_network_choice_multiple_contexts(get_provider_with_unused_chain_id):

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -167,6 +167,7 @@ def test_parse_network_choice_same_provider(chain, networks_connected_to_tester,
         assert provider._web3 is not None
 
 
+@pytest.mark.xdist_group(name="multiple-eth-testers")
 def test_parse_network_choice_new_chain_id(get_provider_with_unused_chain_id, get_context):
     start_count = len(get_context().connected_providers)
     context = get_provider_with_unused_chain_id()
@@ -182,17 +183,26 @@ def test_parse_network_choice_new_chain_id(get_provider_with_unused_chain_id, ge
         assert provider._web3 is not None
 
 
+@pytest.mark.xdist_group(name="multiple-eth-testers")
 def test_disconnect_after(get_provider_with_unused_chain_id):
     context = get_provider_with_unused_chain_id()
     with context as provider:
         connection_id = provider.connection_id
         assert connection_id in context.connected_providers
 
-    assert context not in context.connected_providers
+    assert connection_id not in context.connected_providers
 
 
-def test_parse_network_choice_multiple_contexts(get_provider_with_unused_chain_id):
+@pytest.mark.xdist_group(name="multiple-eth-testers")
+def test_parse_network_choice_multiple_contexts(
+    eth_tester_provider, get_provider_with_unused_chain_id
+):
     first_context = get_provider_with_unused_chain_id()
+    assert (
+        eth_tester_provider.chain_id == DEFAULT_TEST_CHAIN_ID
+    ), "Test setup failed - expecting to start on default chain ID"
+    assert eth_tester_provider._make_request("eth_chainId") == DEFAULT_TEST_CHAIN_ID
+
     with first_context:
         start_count = len(first_context.connected_providers)
         expected_next_count = start_count + 1
@@ -201,6 +211,9 @@ def test_parse_network_choice_multiple_contexts(get_provider_with_unused_chain_i
             # Second context should already know about connected providers
             assert len(first_context.connected_providers) == expected_next_count
             assert len(second_context.connected_providers) == expected_next_count
+
+    assert eth_tester_provider.chain_id == DEFAULT_TEST_CHAIN_ID
+    assert eth_tester_provider._make_request("eth_chainId") == DEFAULT_TEST_CHAIN_ID
 
 
 def test_getattr_ecosystem_with_hyphenated_name(networks, ethereum):

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -147,16 +147,16 @@ def test_parse_network_choice_same_provider(chain, networks_connected_to_tester,
     context = get_context()
     start_count = len(context.connected_providers)
     original_block_number = chain.blocks.height
-    provider_id = id(chain.provider)
+    object_id = id(chain.provider)
 
     with context:
-        assert id(chain.provider) == provider_id
+        assert id(chain.provider) == object_id
         count = len(context.connected_providers)
 
         # Does not create a new provider since it is the same chain ID
         assert count == start_count
 
-    assert id(chain.provider) == provider_id
+    assert id(chain.provider) == object_id
     assert len(context.connected_providers) == start_count
     assert chain.blocks.height == original_block_number
 

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -23,7 +23,7 @@ def get_provider_with_unused_chain_id(networks_connected_to_tester):
         chain_id = chain_id_factory()
         settings = {"chain_id": chain_id, **more_settings}
         choice = "ethereum:local:test"
-        disconnect_after = settings.pop("disconnect_after", False)
+        disconnect_after = settings.pop("disconnect_after", True)
         context = networks.parse_network_choice(
             choice, disconnect_after=disconnect_after, provider_settings=settings
         )
@@ -183,7 +183,7 @@ def test_parse_network_choice_new_chain_id(get_provider_with_unused_chain_id, ge
 
 
 def test_disconnect_after(get_provider_with_unused_chain_id):
-    context = get_provider_with_unused_chain_id(disconnect_after=True)
+    context = get_provider_with_unused_chain_id()
     with context as provider:
         connection_id = provider.connection_id
         assert connection_id in context.connected_providers

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -23,7 +23,10 @@ def get_provider_with_unused_chain_id(networks_connected_to_tester):
         chain_id = chain_id_factory()
         settings = {"chain_id": chain_id, **more_settings}
         choice = "ethereum:local:test"
-        context = networks.parse_network_choice(choice, provider_settings=settings)
+        disconnect_after = settings.pop("disconnect_after", False)
+        context = networks.parse_network_choice(
+            choice, disconnect_after=disconnect_after, provider_settings=settings
+        )
         return context
 
     return fn

--- a/tests/integration/cli/test_networks.py
+++ b/tests/integration/cli/test_networks.py
@@ -109,6 +109,14 @@ def test_list_yaml(ape_cli, runner):
             # Skip these lines in case test-runner has installed providers
             continue
 
+        if (
+            expected_line.lstrip().startswith("- name:")
+            and expected_line not in result.output
+            and "explorer:" in result.output
+        ):
+            # May have explorers installed - ignore that.
+            expected_line = expected_line.lstrip(" -")
+
         assert expected_line in result.output, result.output
 
 

--- a/tests/integration/cli/utils.py
+++ b/tests/integration/cli/utils.py
@@ -4,7 +4,9 @@ from typing import Callable, Dict
 import pytest
 
 __projects_directory__ = Path(__file__).parent / "projects"
-__project_names__ = [p.stem for p in __projects_directory__.iterdir() if p.is_dir()]
+__project_names__ = [
+    p.stem for p in __projects_directory__.iterdir() if p.is_dir() and not p.stem.startswith(".")
+]
 
 
 def assert_failure(result, expected_output):


### PR DESCRIPTION
### What I did

fixed bug with Disconnect => reconnect with new settings was bugged when using the same Python session.
also adds `settings` object which is useful for getting all provider settings mashed together.
Also, fixes an issue where settings were not updated when connecting to an already-connected provider with new settings.

**note**: as I was fixing this, I had some random failing tests pop up; bugs highlighted with the networks yaml not actually filtering. I had to fix this in order to get a passing build on this PR.

That caused this PR to be a little out of scope but I don't think it is worth opening more PRs at this point; it is all network related anyway.

### How I did it

Delete provider from connected providers when disconnecting

### How to verify it

in combo with 

https://github.com/ApeWorX/ape-foundry/pull/74

you can do:

```python
In [4]: with networks.parse_network_choice("ethereum:local:foundry", provider_settings={"port": 8999}) as prv:
   ...:     print(prv.uri)
http://127.0.0.1:8999
```

You can even switch multiple times to have many ongoing foundrys:

```python
with networks.parse_network_choice("ethereum:local:foundry", provider_settings={"port": 8999}) as prv:
   ...:     print(prv.uri)
   ...:     with networks.parse_network_choice("ethereum:local:foundry", provider_settings={"port": 8993}) as prv2:
   ...:         print(prv.uri)
   ...:         print(prv2.uri)
```

Outputs:

```
INFO: Connecting to existing 'anvil' process.
http://127.0.0.1:8999
WARNING: `port` setting is deprecated. Please use `host` key that includes the port.
INFO: Starting 'anvil' process.
http://127.0.0.1:8999
http://127.0.0.1:8993

```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
