### PR TITLE
fix: wrong network when accessing upstream provider [APE-1503]

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -1066,7 +1066,7 @@ class ForkedNetworkAPI(NetworkAPI):
 
         config_choice = self._network_config.get("upstream_provider")
         if provider_name := config_choice or self.upstream_network.default_provider:
-            return self.get_provider(provider_name)
+            return self.upstream_network.get_provider(provider_name)
 
         raise NetworkError(f"Upstream network '{self.upstream_network}' has no providers.")
 

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -40,3 +40,6 @@ def test_forked_networks(ethereum):
     mainnet_fork = ethereum.mainnet_fork
     assert mainnet_fork.upstream_network.name == "mainnet"
     assert mainnet_fork.upstream_chain_id == 1
+    # Just make sure it doesn't fail when trying to access.
+    assert mainnet_fork.upstream_provider
+

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -42,4 +42,3 @@ def test_forked_networks(ethereum):
     assert mainnet_fork.upstream_chain_id == 1
     # Just make sure it doesn't fail when trying to access.
     assert mainnet_fork.upstream_provider
-


### PR DESCRIPTION
### What I did

fixes a mistake from https://github.com/ApeWorX/ape/pull/1714

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
