### PR TITLE
fix: added checks to remove `,` from the RPC URI endpoint [APE-1582]

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -753,7 +753,7 @@ def _sanitize_web3_url(msg: str) -> str:
     prefix = parts[0].strip()
     rest = parts[1].split(" ")
 
-    # * To remote the `,` from the url http://127.0.0.1:8545,
+    # * To remove the `,` from the url http://127.0.0.1:8545,
     if "," in rest[0]:
         rest[0] = rest[0].rstrip(",")
     sanitized_url = sanitize_url(rest[0])

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -755,7 +755,7 @@ def _sanitize_web3_url(msg: str) -> str:
 
     # * To remote the `,` from the url http://127.0.0.1:8545,
     if "," in rest[0]:
-        rest[0] = rest[0].strip(",")
+        rest[0] = rest[0].rstrip(",")
     sanitized_url = sanitize_url(rest[0])
     return f"{prefix} URI: {sanitized_url} {' '.join(rest[1:])}"
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -752,6 +752,10 @@ def _sanitize_web3_url(msg: str) -> str:
     parts = msg.split("URI: ")
     prefix = parts[0].strip()
     rest = parts[1].split(" ")
+
+    # * To remote the `,` from the url http://127.0.0.1:8545,
+    if "," in rest[0]:
+        rest[0] = rest[0].strip(",")
     sanitized_url = sanitize_url(rest[0])
     return f"{prefix} URI: {sanitized_url} {' '.join(rest[1:])}"
 

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -6,6 +6,7 @@ from eth_typing import HexStr
 from eth_utils import ValidationError
 from web3.exceptions import ContractPanicError
 
+from ape.api.providers import _sanitize_web3_url
 from ape.exceptions import BlockNotFoundError, ContractLogicError, TransactionNotFoundError
 from ape.types import LogFilter
 from ape.utils import DEFAULT_TEST_CHAIN_ID
@@ -262,3 +263,10 @@ def test_prepare_tx_with_max_gas(tx_type, eth_tester_provider, ethereum, owner):
 
     actual = eth_tester_provider.prepare_transaction(tx)
     assert actual.gas_limit == eth_tester_provider.max_gas
+
+
+def test_no_comma_in_rpc_url():
+    test_url = "URI: http://127.0.0.1:8545,"
+    sanitised_url = _sanitize_web3_url(test_url)
+
+    assert "," not in sanitised_url


### PR DESCRIPTION
fix: added checks to remove `,` from the RPC URI endpoint

### What I did
Added a check to see if `,` is present in the URL string or not.

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1752

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it
```py
# * To remote the `,` from the url http://127.0.0.1:8545,
    if "," in rest[0]:
        rest[0] = rest[0].strip(",")
```

<!-- Discuss any methods that should be used to verify the change -->
Trust me bro.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [ ] Documentation has been updated
