### PR TITLE
fix: run console under providercontext [APE-1529]

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -4,6 +4,7 @@ from tempfile import mkdtemp
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
     Collection,
     Dict,
     Iterator,
@@ -576,7 +577,7 @@ class ProviderContextManager(ManagerAccessMixin):
     connected_providers: Dict[str, "ProviderAPI"] = {}
     provider_stack: List[str] = []
     disconnect_map: Dict[str, bool] = {}
-    recycled_provider = None
+    recycled_provider: ClassVar[Optional["ProviderAPI"]] = None
 
     def __init__(
         self,

--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -6,6 +6,16 @@ from click import Context
 from ape import networks
 
 
+def check_parents_for_interactive(ctx: Context) -> bool:
+    interactive: bool = ctx.params.get("interactive", False)
+    if interactive:
+        return True
+    # If not found, check the parent context.
+    if interactive is None and ctx.parent:
+        return check_parents_for_interactive(ctx.parent)
+    return False
+
+
 class NetworkBoundCommand(click.Command):
     """
     A command that uses the :meth:`~ape.cli.options.network_option`.
@@ -14,9 +24,6 @@ class NetworkBoundCommand(click.Command):
 
     def invoke(self, ctx: Context) -> Any:
         value = ctx.params.get("network") or networks.default_ecosystem.name
-        interactive = ctx.params.get("interactive")
-        # If not found, check the parent context.
-        if interactive is None and ctx.parent:
-            interactive = ctx.parent.params.get("interactive")
+        interactive = check_parents_for_interactive(ctx)
         with networks.parse_network_choice(value, disconnect_on_exit=not interactive):
             super().invoke(ctx)

--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -14,5 +14,9 @@ class NetworkBoundCommand(click.Command):
 
     def invoke(self, ctx: Context) -> Any:
         value = ctx.params.get("network") or networks.default_ecosystem.name
-        with networks.parse_network_choice(value):
+        interactive = ctx.params.get("interactive")
+        # If not found, check the parent context.
+        if interactive is None and ctx.parent:
+            interactive = ctx.parent.params.get("interactive")
+        with networks.parse_network_choice(value, disconnect_on_exit=not interactive):
             super().invoke(ctx)

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -418,6 +418,7 @@ class NetworkManager(BaseManager):
         network_choice: Optional[str] = None,
         provider_settings: Optional[Dict] = None,
         disconnect_after: bool = False,
+        disconnect_on_exit: bool = True,
     ) -> ProviderContextManager:
         """
         Parse a network choice into a context manager for managing a temporary
@@ -445,7 +446,11 @@ class NetworkManager(BaseManager):
         provider = self.get_provider_from_choice(
             network_choice=network_choice, provider_settings=provider_settings
         )
-        return ProviderContextManager(provider=provider, disconnect_after=disconnect_after)
+        return ProviderContextManager(
+            provider=provider,
+            disconnect_after=disconnect_after,
+            disconnect_on_exit=disconnect_on_exit,
+        )
 
     @property
     def default_ecosystem(self) -> EcosystemAPI:

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Union
 import click
 from click import Command, Context, Option
 
-from ape import project, networks
+from ape import networks, project
 from ape.cli import NetworkBoundCommand, network_option, verbosity_option
 from ape.cli.options import _VERBOSITY_VALUES, _create_verbosity_kwargs
 from ape.exceptions import ApeException, handle_ape_exception

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Union
 import click
 from click import Command, Context, Option
 
-from ape import project
+from ape import project, networks
 from ape.cli import NetworkBoundCommand, network_option, verbosity_option
 from ape.cli.options import _VERBOSITY_VALUES, _create_verbosity_kwargs
 from ape.exceptions import ApeException, handle_ape_exception
@@ -76,13 +76,15 @@ class ScriptCommand(click.MultiCommand):
             if ctx.params["interactive"]:
                 # Print the exception trace and then launch the console
                 # Attempt to use source-traceback style printing.
-                if not isinstance(err, ApeException) or not handle_ape_exception(
-                    err, [ctx.obj.project_manager.path]
-                ):
-                    err_info = traceback.format_exc()
-                    click.echo(err_info)
+                network_value = ctx.params.get("network") or networks.default_ecosystem.name
+                with networks.parse_network_choice(network_value):
+                    if not isinstance(err, ApeException) or not handle_ape_exception(
+                        err, [ctx.obj.project_manager.path]
+                    ):
+                        err_info = traceback.format_exc()
+                        click.echo(err_info)
 
-                self._launch_console()
+                    self._launch_console()
             else:
                 # Don't handle error - raise exception as normal.
                 raise

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -77,7 +77,7 @@ class ScriptCommand(click.MultiCommand):
                 # Print the exception trace and then launch the console
                 # Attempt to use source-traceback style printing.
                 network_value = ctx.params.get("network") or networks.default_ecosystem.name
-                with networks.parse_network_choice(network_value):
+                with networks.parse_network_choice(network_value, disconnect_on_exit=False):
                     if not isinstance(err, ApeException) or not handle_ape_exception(
                         err, [ctx.obj.project_manager.path]
                     ):

--- a/tests/integration/cli/projects/script/scripts/error_cli.py
+++ b/tests/integration/cli/projects/script/scripts/error_cli.py
@@ -1,7 +1,12 @@
 import click
 
+import ape
+
 
 @click.command(short_help="Use a subcommand")
 def cli():
     local_variable = "test foo bar"  # noqa[F841]
+    acct = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+    provider = ape.chain.provider
+    provider.set_balance(acct, 100000000)
     raise Exception("Expected exception")  # noqa: T001

--- a/tests/integration/cli/projects/script/scripts/error_cli.py
+++ b/tests/integration/cli/projects/script/scripts/error_cli.py
@@ -6,7 +6,6 @@ import ape
 @click.command(short_help="Use a subcommand")
 def cli():
     local_variable = "test foo bar"  # noqa[F841]
-    acct = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
     provider = ape.chain.provider
-    provider.set_balance(acct, 100000000)
+    provider.set_timestamp(123123123123123123)
     raise Exception("Expected exception")  # noqa: T001

--- a/tests/integration/cli/projects/script/scripts/error_main.py
+++ b/tests/integration/cli/projects/script/scripts/error_main.py
@@ -1,3 +1,9 @@
+import ape
+
+
 def main():
     local_variable = "test foo bar"  # noqa[F841]
+    acct = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+    provider = ape.chain.provider
+    provider.set_balance(acct, 100000000)
     raise Exception("Expected exception")

--- a/tests/integration/cli/projects/script/scripts/error_main.py
+++ b/tests/integration/cli/projects/script/scripts/error_main.py
@@ -3,7 +3,6 @@ import ape
 
 def main():
     local_variable = "test foo bar"  # noqa[F841]
-    acct = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
     provider = ape.chain.provider
-    provider.set_balance(acct, 100000000)
+    provider.set_timestamp(123123123123123123)
     raise Exception("Expected exception")

--- a/tests/integration/cli/projects/script/scripts/error_no_def.py
+++ b/tests/integration/cli/projects/script/scripts/error_no_def.py
@@ -1,2 +1,7 @@
+import ape
+
 local_variable = "test foo bar"  # noqa[F841]
+acct = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+provider = ape.chain.provider
+provider.set_balance(acct, 100000000)
 raise Exception("Expected exception")

--- a/tests/integration/cli/projects/script/scripts/error_no_def.py
+++ b/tests/integration/cli/projects/script/scripts/error_no_def.py
@@ -1,7 +1,6 @@
 import ape
 
 local_variable = "test foo bar"  # noqa[F841]
-acct = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 provider = ape.chain.provider
-provider.set_balance(acct, 100000000)
+provider.set_timestamp(123123123123123123)
 raise Exception("Expected exception")

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -100,13 +100,14 @@ def test_run_interactive(ape_cli, runner, project):
     ]
 
     # Show that the variable namespace from the script is available in the console.
