### PR TITLE
fix: issue getting items from pydantic extras in PluginConfig [APE-1607]

### DIFF
--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -60,7 +60,7 @@ class PluginConfig(BaseSettings):
 
     def get(self, key: str, default: Optional[T] = None) -> T:
         extra: Dict = self.__pydantic_extra__ or {}
-        return self.__dict__.get(key, extra.get(default, default))
+        return self.__dict__.get(key, extra.get(key, default))
 
 
 class GenericConfig(ConfigDict):

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -428,7 +428,9 @@ class NetworkManager(BaseManager):
         elif len(selections) == 3:
             # Everything is specified, use specified provider for ecosystem and network
             ecosystem_name, network_name, provider_name = selections
-            ecosystem = self.get_ecosystem(ecosystem_name or self.default_ecosystem.name)
+            ecosystem = (
+                self.get_ecosystem(ecosystem_name) if ecosystem_name else self.default_ecosystem
+            )
             network = ecosystem.get_network(network_name or ecosystem.default_network_name)
             return network.get_provider(
                 provider_name=provider_name, provider_settings=provider_settings

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -595,8 +595,9 @@ class ProjectManager(BaseManager):
             for file in directory.iterdir():
                 if file.is_dir():
                     _append_extensions_in_dir(file)
-                else:
-                    extensions_found.add(file.suffix)
+                elif ext := file.suffix:
+                    # NOTE: Also ignores files without extensions for simplicity.
+                    extensions_found.add(ext)
 
         _append_extensions_in_dir(self.contracts_folder)
 

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -103,12 +103,24 @@ class ProjectManager(BaseManager):
         Returns:
             List[pathlib.Path]: A list of a source file paths in the project.
         """
+        contracts_folder = self.contracts_folder
+        if not contracts_folder or not self.contracts_folder.is_dir():
+            return []
+
         files: List[Path] = []
-        if not self.contracts_folder.is_dir():
-            return files
+
+        # Dependency sources should be ignored, as they are pulled in
+        # independently to compiler via import.
+        in_contracts_cache_dir = contracts_folder / ".cache"
 
         for extension in self.compiler_manager.registered_compilers:
-            files.extend((x for x in self.contracts_folder.rglob(f"*{extension}") if x.is_file()))
+            files.extend(
+                (
+                    x
+                    for x in contracts_folder.rglob(f"*{extension}")
+                    if x.is_file() and in_contracts_cache_dir not in x.parents
+                )
+            )
 
         return files
 

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -1,6 +1,7 @@
 from typing import Dict, Union
 
 import pytest
+from pydantic_settings import SettingsConfigDict
 
 from ape.api import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME
@@ -217,3 +218,18 @@ def test_merge_configs_short_circuits():
     ex = {"test": "foo"}
     assert merge_configs({}, {}) == {}
     assert merge_configs(ex, {}) == merge_configs({}, ex) == ex
+
+
+def test_plugin_config_getattr_and_getitem(config):
+    config = config.get_config("ethereum")
+    assert config.mainnet is not None
+    assert config.mainnet == config["mainnet"]
+
+
+def test_custom_plugin_config_with_allow_extra_getattr_and_getitem():
+    class CustomConfig(PluginConfig):
+        model_config = SettingsConfigDict(extra="allow")
+
+    config = CustomConfig(foo="123")
+    assert config.foo == "123"
+    assert config["foo"] == "123"

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -226,10 +226,11 @@ def test_plugin_config_getattr_and_getitem(config):
     assert config.mainnet == config["mainnet"]
 
 
-def test_custom_plugin_config_with_allow_extra_getattr_and_getitem():
+def test_custom_plugin_config_extras():
     class CustomConfig(PluginConfig):
         model_config = SettingsConfigDict(extra="allow")
 
     config = CustomConfig(foo="123")
+    assert "foo" in config
     assert config.foo == "123"
     assert config["foo"] == "123"

--- a/tests/integration/cli/projects/bad-contracts/contracts/file_without_ext
+++ b/tests/integration/cli/projects/bad-contracts/contracts/file_without_ext
@@ -1,0 +1,1 @@
+The point of this file is to show files without extensions are not warned about.


### PR DESCRIPTION
### What I did

Noticed the bug in ape-addressbook

also adds empty ext to list of ignored exts in compiling

* Fixes an issue where dependencies sources being the project sources and causing compiling to take literally years for regular project..

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
