### PR TITLE
fix: issue where `KeyfileAccount` would not stay unlocked [APE-1586]

### DIFF
--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -752,7 +752,8 @@ class ProjectManager(BaseManager):
 
         if destination.is_file():
             logger.debug("Deployment already tracked. Re-tracking.")
-            destination.unlink()
+            # NOTE: missing_ok=True to handle race condition.
+            destination.unlink(missing_ok=True)
 
         destination.write_text(artifact.json())
 

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -32,11 +32,14 @@ class InterfaceCompiler(CompilerAPI):
             )
             source_id = str(source_path)
 
+            # NOTE: Allow empty files to read as empty JSONs.
+            code = path.read_text() or "{}"
+
             try:
                 # NOTE: Always set the source ID to the source of the JSON file
                 #   to avoid manifest corruptions later on.
                 contract_type = self.compile_code(
-                    path.read_text(),
+                    code,
                     base_path=base_path,
                     sourceId=source_id,
                 )

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -31,9 +31,7 @@ class InterfaceCompiler(CompilerAPI):
                 get_relative_path(path, base_path) if base_path and path.is_absolute() else path
             )
             source_id = str(source_path)
-
-            # NOTE: Allow empty files to read as empty JSONs.
-            code = path.read_text() or "{}"
+            code = path.read_text()
 
             try:
                 # NOTE: Always set the source ID to the source of the JSON file

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -32,6 +32,8 @@ class InterfaceCompiler(CompilerAPI):
             )
             source_id = str(source_path)
             code = path.read_text()
+            if not code:
+                continue
 
             try:
                 # NOTE: Always set the source ID to the source of the JSON file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -309,6 +309,8 @@ def empty_data_folder():
 @pytest.fixture
 def keyfile_account(owner, keyparams, temp_accounts_path, temp_keyfile_account_ctx):
     with temp_keyfile_account_ctx(temp_accounts_path, ALIAS, keyparams, owner) as account:
+        # Ensure starts off locked.
+        account.lock()
         yield account
 
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -173,6 +173,8 @@ def address():
 @pytest.fixture
 def second_keyfile_account(sender, keyparams, temp_accounts_path, temp_keyfile_account_ctx):
     with temp_keyfile_account_ctx(temp_accounts_path, ALIAS_2, keyparams, sender) as account:
+        # Ensure starts off locked.
+        account.lock()
         yield account
 
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -372,6 +372,8 @@ def test_unlock_from_prompt_and_sign_transaction(runner, keyfile_account, receiv
 
 def test_unlock_with_passphrase_from_env_and_sign_message(runner, keyfile_account):
     ENV_VARIABLE = f"APE_ACCOUNTS_{keyfile_account.alias}_PASSPHRASE"
+    message = encode_defunct(text="Hello Apes!")
+
     # Set environment variable with passphrase
     environ[ENV_VARIABLE] = PASSPHRASE
 
@@ -380,8 +382,6 @@ def test_unlock_with_passphrase_from_env_and_sign_message(runner, keyfile_accoun
 
     # Account should be unlocked
     assert not keyfile_account.locked
-
-    message = encode_defunct(text="Hello Apes!")
 
     # y: yes, sign (note: unlocking makes the key available but is not the same as autosign).
     with runner.isolation(input="y\n"):


### PR DESCRIPTION
### What I did

In ape-safe, I was prompted `"Leave unlocked?"` over and over again and it was because signers were re-checked and reloaded and thus lost the "yes" to my prompt... So it is would be nice if Ape remembered I said "yes" to leave the account unlocked.

### How I did it

Only create the `KeyfileAccount` class once.

### How to verify it

see second test. The first one was me trying to figure out but is still a nice test

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
