### PR TITLE
feat: add ecosystem to build file structure in ProjectAPI [APE-1540]

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -158,7 +158,8 @@ class ProjectAPI(BaseInterfaceModel):
 
     @property
     def _cache_folder(self) -> Path:
-        folder = self.contracts_folder.parent / ".build"
+        current_ecosystem = self.network_manager.network.ecosystem.name
+        folder = self.contracts_folder.parent / ".build" / current_ecosystem
         # NOTE: If we use the cache folder, we expect it to exist
         folder.mkdir(exist_ok=True, parents=True)
         return folder

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Type, Uni
 
 from ethpm_types.abi import EventABI, MethodABI
 
-from ape._pydantic_compat import BaseModel, NonNegativeInt, PositiveInt, root_validator
+from ape._pydantic_compat import BaseModel, NonNegativeInt, root_validator
 from ape.api.transactions import ReceiptAPI, TransactionAPI
 from ape.logging import logger
 from ape.types import AddressType
@@ -102,7 +102,7 @@ class _BaseQuery(BaseModel):
 class _BaseBlockQuery(_BaseQuery):
     start_block: NonNegativeInt = 0
     stop_block: NonNegativeInt
-    step: PositiveInt = 1
+    step: int = 1
 
     @root_validator(pre=True)
     def check_start_block_before_stop_block(cls, values):
@@ -140,6 +140,7 @@ class AccountTransactionQuery(_BaseQuery):
     account: AddressType
     start_nonce: NonNegativeInt = 0
     stop_nonce: NonNegativeInt
+    step: int = 1
 
     @root_validator(pre=True)
     def check_start_nonce_before_stop_nonce(cls, values: Dict) -> Dict:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -138,9 +138,7 @@ class ForkedNetworkConfig(NetworkConfig):
     """
 
 
-def _create_local_config(
-    default_provider: Optional[str] = None, use_fork: bool = False, **kwargs
-) -> NetworkConfig:
+def _create_local_config(default_provider: Optional[str] = None, use_fork: bool = False, **kwargs):
     return _create_config(
         base_fee_multiplier=1.0,
         default_provider=default_provider,
@@ -155,7 +153,7 @@ def _create_local_config(
 def _create_config(
     required_confirmations: int = 2,
     base_fee_multiplier: float = DEFAULT_LIVE_NETWORK_BASE_FEE_MULTIPLIER,
-    cls: Type[NetworkConfig] = NetworkConfig,
+    cls: Type = NetworkConfig,
     **kwargs,
 ) -> NetworkConfig:
     return cls(

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -399,7 +399,7 @@ def test_getattr_contract_not_exists(project):
 
 def test_build_file_only_modified_once(project_with_contract):
     project = project_with_contract
-    artifact = project.path / ".build" / "__local__.json"
+    artifact = project.path / ".build" / "ethereum" / "__local__.json"
     _ = project.contracts  # Ensure compiled.
 
     # NOTE: This is how re-create the bug. Delete the underscore-prefixed


### PR DESCRIPTION
### What I did

Allow build structure to support multiple ecosystems.

### How I did it

- Added ecosystem to build file structure 
-  ".build" / "ethereum" / "__local__.json"

### How to verify it

- Updated and passes tests

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [X] All changes are completed
- [X] New test cases have been added
- [X] Documentation has been updated
