### PR TITLE
feat: `from_rsv()` and `from_vrs()` Signature class methods [APE-1600]

### DIFF
--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -65,6 +65,22 @@ class _Signature:
         yield self.r
         yield self.s
 
+    @classmethod
+    def from_rsv(cls, rsv: HexBytes) -> "_Signature":
+        # NOTE: Values may be padded.
+        if len(rsv) != 65:
+            raise ValueError("Length of RSV bytes must be 65.")
+
+        return cls(r=HexBytes(rsv[:32]), s=HexBytes(rsv[32:64]), v=rsv[64])
+
+    @classmethod
+    def from_vrs(cls, vrs: HexBytes) -> "_Signature":
+        # NOTE: Values may be padded.
+        if len(vrs) != 65:
+            raise ValueError("Length of VRS bytes must be 65.")
+
+        return cls(v=vrs[0], r=HexBytes(vrs[1:33]), s=HexBytes(vrs[33:]))
+
     def __repr__(self) -> str:
         class_name = getattr(type(self), "__name__", "_Signature")
         return f"<{class_name} v={self.v} r={to_hex(self.r)} s={to_hex(self.s)}>"


### PR DESCRIPTION
### What I did

In ape-safe, we are sometimes just givens the bytes signatures from the API and stuff... would be nice to be able to get it to the right type. So this PR adds classmethods to do exactly that.

### How I did it

parse bytes back to a message sig

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
