### PR TITLE
feat!: network customization and tooling improvements

### DIFF
--- a/docs/userguides/clis.md
+++ b/docs/userguides/clis.md
@@ -63,14 +63,18 @@ def cli(cli_ctx):
 
 ## Network Tools
 
-The [@network_option()](../methoddocs/cli.html#ape.cli.options.network_option) allows you to select an ecosystem, network, and provider combination.
+The [@network_option()](../methoddocs/cli.html#ape.cli.options.network_option) allows you to select an ecosystem, network, and provider.
 To specify the network option, use values like:
 
 ```shell
---network ethereu
+--network ethereum
 --network ethereum:sepolia
 --network ethereum:mainnet:alchemy
+--network ::alchemy
 ```
+
+When omitting values, leave the semi-colons in the network choice for parsing.
+And omitted values means to use the defaul value, so if you omit the ecosystem out-of-the-box, it will default to Ethereum (unless you have configured a different default ecosystem).
 
 Use `ecosystem`, `network`, and  `provider` argument names in your command implementation to have access to the parsed network option:
 
@@ -95,7 +99,7 @@ def cmd_2(ecosystem, network, provider):
 
 The [ConnectedProviderCommand](../methoddocs/cli.html#ape.cli.commands.ConnectedProviderCommand) automatically uses the `--network` option and connects to the network before any of your code executes and disconnected after.
 This is useful if your script or command requires a provider connection in order for it to run.
-Additionally, specify `ecosystem`, `network`, or `provider` in your command function if you need any of those instances in your ``ConnectedProviderCommand`.
+Additionally, specify `ecosystem`, `network`, or `provider` in your command function if you need any of those instances in your `ConnectedProviderCommand`.
 
 ```python
 import click

--- a/docs/userguides/clis.md
+++ b/docs/userguides/clis.md
@@ -63,28 +63,56 @@ def cli(cli_ctx):
 
 ## Network Tools
 
-The [@network_option()](../methoddocs/cli.html#ape.cli.options.network_option) allows you to select an ecosystem / network / provider combination.
-When using with the [NetworkBoundCommand](../methoddocs/cli.html#ape.cli.commands.NetworkBoundCommand) class, you can cause your CLI to connect before any of your code executes.
-This is useful if your script or command requires a provider connection in order for it to run.
+The [@network_option()](../methoddocs/cli.html#ape.cli.options.network_option) allows you to select an ecosystem, network, and provider combination.
+To specify the network option, use values like:
+
+```shell
+--network ethereu
+--network ethereum:sepolia
+--network ethereum:mainnet:alchemy
+```
+
+Use `ecosystem`, `network`, and  `provider` argument names in your command implementation to have access to the parsed network option:
 
 ```python
 import click
-from ape import networks
-from ape.cli import network_option, NetworkBoundCommand
-
+from ape.cli import network_option
 
 @click.command()
 @network_option()
-def cmd(network):
-    # Choices like "ethereum" or "polygon:local:test".
-    click.echo(network)
+def cmd(provider):
+   # This command only needs the provider.
+   click.echo(provider.name)
 
-
-@click.command(cls=NetworkBoundCommand)
+@click.command()
 @network_option()
-def cmd(network):
-    # Fails if we are not connected.
-    click.echo(networks.provider.network.name)
+def cmd_2(ecosystem, network, provider):
+   # This command uses all parts of the parsed network choice.
+   click.echo(ecosystem.name)
+   click.echo(network.name)
+   click.echo(provider.name)
+```
+
+The [ConnectedProviderCommand](../methoddocs/cli.html#ape.cli.commands.ConnectedProviderCommand) automatically uses the `--network` option and connects to the network before any of your code executes and disconnected after.
+This is useful if your script or command requires a provider connection in order for it to run.
+Additionally, specify `ecosystem`, `network`, or `provider` in your command function if you need any of those instances in your ``ConnectedProviderCommand`.
+
+```python
+import click
+from ape.cli import ConnectedProviderCommand
+
+@click.command(cls=ConnectedProviderCommand)
+def cmd(network, provider):
+   click.echo(network.name)
+   click.echo(provider.is_connected)  # True
+
+@click.command(cls=ConnectedProviderCommand)
+def cmd(provider):
+   click.echo(provider.is_connected)  # True
+
+@click.command(cls=ConnectedProviderCommand)
+def cmd():
+   click.echo("Using params is from ConnectedProviderCommand is optional")
 ```
 
 ## Account Tools

--- a/docs/userguides/clis.md
+++ b/docs/userguides/clis.md
@@ -74,9 +74,9 @@ To specify the network option, use values like:
 ```
 
 To use default values automatically, omit sections of the choice, but leave the semi-colons for parsing.
-For example, `::test` means to use the value ecosystem and network and the `test` provider.
+For example, `::test` means use the default ecosystem and network and the `test` provider.
 
-Use `ecosystem`, `network`, and  `provider` argument names in your command implementation to have access to the parsed network option:
+Use `ecosystem`, `network`, and `provider` argument names in your command implementation to access their corresponding class instances:
 
 ```python
 import click
@@ -97,9 +97,9 @@ def cmd_2(ecosystem, network, provider):
    click.echo(provider.name)
 ```
 
-The [ConnectedProviderCommand](../methoddocs/cli.html#ape.cli.commands.ConnectedProviderCommand) automatically uses the `--network` option and connects to the network before any of your code executes and disconnected after.
+The [ConnectedProviderCommand](../methoddocs/cli.html#ape.cli.commands.ConnectedProviderCommand) automatically uses the `--network` option and connects to the network before any of your code executes and then disconnects afterward.
 This is useful if your script or command requires a provider connection in order for it to run.
-Additionally, specify `ecosystem`, `network`, or `provider` in your command function if you need any of those instances in your `ConnectedProviderCommand`.
+Additionally, specify `ecosystem`, `network`, or `provider` in your command function if you need any of those instances in your `ConnectedProviderCommand`, just like when using `network_option`.
 
 ```python
 import click

--- a/docs/userguides/clis.md
+++ b/docs/userguides/clis.md
@@ -70,11 +70,11 @@ To specify the network option, use values like:
 --network ethereum
 --network ethereum:sepolia
 --network ethereum:mainnet:alchemy
---network ::alchemy
+--network ::foundry
 ```
 
-When omitting values, leave the semi-colons in the network choice for parsing.
-And omitted values means to use the defaul value, so if you omit the ecosystem out-of-the-box, it will default to Ethereum (unless you have configured a different default ecosystem).
+To use default values automatically, omit sections of the choice, but leave the semi-colons for parsing.
+For example, `::test` means to use the value ecosystem and network and the `test` provider.
 
 Use `ecosystem`, `network`, and  `provider` argument names in your command implementation to have access to the parsed network option:
 

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -85,9 +85,9 @@ geth:
       uri: https://foo.node.bar
 ```
 
-## Ad-hoc Network Connection
+## Custom Network Connection
 
-If you would like to connect to a URI using the `geth` provider, you can specify a URI for the provider name in the `--network` option:
+If you would like to connect to a URI using the default Ethereum node provider, you can specify a URI for the provider name in the `--network` option:
 
 ```bash
 ape run script --network ethereum:mainnet:https://foo.bar

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -12,7 +12,7 @@ ape test --network ethereum:local:foundry
 ape console --network arbitrum:testnet:alchemy
 ```
 
-You can also use the `--network` option on scripts that use the `main()` method approach or scripts that implement that `NetworkBoundCommand` command type.
+You can also use the `--network` option on scripts that use the `main()` method approach or scripts that implement that `ConnectedProviderCommand` command type.
 See [the scripting guide](./scripts.html) to learn more about scripts and how to add the network option.
 
 **NOTE**: You can omit values to use defaults.

--- a/docs/userguides/scripts.md
+++ b/docs/userguides/scripts.md
@@ -33,17 +33,25 @@ ape run hello helloworld
 ```
 
 Note that by default, `cli` scripts do not have [`ape.cli.network_option`](../methoddocs/cli.html?highlight=options#ape.cli.options.network_option) installed, giving you more flexibility in how you define your scripts.
-However, you can add the `network_option` to your scripts by importing both the `NetworkBoundCommand` and the `network_option` from the `ape.cli` namespace:
+However, you can add the `network_option` or `ConnectedProviderCommand` to your scripts by importing them from the `ape.cli` namespace:
 
 ```python
 import click
-from ape.cli import network_option, NetworkBoundCommand
+from ape.cli import network_option, ConnectedProviderCommand
 
 
-@click.command(cls=NetworkBoundCommand)
-@network_option()
-def cli(network):
-    click.echo(f"You are connected to network '{network}'.")
+@click.command(cls=ConnectedProviderCommand)
+def cli(ecosystem, network):
+    click(f"You selected a provider on ecosystem '{ecosystem.name}' and {network.name}.")
+
+@click.command(cls=ConnectedProviderCommand)
+def cli(network, provider):
+    click.echo(f"You are connected to network '{network.name}'.")
+    click.echo(provider.chain_id)
+
+@click.command(cls=ConnectedProviderCommand)
+def cli_2():
+    click.echo(f"Using any network-based argument is completely optional.")
 ```
 
 Assume we saved this script as `shownet.py` and have the [ape-alchemy](https://github.com/ApeWorX/ape-alchemy) plugin installed.

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -24,7 +24,6 @@ from eth_pydantic_types import HexBytes
 from eth_utils import keccak, to_int
 from ethpm_types import BaseModel, ContractType
 from ethpm_types.abi import ABIType, ConstructorABI, EventABI, MethodABI
-from pydantic import computed_field
 
 from ape.exceptions import (
     NetworkError,
@@ -93,6 +92,29 @@ class EcosystemAPI(BaseInterfaceModel):
 
     def __repr__(self) -> str:
         return f"<{self.name}>"
+
+    @cached_property
+    def adhoc_network(self) -> "NetworkAPI":
+        ethereum_class = None
+        for plugin_name, ecosystem_class in self.plugin_manager.ecosystems:
+            if plugin_name == "ethereum":
+                ethereum_class = ecosystem_class
+                break
+
+        if ethereum_class is None:
+            raise NetworkError("Core Ethereum plugin missing.")
+
+        data_folder = mkdtemp()
+        request_header = self.config_manager.REQUEST_HEADER
+        init_kwargs = {"data_folder": data_folder, "request_header": request_header}
+        ethereum = ethereum_class(**init_kwargs)  # type: ignore
+        return NetworkAPI(
+            name="adhoc",
+            ecosystem=ethereum,
+            data_folder=Path(data_folder),
+            request_header=request_header,
+            _default_provider="geth",
+        )
 
     @classmethod
     @abstractmethod
@@ -258,7 +280,7 @@ class EcosystemAPI(BaseInterfaceModel):
             self.networks[network_name] = network
 
     @property
-    def default_network(self) -> str:
+    def default_network_name(self) -> str:
         """
         The name of the default network in this ecosystem.
 
@@ -283,6 +305,10 @@ class EcosystemAPI(BaseInterfaceModel):
 
         # Very unlikely scenario.
         raise NetworkError("No networks found.")
+
+    @property
+    def default_network(self) -> "NetworkAPI":
+        return self.get_network(self.default_network_name)
 
     def set_default_network(self, network_name: str):
         """
@@ -424,18 +450,21 @@ class EcosystemAPI(BaseInterfaceModel):
         Get the network for the given name.
 
         Args:
-              network_name (str): The name of the network to get.
+          network_name (str): The name of the network to get.
 
         Raises:
-              :class:`~ape.exceptions.NetworkNotFoundError`: When the network is not present.
+          :class:`~ape.exceptions.NetworkNotFoundError`: When the network is not present.
 
         Returns:
-              :class:`~ape.api.networks.NetworkAPI`
+          :class:`~ape.api.networks.NetworkAPI`
         """
 
         name = network_name.replace("_", "-")
         if name in self.networks:
             return self.networks[name]
+
+        elif name == "adhoc":
+            return self.adhoc_network
 
         raise NetworkNotFoundError(network_name, ecosystem=self.name, options=self.networks)
 
@@ -459,7 +488,7 @@ class EcosystemAPI(BaseInterfaceModel):
         data: Dict[str, Any] = {"name": str(network_name)}
 
         # Only add isDefault key when True
-        if network_name == self.default_network:
+        if network_name == self.default_network.name:
             data["isDefault"] = True
 
         data["providers"] = []
@@ -605,6 +634,7 @@ class ProviderContextManager(ManagerAccessMixin):
             # set inner var to the recycled provider for use in push_provider()
             self._provider = self._recycled_provider
             ProviderContextManager._recycled_provider = None
+
         return self.push_provider()
 
     def __exit__(self, exception, *args, **kwargs):
@@ -699,29 +729,6 @@ class NetworkAPI(BaseInterfaceModel):
 
     # See ``.default_provider`` which is the proper field.
     _default_provider: str = ""
-
-    @classmethod
-    def create_adhoc_network(cls) -> "NetworkAPI":
-        ethereum_class = None
-        for plugin_name, ecosystem_class in cls.plugin_manager.ecosystems:
-            if plugin_name == "ethereum":
-                ethereum_class = ecosystem_class
-                break
-
-        if ethereum_class is None:
-            raise NetworkError("Core Ethereum plugin missing.")
-
-        data_folder = mkdtemp()
-        request_header = cls.config_manager.REQUEST_HEADER
-        init_kwargs = {"data_folder": data_folder, "request_header": request_header}
-        ethereum = ethereum_class(**init_kwargs)  # type: ignore
-        return cls(
-            name="adhoc",
-            ecosystem=ethereum,
-            data_folder=Path(data_folder),
-            request_header=request_header,
-            _default_provider="geth",
-        )
 
     def __repr__(self) -> str:
         try:
@@ -879,7 +886,10 @@ class NetworkAPI(BaseInterfaceModel):
             ecosystem_name, network_name, provider_class = plugin_tuple
             provider_name = clean_plugin_name(provider_class.__module__.split(".")[0])
 
-            if self.ecosystem.name == ecosystem_name and self.name == network_name:
+            # NOTE: Adhoc networks work with any provider.
+            if self.name == "adhoc" or (
+                self.ecosystem.name == ecosystem_name and self.name == network_name
+            ):
                 # NOTE: Lazily load provider config
                 providers[provider_name] = partial(
                     provider_class,
@@ -910,7 +920,7 @@ class NetworkAPI(BaseInterfaceModel):
             :class:`~ape.api.providers.ProviderAPI`
         """
 
-        provider_name = provider_name or self.default_provider
+        provider_name = provider_name or self.default_provider_name
         if not provider_name:
             from ape.managers.config import CONFIG_FILE_NAME
 
@@ -950,6 +960,7 @@ class NetworkAPI(BaseInterfaceModel):
         provider_name: str,
         provider_settings: Optional[Dict] = None,
         disconnect_after: bool = False,
+        disconnect_on_exit: bool = True,
     ) -> ProviderContextManager:
         """
         Use and connect to a provider in a temporary context. When entering the context, it calls
@@ -966,11 +977,13 @@ class NetworkAPI(BaseInterfaceModel):
 
         Args:
             provider_name (str): The name of the provider to use.
+            provider_settings (dict, optional): Settings to apply to the provider.
+              Defaults to ``None``.
             disconnect_after (bool): Set to ``True`` to force a disconnect after ending
               the context. This defaults to ``False`` so you can re-connect to the
               same network, such as in a multi-chain testing scenario.
-            provider_settings (dict, optional): Settings to apply to the provider.
-              Defaults to ``None``.
+            disconnect_on_exit (bool): Whether to disconnect on the exit of the python
+              session. Defaults to ``True``.
 
         Returns:
             :class:`~ape.api.networks.ProviderContextManager`
@@ -978,11 +991,14 @@ class NetworkAPI(BaseInterfaceModel):
 
         settings = provider_settings or {}
         provider = self.get_provider(provider_name=provider_name, provider_settings=settings)
-        return ProviderContextManager(provider=provider, disconnect_after=disconnect_after)
+        return ProviderContextManager(
+            provider=provider,
+            disconnect_after=disconnect_after,
+            disconnect_on_exit=disconnect_on_exit,
+        )
 
-    @computed_field()  # type: ignore[misc]
     @property
-    def default_provider(self) -> Optional[str]:
+    def default_provider_name(self) -> Optional[str]:
         """
         The name of the default provider or ``None``.
 
@@ -1003,6 +1019,13 @@ class NetworkAPI(BaseInterfaceModel):
             return list(self.providers)[0]
 
         # There are no providers at all for this network.
+        return None
+
+    @property
+    def default_provider(self) -> Optional["ProviderAPI"]:
+        if name := self.default_provider_name:
+            return self.get_provider(name)
+
         return None
 
     @property
@@ -1056,7 +1079,9 @@ class NetworkAPI(BaseInterfaceModel):
         if self.default_provider:
             settings = provider_settings or {}
             return self.use_provider(
-                self.default_provider, provider_settings=settings, disconnect_after=disconnect_after
+                self.default_provider.name,
+                provider_settings=settings,
+                disconnect_after=disconnect_after,
             )
 
         raise NetworkError(f"No providers for network '{self.name}'.")
@@ -1112,7 +1137,7 @@ class ForkedNetworkAPI(NetworkAPI):
         """
 
         config_choice = self._network_config.get("upstream_provider")
-        if provider_name := config_choice or self.upstream_network.default_provider:
+        if provider_name := config_choice or self.upstream_network.default_provider_name:
             return self.upstream_network.get_provider(provider_name)
 
         raise NetworkError(f"Upstream network '{self.upstream_network}' has no providers.")

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -488,7 +488,7 @@ class EcosystemAPI(BaseInterfaceModel):
         data: Dict[str, Any] = {"name": str(network_name)}
 
         # Only add isDefault key when True
-        if network_name == self.default_network.name:
+        if network_name == self.default_network_name:
             data["isDefault"] = True
 
         data["providers"] = []
@@ -504,7 +504,7 @@ class EcosystemAPI(BaseInterfaceModel):
             provider_data: Dict = {"name": str(provider_name)}
 
             # Only add isDefault key when True
-            if provider_name == network.default_provider:
+            if provider_name == network.default_provider_name:
                 provider_data["isDefault"] = True
 
             data["providers"].append(provider_data)
@@ -1023,7 +1023,7 @@ class NetworkAPI(BaseInterfaceModel):
 
     @property
     def default_provider(self) -> Optional["ProviderAPI"]:
-        if name := self.default_provider_name:
+        if (name := self.default_provider_name) and name in self.providers:
             return self.get_provider(name)
 
         return None

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -94,7 +94,7 @@ class EcosystemAPI(BaseInterfaceModel):
         return f"<{self.name}>"
 
     @cached_property
-    def adhoc_network(self) -> "NetworkAPI":
+    def custom_network(self) -> "NetworkAPI":
         ethereum_class = None
         for plugin_name, ecosystem_class in self.plugin_manager.ecosystems:
             if plugin_name == "ethereum":
@@ -109,7 +109,7 @@ class EcosystemAPI(BaseInterfaceModel):
         init_kwargs = {"data_folder": data_folder, "request_header": request_header}
         ethereum = ethereum_class(**init_kwargs)  # type: ignore
         return NetworkAPI(
-            name="adhoc",
+            name="custom",
             ecosystem=ethereum,
             data_folder=Path(data_folder),
             request_header=request_header,
@@ -463,8 +463,8 @@ class EcosystemAPI(BaseInterfaceModel):
         if name in self.networks:
             return self.networks[name]
 
-        elif name == "adhoc":
-            return self.adhoc_network
+        elif name == "custom":
+            return self.custom_network
 
         raise NetworkNotFoundError(network_name, ecosystem=self.name, options=self.networks)
 
@@ -886,8 +886,8 @@ class NetworkAPI(BaseInterfaceModel):
             ecosystem_name, network_name, provider_class = plugin_tuple
             provider_name = clean_plugin_name(provider_class.__module__.split(".")[0])
 
-            # NOTE: Adhoc networks work with any provider.
-            if self.name == "adhoc" or (
+            # NOTE: Custom networks work with any provider.
+            if self.name == "custom" or (
                 self.ecosystem.name == ecosystem_name and self.name == network_name
             ):
                 # NOTE: Lazily load provider config
@@ -1122,7 +1122,7 @@ class NetworkAPI(BaseInterfaceModel):
               not local or adhoc and has a different hardcoded chain ID than
               the given one.
         """
-        if self.name not in ("adhoc", LOCAL_NETWORK_NAME) and self.chain_id != chain_id:
+        if self.name not in ("custom", LOCAL_NETWORK_NAME) and self.chain_id != chain_id:
             raise NetworkMismatchError(chain_id, self)
 
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -6,6 +6,7 @@ import platform
 import shutil
 import sys
 import time
+import warnings
 from logging import FileHandler, Formatter, Logger, getLogger
 from pathlib import Path
 from signal import SIGINT, SIGTERM, signal
@@ -234,6 +235,13 @@ class ProviderAPI(BaseInterfaceModel):
         The connected network choice string.
         """
         return f"{self.network.choice}:{self.name}"
+
+    def get_storage_at(self, *args, **kwargs) -> HexBytes:
+        warnings.warn(
+            "'provider.get_storage_at()' is deprecated. Use 'provider.get_storage()'.",
+            DeprecationWarning,
+        )
+        return self.get_storage(*args, **kwargs)
 
     @raises_not_implemented
     def get_storage(  # type: ignore[empty-body]

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -233,6 +233,9 @@ class ProviderAPI(BaseInterfaceModel):
         """
         The connected network choice string.
         """
+        if self.network.name == "adhoc" and hasattr(self, "uri"):
+            return self.uri
+
         return f"{self.network.choice}:{self.name}"
 
     @raises_not_implemented

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -233,8 +233,8 @@ class ProviderAPI(BaseInterfaceModel):
         """
         The connected network choice string.
         """
-        if self.network.name == "adhoc" and hasattr(self, "uri"):
-            return self.uri
+        if self.network.name == "adhoc" and self.http_uri:
+            return self.http_uri
 
         return f"{self.network.choice}:{self.name}"
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -233,9 +233,6 @@ class ProviderAPI(BaseInterfaceModel):
         """
         The connected network choice string.
         """
-        if self.network.name == "adhoc" and self.http_uri:
-            return self.http_uri
-
         return f"{self.network.choice}:{self.name}"
 
     @raises_not_implemented

--- a/src/ape/cli/__init__.py
+++ b/src/ape/cli/__init__.py
@@ -12,9 +12,10 @@ from ape.cli.choices import (
     output_format_choice,
     select_account,
 )
-from ape.cli.commands import ConnectedProviderCommand
+from ape.cli.commands import ConnectedProviderCommand, NetworkBoundCommand
 from ape.cli.options import (
     ApeCliContextObject,
+    NetworkOption,
     account_option,
     ape_cli_context,
     contract_option,
@@ -33,20 +34,22 @@ __all__ = [
     "AllFilePaths",
     "ape_cli_context",
     "ApeCliContextObject",
+    "ConnectedProviderCommand",
     "contract_file_paths_argument",
     "contract_option",
     "existing_alias_argument",
-    "select_account",
     "incompatible_with",
     "network_option",
-    "ConnectedProviderCommand",
+    "NetworkBoundCommand",
     "NetworkChoice",
+    "NetworkOption",
     "non_existing_alias_argument",
     "output_format_choice",
     "output_format_option",
     "OutputFormat",
     "Path",
     "PromptChoice",
+    "select_account",
     "skip_confirmation_option",
     "verbosity_option",
 ]

--- a/src/ape/cli/__init__.py
+++ b/src/ape/cli/__init__.py
@@ -12,7 +12,7 @@ from ape.cli.choices import (
     output_format_choice,
     select_account,
 )
-from ape.cli.commands import NetworkBoundCommand
+from ape.cli.commands import ConnectedProviderCommand
 from ape.cli.options import (
     ApeCliContextObject,
     account_option,
@@ -39,7 +39,7 @@ __all__ = [
     "select_account",
     "incompatible_with",
     "network_option",
-    "NetworkBoundCommand",
+    "ConnectedProviderCommand",
     "NetworkChoice",
     "non_existing_alias_argument",
     "output_format_choice",

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from enum import Enum
 from functools import lru_cache
 from typing import Any, Callable, Iterator, List, Optional, Sequence, Type, Union
@@ -136,6 +137,18 @@ class PromptChoice(click.ParamType):
             return self.choices[choice_idx]
 
         raise IndexError(f"Choice index '{choice_idx}' out of range.")
+
+
+def get_user_selected_account(
+    prompt_message: Optional[str] = None, account_type: _ACCOUNT_TYPE_FILTER = None
+) -> AccountAPI:
+    """
+    **DEPRECATED**: Use :meth:`~ape.cli.choices.select_account` instead.
+    """
+    warnings.warn(
+        "'get_user_selected_account' is deprecated. Use 'select_account'.", DeprecationWarning
+    )
+    return select_account(prompt_message=prompt_message, key=account_type)
 
 
 def select_account(

--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -51,7 +51,7 @@ class ConnectedProviderCommand(click.Command):
         if param is not None and isinstance(param, ProviderAPI):
             provider = param
             network_context = provider.network.use_provider(
-                provider.name, disconnect_on_exit=not interactive
+                provider, disconnect_on_exit=not interactive
             )
         elif param is not None and isinstance(param, str):
             network_context = networks.parse_network_choice(param)
@@ -87,6 +87,7 @@ class ConnectedProviderCommand(click.Command):
 
                 elif isinstance(param, ProviderAPI):
                     provider = param
+
                 elif isinstance(param, str):
                     # Is a choice str
                     provider = networks.parse_network_choice(param)._provider

--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -70,7 +70,7 @@ class ConnectedProviderCommand(click.Command):
                     provider = param
                 elif isinstance(param, str):
                     # Is a choice str
-                    provider = provider = networks.parse_network_choice(provider)._provider
+                    provider = networks.parse_network_choice(param)._provider
                 else:
                     raise TypeError(f"Can't handle type of parameter '{param}'.")
 

--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -65,7 +65,14 @@ class ConnectedProviderCommand(click.Command):
                 callback_args = [x.name for x in signature.parameters.values()]
 
                 opt_name = "network"
-                provider = ctx.params.pop(opt_name)
+                param = ctx.params.pop(opt_name)
+                if isinstance(param, ProviderAPI):
+                    provider = param
+                elif isinstance(param, str):
+                    # Is a choice str
+                    provider = provider = networks.parse_network_choice(provider)._provider
+                else:
+                    raise TypeError(f"Can't handle type of parameter '{param}'.")
 
                 if "ecosystem" in callback_args:
                     ctx.params["ecosystem"] = provider.network.ecosystem

--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -1,29 +1,63 @@
-from typing import Any
+import inspect
+from typing import Any, List
 
 import click
 from click import Context
 
 from ape import networks
+from ape.api import ProviderAPI
 
 
 def check_parents_for_interactive(ctx: Context) -> bool:
     interactive: bool = ctx.params.get("interactive", False)
     if interactive:
         return True
+
     # If not found, check the parent context.
     if interactive is None and ctx.parent:
         return check_parents_for_interactive(ctx.parent)
+
     return False
 
 
-class NetworkBoundCommand(click.Command):
+class ConnectedProviderCommand(click.Command):
     """
     A command that uses the :meth:`~ape.cli.options.network_option`.
     It will automatically set the network for the duration of the command execution.
     """
 
+    def parse_args(self, ctx: Context, args: List[str]) -> List[str]:
+        if not any(
+            isinstance(param, click.core.Option) and param.name == "network"
+            for param in self.params
+        ):
+            from ape.cli.options import NetworkOption
+
+            option = NetworkOption()
+            self.params.append(option)
+
+        return super().parse_args(ctx, args)
+
     def invoke(self, ctx: Context) -> Any:
-        value = ctx.params.get("network") or networks.default_ecosystem.name
+        default = networks.default_ecosystem.default_network.default_provider
+        param = ctx.params.get("network")
+        provider: ProviderAPI = param or default  # type: ignore
         interactive = check_parents_for_interactive(ctx)
-        with networks.parse_network_choice(value, disconnect_on_exit=not interactive):
-            super().invoke(ctx)
+        with provider.network.use_provider(provider.name, disconnect_on_exit=not interactive):
+            if self.callback is not None:
+                signature = inspect.signature(self.callback)
+                callback_args = [x.name for x in signature.parameters.values()]
+
+                opt_name = "network"
+                provider = ctx.params.pop(opt_name)
+
+                if "ecosystem" in callback_args:
+                    ctx.params["ecosystem"] = provider.network.ecosystem
+                if "network" in callback_args:
+                    ctx.params["network"] = provider.network
+                if "provider" in callback_args:
+                    ctx.params["provider"] = provider
+
+                # If none of he above, the user doesn't use any network value.
+
+                return ctx.invoke(self.callback, **ctx.params)

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -8,6 +8,7 @@ from click import Option
 from ethpm_types import ContractType
 
 from ape import networks, project
+from ape.api import ProviderAPI
 from ape.cli.choices import (
     _ACCOUNT_TYPE_FILTER,
     AccountAliasPromptChoice,
@@ -116,12 +117,17 @@ class NetworkOption(Option):
         network = kwargs.pop("network", None)
         provider = kwargs.pop("provider", None)
         default = kwargs.pop("default", "auto")
+        base_type = kwargs.pop("base_type", ProviderAPI)
 
         # NOTE: If using network_option, this part is skipped
         #  because parsing happens earlier to handle advanced usage.
         if "type" not in kwargs:
             kwargs["type"] = NetworkChoice(
-                case_sensitive=False, ecosystem=ecosystem, network=network, provider=provider
+                case_sensitive=False,
+                ecosystem=ecosystem,
+                network=network,
+                provider=provider,
+                base_type=base_type,
             )
         auto = default == "auto"
         required = kwargs.get("required", False)

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -204,7 +204,7 @@ def network_option(
 
         if network_choice in ("None", "none"):
             # Specified None in cmd line- ignore.
-            # Or is an adhoc value.
+            # Or is a custom value.
             choice_classes = None
 
         elif network_choice is None:

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -160,7 +160,7 @@ class NetworkManager(BaseManager):
         provider_name: Optional[str] = None,
     ) -> ProviderAPI:
         """
-        Create an ad-hoc connection to a URI using the GethProvider core plugin.
+        Create a custom connection to a URI using the EthereumNodeProvider provider.
         **NOTE**: This provider will assume EVM-like behavior and this is generally not recommended.
         Use plugins when possible!
 
@@ -176,7 +176,7 @@ class NetworkManager(BaseManager):
               implementation that comes with Ape.
         """
 
-        network = self.ethereum.adhoc_network
+        network = self.ethereum.custom_network
 
         if provider_name is None:
             if issubclass(provider_cls, EthereumNodeProvider):
@@ -407,8 +407,8 @@ class NetworkManager(BaseManager):
             selections = selections[:3]
 
             if provider_value.startswith("https://") or provider_value.startswith("https://"):
-                # Network must be adhoc when using a URI.
-                selections[1] = "adhoc"
+                # Network must be 'custom' when using a URI.
+                selections[1] = "custom"
 
         if selections == network_choice or len(selections) == 1:
             # Either split didn't work (in which case it matches the start)

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -407,8 +407,7 @@ class NetworkManager(BaseManager):
             selections = selections[:3]
 
             if provider_value.startswith("https://") or provider_value.startswith("https://"):
-                # Network must be 'custom' when using a URI.
-                selections[1] = "custom"
+                selections[1] = selections[1] or "custom"
 
         if selections == network_choice or len(selections) == 1:
             # Either split didn't work (in which case it matches the start)

--- a/src/ape_cache/_cli.py
+++ b/src/ape_cache/_cli.py
@@ -1,8 +1,7 @@
 import click
 import pandas as pd
 
-from ape import networks
-from ape.cli import NetworkBoundCommand, network_option
+from ape.cli import ConnectedProviderCommand, network_option
 from ape.logging import logger
 from ape.utils import ManagerAccessMixin
 
@@ -20,7 +19,7 @@ def cli():
 
 @cli.command(short_help="Initialize a new cache database")
 @network_option(required=True)
-def init(network):
+def init(ecosystem, network):
     """
     Initializes an SQLite database and creates a file to store data
     from the provider.
@@ -29,21 +28,16 @@ def init(network):
     give an ecosystem name and a network name to initialize the database.
     """
 
-    provider = networks.get_provider_from_choice(network)
-    ecosystem_name = provider.network.ecosystem.name
-    network_name = provider.network.name
-
-    get_engine().init_database(ecosystem_name, network_name)
-    logger.success(f"Caching database initialized for {ecosystem_name}:{network_name}.")
+    get_engine().init_database(ecosystem.name, network.name)
+    logger.success(f"Caching database initialized for {ecosystem.name}:{network.name}.")
 
 
 @cli.command(
-    cls=NetworkBoundCommand,
+    cls=ConnectedProviderCommand,
     short_help="Call and print SQL statement to the cache database",
 )
-@network_option()
 @click.argument("query_str")
-def query(query_str, network):
+def query(query_str):
     """
     Allows for a query of the database from an SQL statement.
 
@@ -62,7 +56,7 @@ def query(query_str, network):
 
 @cli.command(short_help="Purges entire database")
 @network_option(required=True)
-def purge(network):
+def purge(ecosystem, network):
     """
     Purges data from the selected database instance.
 
@@ -74,9 +68,7 @@ def purge(network):
     purge the database of choice.
     """
 
-    provider = networks.get_provider_from_choice(network)
-    ecosystem_name = provider.network.ecosystem.name
-    network_name = provider.network.name
-
+    ecosystem_name = network.ecosystem.name
+    network_name = network.name
     get_engine().purge_database(ecosystem_name, network_name)
     logger.success(f"Caching database purged for {ecosystem_name}:{network_name}.")

--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -14,7 +14,7 @@ from IPython.terminal.ipapp import Config as IPythonConfig
 
 from ape import config
 from ape import project as default_project
-from ape.cli import NetworkBoundCommand, ape_cli_context, network_option
+from ape.cli import ConnectedProviderCommand, ape_cli_context
 from ape.utils.misc import _python_version
 from ape.version import version as ape_version
 from ape_console.config import ConsoleConfig
@@ -23,13 +23,12 @@ CONSOLE_EXTRAS_FILENAME = "ape_console_extras.py"
 
 
 @click.command(
-    cls=NetworkBoundCommand,
+    cls=ConnectedProviderCommand,
     short_help="Load the console",
     context_settings=dict(ignore_unknown_options=True),
 )
-@network_option()
 @ape_cli_context()
-def cli(cli_ctx, network):
+def cli(cli_ctx):
     """Opens a console for the local project."""
     verbose = cli_ctx.logger.level == logging.DEBUG
     return console(verbose=verbose)

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -214,7 +214,7 @@ class Ethereum(EcosystemAPI):
 
     @property
     def default_transaction_type(self) -> TransactionType:
-        network = self.default_network.replace("-", "_")
+        network = self.default_network_name.replace("-", "_")
         return self.config[network].default_transaction_type
 
     @classmethod

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -257,7 +257,7 @@ class Web3Provider(ProviderAPI, ABC):
         if (
             self.network.name
             not in (
-                "adhoc",
+                "custom",
                 LOCAL_NETWORK_NAME,
             )
             and not self.network.is_fork

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -994,7 +994,12 @@ class Web3Provider(ProviderAPI, ABC):
                 elif txn:
                     err_trace = self.provider.get_transaction_trace(txn.txn_hash.hex())
 
-                trace_ls: List[TraceFrame] = list(err_trace) if err_trace else []
+                try:
+                    trace_ls: List[TraceFrame] = list(err_trace) if err_trace else []
+                except Exception as err:
+                    logger.error(f"Failed getting traceback: {err}")
+                    trace_ls = []
+
                 data = trace_ls[-1].raw if len(trace_ls) > 0 else {}
                 memory = data.get("memory", [])
                 return_value = "".join([x[2:] for x in memory[4:]])

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1,21 +1,42 @@
+import os
+import sys
 import time
 from abc import ABC
 from concurrent.futures import ThreadPoolExecutor
 from copy import copy
 from functools import cached_property
 from itertools import tee
+from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Union, cast
 
+import ijson  # type: ignore
+import requests
 from eth_pydantic_types import HexBytes
 from eth_typing import BlockNumber, HexStr
 from eth_utils import add_0x_prefix, to_hex
 from ethpm_types import EventABI
 from evm_trace import CallTreeNode as EvmCallTreeNode
+from evm_trace import ParityTraceList
 from evm_trace import TraceFrame as EvmTraceFrame
+from evm_trace import (
+    create_trace_frames,
+    get_calltree_from_geth_call_trace,
+    get_calltree_from_parity_trace,
+)
 from pydantic.dataclasses import dataclass
-from web3 import Web3
+from web3 import HTTPProvider, IPCProvider, Web3
 from web3.exceptions import ContractLogicError as Web3ContractLogicError
-from web3.exceptions import MethodUnavailable, TimeExhausted, TransactionNotFound
+from web3.exceptions import (
+    ExtraDataLengthError,
+    MethodUnavailable,
+    TimeExhausted,
+    TransactionNotFound,
+)
+from web3.gas_strategies.rpc import rpc_gas_price_strategy
+from web3.middleware import geth_poa_middleware
+from web3.middleware.validation import MAX_EXTRADATA_LENGTH
+from web3.providers import AutoProvider
+from web3.providers.auto import load_provider_from_environment
 from web3.types import RPCEndpoint, TxParams
 
 from ape.api import BlockAPI, ProviderAPI, ReceiptAPI, TransactionAPI
@@ -25,6 +46,7 @@ from ape.exceptions import (
     APINotImplementedError,
     BlockNotFoundError,
     ContractLogicError,
+    ContractNotFoundError,
     OutOfGasError,
     ProviderError,
     ProviderNotConnectedError,
@@ -46,6 +68,10 @@ from ape.types import (
 )
 from ape.utils import gas_estimation_error_message, run_until_complete, to_int
 from ape.utils.misc import DEFAULT_MAX_RETRIES_TX
+
+DEFAULT_PORT = 8545
+DEFAULT_HOSTNAME = "localhost"
+DEFAULT_SETTINGS = {"uri": f"http://{DEFAULT_HOSTNAME}:{DEFAULT_PORT}"}
 
 
 def _sanitize_web3_url(msg: str) -> str:
@@ -1022,3 +1048,271 @@ class Web3Provider(ProviderAPI, ABC):
             )
         )
         return self.compiler_manager.enrich_error(result)
+
+
+class EthereumNodeProvider(Web3Provider, ABC):
+    # optimal values for geth
+    block_page_size: int = 5000
+    concurrency: int = 16
+
+    name: str = "geth"
+
+    """Is ``None`` until known."""
+    can_use_parity_traces: Optional[bool] = None
+
+    @property
+    def uri(self) -> str:
+        if "uri" in self.provider_settings:
+            # Use adhoc, scripted value
+            return self.provider_settings["uri"]
+
+        config = self.config.model_dump(mode="json").get(self.network.ecosystem.name, None)
+        if config is None:
+            return DEFAULT_SETTINGS["uri"]
+
+        # Use value from config file
+        network_config = config.get(self.network.name) or DEFAULT_SETTINGS
+        return network_config.get("uri", DEFAULT_SETTINGS["uri"])
+
+    @property
+    def connection_str(self) -> str:
+        return self.uri
+
+    @property
+    def connection_id(self) -> Optional[str]:
+        return f"{self.network_choice}:{self.uri}"
+
+    @property
+    def _clean_uri(self) -> str:
+        return sanitize_url(self.uri)
+
+    @property
+    def ipc_path(self) -> Path:
+        return self.settings.ipc_path or self.data_dir / "geth.ipc"
+
+    @property
+    def data_dir(self) -> Path:
+        if self.settings.data_dir:
+            return self.settings.data_dir.expanduser()
+
+        return _get_default_data_dir()
+
+    @cached_property
+    def _ots_api_level(self) -> Optional[int]:
+        # NOTE: Returns None when OTS namespace is not enabled.
+        try:
+            result = self._make_request("ots_getApiLevel")
+        except (NotImplementedError, ApeException, ValueError):
+            return None
+
+        if isinstance(result, int):
+            return result
+
+        elif isinstance(result, str) and result.isnumeric():
+            return int(result)
+
+        return None
+
+    def _set_web3(self):
+        # Clear cached version when connecting to another URI.
+        self._client_version = None  # type: ignore
+        self._web3 = _create_web3(self.uri, ipc_path=self.ipc_path)
+
+    def _complete_connect(self):
+        client_version = self.client_version.lower()
+        if "geth" in client_version:
+            self._log_connection("Geth")
+        elif "reth" in client_version:
+            self._log_connection("Reth")
+        elif "erigon" in client_version:
+            self._log_connection("Erigon")
+            self.concurrency = 8
+            self.block_page_size = 40_000
+        elif "nethermind" in client_version:
+            self._log_connection("Nethermind")
+            self.concurrency = 32
+            self.block_page_size = 50_000
+        else:
+            client_name = client_version.split("/")[0]
+            logger.warning(f"Connecting Geth plugin to non-Geth client '{client_name}'.")
+            logger.warning(f"Connecting Geth plugin to non-Geth client '{client_name}'.")
+
+        self.web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
+
+        # Check for chain errors, including syncing
+        try:
+            chain_id = self.web3.eth.chain_id
+        except ValueError as err:
+            raise ProviderError(
+                err.args[0].get("message")
+                if all((hasattr(err, "args"), err.args, isinstance(err.args[0], dict)))
+                else "Error getting chain id."
+            )
+
+        try:
+            block = self.web3.eth.get_block("latest")
+        except ExtraDataLengthError:
+            is_likely_poa = True
+        else:
+            is_likely_poa = (
+                "proofOfAuthorityData" in block
+                or len(block.get("extraData", "")) > MAX_EXTRADATA_LENGTH
+            )
+
+        if is_likely_poa and geth_poa_middleware not in self.web3.middleware_onion:
+            self.web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+
+        self.network.verify_chain_id(chain_id)
+
+    def disconnect(self):
+        self.can_use_parity_traces = None
+        self._web3 = None  # type: ignore
+        self._client_version = None  # type: ignore
+
+    def get_transaction_trace(self, txn_hash: str) -> Iterator[TraceFrame]:
+        frames = self._stream_request(
+            "debug_traceTransaction", [txn_hash, {"enableMemory": True}], "result.structLogs.item"
+        )
+        for frame in create_trace_frames(frames):
+            yield self._create_trace_frame(frame)
+
+    def _get_transaction_trace_using_call_tracer(self, txn_hash: str) -> Dict:
+        return self._make_request(
+            "debug_traceTransaction", [txn_hash, {"enableMemory": True, "tracer": "callTracer"}]
+        )
+
+    def get_call_tree(self, txn_hash: str) -> CallTreeNode:
+        if self.can_use_parity_traces is True:
+            return self._get_parity_call_tree(txn_hash)
+
+        elif self.can_use_parity_traces is False:
+            return self._get_geth_call_tree(txn_hash)
+
+        elif "erigon" in self.client_version.lower():
+            tree = self._get_parity_call_tree(txn_hash)
+            self.can_use_parity_traces = True
+            return tree
+
+        try:
+            # Try the Parity traces first, in case node client supports it.
+            tree = self._get_parity_call_tree(txn_hash)
+        except (ValueError, APINotImplementedError, ProviderError):
+            self.can_use_parity_traces = False
+            return self._get_geth_call_tree(txn_hash)
+
+        # Parity style works.
+        self.can_use_parity_traces = True
+        return tree
+
+    def _get_parity_call_tree(self, txn_hash: str) -> CallTreeNode:
+        result = self._make_request("trace_transaction", [txn_hash])
+        if not result:
+            raise ProviderError(f"Failed to get trace for '{txn_hash}'.")
+
+        traces = ParityTraceList.model_validate(result)
+        evm_call = get_calltree_from_parity_trace(traces)
+        return self._create_call_tree_node(evm_call, txn_hash=txn_hash)
+
+    def _get_geth_call_tree(self, txn_hash: str) -> CallTreeNode:
+        calls = self._get_transaction_trace_using_call_tracer(txn_hash)
+        evm_call = get_calltree_from_geth_call_trace(calls)
+        return self._create_call_tree_node(evm_call, txn_hash=txn_hash)
+
+    def _log_connection(self, client_name: str):
+        msg = f"Connecting to existing {client_name.strip()} node at"
+        suffix = (
+            self.ipc_path.as_posix().replace(Path.home().as_posix(), "$HOME")
+            if self.ipc_path.exists()
+            else self._clean_uri
+        )
+        logger.info(f"{msg} {suffix}.")
+
+    def ots_get_contract_creator(self, address: AddressType) -> Optional[Dict]:
+        if self._ots_api_level is None:
+            return None
+
+        result = self._make_request("ots_getContractCreator", [address])
+        if result is None:
+            # NOTE: Skip the explorer part of the error message via `has_explorer=True`.
+            raise ContractNotFoundError(address, has_explorer=True, provider_name=self.name)
+
+        return result
+
+    def _get_contract_creation_receipt(self, address: AddressType) -> Optional[ReceiptAPI]:
+        if result := self.ots_get_contract_creator(address):
+            tx_hash = result["hash"]
+            return self.get_receipt(tx_hash)
+
+        return None
+
+    def _make_request(self, endpoint: str, parameters: Optional[List] = None) -> Any:
+        parameters = parameters or []
+        try:
+            return super()._make_request(endpoint, parameters)
+        except ProviderError as err:
+            if "does not exist/is not available" in str(err):
+                raise APINotImplementedError(
+                    f"RPC method '{endpoint}' is not implemented by this node instance."
+                ) from err
+
+            raise  # Original error
+
+    def _stream_request(self, method: str, params: List, iter_path="result.item"):
+        payload = {"jsonrpc": "2.0", "id": 1, "method": method, "params": params}
+        results = ijson.sendable_list()
+        coroutine = ijson.items_coro(results, iter_path)
+        resp = requests.post(self.uri, json=payload, stream=True)
+        resp.raise_for_status()
+
+        for chunk in resp.iter_content(chunk_size=2**17):
+            coroutine.send(chunk)
+            yield from results
+            del results[:]
+
+    def connect(self):
+        self._set_web3()
+        if not self.is_connected:
+            raise ProviderError(f"No node found on '{self._clean_uri}'.")
+
+        self._complete_connect()
+
+
+def _create_web3(uri: str, ipc_path: Optional[Path] = None):
+    # Separated into helper method for testing purposes.
+    def http_provider():
+        return HTTPProvider(uri, request_kwargs={"timeout": 30 * 60})
+
+    def ipc_provider():
+        # NOTE: This mypy complaint seems incorrect.
+        if not (path := ipc_path):
+            raise ValueError("IPC Path required.")
+
+        return IPCProvider(ipc_path=path)
+
+    # NOTE: This tuple is ordered by try-attempt.
+    # Try ENV, then IPC, and then HTTP last.
+    providers = (
+        load_provider_from_environment,
+        ipc_provider,
+        http_provider,
+    )
+    provider = AutoProvider(potential_providers=providers)
+    return Web3(provider)
+
+
+def _get_default_data_dir() -> Path:
+    # Modified from web3.py package to always return IPC even when none exist.
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Ethereum"
+
+    elif sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
+        return Path.home() / "ethereum"
+
+    elif sys.platform == "win32":
+        return Path(os.path.join("\\\\", ".", "pipe"))
+
+    else:
+        raise ValueError(
+            f"Unsupported platform '{sys.platform}'.  Only darwin/linux/win32/"
+            "freebsd are supported.  You must specify the data_dir."
+        )

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -454,7 +454,6 @@ class BaseGethProvider(Web3Provider, ABC):
         payload = {"jsonrpc": "2.0", "id": 1, "method": method, "params": params}
         results = ijson.sendable_list()
         coroutine = ijson.items_coro(results, iter_path)
-
         resp = requests.post(self.uri, json=payload, stream=True)
         resp.raise_for_status()
 

--- a/src/ape_geth/query.py
+++ b/src/ape_geth/query.py
@@ -4,7 +4,7 @@ from typing import Iterator, Optional
 from ape.api import ReceiptAPI
 from ape.api.query import ContractCreationQuery, QueryAPI, QueryType
 from ape.exceptions import QueryEngineError
-from ape_geth.provider import BaseGethProvider
+from ape_ethereum.provider import EthereumNodeProvider
 
 
 class OTSQueryEngine(QueryAPI):
@@ -21,7 +21,7 @@ class OTSQueryEngine(QueryAPI):
     @estimate_query.register
     def estimate_contract_creation_query(self, query: ContractCreationQuery) -> Optional[int]:
         if provider := self.network_manager.active_provider:
-            if not isinstance(provider, BaseGethProvider):
+            if not isinstance(provider, EthereumNodeProvider):
                 return None
             elif uri := provider.http_uri:
                 return 225 if uri.startswith("http://") else 600
@@ -30,6 +30,6 @@ class OTSQueryEngine(QueryAPI):
 
     @perform_query.register
     def get_contract_creation_receipt(self, query: ContractCreationQuery) -> Iterator[ReceiptAPI]:
-        if self.network_manager.active_provider and isinstance(self.provider, BaseGethProvider):
+        if self.network_manager.active_provider and isinstance(self.provider, EthereumNodeProvider):
             if receipt := self.provider._get_contract_creation_receipt(query.contract):
                 yield receipt

--- a/src/ape_networks/_cli.py
+++ b/src/ape_networks/_cli.py
@@ -105,16 +105,13 @@ def _list(cli_ctx, output_format, ecosystem_filter, network_filter, provider_fil
 @cli.command()
 @ape_cli_context()
 @network_option(default="ethereum:local:geth")
-def run(cli_ctx, network):
+def run(cli_ctx, provider):
     """
     Start a node process
     """
-
     # Ignore extra loggers, such as web3 loggers.
     cli_ctx.logger._extra_loggers = {}
 
-    network_ctx = cli_ctx.network_manager.parse_network_choice(network)
-    provider = network_ctx._provider
     if not isinstance(provider, SubprocessProvider):
         cli_ctx.abort(
             f"`ape networks run` requires a provider that manages a process, not '{provider.name}'."

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -11,7 +11,7 @@ import click
 from click import Command, Context, Option
 
 from ape import networks, project
-from ape.cli import NetworkBoundCommand, network_option, verbosity_option
+from ape.cli import ConnectedProviderCommand, verbosity_option
 from ape.cli.options import _VERBOSITY_VALUES, _create_verbosity_kwargs
 from ape.exceptions import ApeException, handle_ape_exception
 from ape.logging import logger
@@ -134,11 +134,10 @@ class ScriptCommand(click.MultiCommand):
             logger.debug(f"Found 'main' method in script: {relative_filepath}")
 
             @click.command(
-                cls=NetworkBoundCommand,
+                cls=ConnectedProviderCommand,
                 short_help=f"Run '{relative_filepath}:main'",
                 name=relative_filepath.stem,
             )
-            @network_option()
             @verbosity_option()
             def call(network):
                 _ = network  # Downstream might use this
@@ -154,13 +153,11 @@ class ScriptCommand(click.MultiCommand):
             logger.warning(f"No 'main' method or 'cli' command in script: {relative_filepath}")
 
             @click.command(
-                cls=NetworkBoundCommand,
+                cls=ConnectedProviderCommand,
                 short_help=f"Run '{relative_filepath}:main'",
                 name=relative_filepath.stem,
             )
-            @network_option()
-            def call(network):
-                _ = network  # Downstream might use this
+            def call():
                 with use_scripts_sys_path(filepath.parent.parent):
                     empty_ns = run_script_module(filepath)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -511,3 +511,8 @@ class SubprocessResult:
     @property
     def output(self) -> str:
         return self._completed_process.stdout
+
+
+@pytest.fixture
+def mock_sys_argv(mocker):
+    return mocker.patch("ape.cli.options._get_sys_argv")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,9 +183,18 @@ def temp_accounts_path(config):
         shutil.rmtree(path)
 
 
-@pytest.fixture(scope="session")
-def runner():
-    yield CliRunner()
+@pytest.fixture
+def runner(mock_sys_argv):
+    class ApeRunner(CliRunner):
+        def invoke(self, *args, **kwargs):
+            # Also make the command appear in sys.argv
+            mock_sys_argv.return_value = ("ape", *(args[1] if len(args) > 1 else []))
+            try:
+                return super().invoke(*args, **kwargs)
+            finally:
+                mock_sys_argv.return_value = sys.argv
+
+    yield ApeRunner()
 
 
 @pytest.fixture

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -88,7 +88,7 @@ def test_connect_wrong_chain_id(mocker, ethereum, geth_provider):
         geth_provider.network = ethereum.get_network("goerli")
 
         # Ensure when reconnecting, it does not use HTTP
-        factory = mocker.patch("ape_geth.provider._create_web3")
+        factory = mocker.patch("ape_ethereum.provider._create_web3")
         factory.return_value = geth_provider._web3
         expected_error_message = (
             f"Provider connected to chain ID '{geth_provider._web3.eth.chain_id}', "

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -202,12 +202,20 @@ def test_network_option_unknown(network_cmd):
         "https://foo.bar:8000",
     ),
 )
-def test_network_option_uri(runner, network_cmd, network_input):
+def test_network_option_custom_uri(runner, network_cmd, network_input):
     network_part = ("--network", network_input)
     cmd = network_cmd(network_part)
     result = runner.invoke(cmd, network_part)
     assert result.exit_code == 0, result.output
     assert "custom" in result.output
+
+
+def test_network_option_existing_network_with_custom_uri(runner, network_cmd):
+    network_part = ("--network", "ethereum:sepolia:https://foo.bar:8000")
+    cmd = network_cmd(network_part)
+    result = runner.invoke(cmd, network_part)
+    assert result.exit_code == 0, result.output
+    assert "sepolia" in result.output
 
 
 def test_network_option_make_required(runner):

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -191,23 +191,23 @@ def test_network_option_unknown(network_cmd):
 @pytest.mark.parametrize(
     "network_input",
     (
-        "ethereum:adhoc:https://127.0.0.1:4545",
-        "ethereum:adhoc:https://127.0.0.1",
-        "ethereum:adhoc:http://127.0.0.1:4545",
-        "ethereum:adhoc:http://127.0.0.1",
-        "ethereum:adhoc:http://foo.bar",
-        "ethereum:adhoc:https://foo.bar:8000",
-        ":adhoc:https://foo.bar:8000",
+        "ethereum:custom:https://127.0.0.1:4545",
+        "ethereum:custom:https://127.0.0.1",
+        "ethereum:custom:http://127.0.0.1:4545",
+        "ethereum:custom:http://127.0.0.1",
+        "ethereum:custom:http://foo.bar",
+        "ethereum:custom:https://foo.bar:8000",
+        ":custom:https://foo.bar:8000",
         "::https://foo.bar:8000",
         "https://foo.bar:8000",
     ),
 )
-def test_network_option_adhoc(runner, network_cmd, network_input):
+def test_network_option_uri(runner, network_cmd, network_input):
     network_part = ("--network", network_input)
     cmd = network_cmd(network_part)
     result = runner.invoke(cmd, network_part)
     assert result.exit_code == 0, result.output
-    assert "adhoc" in result.output
+    assert "custom" in result.output
 
 
 def test_network_option_make_required(runner):

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -18,7 +18,6 @@ from ape.cli import (
 )
 from ape.exceptions import AccountsError, EcosystemNotFoundError
 from ape.logging import logger
-from tests.conftest import geth_process_test
 
 OUTPUT_FORMAT = "__TEST__{0}:{1}:{2}_"
 
@@ -106,11 +105,6 @@ def one_account(accounts, empty_data_folder, temp_config, test_accounts):
         yield test_accounts[0]
 
     _teardown_numb_acct_change(accounts)
-
-
-@pytest.fixture
-def mock_sys_argv(mocker):
-    return mocker.patch("ape.cli.options._get_sys_argv")
 
 
 def get_expected_account_str(acct):
@@ -452,12 +446,11 @@ def test_connected_provider_use_ecosystem_network_and_provider(runner):
     assert "ethereum:local:test" in result.output, result.output
 
 
-@geth_process_test
 def test_connected_provider_use_ecosystem_network_and_provider_with_network_specified(runner):
     @click.command(cls=ConnectedProviderCommand)
     def cmd(ecosystem, network, provider):
         click.echo(f"{ecosystem.name}:{network.name}:{provider.name}")
 
-    result = runner.invoke(cmd, ["--network", "ethereum:local:geth"])
+    result = runner.invoke(cmd, ["--network", "ethereum:local:test"])
     assert result.exit_code == 0
-    assert "ethereum:local:geth" in result.output, result.output
+    assert "ethereum:local:test" in result.output, result.output

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -318,7 +318,7 @@ def test_configure_default_txn_type(temp_config, ethereum):
 
     with temp_config(config_dict):
         ethereum._default_network = "mainnet-fork"
-        assert ethereum.default_network == "mainnet-fork"
+        assert ethereum.default_network_name == "mainnet-fork"
         assert ethereum.default_transaction_type == TransactionType.STATIC
         ethereum._default_network = LOCAL_NETWORK_NAME
 

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -152,7 +152,7 @@ def test_get_provider_from_choice_custom_provider(networks_connected_to_tester):
     assert uri in provider.connection_id
     assert provider.name == "geth"
     assert provider.uri == uri
-    assert provider.network.name == "custom"
+    assert provider.network.name == "local"  # Network was specified to be local!
     assert provider.network.ecosystem.name == "ethereum"
 
 

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -146,22 +146,22 @@ def test_repr_disconnected(networks_disconnected):
     assert repr(networks_disconnected.ethereum.goerli) == "<ethereum:goerli chain_id=5>"
 
 
-def test_get_provider_from_choice_adhoc_provider(networks_connected_to_tester):
+def test_get_provider_from_choice_custom_provider(networks_connected_to_tester):
     uri = "https://geth:1234567890abcdef@geth.foo.bar/"
     provider = networks_connected_to_tester.get_provider_from_choice(f"ethereum:local:{uri}")
     assert uri in provider.connection_id
     assert provider.name == "geth"
     assert provider.uri == uri
-    assert provider.network.name == "adhoc"
+    assert provider.network.name == "custom"
     assert provider.network.ecosystem.name == "ethereum"
 
 
-def test_get_provider_from_choice_adhoc_ecosystem(networks_connected_to_tester):
+def test_get_provider_from_choice_custom_ecosystem(networks_connected_to_tester):
     uri = "https://geth:1234567890abcdef@geth.foo.bar/"
     provider = networks_connected_to_tester.get_provider_from_choice(uri)
     assert provider.name == "geth"
     assert provider.uri == uri
-    assert provider.network.name == "adhoc"
+    assert provider.network.name == "custom"
     assert provider.network.ecosystem.name == "ethereum"
 
 

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -152,7 +152,7 @@ def test_get_provider_from_choice_adhoc_provider(networks_connected_to_tester):
     assert uri in provider.connection_id
     assert provider.name == "geth"
     assert provider.uri == uri
-    assert provider.network.name == "local"
+    assert provider.network.name == "adhoc"
     assert provider.network.ecosystem.name == "ethereum"
 
 

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -270,3 +270,9 @@ def test_no_comma_in_rpc_url():
     sanitised_url = _sanitize_web3_url(test_url)
 
     assert "," not in sanitised_url
+
+
+def test_use_provider_using_provider_instance(eth_tester_provider):
+    network = eth_tester_provider.network
+    with network.use_provider(eth_tester_provider) as provider:
+        assert id(provider) == id(eth_tester_provider)

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -7,8 +7,8 @@ from typing import Dict, List, Optional
 import pytest
 
 from ape.managers.config import CONFIG_FILE_NAME
+from tests.conftest import ApeSubprocessRunner
 
-from ...conftest import ApeSubprocessRunner
 from .test_plugins import ListResult
 from .utils import NodeId, __project_names__, __projects_directory__, project_skipper
 

--- a/tests/integration/cli/test_cache.py
+++ b/tests/integration/cli/test_cache.py
@@ -1,5 +1,7 @@
-def test_cache_init_purge(ape_cli, runner):
-    result = runner.invoke(ape_cli, ["cache", "init", "--network", "ethereum:goerli"])
+def test_cache_init_purge(ape_cli, runner, mock_sys_argv):
+    cmd = ("cache", "init", "--network", "ethereum:goerli")
+    mock_sys_argv.return_value = ["ape", *cmd]  # For --network option
+    result = runner.invoke(ape_cli, cmd)
     assert result.output == "SUCCESS: Caching database initialized for ethereum:goerli.\n"
     result = runner.invoke(ape_cli, ["cache", "purge", "--network", "ethereum:goerli"])
     assert result.output == "SUCCESS: Caching database purged for ethereum:goerli.\n"

--- a/tests/integration/cli/test_cache.py
+++ b/tests/integration/cli/test_cache.py
@@ -1,6 +1,5 @@
-def test_cache_init_purge(ape_cli, runner, mock_sys_argv):
+def test_cache_init_purge(ape_cli, runner):
     cmd = ("cache", "init", "--network", "ethereum:goerli")
-    mock_sys_argv.return_value = ["ape", *cmd]  # For --network option
     result = runner.invoke(ape_cli, cmd)
     assert result.output == "SUCCESS: Caching database initialized for ethereum:goerli.\n"
     result = runner.invoke(ape_cli, ["cache", "purge", "--network", "ethereum:goerli"])

--- a/tests/integration/cli/test_networks.py
+++ b/tests/integration/cli/test_networks.py
@@ -158,7 +158,8 @@ def test_filter_providers(ape_cli, runner, networks):
 
 @run_once
 def test_node_not_subprocess_provider(ape_cli, runner):
-    result = runner.invoke(ape_cli, ["networks", "run", "--network", "ethereum:local:test"])
+    cmd = ("networks", "run", "--network", "ethereum:local:test")
+    result = runner.invoke(ape_cli, ["networks", "run", "--network", cmd])
     assert result.exit_code != 0
     assert (
         result.output

--- a/tests/integration/cli/test_networks.py
+++ b/tests/integration/cli/test_networks.py
@@ -123,9 +123,6 @@ def test_list_yaml(ape_cli, runner):
 @skip_projects_except("geth")
 def test_geth(ape_cli, runner, networks, project):
     result = runner.invoke(ape_cli, ["networks", "list"])
-    assert (
-        networks.provider.network.default_provider == "geth"
-    ), "Setup failed - default provider didn't apply from config"
 
     # Grab ethereum
     actual = "ethereum  (default)\n" + "".join(result.output.split("ethereum  (default)\n")[-1])

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -111,7 +111,7 @@ def test_run_interactive(ape_cli, runner, project):
 
 
 @skip_projects_except("script")
-def test_run_adhoc_provider(ape_cli, runner, project):
+def test_run_custom_provider(ape_cli, runner, project):
     result = runner.invoke(
         ape_cli,
         ["run", "deploy", "--network", "ethereum:mainnet:http://127.0.0.1:9545"],
@@ -124,7 +124,7 @@ def test_run_adhoc_provider(ape_cli, runner, project):
 
 
 @skip_projects_except("script")
-def test_run_adhoc_network(ape_cli, runner, project):
+def test_run_custom_network(ape_cli, runner, project):
     result = runner.invoke(ape_cli, ["run", "deploy", "--network", "http://127.0.0.1:9545"])
 
     # Show that it attempts to connect

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -113,7 +113,9 @@ def test_run_interactive(ape_cli, runner, project):
 @skip_projects_except("script")
 def test_run_adhoc_provider(ape_cli, runner, project):
     result = runner.invoke(
-        ape_cli, ["run", "deploy", "--network", "ethereum:mainnet:http://127.0.0.1:9545"]
+        ape_cli,
+        ["run", "deploy", "--network", "ethereum:mainnet:http://127.0.0.1:9545"],
+        catch_exceptions=False,
     )
 
     # Show that it attempts to connect


### PR DESCRIPTION
### What I did

* `NetworkBoundCommand` renamed to `ConnectedProviderCommand` and no longer requires explicitly setting the network option (base wasn't removed and warns a DeprecatedWarning with instructions how to migrate and it has the legacy behavior).
* Both `@network_option` and `ConnectedProviderCommand` allow key-args in your callback for `ecosystem`, `network,` and `provider` for each instance respectively. You don't need to use any of them either (yay, can delete all the `_ = network  # needed for NetworkBoundCommand` lines).
* Move another class to `ape_ethereum` called `EthereumNodeProvider`.. It is exactly what was in ape-geth, however ape-geth still sorta re-exports because `EthereumNodeProvider` is the default class for custom networks and such and just sounds better and in some cases may be a better base class than `Web3Provider` alone. So on the node, `adhoc` neworks are rebranded as `custom` networks so itll be smoother to add the config-based ones with names and chaind IDs and such.
* Adds some other Deprecated methods back to less the damager of 0.7 on scripts and emit Deprecated warnings and TODOs to delete on 0.8 which **is going to happen**.


fixes: #1572 
Fixes: APE-1239
fixes: #1401 
Fixes: APE-881
Fixes: APE-486

### How I did it

when you use `@network_option` now, it analyzes the fn  you give it via `inspect` and then it checks out `sys.argv` to parse the value, since at option time it does not have access to it. It then turns the callback fn to a partial with the fields filled out.

`ConnectedProviderCommand` (f.k.a NetworkBoundCommand) changes were much easier to implement because it has access to code responsible for pass kwargs into your command callback.. so at that time, it is able to put the right ones in, also via using `inspect` to see what the callback is even requesting.

But because `NetworkBoundCommand` no longer needs `network_option` and most likely never will use it together because it is pointless unless you are being super custom with it, it will never have the partially-filled callback.. Thus it utiliizes is own way of passing in the instances..

it was a little more complex than i anticipated, mostly because Options are parsed so early on. If this only happened in `ConnectedProviderCommand`, it'd be easier, but I got it working nonetheless.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
