### PR TITLE
refactor: loosen up the urllib3 version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
         "SQLAlchemy>=1.4.35",
         "tqdm>=4.62.3,<5.0",
         "traitlets>=5.3.0",
-        "urllib3>=2.1.0,<3",
+        "urllib3>=2.0.0,<3",
         "watchdog>=3.0,<4",
         # ** Dependencies maintained by Ethereum Foundation **
         "eth-abi>=4.2.1,<5",


### PR DESCRIPTION
### What I did

Updates version requirements for urllib3 to allow 2.0.

### How I did it

Some old slow libs are slow to adopt new versions of urllib3 for whatever reason.

### How to verify it

I explicitly installed 2.0 and ran the test suite against it, no issues.

### Checklist

- [x] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
