### PR TITLE
fix: issue where NotImplmeneted error was not raised

### DIFF
--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -6,6 +6,7 @@ from eth_typing import HexStr
 from hexbytes import HexBytes
 
 from ape.exceptions import (
+    APINotImplementedError,
     BlockNotFoundError,
     NetworkMismatchError,
     TransactionError,
@@ -308,3 +309,11 @@ def test_network_choice_when_custom(geth_provider):
         geth_provider.network.name = name
 
     assert actual == "http://127.0.0.1:5550"
+
+
+def test_make_request_not_exists(geth_provider):
+    with pytest.raises(
+        APINotImplementedError,
+        match="RPC method 'ape_thisDoesNotExist' is not implemented by this node instance.",
+    ):
+        geth_provider._make_request("ape_thisDoesNotExist")


### PR DESCRIPTION
### What I did

I noticed for all the dev providers, when calling a method that didnt exist (such as debug_traceCall in non-updated hardhat nodes), it would **not** fail with `NotImplemented` error. We have some other logic in trace mgmt that depends on these errors being raised so this PR fixes it here in core.

### How I did it

I figured this was shareable, small enough, and generic enough to just put in core.

I noticed this problem when trying to repro https://github.com/ApeWorX/ape/issues/1777 ; it _did_ cause some issues for my in my coverage , but not the same as the ones from the issue so im not sure how related it is.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
