### PR TITLE
fix: issue where would not get a transaction error when expected

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -1,7 +1,7 @@
 import sys
 import time
 from datetime import datetime
-from typing import IO, TYPE_CHECKING, Any, Iterator, List, Optional, Union
+from typing import IO, TYPE_CHECKING, Any, Iterator, List, NoReturn, Optional, Union
 
 from eth_pydantic_types import HexBytes
 from eth_utils import is_0x_prefixed, is_hex, to_int
@@ -382,7 +382,7 @@ class ReceiptAPI(BaseInterfaceModel):
             List[:class:`~ape.types.ContractLog`]
         """
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> Optional[NoReturn]:
         """
         Handle provider-specific errors regarding a non-successful
         :class:`~api.providers.TransactionStatusEnum`.

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -362,7 +362,7 @@ class Ethereum(EcosystemAPI):
         elif "input" in data and isinstance(data["input"], str):
             data["input"] = HexBytes(data["input"])
 
-        block_number = data.get("block_number") or data.get("blockNumber")
+        block_number = data.get("block_number", data.get("blockNumber"))
         if block_number is None:
             raise ValueError("Missing block number.")
 

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -207,6 +207,10 @@ class LocalProvider(TestProviderAPI, Web3Provider):
                 vm_err = self.get_virtual_machine_error(err, txn=receipt)
                 raise vm_err from err
 
+            # If we get here, for some reason the tx-replay did not produce
+            # a VM error.
+            receipt.raise_for_status()
+
         return receipt
 
     def snapshot(self) -> SnapshotID:

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -9,7 +9,6 @@ from eth_pydantic_types import HexBytes
 from ethpm_types import ContractType, MethodABI
 
 import ape
-from ape.api import TransactionAPI
 from ape.contracts import ContractContainer, ContractInstance
 from ape.contracts.base import ContractCallHandler
 from ape.exceptions import ChainError, ContractLogicError, ProviderError
@@ -154,7 +153,9 @@ def mock_web3(mocker):
 
 @pytest.fixture
 def mock_transaction(mocker):
-    return mocker.MagicMock(spec=TransactionAPI)
+    tx = mocker.MagicMock()
+    tx.required_confirmations = 0
+    return tx
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
### What I did

after replaying a tx to try and get a proper web3.py extracted error, if that don't work, we were not erroring.

### How I did it

if get to a certain point, call `receipt.raise_for_status()`

### How to verify it

trust me lol...
i dont know how the chain gets in this condition but it seems like it happens on foundry in a forked network when using an impersonated account, or at least that is when i have seen it.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
