### PR TITLE
refactor: use build artifacts from compilers in `project.compiler_data` [APE-1495]

### DIFF
--- a/docs/userguides/compile.md
+++ b/docs/userguides/compile.md
@@ -111,6 +111,25 @@ solidity = compilers.get_compiler("solidity", settings=settings["solidity"])
 vyper.compile([Path("path/to/contract.sol")])
 ```
 
+### Settings Artifacts
+
+Compiler build artifacts can be found in the the `<project>/.build/compilers.json` file.
+Each compiler in your project has an associated [ethpm_types.source.Compiler](https://github.com/ApeWorX/ethpm-types/blob/main/ethpm_types/source.py) build artifact.
+This data contains the versions and settings used for each contract in your project.
+For example, assume you have`ape-solidity` creating a contract named `Test` from file `Test.sol`.
+The structure of `.builds/compilers.json` file would be:
+
+```json
+[
+   {
+      "contractTypes": ["Test"],
+      "name": "solidity",
+      "settings": {"optimizer": {"enabled": true, "runs": 200}, "outputSelection": {"Test.sol": {"": ["ast"], "*": ["abi", "bin-runtime", "devdoc", "userdoc", "evm.bytecode.object", "evm.bytecode.sourceMap", "evm.deployedBytecode.object"]}}, "viaIR": false},
+      "version": "0.8.17+commit.8df45f5f"
+   }
+]
+```
+
 ## Compile Source Code
 
 Instead of compiling project source files, you can compile code (str) directly:

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -143,7 +143,7 @@ class ProjectAPI(BaseInterfaceModel):
 
         contracts = {}
         for p in self._cache_folder.glob("*.json"):
-            if p == self.manifest_cachefile:
+            if p == self.manifest_cachefile or p.name.startswith(".") or not p.is_file():
                 continue
 
             contract_name = p.stem

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -1,8 +1,9 @@
+import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Set, Union
 
 from ethpm_types import ContractType
-from ethpm_types.source import Content
+from ethpm_types.source import Compiler, Content
 
 from ape.api import CompilerAPI
 from ape.contracts import ContractContainer
@@ -41,6 +42,19 @@ class CompilerManager(BaseManager):
             return compiler
 
         raise ApeAttributeError(f"No attribute or compiler named '{name}'.")
+
+    @property
+    def compilers_data_file(self) -> Path:
+        # NOTE: Private file to avoid collision with contract type JSONs.
+        return self.project_manager.local_project._cache_folder / ".compilers.json"
+
+    @property
+    def compiler_data(self) -> List[Compiler]:
+        return (
+            [Compiler.parse_obj(x) for x in json.loads(self.compilers_data_file.read_text())]
+            if self.compilers_data_file.is_file()
+            else []
+        )
 
     @property
     def registered_compilers(self) -> Dict[str, CompilerAPI]:


### PR DESCRIPTION
### What I did

partially fixes https://github.com/ApeWorX/ape/issues/1590

### How I did it

* Creates root properties for the location and decoding of such data (this is the part that `ape-solidity` and `ape-vyper` depend on to _actually_ accomplish the goal.
* Refactor manifest extract (used in publishing) to rely on the build artifacts instead of making shit up
* Test: We can actually test compiler data in core now because of this because we just create the raw JSON and test that it decoded properly. In the soon-coming PRs for `ape-solidity` and `ape-vyper`, there will be more end-to-end testing because they are responsible for creating such data and we can see that both it'll be created and show up in the extracted manifest correctly


### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
