### PR TITLE
feat: messageHash, signature added to the `_Signature` class [APE-1536]

### DIFF
--- a/docs/userguides/accounts.md
+++ b/docs/userguides/accounts.md
@@ -239,20 +239,18 @@ signature = account.sign_message(message)
 Get the signed message signature as well as message hash signed by the account
 
 ```py
-from ape import accounts
-from eth_account.messages import encode_defunct
+from ape.types.signatures import recover_signer
 
-account = accounts.load("<ALIAS>")
-account.set_autosign(True)
-
-# Now, you will not be prompted to sign messages or transactions
-message = encode_defunct(text="Hello Apes!")
+[...]
 signature = account.sign_message(message)
 
 # signature
 print(signature.encode_vrs())
 # message hash
-print(signature.messageHash)
+print(signature.message_hash)
+
+# recover the signer from
+signer = recover_signer(message, signature.encode_vrs())
 ```
 
 ## Hardware Wallets

--- a/docs/userguides/accounts.md
+++ b/docs/userguides/accounts.md
@@ -241,7 +241,6 @@ Get the signed message signature as well as message hash signed by the account
 ```py
 from ape.types.signatures import recover_signer
 
-[...]
 signature = account.sign_message(message)
 
 # signature

--- a/docs/userguides/accounts.md
+++ b/docs/userguides/accounts.md
@@ -4,7 +4,7 @@ Accounts in Ape come from [AccountAPI](../methoddocs/api.html#ape.api.accounts.A
 There are typically two types of accounts:
 
 1. Test accounts
-1. Live network accounts
+2. Live network accounts
 
 Test accounts are useful for local network testing and debugging contracts.
 Live network accounts are for interacting with live blockchains and should be secured.

--- a/docs/userguides/accounts.md
+++ b/docs/userguides/accounts.md
@@ -249,8 +249,6 @@ print(signature.encode_vrs())
 # message hash
 print(signature.message_hash)
 
-# recover the signer from
-signer = recover_signer(message, signature.encode_vrs())
 ```
 
 ## Hardware Wallets

--- a/docs/userguides/accounts.md
+++ b/docs/userguides/accounts.md
@@ -246,8 +246,8 @@ signature = account.sign_message(message)
 
 # signature
 print(signature.encode_vrs())
-# message hash
-print(signature.message_hash)
+# get original signer
+print(recover_signer(...))
 ```
 
 ## Hardware Wallets

--- a/docs/userguides/accounts.md
+++ b/docs/userguides/accounts.md
@@ -4,7 +4,7 @@ Accounts in Ape come from [AccountAPI](../methoddocs/api.html#ape.api.accounts.A
 There are typically two types of accounts:
 
 1. Test accounts
-2. Live network accounts
+1. Live network accounts
 
 Test accounts are useful for local network testing and debugging contracts.
 Live network accounts are for interacting with live blockchains and should be secured.
@@ -250,7 +250,7 @@ message = encode_defunct(text="Hello Apes!")
 signature = account.sign_message(message)
 
 # signature
-print(signature.signature)
+print(signature.encode_vrs())
 # message hash
 print(signature.messageHash)
 ```

--- a/docs/userguides/accounts.md
+++ b/docs/userguides/accounts.md
@@ -248,7 +248,6 @@ signature = account.sign_message(message)
 print(signature.encode_vrs())
 # message hash
 print(signature.message_hash)
-
 ```
 
 ## Hardware Wallets

--- a/docs/userguides/accounts.md
+++ b/docs/userguides/accounts.md
@@ -234,6 +234,27 @@ message = encode_defunct(text="Hello Apes!")
 signature = account.sign_message(message)
 ```
 
+## Signed Message
+
+Get the signed message signature as well as message hash signed by the account
+
+```py
+from ape import accounts
+from eth_account.messages import encode_defunct
+
+account = accounts.load("<ALIAS>")
+account.set_autosign(True)
+
+# Now, you will not be prompted to sign messages or transactions
+message = encode_defunct(text="Hello Apes!")
+signature = account.sign_message(message)
+
+# signature
+print(signature.signature)
+# message hash
+print(signature.messageHash)
+```
+
 ## Hardware Wallets
 
 Because of the plugin system in Ape, we are able to support other types of accounts including hardware wallet accounts.

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -22,7 +22,7 @@ class _Signature:
     v: int
     r: bytes
     s: bytes