-    user_input = "local_variable\nexit\n"
+    user_input = "local_variable\nprovider = ape.chain.provider\nprovider.get_balance(acct)\nexit\n"
 
     result = runner.invoke(ape_cli, ["run", "--interactive", scripts[0].stem], input=user_input)
     assert result.exit_code == 0, result.output
 
     # From script: local_variable = "test foo bar"
     assert "test foo bar" in result.output
+    assert "100000000" in result.output
 
 
 @skip_projects_except("script")

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -100,14 +100,14 @@ def test_run_interactive(ape_cli, runner, project):
     ]
 
     # Show that the variable namespace from the script is available in the console.
-    user_input = "local_variable\nprovider = ape.chain.provider\nprovider.get_balance(acct)\nexit\n"
+    user_input = "local_variable\nape.chain.provider.mine()\nape.chain.blocks.head\nexit\n"
 
     result = runner.invoke(ape_cli, ["run", "--interactive", scripts[0].stem], input=user_input)
     assert result.exit_code == 0, result.output
 
     # From script: local_variable = "test foo bar"
     assert "test foo bar" in result.output
-    assert "100000000" in result.output
+    assert "timestamp=123123123123123" in result.output
 
 
 @skip_projects_except("script")


### PR DESCRIPTION
### What I did

Run the interactive console under a Provider context


fixes: #581 

### How I did it

Before launching the console, run under a new provider context manager because the old one exits

### How to verify it

run a script with `ape run -I ...` and evaluate `ape.chain.provider`

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
