### PR TITLE
fix: ContractInstance deploy error message

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -227,6 +227,18 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         Returns:
             :class:`~ape.contracts.ContractInstance`: An instance of the deployed contract.
         """
+        from ape.contracts import ContractContainer
+
+        # NOTE: It is important to type check here to prevent cases where user
+        #    may accidentally pass in a ContractInstance, which has a very
+        #    different implementation for __call__ than ContractContainer.
+        if not isinstance(contract, ContractContainer):
+            raise TypeError(
+                "contract argument must be a ContractContainer type, "
+                "such as 'project.MyContract' where 'MyContract' is the name of "
+                "a contract in your project."
+            )
+
         txn = contract(*args, **kwargs)
         if kwargs.get("value") and not contract.contract_type.constructor.is_payable:
             raise MethodNonPayableError("Sending funds to a non-payable constructor.")

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -267,6 +267,22 @@ def test_deploy_proxy(owner, vyper_contract_instance, proxy_contract_container, 
     assert implementation.contract_type == vyper_contract_instance.contract_type
 
 
+def test_deploy_instance(owner, vyper_contract_instance, chain, clean_contracts_cache):
+    """
+    Tests against a confusing scenario where you would get a SignatureError when
+    trying to deploy a ContractInstance because Ape would attempt to create a tx
+    by calling the contract's default handler.
+    """
+
+    expected = (
+        r"contract argument must be a ContractContainer type, "
+        r"such as 'project\.MyContract' where 'MyContract' is the "
+        r"name of a contract in your project\."
+    )
+    with pytest.raises(TypeError, match=expected):
+        owner.deploy(vyper_contract_instance)
+
+
 def test_send_transaction_with_bad_nonce(sender, receiver):
     # Bump the nonce so we can set one that is too low.
     sender.transfer(receiver, "1 gwei", type=0)


### PR DESCRIPTION
### What I did

fixes: #1797

### How I did it

Type-checking. Unfortunately, this required a local import. However, it is worth it imo... the ramifications of the type being wrong are too big NOT to type-check here, as we have seen with the issue.

So more info: the problem is the a ContractInstance has its own `__call__` implementation and that also makes a txn, so it was like kinda "working" by doing that except itd get a SignatureError and ya it was jus weird... forceful type checking is the way.

### How to verify it

try to deploy an instance

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
