### PR TITLE
feat: update setup.py, removal of urllib3 module version upper boundary requirement [APE-1610]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
         "SQLAlchemy>=1.4.35",
         "tqdm>=4.62.3,<5.0",
         "traitlets>=5.3.0",
-        "urllib3>=1.26.16,<2",
+        "urllib3>=1.26.16",
         "watchdog>=3.0,<4",
         # ** Dependencies maintained by Ethereum Foundation **
         "eth-abi>=4.1.0,<5",


### PR DESCRIPTION
Update setup.py - removal of urllib3 module version requirement

### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1741

### How I did it

<!-- Discuss the thought process behind the change -->
Updated `setup.py` by removal of `urllib3` module version upper boundary requirement
### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
