### PR TITLE
feat: allow custom cli ctx obj types [APE-1483]

### DIFF
--- a/docs/userguides/clis.md
+++ b/docs/userguides/clis.md
@@ -34,6 +34,33 @@ def cmd(cli_ctx):
     cli_ctx.abort(f"Bad account: {account.address}")
 ```
 
+In Ape, it is easy to extend the CLI context object and use the extended version in your CLIs:
+
+```python
+from ape.cli import ApeCliContextObject, ape_cli_context
+import click
+
+class MyManager:
+   """My custom manager."""
+
+class CustomContext(ApeCliContextObject):
+   """Add new managers to your custom context"""
+   my_manager: MyManager = MyManager()
+   
+   @property
+   def signer(self):
+      """Utilize existing managers in your custom context."""
+      return self.account_manager.load("my_account")
+
+@click.command()
+@ape_cli_context(obj_type=CustomContext)
+def cli(cli_ctx):
+    # Access your manager.
+    print(cli_ctx.my_manager)
+    # Access other Ape managers.
+    print(cli_ctx.account_manager)
+```
+
 ## Network Tools
 
 The `@network_option()` allows you to select an ecosystem / network / provider combination.

--- a/src/ape/cli/__init__.py
+++ b/src/ape/cli/__init__.py
@@ -14,6 +14,7 @@ from ape.cli.choices import (
 )
 from ape.cli.commands import NetworkBoundCommand
 from ape.cli.options import (
+    ApeCliContextObject,
     account_option,
     ape_cli_context,
     contract_option,
@@ -33,6 +34,7 @@ __all__ = [
     "Alias",
     "AllFilePaths",
     "ape_cli_context",
+    "ApeCliContextObject",
     "contract_file_paths_argument",
     "contract_option",
     "existing_alias_argument",

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, NoReturn, Optional, Union
+from typing import Callable, Dict, List, NoReturn, Optional, Type, Union
 
 import click
 from ethpm_types import ContractType
@@ -75,7 +75,9 @@ def _create_verbosity_kwargs(
     }
 
 
-def ape_cli_context(default_log_level: str = DEFAULT_LOG_LEVEL):
+def ape_cli_context(
+    default_log_level: str = DEFAULT_LOG_LEVEL, obj_type: Type = ApeCliContextObject
+):
     """
     A ``click`` context object with helpful utilities.
     Use in your commands to get access to common utility features,
@@ -84,11 +86,16 @@ def ape_cli_context(default_log_level: str = DEFAULT_LOG_LEVEL):
     Args:
         default_log_level (str): The log-level value to pass to
           :meth:`~ape.cli.options.verbosity_option`.
+        obj_type (Type): The context object type. Defaults to
+          :class:`~ape.cli.options.ApeCliContextObject`. Sub-class
+          the context to extend its functionality in your CLIs,
+          such as if you want to add additional manager classes
+          to the context.
     """
 
     def decorator(f):
         f = verbosity_option(logger, default=default_log_level)(f)
-        f = click.make_pass_decorator(ApeCliContextObject, ensure=True)(f)
+        f = click.make_pass_decorator(obj_type, ensure=True)(f)
         return f
 
     return decorator


### PR DESCRIPTION
### What I did

For some complex plugins, it'd be nice to be able to customize the shared CLI object context.
This allows that to happen via an `obj_type` kwarg in the decorator and a guide on how to subclass and use this new context.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
