### PR TITLE
chore: add class method decorator to all validators [APE-1606]

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -74,6 +74,7 @@ class BlockAPI(BaseInterfaceModel):
         return datetime.datetime.fromtimestamp(self.timestamp, tz=datetime.timezone.utc)
 
     @model_validator(mode="before")
+    @classmethod
     def convert_parent_hash(cls, data):
         parent_hash = data.get("parent_hash", data.get("parentHash")) or EMPTY_BYTES32
         data["parentHash"] = parent_hash

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -105,6 +105,7 @@ class _BaseBlockQuery(_BaseQuery):
     step: PositiveInt = 1
 
     @model_validator(mode="before")
+    @classmethod
     def check_start_block_before_stop_block(cls, values):
         if values["stop_block"] < values["start_block"]:
             raise ValueError(
@@ -142,6 +143,7 @@ class AccountTransactionQuery(_BaseQuery):
     stop_nonce: NonNegativeInt
 
     @model_validator(mode="before")
+    @classmethod
     def check_start_nonce_before_stop_nonce(cls, values: Dict) -> Dict:
         if values["stop_nonce"] < values["start_nonce"]:
             raise ValueError(

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -67,6 +67,7 @@ class TransactionAPI(BaseInterfaceModel):
     model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("gas_limit", mode="before")
+    @classmethod
     def validate_gas_limit(cls, value):
         if value is None:
             if not cls.network_manager.active_provider:
@@ -92,6 +93,7 @@ class TransactionAPI(BaseInterfaceModel):
         return value
 
     @field_validator("max_fee", "max_priority_fee", mode="before")
+    @classmethod
     def convert_fees(cls, value):
         if isinstance(value, str):
             return cls.conversion_manager.convert(value, int)
@@ -99,6 +101,7 @@ class TransactionAPI(BaseInterfaceModel):
         return value
 
     @field_validator("data", mode="before")
+    @classmethod
     def validate_data(cls, value):
         if isinstance(value, str):
             return HexBytes(value)
@@ -106,6 +109,7 @@ class TransactionAPI(BaseInterfaceModel):
         return value
 
     @field_validator("value", mode="before")
+    @classmethod
     def validate_value(cls, value):
         if isinstance(value, int):
             return value
@@ -273,6 +277,7 @@ class ReceiptAPI(BaseInterfaceModel):
         yield ExtraModelAttributes(name="transaction", attributes=vars(self.transaction))
 
     @field_validator("transaction", mode="before")
+    @classmethod
     def confirm_transaction(cls, value):
         if isinstance(value, dict):
             value = TransactionAPI.model_validate(value)
@@ -280,6 +285,7 @@ class ReceiptAPI(BaseInterfaceModel):
         return value
 
     @field_validator("txn_hash", mode="before")
+    @classmethod
     def validate_txn_hash(cls, value):
         return HexBytes(value).hex()
 

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -30,6 +30,7 @@ class CompilerConfig(PluginConfig):
 
 class DeploymentConfigCollection(RootModel[dict]):
     @model_validator(mode="before")
+    @classmethod
     def validate_deployments(cls, data: Dict, info):
         valid_ecosystems = data.pop("valid_ecosystems", {})
         valid_networks = data.pop("valid_networks", {})
@@ -127,6 +128,7 @@ class ConfigManager(BaseInterfaceModel):
     _cached_configs: Dict[str, Dict[str, Any]] = {}
 
     @model_validator(mode="before")
+    @classmethod
     def check_config_for_extra_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         extra = [key for key in values.keys() if key not in cls.model_fields]
         if extra:

--- a/src/ape/managers/project/dependency.py
+++ b/src/ape/managers/project/dependency.py
@@ -273,6 +273,7 @@ class LocalDependency(DependencyAPI):
     version: str = "local"
 
     @model_validator(mode="before")
+    @classmethod
     def validate_contracts_folder(cls, value):
         if value.get("contracts_folder") not in (None, "contracts"):
             return value

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -85,6 +85,7 @@ class AutoGasLimit(BaseModel):
     """
 
     @field_validator("multiplier", mode="before")
+    @classmethod
     def validate_multiplier(cls, value):
         if isinstance(value, str):
             return float(value)
@@ -137,6 +138,7 @@ class LogFilter(BaseModel):
     selectors: Dict[str, EventABI] = {}
 
     @model_validator(mode="before")
+    @classmethod
     def compute_selectors(cls, values):
         values["selectors"] = {
             encode_hex(keccak(text=event.selector)): event for event in values.get("events", [])
@@ -145,6 +147,7 @@ class LogFilter(BaseModel):
         return values
 
     @field_validator("start_block", mode="before")
+    @classmethod
     def validate_start_block(cls, value):
         return value or 0
 
@@ -231,6 +234,7 @@ class BaseContractLog(BaseInterfaceModel):
     """The arguments to the event, including both indexed and non-indexed data."""
 
     @field_validator("contract_address", mode="before")
+    @classmethod
     def validate_address(cls, value):
         return cls.conversion_manager.convert(value, AddressType)
 
@@ -270,6 +274,7 @@ class ContractLog(BaseContractLog):
     """
 
     @field_validator("block_number", "log_index", "transaction_index", mode="before")
+    @classmethod
     def validate_hex_ints(cls, value):
         if value is None:
             # Should only happen for optionals.
@@ -281,6 +286,7 @@ class ContractLog(BaseContractLog):
         return value
 
     @field_validator("contract_address", mode="before")
+    @classmethod
     def validate_address(cls, value):
         return cls.conversion_manager.convert(value, AddressType)
 

--- a/src/ape/types/coverage.py
+++ b/src/ape/types/coverage.py
@@ -576,6 +576,7 @@ class CoverageReport(BaseModel):
     """
 
     @field_validator("timestamp", mode="before")
+    @classmethod
     def validate_timestamp(cls, value):
         # Default to current UTC timestamp (ms).
         return value or get_current_timestamp_ms()

--- a/src/ape_compile/__init__.py
+++ b/src/ape_compile/__init__.py
@@ -24,6 +24,7 @@ class Config(PluginConfig):
     """
 
     @field_validator("exclude", mode="before")
+    @classmethod
     def validate_exclude(cls, value):
         return value or []
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -101,6 +101,7 @@ class NetworkConfig(PluginConfig):
     """A multiplier to apply to a transaction base fee."""
 
     @field_validator("gas_limit", mode="before")
+    @classmethod
     def validate_gas_limit(cls, value):
         if isinstance(value, dict) and "auto" in value:
             return AutoGasLimit.model_validate(value["auto"])
@@ -194,6 +195,7 @@ class Block(BlockAPI):
         "total_difficulty",
         mode="before",
     )
+    @classmethod
     def validate_ints(cls, value):
         return to_int(value) if value else 0
 

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -97,6 +97,7 @@ class StaticFeeTransaction(BaseTransaction):
     max_fee: Optional[int] = Field(None, exclude=True)  # type: ignore
 
     @model_validator(mode="before")
+    @classmethod
     def calculate_read_only_max_fee(cls, values) -> Dict:
         # NOTE: Work-around, Pydantic doesn't handle calculated fields well.
         values["max_fee"] = values.get("gas_limit", 0) * values.get("gas_price", 0)
@@ -115,6 +116,7 @@ class DynamicFeeTransaction(BaseTransaction):
     access_list: List[AccessList] = Field(default_factory=list, alias="accessList")
 
     @field_validator("type")
+    @classmethod
     def check_type(cls, value):
         return value.value if isinstance(value, TransactionType) else value
 
@@ -129,6 +131,7 @@ class AccessListTransaction(BaseTransaction):
     access_list: List[AccessList] = Field(default_factory=list, alias="accessList")
 
     @field_validator("type")
+    @classmethod
     def check_type(cls, value):
         return value.value if isinstance(value, TransactionType) else value
 

--- a/src/ape_plugins/utils.py
+++ b/src/ape_plugins/utils.py
@@ -138,6 +138,7 @@ class PluginMetadata(BaseInterfaceModel):
     """The version requested, if there is one."""
 
     @model_validator(mode="before")
+    @classmethod
     def validate_name(cls, values):
         if "name" not in values:
             raise ValueError("'name' required.")
@@ -385,6 +386,7 @@ class PluginGroup(BaseModel):
         return self.to_str()
 
     @field_validator("plugin_type", mode="before")
+    @classmethod
     def validate_plugin_type(cls, value):
         return PluginType(value) if isinstance(value, str) else value
 


### PR DESCRIPTION
### What I did

Pydantic recommends doing this and even includes it in their migration tool, as pointed out by @NotPeopling2day and I agree it is more readable.

However - it is a little problematic imo because their validator decorators already return class methods, so now I am getting errors in Pycharm warning me the decorator types dont match, kinda opposite of what Pydantic warns about in their docs here: 

https://docs.pydantic.dev/latest/concepts/validators/#field-validators

```
@field_validators are "class methods", so the first argument value they receive is the UserModel class, not an instance of UserModel. We recommend you use the @classmethod decorator on them below the @field_validator decorator to get proper type checking.
```

nonetheless opting to use them.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