-    messageHash: Optional[bytes] = None
+    message_hash: Optional[bytes] = None
 
     def __iter__(self) -> Iterator[Union[int, bytes]]:
         # NOTE: Allows tuple destructuring

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -22,7 +22,7 @@ class _Signature:
     v: int
     r: bytes
     s: bytes
-    _messageHash: Optional[SignableMessage] = None
+    messageHash: Optional[SignableMessage] = None
 
     def __iter__(self) -> Iterator[Union[int, bytes]]:
         # NOTE: Allows tuple destructuring
@@ -38,7 +38,6 @@ class _Signature:
 
     def encode_rsv(self) -> bytes:
         return _left_pad_bytes(self.r, 32) + _left_pad_bytes(self.s, 32) + to_bytes(self.v)
-
 
 
 class MessageSignature(_Signature):

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -3,7 +3,6 @@ from typing import Iterator, Optional, Union
 from eth_account import Account
 from eth_account.messages import SignableMessage
 from eth_utils import to_bytes, to_hex
-from hexbytes import HexBytes
 from pydantic.dataclasses import dataclass
 
 from ape.types import AddressType

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -3,7 +3,6 @@ from typing import Iterator, Optional, Union
 from eth_account import Account
 from eth_account.messages import SignableMessage
 from eth_utils import to_bytes, to_hex
-from hexbytes import HexBytes
 from pydantic.dataclasses import dataclass
 
 from ape.types import AddressType
@@ -23,7 +22,7 @@ class _Signature:
     v: int
     r: bytes
     s: bytes
-    messageHash: Optional[HexBytes] = None
+    messageHash: Optional[bytes] = None
 
     def __iter__(self) -> Iterator[Union[int, bytes]]:
         # NOTE: Allows tuple destructuring

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -3,6 +3,7 @@ from typing import Iterator, Union
 from eth_account import Account
 from eth_account.messages import SignableMessage
 from eth_utils import to_bytes, to_hex
+from hexbytes import HexBytes
 from pydantic.dataclasses import dataclass
 
 from ape.types import AddressType
@@ -22,6 +23,8 @@ class _Signature:
     v: int
     r: bytes
     s: bytes
+    _messageHash: HexBytes
+    _signature: HexBytes
 
     def __iter__(self) -> Iterator[Union[int, bytes]]:
         # NOTE: Allows tuple destructuring
@@ -37,6 +40,12 @@ class _Signature:
 
     def encode_rsv(self) -> bytes:
         return _left_pad_bytes(self.r, 32) + _left_pad_bytes(self.s, 32) + to_bytes(self.v)
+
+    def messageHash(self) -> HexBytes:
+        return self._messageHash
+
+    def signature(self) -> HexBytes:
+        return self._signature
 
 
 class MessageSignature(_Signature):

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -39,8 +39,6 @@ class _Signature:
     def encode_rsv(self) -> bytes:
         return _left_pad_bytes(self.r, 32) + _left_pad_bytes(self.s, 32) + to_bytes(self.v)
 
-    def messageHash(self) -> SignableMessage:
-        return self._messageHash
 
 
 class MessageSignature(_Signature):

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -1,4 +1,4 @@
-from typing import Iterator, Union
+from typing import Iterator, Optional, Union
 
 from eth_account import Account
 from eth_account.messages import SignableMessage
@@ -23,8 +23,7 @@ class _Signature:
     v: int
     r: bytes
     s: bytes
-    _messageHash: HexBytes
-    _signature: HexBytes
+    _messageHash: Optional[SignableMessage] = None
 
     def __iter__(self) -> Iterator[Union[int, bytes]]:
         # NOTE: Allows tuple destructuring
@@ -41,11 +40,8 @@ class _Signature:
     def encode_rsv(self) -> bytes:
         return _left_pad_bytes(self.r, 32) + _left_pad_bytes(self.s, 32) + to_bytes(self.v)
 
-    def messageHash(self) -> HexBytes:
+    def messageHash(self) -> SignableMessage:
         return self._messageHash
