### PR TITLE
fix: network choice parsing and re-parsing fix

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -127,6 +127,15 @@ class ProviderAPI(BaseInterfaceModel):
         ``True`` if currently connected to the provider. ``False`` otherwise.
         """
 
+    @property
+    def connection_str(self) -> str:
+        """
+        The str representing how to connect
+        to the node, such as an HTTP URL
+        or an IPC path.
+        """
+        return ""
+
     @abstractmethod
     def connect(self):
         """
@@ -235,6 +244,14 @@ class ProviderAPI(BaseInterfaceModel):
         """
         The connected network choice string.
         """
+        if self.network.name == "custom" and self.connection_str:
+            # `custom` is not a real network and is same
+            # as using raw connection str
+            return self.connection_str
+
+        elif self.network.name == "custom":
+            raise ProviderError("Custom network provider missing `connection_str`.")
+
         return f"{self.network.choice}:{self.name}"
 
     def get_storage_at(self, *args, **kwargs) -> HexBytes:
@@ -820,14 +837,6 @@ class UpstreamProvider(ProviderAPI):
     """
     A provider that can also be set as another provider's upstream.
     """
-
-    @property
-    @abstractmethod
-    def connection_str(self) -> str:
-        """
-        The str used by downstream providers to connect to this one.
-        For example, the URL for HTTP-based providers.
-        """
 
 
 class SubprocessProvider(ProviderAPI):

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -289,3 +289,22 @@ def test_send_transaction_when_no_error_and_receipt_fails(
 
     finally:
         geth_provider._web3 = start_web3
+
+
+@geth_process_test
+def test_network_choice(geth_provider):
+    actual = geth_provider.network_choice
+    expected = "ethereum:local:geth"
+    assert actual == expected
+
+
+@geth_process_test
+def test_network_choice_when_custom(geth_provider):
+    name = geth_provider.network.name
+    geth_provider.network.name = "custom"
+    try:
+        actual = geth_provider.network_choice
+    finally:
+        geth_provider.network.name = name
+
+    assert actual == "http://127.0.0.1:5550"

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -11,6 +11,7 @@ from web3.exceptions import ContractPanicError
 from ape.exceptions import (
     BlockNotFoundError,
     ContractLogicError,
+    ProviderError,
     TransactionError,
     TransactionNotFoundError,
 )
@@ -321,3 +322,23 @@ def test_send_transaction_when_no_error_and_receipt_fails(
 
     finally:
         eth_tester_provider._web3 = start_web3
+
+
+def test_network_choice(eth_tester_provider):
+    actual = eth_tester_provider.network_choice
+    expected = "ethereum:local:test"
+    assert actual == expected
+
+
+def test_network_choice_when_custom(eth_tester_provider):
+    name = eth_tester_provider.network.name
+    eth_tester_provider.network.name = "custom"
+    try:
+        # NOTE: Raises this error because EthTester does not support custom
+        #   connections.
+        with pytest.raises(
+            ProviderError, match=".*Custom network provider missing `connection_str`.*"
+        ):
+            _ = eth_tester_provider.network_choice
+    finally:
+        eth_tester_provider.network.name = name


### PR DESCRIPTION
### What I did

fixes: #1762

### How I did it

pt 1: If the provider uses a custom network, return its uri as the name instead of the provider name in the choice so it knows to connect this way again.

pt 2: if the provider section of the choice-str is missing and the network says to use custom, raise a nicer error that should hopefully help in many ways!

I also added a load of tests

### How to verify it

test it out of course!

i use ape console and connection to random connection strs, ipcs, whatever, sometimes specifying networks and sometimes not

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
