### PR TITLE
fix: do not fetch history if there is no history in poll_blocks()

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -287,9 +287,10 @@ class BlockContainer(BaseManager):
         # Get number of last block with the necessary amount of confirmations.
         block = None
 
-        if start_block is not None:
+        head_minus_confirms = self.height - required_confirmations
+        if start_block is not None and start_block <= head_minus_confirms:
             # Front-load historical blocks.
-            for block in self.range(start_block, self.height - required_confirmations + 1):
+            for block in self.range(start_block, head_minus_confirms + 1):
                 yield block
 
         if block:

--- a/tests/functional/test_block_container.py
+++ b/tests/functional/test_block_container.py
@@ -147,3 +147,22 @@ def test_poll_blocks_timeout(
     with pytest.raises(ChainError, match=r"Timed out waiting for new block \(time_waited=1.\d+\)."):
         with PollDaemon("blocks", poller, lambda x: None, lambda: False):
             time.sleep(1.5)
+
+
+def test_poll_blocks_future(chain_that_mined_5, eth_tester_provider, owner, PollDaemon):
+    blocks: Queue = Queue(maxsize=3)
+    poller = chain_that_mined_5.blocks.poll_blocks(
+        start_block=chain_that_mined_5.blocks.head.number + 1
+    )
+
+    with PollDaemon("blocks", poller, blocks.put, blocks.full):
+        # Sleep first to ensure listening before mining.
+        time.sleep(1)
+        eth_tester_provider.mine(3)
+
+    assert blocks.full()
+    first = blocks.get().number
+    second = blocks.get().number
+    third = blocks.get().number
+    assert first == second - 1
+    assert second == third - 1


### PR DESCRIPTION
### What I did

This alters the behavior of `chain.blocks.poll_blocks()` to prevent an out of bounds `range()` call.

Fixes #1743

### How to verify it

Could use a sanity check to make sure I'm not logically skipping a block with the change.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
~~- [ ] Documentation has been updated~~

Do docs need to be updated?  I believe this is just a bugfix not a behavior change.