-
-    def signature(self) -> HexBytes:
-        return self._signature
 
 
 class MessageSignature(_Signature):

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -4,7 +4,7 @@ from eth_account import Account
 from eth_account.messages import SignableMessage
 from eth_utils import to_bytes, to_hex
 from pydantic.dataclasses import dataclass
-
+from hexbytes import HexBytes
 from ape.types import AddressType
 
 # Fix 404 in doc link.
@@ -22,7 +22,7 @@ class _Signature:
     v: int
     r: bytes
     s: bytes
-    messageHash: Optional[SignableMessage] = None
+    messageHash: Optional[HexBytes] = None
 
     def __iter__(self) -> Iterator[Union[int, bytes]]:
         # NOTE: Allows tuple destructuring

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -3,8 +3,9 @@ from typing import Iterator, Optional, Union
 from eth_account import Account
 from eth_account.messages import SignableMessage
 from eth_utils import to_bytes, to_hex
-from pydantic.dataclasses import dataclass
 from hexbytes import HexBytes
+from pydantic.dataclasses import dataclass
+
 from ape.types import AddressType
 
 # Fix 404 in doc link.

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -156,7 +156,7 @@ class KeyfileAccount(AccountAPI):
 
         signed_msg = EthAccount.sign_message(msg, self.__key)
         return MessageSignature(
-            messageHash=signed_msg.messageHash,
+            message_hash=signed_msg.message_hash,
             v=signed_msg.v,
             r=to_bytes(signed_msg.r),
             s=to_bytes(signed_msg.s),

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -156,9 +156,11 @@ class KeyfileAccount(AccountAPI):
 
         signed_msg = EthAccount.sign_message(msg, self.__key)
         return MessageSignature(
+            _messageHash=signed_msg.messageHash,
             v=signed_msg.v,
             r=to_bytes(signed_msg.r),
             s=to_bytes(signed_msg.s),
+            _signature=signed_msg.signature,
         )
 
     def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -160,7 +160,6 @@ class KeyfileAccount(AccountAPI):
             v=signed_msg.v,
             r=to_bytes(signed_msg.r),
             s=to_bytes(signed_msg.s),
-            _signature=signed_msg.signature,
         )
 
     def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -156,7 +156,7 @@ class KeyfileAccount(AccountAPI):
 
         signed_msg = EthAccount.sign_message(msg, self.__key)
         return MessageSignature(
-            message_hash=signed_msg.message_hash,
+            message_hash=signed_msg.messageHash,
             v=signed_msg.v,
             r=to_bytes(signed_msg.r),
             s=to_bytes(signed_msg.s),

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -156,7 +156,7 @@ class KeyfileAccount(AccountAPI):
 
         signed_msg = EthAccount.sign_message(msg, self.__key)
         return MessageSignature(
-            _messageHash=signed_msg.messageHash,
+            messageHash=signed_msg.messageHash,
             v=signed_msg.v,
             r=to_bytes(signed_msg.r),
             s=to_bytes(signed_msg.s),

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -104,7 +104,7 @@ class TestAccount(TestAccountAPI):
     def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
         signed_msg = EthAccount.sign_message(msg, self.private_key)
         return MessageSignature(
-            message_hash=signed_msg.message_hash,
+            message_hash=signed_msg.messageHash,
             v=signed_msg.v,
             r=to_bytes(signed_msg.r),
             s=to_bytes(signed_msg.s),

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -104,7 +104,7 @@ class TestAccount(TestAccountAPI):
     def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
         signed_msg = EthAccount.sign_message(msg, self.private_key)
         return MessageSignature(
-            messageHash=signed_msg.messageHash,
+            message_hash=signed_msg.message_hash,
             v=signed_msg.v,
             r=to_bytes(signed_msg.r),
             s=to_bytes(signed_msg.s),

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -104,9 +104,11 @@ class TestAccount(TestAccountAPI):
     def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
         signed_msg = EthAccount.sign_message(msg, self.private_key)
         return MessageSignature(
+            _messageHash=signed_msg.messageHash,
             v=signed_msg.v,
             r=to_bytes(signed_msg.r),
             s=to_bytes(signed_msg.s),
+            _signature=signed_msg.signature,
         )
 
     def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -104,7 +104,7 @@ class TestAccount(TestAccountAPI):
     def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
         signed_msg = EthAccount.sign_message(msg, self.private_key)
         return MessageSignature(
-            _messageHash=signed_msg.messageHash,
+            messageHash=signed_msg.messageHash,
             v=signed_msg.v,
             r=to_bytes(signed_msg.r),
             s=to_bytes(signed_msg.s),

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -108,7 +108,6 @@ class TestAccount(TestAccountAPI):
             v=signed_msg.v,
             r=to_bytes(signed_msg.r),
             s=to_bytes(signed_msg.s),
-            _signature=signed_msg.signature,
         )
 
     def sign_transaction(self, txn: TransactionAPI, **kwargs) -> Optional[TransactionAPI]:

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -583,3 +583,24 @@ def test_load_public_key_from_keyfile(runner, keyfile_account):
         )
         # no need for password when loading from the keyfile
         assert keyfile_account.public_key
+
+
+def test_signed_messge_hash(signer):
+    message = encode_defunct(text="Hello Apes!")
+    signature = signer.sign_message(message)
+
+    assert signer.check_signature(message, signature)
+    assert isinstance(signature.messageHash, HexBytes)
+    assert (
+        signature.messageHash.hex()
+        == "0x46b937e48a6aaec0a17aac9dc326950632c949b1f1f9300073b1ef55b905c278"
+    )
+
+
+def test_signed_messge_signature(signer):
+    message = encode_defunct(text="Hello Apes!")
+    signature = signer.sign_message(message)
+
+    assert signer.check_signature(message, signature)
+    assert isinstance(signature.signature, HexBytes)
+    assert signature.signature

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -590,9 +590,9 @@ def test_signed_messge_hash(signer):
     signature = signer.sign_message(message)
 
     assert signer.check_signature(message, signature)
-    assert isinstance(signature.messageHash, HexBytes)
+    assert isinstance(signature.message_hash, HexBytes)
     assert (
-        signature.messageHash.hex()
+        signature.message_hash.hex()
         == "0x46b937e48a6aaec0a17aac9dc326950632c949b1f1f9300073b1ef55b905c278"
     )
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -595,3 +595,5 @@ def test_signed_messge_hash(signer):
         signature.messageHash.hex()
         == "0x46b937e48a6aaec0a17aac9dc326950632c949b1f1f9300073b1ef55b905c278"
     )
+
+    assert recover_signer(message, signature) == signer

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -595,12 +595,3 @@ def test_signed_messge_hash(signer):
         signature.messageHash.hex()
         == "0x46b937e48a6aaec0a17aac9dc326950632c949b1f1f9300073b1ef55b905c278"
     )
-
-
-def test_signed_messge_signature(signer):
-    message = encode_defunct(text="Hello Apes!")
-    signature = signer.sign_message(message)
-
-    assert signer.check_signature(message, signature)
-    assert isinstance(signature.signature, HexBytes)
-    assert signature.signature


### PR DESCRIPTION
### What I did


Added the `messageHash` & `signature` to the `_Signature` dataclass

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1727

### How I did it

```py
[...]
def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
        signed_msg = EthAccount.sign_message(msg, self.private_key)
        return MessageSignature(
            _messageHash=signed_msg.messageHash,
            v=signed_msg.v,
            r=to_bytes(signed_msg.r),
            s=to_bytes(signed_msg.s),
            _signature=signed_msg.signature,
        )
```

### How to verify it
```py
>>> ape console
from eth_account.messages import encode_defunct
message = encode_defunct(text="Hello Apes!")
signer = accounts.test_accounts[0]

signature = signer.sign_message(message)
signature.messageHash
>>> HexBytes('0x46b937e48a6aaec0a17aac9dc326950632c949b1f1f9300073b1ef55b905c278')
In [6]: signer.sign_message(message).signature
Out[6]: HexBytes('0x8a1826611000533319d940bd2b5cd90d6a5ea40015e68fb65252cb7eb2b656450cb90a84b287f25eaff5a2b4259245486f985a30ac88b712af2afb661d0f5c161c')


```


<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
