### PR TITLE
feat: allow adhoc IPC connect and show a better error for unsupported schemes

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -931,7 +931,6 @@ class NetworkAPI(BaseInterfaceModel):
         Returns:
             :class:`~ape.api.providers.ProviderAPI`
         """
-
         provider_name = provider_name or self.default_provider_name
         if not provider_name:
             from ape.managers.config import CONFIG_FILE_NAME
@@ -949,6 +948,10 @@ class NetworkAPI(BaseInterfaceModel):
         if ":" in provider_name:
             # NOTE: Shortcut that allows `--network ecosystem:network:http://...` to work
             provider_settings["uri"] = provider_name
+            provider_name = "geth"
+
+        elif provider_name.endswith(".ipc"):
+            provider_settings["ipc_path"] = provider_name
             provider_name = "geth"
 
         if provider_name in self.providers:

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -328,7 +328,7 @@ class NetworkChoice(click.Choice):
     This is used in :meth:`~ape.cli.options.network_option`.
     """
 
-    CUSTOM_NETWORK_PATTERN = re.compile(r"\w*:\w*:https?://\w*.*")
+    CUSTOM_NETWORK_PATTERN = re.compile(r"\w*:\w*:(https?|wss?)://\w*.*|.*\.ipc")
 
     def __init__(
         self,

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -400,7 +400,7 @@ class NetworkManager(BaseManager):
             default_network = self.default_ecosystem.default_network
             return default_network.get_provider(provider_settings=provider_settings)
 
-        elif _is_url(network_choice):
+        elif _is_custom_network(network_choice):
             return self.create_custom_provider(network_choice)
 
         selections = network_choice.split(":")
@@ -411,7 +411,7 @@ class NetworkManager(BaseManager):
             selections[2] = provider_value
             selections = selections[:3]
 
-            if _is_url(provider_value):
+            if _is_custom_network(provider_value):
                 selections[1] = selections[1] or "custom"
 
         if selections == network_choice or len(selections) == 1:
@@ -632,7 +632,7 @@ def _validate_filter(arg: Optional[Union[List[str], str]], options: Set[str]):
     return filters
 
 
-def _is_url(value: str) -> bool:
+def _is_custom_network(value: str) -> bool:
     return (
         value.startswith("http://")
         or value.startswith("https://")

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -410,7 +410,6 @@ class NetworkManager(BaseManager):
             provider_value = ":".join(selections[2:])
             selections[2] = provider_value
             selections = selections[:3]
-
             if _is_custom_network(provider_value):
                 selections[1] = selections[1] or "custom"
 
@@ -638,5 +637,5 @@ def _is_custom_network(value: str) -> bool:
         or value.startswith("https://")
         or value.startswith("ws://")
         or value.startswith("wss://")
-        or value.endswith(".ipc")
+        or (value.endswith(".ipc") and ":" not in value)
     )

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -195,13 +195,18 @@ class NetworkManager(BaseManager):
         else:
             name = provider_name
 
-        if not connection_str.startswith("http"):
-            raise ValueError("Currently, only HTTP-based custom nodes are supported.")
+        provider_settings: Dict = {}
+        if connection_str.startswith("https://") or connection_str.startswith("http://"):
+            provider_settings["uri"] = connection_str
+        elif connection_str.endswith(".ipc"):
+            provider_settings["ipc_path"] = connection_str
+        else:
+            raise NetworkError(f"Scheme for '{connection_str}' not yet supported.")
 
         return (provider_cls or EthereumNodeProvider)(
             name=name,
             network=network,
-            provider_settings={"uri": connection_str},
+            provider_settings=provider_settings,
             data_folder=network.data_folder,
             request_header=network.request_header,
         )
@@ -395,7 +400,7 @@ class NetworkManager(BaseManager):
             default_network = self.default_ecosystem.default_network
             return default_network.get_provider(provider_settings=provider_settings)
 
-        elif network_choice.startswith("http://") or network_choice.startswith("https://"):
+        elif _is_url(network_choice):
             return self.create_custom_provider(network_choice)
 
         selections = network_choice.split(":")
@@ -406,7 +411,7 @@ class NetworkManager(BaseManager):
             selections[2] = provider_value
             selections = selections[:3]
 
-            if provider_value.startswith("https://") or provider_value.startswith("https://"):
+            if _is_url(provider_value):
                 selections[1] = selections[1] or "custom"
 
         if selections == network_choice or len(selections) == 1:
@@ -625,3 +630,13 @@ def _validate_filter(arg: Optional[Union[List[str], str]], options: Set[str]):
             raise NetworkError(f"Unknown option '{_filter}'.")
 
     return filters
+
+
+def _is_url(value: str) -> bool:
+    return (
+        value.startswith("http://")
+        or value.startswith("https://")
+        or value.startswith("ws://")
+        or value.startswith("wss://")
+        or value.endswith(".ipc")
+    )

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1072,12 +1072,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
         # Use value from config file
         network_config = config.get(self.network.name) or DEFAULT_SETTINGS
         settings_uri = network_config.get("uri", DEFAULT_SETTINGS["uri"])
-        if (
-            settings_uri.startswith("http://")
-            or settings_uri.startswith("https://")
-            or settings_uri.startswith("wss://")
-            or settings_uri.startswith("ws://")
-        ):
+        if _is_url(settings_uri):
             return settings_uri
 
         # Likely was an IPC Path and will connect that way.
@@ -1085,7 +1080,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
 
     @property
     def connection_str(self) -> str:
-        return self.uri
+        return self.uri or f"{self.ipc_path}"
 
     @property
     def connection_id(self) -> Optional[str]:
@@ -1093,14 +1088,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
 
     @property
     def _clean_uri(self) -> str:
-        return (
-            sanitize_url(self.uri)
-            if self.uri.startswith("https://")
-            or self.uri.startswith("http://")
-            or self.uri.startswith("wss://")
-            or self.uri.startswith("ws://")
-            else self.uri
-        )
+        return sanitize_url(self.uri) if _is_url(self.uri) else self.uri
 
     @property
     def ipc_path(self) -> Path:
@@ -1335,3 +1323,12 @@ def _get_default_data_dir() -> Path:
             f"Unsupported platform '{sys.platform}'.  Only darwin/linux/win32/"
             "freebsd are supported.  You must specify the data_dir."
         )
