### PR TITLE
feat: add `network_option` if it is not present w/ `NetworkBoundCommand` [APE-1575]

### DIFF
--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -4,6 +4,7 @@ import click
 from click import Context
 
 from ape import networks
+from ape.cli.options import network_option
 
 
 def check_parents_for_interactive(ctx: Context) -> bool:
@@ -23,6 +24,13 @@ class NetworkBoundCommand(click.Command):
     """
 
     def invoke(self, ctx: Context) -> Any:
+        # Check if the network_option is defined, if not, add it with default values
+        if not any(
+            isinstance(param, click.core.Option) and param.name == "network"
+            for param in self.params
+        ):
+            self.params.append(network_option())
+
         value = ctx.params.get("network") or networks.default_ecosystem.name
         interactive = check_parents_for_interactive(ctx)
         with networks.parse_network_choice(value, disconnect_on_exit=not interactive):

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -530,10 +530,11 @@ class AccountHistory(BaseInterfaceModel):
 
     @__getitem__.register
     def __getitem_slice(self, indices: slice) -> List[ReceiptAPI]:
-        start, stop, step = (
+        # start, stop, step = (
+        start, stop = (
             indices.start or 0,
             indices.stop or len(self),
-            indices.step or 1,
+            # indices.step  or 1,
         )
 
         if start < 0:
@@ -559,7 +560,7 @@ class AccountHistory(BaseInterfaceModel):
                         account=self.address,
                         start_nonce=start,
                         stop_nonce=stop - 1,
-                        step=step,
+                        # step=step,
                     )
                 )
             ),


### PR DESCRIPTION
### What I did

`NetworkBoundCommand` automatically adds `network_option` if it is not there.

fixes: #1572

### How I did it

`network_option` could be pass to the default arguments if is not present. WIP

### How to verify it

Haven't had too much time to test it yet, will update PR once tested. 

### Checklist


- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
