### PR TITLE
refactor: move `__getattr__` overload to new mixin and only use where needed

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -39,6 +39,7 @@ from ape.types import AddressType, AutoGasLimit, CallTreeNode, ContractLog, GasL
 from ape.utils import (
     DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT,
     BaseInterfaceModel,
+    ExtraAttributesMixin,
     ExtraModelAttributes,
     ManagerAccessMixin,
     abstractmethod,
@@ -66,7 +67,7 @@ class ProxyInfoAPI(BaseModel):
     """The address of the implementation contract."""
 
 
-class EcosystemAPI(BaseInterfaceModel):
+class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
     """
     A set of related networks, such as Ethereum.
     """

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -13,6 +13,7 @@ from ape.exceptions import ProjectError
 from ape.logging import logger
 from ape.utils import (
     BaseInterfaceModel,
+    ExtraAttributesMixin,
     ExtraModelAttributes,
     abstractmethod,
     cached_property,
@@ -324,7 +325,7 @@ class ProjectAPI(BaseInterfaceModel):
         return source_dict  # {source_id: Source}
 
 
-class DependencyAPI(BaseInterfaceModel):
+class DependencyAPI(ExtraAttributesMixin, BaseInterfaceModel):
     """
     A base-class for dependency sources, such as GitHub or IPFS.
     """

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -29,6 +29,7 @@ from ape.types import (
 )
 from ape.utils import (
     BaseInterfaceModel,
+    ExtraAttributesMixin,
     ExtraModelAttributes,
     abstractmethod,
     cached_property,
@@ -248,7 +249,7 @@ class ConfirmationsProgressBar:
         self._bar.set_description(f"Confirmations ({self._confs}/{self._req_confs})")
 
 
-class ReceiptAPI(BaseInterfaceModel):
+class ReceiptAPI(ExtraAttributesMixin, BaseInterfaceModel):
     """
     An abstract class to represent a transaction receipt. The receipt
     contains information about the transaction, such as the status

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -45,7 +45,12 @@ from ape.types.coverage import (
 )
 from ape.types.signatures import MessageSignature, SignableMessage, TransactionSignature
 from ape.types.trace import CallTreeNode, ControlFlow, GasReport, SourceTraceback, TraceFrame
-from ape.utils import BaseInterfaceModel, ExtraModelAttributes, cached_property
+from ape.utils import (
+    BaseInterfaceModel,
+    ExtraAttributesMixin,
+    ExtraModelAttributes,
+    cached_property,
+)
 from ape.utils.misc import ZERO_ADDRESS, to_int
 
 if TYPE_CHECKING:
@@ -250,7 +255,7 @@ class BaseContractLog(BaseInterfaceModel):
         return True
 
 
-class ContractLog(BaseContractLog):
+class ContractLog(ExtraAttributesMixin, BaseContractLog):
     """
     An instance of a log from a contract.
     """

--- a/src/ape/utils/__init__.py
+++ b/src/ape/utils/__init__.py
@@ -13,6 +13,7 @@ from ape.utils.abi import (
 from ape.utils.basemodel import (
     BaseInterface,
     BaseInterfaceModel,
+    ExtraAttributesMixin,
     ExtraModelAttributes,
     ManagerAccessMixin,
     injected_before_use,
@@ -75,6 +76,7 @@ __all__ = [
     "DEFAULT_TEST_HD_PATH",
     "DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT",
     "EMPTY_BYTES32",
+    "ExtraAttributesMixin",
     "expand_environment_variables",
     "extract_nested_value",
     "ExtraModelAttributes",

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -218,6 +218,13 @@ class BaseModel(EthpmTypesBaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
+
+class ExtraAttributesMixin:
+    """
+    A mixin to use on models that provide ``ExtraModelAttributes``.
+    **NOTE**: Must come _before_ your base-model class in subclass tuple to function.
+    """
+
     def __ape_extra_attributes__(self) -> Iterator[ExtraModelAttributes]:
         """
         Override this method to supply extra attributes


### PR DESCRIPTION
### What I did

This should also be a performance gain.
But more importantly, it lessens the chance of problems occurring from this because now we are only using `__getattr__` overloading where extras are.

### How I did it

* Make new mixin
* Use new mixin in all spots that implement `__ape_attributes_extras__`

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