+
+
+def _is_url(val: str) -> bool:
+    return (
+        val.startswith("https://")
+        or val.startswith("http://")
+        or val.startswith("wss://")
+        or val.startswith("ws://")
+    )

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -27,10 +27,11 @@ def test_uri(geth_provider):
 def test_uri_uses_value_from_config(geth_provider, temp_config):
     settings = geth_provider.provider_settings
     geth_provider.provider_settings = {}
-    config = {"geth": {"ethereum": {"local": {"uri": "value/from/config"}}}}
+    value = "https://value/from/config"
+    config = {"geth": {"ethereum": {"local": {"uri": value}}}}
     try:
         with temp_config(config):
-            assert geth_provider.uri == "value/from/config"
+            assert geth_provider.uri == value
     finally:
         geth_provider.provider_settings = settings
 

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -19,6 +19,7 @@ def test_get_provider_http(ethereum, scheme):
     network = ethereum.get_network("goerli")
     actual = network.get_provider(uri)
     assert actual.uri == uri
+    assert actual.network.name == "goerli"
 
 
 def test_get_provider_ipc(ethereum):
@@ -26,6 +27,7 @@ def test_get_provider_ipc(ethereum):
     network = ethereum.get_network("goerli")
     actual = network.get_provider(path)
     assert actual.ipc_path == Path(path)
+    assert actual.network.name == "goerli"
 
 
 def test_block_times(ethereum):

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from ape.exceptions import NetworkError, ProviderNotFoundError
@@ -11,11 +13,26 @@ def test_get_provider_when_not_found(ethereum):
         network.get_provider("test")
 
 
+@pytest.mark.parametrize("scheme", ("http", "https", "ws", "wss"))
+def test_get_provider_http(ethereum, scheme):
+    uri = f"{scheme}://example.com"
+    network = ethereum.get_network("goerli")
+    actual = network.get_provider(uri)
+    assert actual.uri == uri
+
+
+def test_get_provider_ipc(ethereum):
+    path = "path/to/geth.ipc"
+    network = ethereum.get_network("goerli")
+    actual = network.get_provider(path)
+    assert actual.ipc_path == Path(path)
+
+
 def test_block_times(ethereum):
     assert ethereum.goerli.block_time == 15
 
 
-def test_set_defaul_provider_not_exists(temp_config, ape_caplog, networks):
+def test_set_default_provider_not_exists(temp_config, ape_caplog, networks):
     bad_provider = "NOT_EXISTS"
     expected = f"Provider '{bad_provider}' not found in network 'ethereum:goerli'."
     with pytest.raises(NetworkError, match=expected):

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from ape.exceptions import NetworkError
@@ -239,3 +241,24 @@ def test_getattr_ecosystem_with_hyphenated_name(networks, ethereum):
     networks.ecosystems["hyphen-in-name"] = networks.ecosystems["ethereum"]
     assert networks.hyphen_in_name  # Make sure does not raise AttributeError
     del networks.ecosystems["hyphen-in-name"]
+
+
+@pytest.mark.parametrize("scheme", ("http", "https"))
+def test_create_custom_provider_http(networks, scheme):
+    provider = networks.create_custom_provider(f"{scheme}://example.com")
+    assert provider.uri == f"{scheme}://example.com"
+
+
+@pytest.mark.parametrize("scheme", ("ws", "wss"))
+def test_create_custom_provider_ws(networks, scheme):
+    with pytest.raises(NetworkError):
+        networks.create_custom_provider(f"{scheme}://example.com")
+
+
+def test_create_custom_provider_ipc(networks):
+    provider = networks.create_custom_provider("path/to/geth.ipc")
+    assert provider.ipc_path == Path("path/to/geth.ipc")
+
+    # The IPC path should not be in URI field, different parts
+    # of codebase may expect an actual URI.
+    assert provider.uri != provider.ipc_path

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -120,7 +120,7 @@ def test_run_custom_provider(ape_cli, runner, project):
 
     # Show that it attempts to connect
     assert result.exit_code == 1, result.output
-    assert "No node found on 'http://127.0.0.1:9545" in result.output
+    assert "No (supported) node found on 'http://127.0.0.1:9545" in result.output
 
 
 @skip_projects_except("script")
@@ -129,7 +129,7 @@ def test_run_custom_network(ape_cli, runner, project):
 
     # Show that it attempts to connect
     assert result.exit_code == 1, result.output
-    assert "No node found on 'http://127.0.0.1:9545" in result.output
+    assert "No (supported) node found on 'http://127.0.0.1:9545" in result.output
 
 
 @skip_projects_except("script")


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1761

Also, allows adhoc IPC connection like this:

```sh
ape console --network "ethereum:local:$HOME/.ape/ethereum/local/geth/geth.ipc"
ape console --network "$HOME/.ape/ethereum/local/geth/geth.ipc"
```

### How I did it

just adding more handling and checking

### How to verify it

I did add some func tests
but also run the console commands i placed above

yo need to start an anvil or geth first, or any node i guess.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
