### PR TITLE
fix: handle PackageName regression from ethpm-types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
         "web3[tester]>=6.7.0,<7",
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.2.1,<0.3",
-        "ethpm-types>=0.5.8,<0.6",
+        "ethpm-types>=0.5.10,<0.6",
         "evm-trace>=0.1.0a23",
     ],
     entry_points={

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -182,7 +182,7 @@ class ProjectAPI(BaseInterfaceModel):
         initial_manifest: Optional[PackageManifest] = None,
     ) -> PackageManifest:
         manifest = initial_manifest or PackageManifest()
-        manifest.name = PackageName(name.lower()) if name is not None else manifest.name
+        manifest.name = PackageName(__root__=name.lower()) if name is not None else manifest.name
         manifest.version = version or manifest.version
         manifest.sources = cls._create_source_dict(source_paths, contracts_path)
         manifest.contract_types = contract_types

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -274,11 +274,11 @@ class ProjectManager(BaseManager):
         manifest.dependencies = self._extract_manifest_dependencies()
         return manifest
 
-    def _extract_manifest_dependencies(self) -> Optional[Dict[PackageName, AnyUrl]]:
-        package_dependencies: Dict[PackageName, AnyUrl] = {}
+    def _extract_manifest_dependencies(self) -> Optional[Dict[str, AnyUrl]]:
+        package_dependencies: Dict[str, AnyUrl] = {}
         for dependency_config in self.config_manager.dependencies:
             package_name = dependency_config.name.replace("_", "-").lower()
-            package_dependencies[PackageName(package_name)] = dependency_config.uri
+            package_dependencies[package_name] = dependency_config.uri
 
         return package_dependencies
 


### PR DESCRIPTION
### What I did

we accidentally broke PackageName initialization by switching to use BaseModel, which we needed to do for proper schema control.... 

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
