### PR TITLE
fix: issue preventing transferring a value of `0`.

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -198,13 +198,13 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         if data:
             txn.data = self.conversion_manager.convert(data, bytes)
 
-        if not value and not kwargs.get("send_everything"):
+        if value is None and not kwargs.get("send_everything"):
             raise AccountsError("Must provide 'VALUE' or use 'send_everything=True'")
 
-        elif value and kwargs.get("send_everything"):
+        elif value is not None and kwargs.get("send_everything"):
             raise AccountsError("Cannot use 'send_everything=True' with 'VALUE'.")
 
-        elif value:
+        elif value is not None:
             txn.value = self.conversion_manager.convert(value, int)
             if txn.value < 0:
                 raise AccountsError("Value cannot be negative.")

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -196,6 +196,15 @@ def test_transfer_using_type_0(sender, receiver, convert):
     assert receiver.balance == expected
 
 
+def test_transfer_value_of_0(sender, receiver):
+    """
+    There was a bug where this failed, thinking there was no value.
+    """
+    initial_balance = receiver.balance
+    sender.transfer(receiver, 0)
+    assert receiver.balance == initial_balance
+
+
 def test_deploy(owner, contract_container, chain, clean_contracts_cache):
     contract = owner.deploy(contract_container, 0)
     assert contract.address

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -204,6 +204,10 @@ def test_transfer_value_of_0(sender, receiver):
     sender.transfer(receiver, 0)
     assert receiver.balance == initial_balance
 
+    # Also show conversion works.
+    sender.transfer(receiver, "0 wei")
+    assert receiver.balance == initial_balance
+
 
 def test_deploy(owner, contract_container, chain, clean_contracts_cache):
     contract = owner.deploy(contract_container, 0)


### PR DESCRIPTION
### What I did

We were unable to transfer a value of 0 without doing some hack.

note: use-case for this is replacing a tx with a noop one.

### How I did it

check for None instead of truthy.

### How to verify it

transfer 0 somewhere

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
