### PR TITLE
fix: issue where network choices were missing [APE-1475]

### DIFF
--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -305,12 +305,13 @@ class NetworkManager(BaseManager):
                     ):
                         yield f"::{provider_name}"
 
-                    elif ecosystem_name == self.default_ecosystem.name:
+                    if ecosystem_name == self.default_ecosystem.name:
                         yield f":{network_name}:{provider_name}"
 
-                    elif network_name == ecosystem.default_network:
+                    if network_name == ecosystem.default_network:
                         yield f"{ecosystem_name}::{provider_name}"
 
+                    # Always include the full path as an option.
                     yield f"{ecosystem_name}:{network_name}:{provider_name}"
 
                 # Providers were yielded if we reached this point.

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -14,6 +14,30 @@ class NewChainID:
 
 chain_id_factory = NewChainID()
 
+DEFAULT_CHOICES = {
+    "::geth",
+    "::test",
+    ":goerli",
+    ":goerli:geth",
+    ":sepolia",
+    ":sepolia:geth",
+    ":local",
+    ":mainnet",
+    ":mainnet:geth",
+    "ethereum",
+    "ethereum::test",
+    "ethereum::geth",
+    "ethereum:goerli",
+    "ethereum:goerli:geth",
+    "ethereum:sepolia",
+    "ethereum:sepolia:geth",
+    "ethereum:local",
+    "ethereum:local:geth",
+    "ethereum:local:test",
+    "ethereum:mainnet",
+    "ethereum:mainnet:geth",
+}
+
 
 @pytest.fixture
 def get_provider_with_unused_chain_id(networks_connected_to_tester):
@@ -55,30 +79,24 @@ def network_with_no_providers(ethereum):
         network.__dict__["providers"] = providers
 
 
+def test_get_network_choices(networks, ethereum, mocker):
+    # Simulate having a provider like foundry installed.
+    mock_provider = mocker.MagicMock()
+    ethereum.networks["mainnet-fork"].providers["mock"] = mock_provider
+    ethereum.networks["local"].providers["mock"] = mock_provider
+
+    # Ensure the provider shows up both mainnet fork and local
+    # (There was once a bug where it was skipped!)
+    expected = {":mainnet-fork:mock", ":local:mock"}
+
+    actual = {c for c in networks.get_network_choices()}
+    expected = DEFAULT_CHOICES.union(expected)
+    assert expected.issubset(actual)
+
+
 def test_get_network_choices_filter_ecosystem(networks):
     actual = {c for c in networks.get_network_choices(ecosystem_filter="ethereum")}
-    all_choices = {
-        "::geth",
-        "::test",
-        ":goerli",
-        ":goerli:geth",
-        ":sepolia",
-        ":sepolia:geth",
-        ":local",
-        ":mainnet",
-        ":mainnet:geth",
-        "ethereum",
-        "ethereum:goerli",
-        "ethereum:goerli:geth",
-        "ethereum:sepolia",
-        "ethereum:sepolia:geth",
-        "ethereum:local",
-        "ethereum:local:geth",
-        "ethereum:local:test",
-        "ethereum:mainnet",
-        "ethereum:mainnet:geth",
-    }
-    assert all_choices.issubset(actual)
+    assert DEFAULT_CHOICES.issubset(actual)
 
 
 def test_get_network_choices_filter_network(networks):


### PR DESCRIPTION
### What I did

* Issue where only one of `:local:foundry`: or `:mainnet-fork:foundry` would be available (depending on user-config and default settings).
* Issue where `ethereum::foundry` would be missing as well

### How I did it

use `if` instead of `elif`

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
