### PR TITLE
fix: more warning when missing compiler plugins [APE-1491]

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -270,6 +270,7 @@ class DependencyAPI(BaseInterfaceModel):
             attributes=self.contracts,
             include_getattr=True,
             include_getitem=True,
+            additional_error_message="Do you have the necessary compiler plugins installed?"
         )
 
     @property
@@ -382,6 +383,15 @@ class DependencyAPI(BaseInterfaceModel):
             ) as project:
                 manifest.unpack_sources(contracts_folder)
                 compiled_manifest = project.local_project.create_manifest()
+
+                if not compiled_manifest.contract_types:
+                    # Manifest is empty. Don't save so compiling re-triggers after the
+                    # user makes necessary changes.
+                    logger.warning(
+                        "Compiled manifest produced no contract types! Are you missing compiler plugins?"
+                    )
+                    return compiled_manifest
+
                 self._write_manifest_to_cache(compiled_manifest)
                 return compiled_manifest
 

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -270,7 +270,7 @@ class DependencyAPI(BaseInterfaceModel):
             attributes=self.contracts,
             include_getattr=True,
             include_getitem=True,
-            additional_error_message="Do you have the necessary compiler plugins installed?"
+            additional_error_message="Do you have the necessary compiler plugins installed?",
         )
 
     @property
@@ -385,10 +385,10 @@ class DependencyAPI(BaseInterfaceModel):
                 compiled_manifest = project.local_project.create_manifest()
 
                 if not compiled_manifest.contract_types:
-                    # Manifest is empty. Don't save so compiling re-triggers after the
-                    # user makes necessary changes.
+                    # Manifest is empty. No need to write to disk.
                     logger.warning(
-                        "Compiled manifest produced no contract types! Are you missing compiler plugins?"
+                        "Compiled manifest produced no contract types! "
+                        "Are you missing compiler plugins?"
                     )
                     return compiled_manifest
 

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -32,6 +32,13 @@ class ApeException(Exception):
     """
 
 
+class ApeIndexError(ApeException, IndexError):
+    """
+    An exception that is also an IndexError.
+    Useful for nicely displaying IndexErrors.
+    """
+
+
 class APINotImplementedError(ApeException, NotImplementedError):
     """
     An error raised when an API class does not implement an abstract method.

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, List, Optional,
 
 from ethpm_types import BaseModel as _BaseModel
 
-from ape.exceptions import ApeAttributeError, ProviderNotConnectedError, ApeIndexError
+from ape.exceptions import ApeAttributeError, ApeIndexError, ProviderNotConnectedError
 from ape.logging import logger
 from ape.utils.misc import cached_property, singledispatchmethod
 
@@ -136,8 +136,7 @@ class ExtraModelAttributes(_BaseModel):
     additional_error_message: Optional[str] = None
     """
     An additional error message to include at the end of
-    the normal IndexError message. The full message would
-    be ``"Unable to find '<key>' in any of '<extra0>, <extra1>'.[?]<additional_error_message>"``
+    the normal IndexError message.
     """
 
     def __contains__(self, name: str) -> bool:

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, List, Optional,
 
 from ethpm_types import BaseModel as _BaseModel
 
-from ape.exceptions import ApeAttributeError, ProviderNotConnectedError
+from ape.exceptions import ApeAttributeError, ProviderNotConnectedError, ApeIndexError
 from ape.logging import logger
 from ape.utils.misc import cached_property, singledispatchmethod
 
@@ -133,6 +133,13 @@ class ExtraModelAttributes(_BaseModel):
     include_getitem: bool = False
     """Whether to use these in ``__getitem__``."""
 
+    additional_error_message: Optional[str] = None
+    """
+    An additional error message to include at the end of
+    the normal IndexError message. The full message would
+    be ``"Unable to find '<key>' in any of '<extra0>, <extra1>'.[?]<additional_error_message>"``
+    """
+
     def __contains__(self, name: str) -> bool:
         attr_dict = self.attributes if isinstance(self.attributes, dict) else self.attributes.dict()
         if name in attr_dict:
@@ -223,6 +230,7 @@ class BaseModel(_BaseModel):
     def __getitem__(self, name: Any) -> Any:
         # For __getitem__, we first try the extra (unlike `__getattr__`).
         extras_checked = set()
+        additional_error_messages = {}
         for extra in self.__ape_extra_attributes__():
             if not extra.include_getitem:
                 continue
@@ -232,11 +240,27 @@ class BaseModel(_BaseModel):
 
             extras_checked.add(extra.name)
 
+            if extra.additional_error_message:
+                additional_error_messages[extra.name] = extra.additional_error_message
+
         # NOTE: If extras were supplied, the user was expecting it to be
         #   there (unlike __getattr__).
         if extras_checked:
-            extras_str = ", ".join(extras_checked)
-            raise IndexError(f"Unable to find '{name}' in any of '{extras_str}'.")
+            prefix = f"Unable to find '{name}' in"
+            if not additional_error_messages:
+                extras_str = ", ".join(extras_checked)
+                message = f"{prefix} any of '{extras_str}'."
+
+            else:
+                # The class is including additional error messages for the IndexError.
+                message = ""
+                for extra_checked in extras_checked:
+                    additional_message = additional_error_messages.get(extra_checked)
+                    suffix = f" {additional_message}" if additional_message else ""
+                    sub_message = f"{prefix} '{extra_checked}'.{suffix}"
+                    message = f"{message}\n{sub_message}" if message else sub_message
+
+            raise ApeIndexError(message)
 
         # The user did not supply any extra __getitem__ attributes.
         # Do what you would have normally done.


### PR DESCRIPTION
### What I did

fixes: #1222 

I ran into this as well and got kinda confused for a minute!

This PR does the following to address the problem:

1. If after compiling, a manifest is empty, the user gets another warning
2. If trying to access a missing contract from a manifest, the IndexError is adjusted to also suggest you may be missing compiler plugins.

The full output looks like this now:

```python
(ape310-pydanticv1) ➜  ape-safe git:(feat/safe-api) ✗ ape console                          
WARNING: Unprocessed plugin config(s): solidity. Plugins may not be installed yet or keys may be mis-spelled.

In [1]: project.dependencies["safe-contracts"]["1.3.0"]["GnosisSafe"]
WARNING: Compiled manifest produced no contract types! Are you missing compiler plugins?
ERROR: (ApeIndexError) Unable to find 'GnosisSafe' in 'safe-contracts'. Do you have the necessary compiler plugins installed?

In [2]: exit
```

You can see I was warned 3 times about stuff possible from missing compiler plugins.
Once at first because of an unprocessed config key. Another from compiling the dependency. And the final one, the IndexError, which I think is important, also asks me if I am missing a compiler plugin. It is important to be in the final error I believe because users always look there first.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
