### PR TITLE
fix: issues with GitHub dependencies when not specifying `ref:` or `version:`

### DIFF
--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -128,6 +128,11 @@ class ConfigManager(BaseInterfaceModel):
 
         return values
 
+    @model_validator(mode="after")
+    @classmethod
+    def load_configs(cls, cm):
+        return cm.load()
+
     @property
     def packages_folder(self) -> Path:
         self.dependency_manager.packages_folder.mkdir(parents=True, exist_ok=True)

--- a/src/ape/managers/project/dependency.py
+++ b/src/ape/managers/project/dependency.py
@@ -204,6 +204,14 @@ class GithubDependency(DependencyAPI):
     **NOTE**: Will be ignored if given a version.
     """
 
+    @model_validator(mode="after")
+    @classmethod
+    def ensure_ref_or_version(cls, dep):
+        if dep.ref is None and dep.version is None:
+            raise ValueError("GitHub dependency must have either ref or version specified.")
+
+        return dep
+
     @cached_property
     def version_id(self) -> str:
         if self.ref:

--- a/src/ape_pm/_cli.py
+++ b/src/ape_pm/_cli.py
@@ -173,6 +173,7 @@ def install(cli_ctx, package, name, version, ref, force):
         try:
             cli_ctx.project_manager.load_dependencies(use_cache=not force)
         except Exception as err:
+            cli_ctx.logger.log_debug_stack_trace()
             cli_ctx.abort(f"Failed loading dependencies: {err}")
 
     elif name:

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -5,8 +5,9 @@ from pathlib import Path
 from typing import Dict
 
 import pytest
+from pydantic import ValidationError
 
-from ape.managers.project.dependency import NpmDependency
+from ape.managers.project.dependency import GithubDependency, NpmDependency
 
 
 @pytest.fixture
@@ -141,3 +142,9 @@ def test_compile_with_extra_settings(dependency_manager, project):
     data = {"name": "FooBar", "local": path, "config_override": settings}
     dependency = dependency_manager.decode_dependency(data)
     assert dependency.config_override == settings
+
+
+def test_github_dependency_ref_or_version_is_required():
+    expected = r"GitHub dependency must have either ref or version specified"
+    with pytest.raises(ValidationError, match=expected):
+        _ = GithubDependency(name="foo", github="asdf")


### PR DESCRIPTION
### What I did

fixes: #1800 

Make ref or version required, at least one or other

### How I did it

simply make `ref:` required so the error is correct.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
