### PR TITLE
fix: issue with fee history for some nodes

### DIFF
--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -240,7 +240,7 @@ class ExtraAttributesMixin:
     def __getattr__(self, name: str) -> Any:
         """
         An overridden ``__getattr__`` implementation that takes into
-        account :meth:`~ape.utils.basemodel.BaseModel.__ape_extra_attributes__`.
+        account :meth:`~ape.utils.basemodel.ExtraAttributesMixin.__ape_extra_attributes__`.
         """
 
         private_attrs = self.__pydantic_private__ or {}

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -378,7 +378,7 @@ def test_make_request_not_exists_dev_nodes(eth_tester_provider, mock_web3, msg):
 
 def test_base_fee(eth_tester_provider):
     actual = eth_tester_provider.base_fee
-    assert actual == 1000000000
+    assert actual > 0
 
     # NOTE: Mostly doing this to ensure we are calling the fee history
     #   RPC correctly. There was a bug where we were not.

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -374,3 +374,13 @@ def test_make_request_not_exists_dev_nodes(eth_tester_provider, mock_web3, msg):
         match="RPC method 'ape_thisDoesNotExist' is not implemented by this node instance.",
     ):
         eth_tester_provider._make_request("ape_thisDoesNotExist")
+
+
+def test_base_fee(eth_tester_provider):
+    actual = eth_tester_provider.base_fee
+    assert actual == 1000000000
+
+    # NOTE: Mostly doing this to ensure we are calling the fee history
+    #   RPC correctly. There was a bug where we were not.
+    with pytest.raises(APINotImplementedError):
+        _ = eth_tester_provider._get_fee_history(0)


### PR DESCRIPTION
### What I did

Working around this bug: https://github.com/ethereum/web3.py/issues/3184
(update: not sure it is really a bug, as it only happens in anvil and hardhat and not real nodes.. perhaps they are the ones that are bugged? either way, this change is good still as it allows it to work on all nodes, even geth still... else, maybe the bug is that web3.py is passing null when it should be omitting the value entirely... im not sure!)

fee history was failing always in web3.py with some recent changes.
Default parameter was not handled correctly.

### How I did it

specify default parameter so that the request works.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
