### PR TITLE
fix: use last frame to get locals when launching interactive test console

### DIFF
--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -80,7 +80,7 @@ class PytestApeRunner(ManagerAccessMixin):
             )
 
         if self.config_wrapper.interactive and report.failed:
-            traceback = call.excinfo.traceback[0]
+            traceback = call.excinfo.traceback[-1]
 
             # Suspend capsys to ignore our own output.
             capman = self.config_wrapper.get_pytest_plugin("capturemanager")


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1801

### How I did it

So I never could reproduce the bug...
However, I noticed in the screenshot that locals successfully appear in the repr output.
I know the repr output and the locals namespaces are using the same data, so i went to look and I noticed the repr output logic actually uses the last frame whereas the local namespaces was using the first frame. Perhaps in Wavey's env, this made a huge difference...  So I changed them to match. We have to wait on @wavey0x to confirm if this fixes the issue though, as I am not sure.

I also noticed a test was missing for this feature. We had a test in the `ape run` version of the same feature but not in the `ape test` version, so I added a test. HOWEVER, the test passes on main branch as well as this branch (as like I said, never able to actually reproduce the bug)

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
