### PR TITLE
fix: typing in method `from_rvs()` and `from_vrs()` in signature classes

### DIFF
--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -5,6 +5,7 @@ from eth_account.messages import SignableMessage
 from eth_utils import to_bytes, to_hex
 from hexbytes import HexBytes
 from pydantic.dataclasses import dataclass
+from typing_extensions import Self
 
 from ape.types import AddressType
 
@@ -66,7 +67,7 @@ class _Signature:
         yield self.s
 
     @classmethod
-    def from_rsv(cls, rsv: HexBytes) -> "_Signature":
+    def from_rsv(cls, rsv: HexBytes) -> Self:
         # NOTE: Values may be padded.
         if len(rsv) != 65:
             raise ValueError("Length of RSV bytes must be 65.")
@@ -74,7 +75,7 @@ class _Signature:
         return cls(r=HexBytes(rsv[:32]), s=HexBytes(rsv[32:64]), v=rsv[64])
 
     @classmethod
-    def from_vrs(cls, vrs: HexBytes) -> "_Signature":
+    def from_vrs(cls, vrs: HexBytes) -> Self:
         # NOTE: Values may be padded.
         if len(vrs) != 65:
             raise ValueError("Length of VRS bytes must be 65.")

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -5,7 +5,12 @@ from eth_account.messages import SignableMessage
 from eth_utils import to_bytes, to_hex
 from hexbytes import HexBytes
 from pydantic.dataclasses import dataclass
-from typing_extensions import Self
+
+try:
+    # Only on Python 3.11
+    from typing import Self  # type: ignore
+except ImportError:
+    from typing_extensions import Self  # type: ignore
 
 from ape.types import AddressType
 

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -6,7 +6,14 @@ from ethpm_types.abi import EventABI
 from hexbytes import HexBytes
 from pydantic import BaseModel
 
-from ape.types import AddressType, ContractLog, LogFilter, SignableMessage, TransactionSignature
+from ape.types import (
+    AddressType,
+    ContractLog,
+    LogFilter,
+    MessageSignature,
+    SignableMessage,
+    TransactionSignature,
+)
 from ape.utils import ZERO_ADDRESS
 
 TXN_HASH = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa222222222222222222222222"
@@ -146,8 +153,12 @@ def test_signable_message_repr(signable_message):
 def test_signature_from_rsv_and_vrs(signature):
     rsv = signature.encode_rsv()
     vrs = signature.encode_vrs()
-    from_rsv = signature.from_rsv(rsv)
-    from_vrs = signature.from_vrs(vrs)
+
+    # NOTE: Type declaring for sake of ensuring
+    #   type-checking works since class-method is
+    #   defined in base-class.
+    from_rsv: MessageSignature = signature.from_rsv(rsv)
+    from_vrs: MessageSignature = signature.from_vrs(vrs)
     assert from_rsv == from_vrs == signature
 
 


### PR DESCRIPTION
### What I did

mypy was failing checks in ape-safe because of this, it wasnt honoring the fact that it was coming from a base class. now it does!

### How I did it

use `from typing import Self`

basically same as doing the big long TypeVar dance but so much simpler for this exact use-case.

### How to verify it

mypy works now on my branch in ape-safe

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
