### PR TITLE
feat: Allow converting AddressAPI to address-int

### DIFF
--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -76,6 +76,14 @@ class StringIntConverter(ConverterAPI):
         return int(value)
 
 
+class AccountIntConverter(ConverterAPI):
+    def is_convertible(self, value: Any) -> bool:
+        return isinstance(value, BaseAddress)
+
+    def convert(self, value: BaseAddress) -> int:
+        return self.conversion_manager.convert(value.address, int)
+
+
 class AddressAPIConverter(ConverterAPI):
     """
     A converter that converts an :class:`~ape.api.address.BaseAddress`
@@ -205,7 +213,12 @@ class ConversionManager(BaseManager):
                 IntAddressConverter(),
             ],
             bytes: [HexConverter()],
-            int: [TimestampConverter(), HexIntConverter(), StringIntConverter()],
+            int: [
+                TimestampConverter(),
+                HexIntConverter(),
+                StringIntConverter(),
+                AccountIntConverter(),
+            ],
             Decimal: [],
             bool: [],
             str: [],

--- a/tests/functional/conversion/test_address.py
+++ b/tests/functional/conversion/test_address.py
@@ -1,0 +1,21 @@
+from ape.types import AddressType
+
+
+def test_convert_keyfile_account_to_address(convert, keyfile_account):
+    actual = convert(keyfile_account, AddressType)
+    assert actual == keyfile_account.address
+
+
+def test_convert_test_account_to_address(convert, owner):
+    actual = convert(owner, AddressType)
+    assert actual == owner.address
+
+
+def test_convert_address_to_int(convert, owner):
+    actual = convert(owner.address, int)
+    assert actual == int(owner.address, 16)
+
+
+def test_convert_account_to_int(convert, owner):
+    actual = convert(owner, int)
+    assert actual == int(owner.address, 16)


### PR DESCRIPTION
### What I did

when you need int addresses in ape, you can't use account APIs I noticed.

### How I did it

add another converter for address api to int

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
