### PR TITLE
feat: allow alias-based argument click overrides [APE-1502]

### DIFF
--- a/src/ape/cli/arguments.py
+++ b/src/ape/cli/arguments.py
@@ -24,24 +24,30 @@ def _alias_callback(ctx, param, value):
     return value
 
 
-def existing_alias_argument(account_type: _ACCOUNT_TYPE_FILTER = None):
+def existing_alias_argument(account_type: _ACCOUNT_TYPE_FILTER = None, **kwargs):
     """
     A ``click.argument`` for an existing account alias.
 
     Args:
         account_type (Type[:class:`~ape.api.accounts.AccountAPI`], optional):
           If given, limits the type of account the user may choose from.
+        **kwargs: click.argument overrides.
     """
 
-    return click.argument("alias", type=Alias(account_type=account_type))
+    type_ = kwargs.pop("type", Alias(account_type=account_type))
+    return click.argument("alias", type=type_, **kwargs)
 
 
-def non_existing_alias_argument():
+def non_existing_alias_argument(**kwargs):
     """
     A ``click.argument`` for an account alias that does not yet exist in ape.
+
+    Args:
+        **kwargs: click.argument overrides.
     """
 
-    return click.argument("alias", callback=_alias_callback)
+    callback = kwargs.pop("callback", _alias_callback)
+    return click.argument("alias", callback=callback, **kwargs)
 
 
 def _create_contracts_paths(ctx, param, value):

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -9,8 +9,10 @@ from ape.cli import (
     PromptChoice,
     account_option,
     contract_file_paths_argument,
+    existing_alias_argument,
     get_user_selected_account,
     network_option,
+    non_existing_alias_argument,
     verbosity_option,
 )
 from ape.exceptions import AccountsError
@@ -346,3 +348,53 @@ def test_contract_file_paths_argument(runner):
 
     result = runner.invoke(cmd, ["path0", "path1"])
     assert "Contract 'path0' not found" in result.output
+
+
+def test_existing_alias_option(runner):
+    @click.command()
+    @existing_alias_argument()
+    def cmd(alias):
+        click.echo(alias)
+
+    result = runner.invoke(cmd, ["TEST::0"])
+    assert "TEST::0" in result.output
+
+
+def test_existing_alias_option_custom_callback(runner):
+    magic_value = "THIS IS A TEST"
+
+    def custom_callback(*args, **kwargs):
+        return magic_value
+
+    @click.command()
+    @existing_alias_argument(callback=custom_callback)
+    def cmd(alias):
+        click.echo(alias)
+
+    result = runner.invoke(cmd, ["TEST::0"])
+    assert magic_value in result.output
+
+
+def test_non_existing_alias_option(runner):
+    @click.command()
+    @non_existing_alias_argument()
+    def cmd(alias):
+        click.echo(alias)
+
+    result = runner.invoke(cmd, ["non-exists"])
+    assert "non-exists" in result.output
+
+
+def test_non_existing_alias_option_custom_callback(runner):
+    magic_value = "THIS IS A TEST"
+
+    def custom_callback(*args, **kwargs):
+        return magic_value
+
+    @click.command()
+    @non_existing_alias_argument(callback=custom_callback)
+    def cmd(alias):
+        click.echo(alias)
+
+    result = runner.invoke(cmd, ["non-exists"])
+    assert magic_value in result.output


### PR DESCRIPTION
### What I did

I was trying customize the callback for the non_existing_alias_argument  but it wouldnt let me so i had to redefine it
This will allow future apes to customize these options more.

### How I did it

kwargs, pop, check, missing tests

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
