### PR TITLE
fix: empty plugins sections repr [APE-1538]

### DIFF
--- a/src/ape_plugins/utils.py
+++ b/src/ape_plugins/utils.py
@@ -441,6 +441,9 @@ class ApePluginsRepr:
         if PluginType.AVAILABLE in self.include and self.metadata.available:
             sections.append(self.metadata.available)
 
+        if not sections:
+            return ""
+
         # Use a single max length for all the sections.
         max_length = max(x.max_name_length for x in sections)
 

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -115,8 +115,8 @@ class TestPluginMetadata:
 
 class TestApePluginsRepr:
     def test_str(self, plugin_metadata):
-        plugin_map = ApePluginsRepr(plugin_metadata)
-        actual = str(plugin_map)
+        representation = ApePluginsRepr(plugin_metadata)
+        actual = str(representation)
         expected = f"""
 Installed Plugins
   installed     {VERSION}
@@ -127,8 +127,8 @@ Third-party Plugins
         assert actual == expected.strip()
 
     def test_str_all_types(self, plugin_metadata):
-        plugin_map = ApePluginsRepr(plugin_metadata, include=list(PluginType))
-        actual = str(plugin_map)
+        representation = ApePluginsRepr(plugin_metadata, include=list(PluginType))
+        actual = str(representation)
         expected = f"""
 Core Plugins
   run
@@ -143,3 +143,8 @@ Available Plugins
   available
         """
         assert actual == expected.strip()
+
+    def test_str_no_plugins(self):
+        plugins = PluginMetadataList.from_package_names([])
+        representation = ApePluginsRepr(plugins)
+        assert str(representation) == ""


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1737

### How I did it

early return


### How to verify it

Use an env with no plugins and run

```sh
ape plugins list
```

it should show:

```sh
No plugins installed.
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
