### PR TITLE
fix: issue where `ape_console_extras` file loaded with wrong namespace

### DIFF
--- a/tests/functional/test_console.py
+++ b/tests/functional/test_console.py
@@ -1,0 +1,33 @@
+import pytest
+
+from ape_console._cli import console
+
+
+@pytest.fixture(autouse=True)
+def mock_console(mocker):
+    """Prevent console from actually launching."""
+    return mocker.patch("ape_console._cli._launch_console")
+
+
+@pytest.fixture(autouse=True)
+def mock_ape_console_extras(mocker):
+    """Prevent actually loading console extras files."""
+    return mocker.patch("ape_console._cli.load_console_extras")
+
+
+def test_console_extras_uses_ape_namespace(mocker, mock_console, mock_ape_console_extras):
+    """
+    Test that if console is given extras, those are included in the console
+    but not as args to the extras files, as those files expect items from the
+    default ape namespace.
+    """
+    accounts_custom = mocker.MagicMock()
+    extras = {"accounts": accounts_custom}
+    console(extra_locals=extras)
+
+    # Show extras file still load using Ape namespace.
+    actual = mock_ape_console_extras.call_args[1]
+    assert actual["accounts"] != accounts_custom
+
+    # Show the custom accounts do get used in console.
+    assert mock_console.call_args[0][0]["accounts"] == accounts_custom


### PR DESCRIPTION
### What I did

**Background**
* You can customize your ape console by including `ape_console_extras.py` in your .ape dir that takes items from the ape namespace and returns a modified one
* Ape's `console` is launched at several points in the app, like during testing with `-I` or during scripts with `-I`... each case adjusts the namespace it passes to the console, which is great. if locally you have something with the same name as globally, it makes sense the local one is preferred when using the console in this case.
* HOWEVER, it is not really something to ever expect `ape_console_extras` from handling local random items in the namespace, does that make sense? Like `ape_console_extras.py` is only reasonable to expect items from Ape's global namespace, like if you have a local var called `accounts` in your test and your console extras file works with the accounts manger, it will get screwed up now if it gets the adjusted namespace, and that is exactly the bug I ran into...

### How I did it

DON'T pass local namespace to `ape_console_extras` file. Instead, pass the global one only and then grab locals and then merge them

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
