### PR TITLE
fix: use helpful `IndexError` in `AccountManager.__getitem__()`  when conversion error occurs

### DIFF
--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -338,7 +338,7 @@ class AccountManager(BaseManager):
             account_id = self.conversion_manager.convert(account_str, AddressType)
         except ConversionError as err:
             prefix = f"No account with ID '{account_str}'"
-            if account_str.endswith(".ens"):
+            if account_str.endswith(".eth"):
                 suffix = "Do you have `ape-ens` installed?"
             else:
                 suffix = "Do you have the necessary conversion plugins installed?"

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -299,6 +299,34 @@ def test_accounts_address_access(owner, accounts):
     assert accounts[owner.address] == owner
 
 
+def test_accounts_address_access_conversion_fail(accounts):
+    with pytest.raises(
+        IndexError,
+        match=(
+            r"No account with ID 'FAILS'\. "
+            r"Do you have the necessary conversion plugins installed?"
+        ),
+    ):
+        _ = accounts["FAILS"]
+
+
+def test_accounts_address_access_not_found(accounts):
+    address = "0x1222262222222922222222222222222222222222"
+    with pytest.raises(IndexError, match=rf"No account with address '{address}'\."):
+        _ = accounts[address]
+
+
+def test_test_accounts_address_access_conversion_fail(test_accounts):
+    with pytest.raises(IndexError, match=r"No account with ID 'FAILS'"):
+        _ = test_accounts["FAILS"]
+
+
+def test_test_accounts_address_access_not_found(test_accounts):
+    address = "0x1222262222222922222222222222222222222222"
+    with pytest.raises(IndexError, match=rf"No account with address '{address}'\."):
+        _ = test_accounts[address]
+
+
 def test_accounts_contains(accounts, owner):
     assert owner.address in accounts
 


### PR DESCRIPTION
### What I did

issue 1: __getitem__ is supposed to raise IndexError when it fails but i was getting conversion errors.
issue 2: I accidentally did `ape.accounts["safe"]` instead of `ape.accounts.containers["safe"]` once and the error was confusing for a second and also was not an index error.
issue 3: when ape-ens or conversion plugin not installed, the index error should hint at that.

### How I did it

catch and handle `ConversionError` in account manager `__getitem__` implementation.

### How to verify it

```python
ape.accounts["BOBO"]
# then without ens installed
ape.accounts["antazoey.eth"]
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
