### PR TITLE
docs: fix plugin install command [APE-1519]

### DIFF
--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -132,7 +132,7 @@ plugins:
 Install these plugins by running command:
 
 ```bash
-ape plugins install
+ape plugins install .
 ```
 
 ## Testing


### PR DESCRIPTION
### What I did

Added `.` in the plugins install command in the docs as it requires `.` for plugins to be installed from ape-config.yaml. 

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->


### How I did it

Added a simple dot in the docs.

<!-- Discuss the thought process behind the change -->

### How to verify it

The plugins won't be installed if there is no `.`. 
<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
