### PR TITLE
feat: support global NPM dependencies [APE-1490]

### DIFF
--- a/src/ape/managers/project/dependency.py
+++ b/src/ape/managers/project/dependency.py
@@ -374,8 +374,16 @@ class NpmDependency(DependencyAPI):
             )
 
     @property
+    def package_suffix(self) -> Path:
+        return Path("node_modules") / str(self.npm)
+
+    @property
     def package_folder(self) -> Path:
-        return Path.cwd() / "node_modules" / str(self.npm)
+        return Path.cwd() / self.package_suffix
+
+    @property
+    def global_package_folder(self) -> Path:
+        return Path.home() / self.package_suffix
 
     @cached_property
     def version_from_json(self) -> Optional[str]:
@@ -416,6 +424,9 @@ class NpmDependency(DependencyAPI):
                 )
 
             return self._extract_local_manifest(self.package_folder, use_cache=use_cache)
+
+        elif self.global_package_folder.is_dir():
+            return self._extract_local_manifest(self.global_package_folder, use_cache=use_cache)
 
         else:
             raise ProjectError(f"NPM package '{self.npm}' not installed.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -459,3 +459,11 @@ def ape_caplog(caplog):
             pytest.fail(self.fail_message)
 
     return ApeCaplog()
+
+
+@pytest.fixture
+def mock_home_directory(tmp_path):
+    original_home = Path.home()
+    Path.home = lambda: tmp_path  # type: ignore[method-assign]
+    yield tmp_path
+    Path.home = lambda: original_home  # type: ignore[method-assign]


### PR DESCRIPTION
### What I did

Currently, NPM dependencies require using a local node modules installs.
This PR will also check your home directory for the install.

### How I did it

Do everything with `Path.home()` that you did to `Path.cwd()`.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
