### PR TITLE
fix: issue where Ape no longer worked AT ALL when using custom contracts folder

### DIFF
--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -192,7 +192,7 @@ class ConfigManager(BaseInterfaceModel):
         # NOTE: It is okay for this directory not to exist at this point.
         contracts_folder = user_config.pop("contracts_folder", None)
         contracts_folder = (
-            (self.project_manager.path / Path(contracts_folder)).expanduser().resolve()
+            (self.PROJECT_FOLDER / Path(contracts_folder)).expanduser().resolve()
             if contracts_folder
             else self.PROJECT_FOLDER / "contracts"
         )
@@ -244,6 +244,7 @@ class ConfigManager(BaseInterfaceModel):
             self._cached_configs = {}
 
         _ = self._plugin_configs
+
         return self
 
     def get_config(self, plugin_name: str) -> PluginConfig:

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -268,3 +268,19 @@ def test_config_manager_loads_on_init(config):
         (path / "ape-config.yaml").write_text(config)
         manager = ConfigManager(REQUEST_HEADER={}, DATA_FOLDER=Path.cwd(), PROJECT_FOLDER=path)
         assert manager.name == name
+
+
+def test_load_does_not_call_project_manager(temp_config, config):
+    """
+    It is highly critical that `load()` does not call anything from
+    `project_manager` as it is not loaded yet in the manager access mixin.
+    """
+    orig = config.project_manager.path
+    path = Path("_should_not_be_in_parents_")
+    try:
+        with temp_config({"contracts_folder": "src"}):
+            config.project_manager.path = path
+            assert config.load(force_reload=True)
+            assert path.name not in [x.name for x in config.contracts_folder.parents]
+    finally:
+        config.project_manager.path = orig


### PR DESCRIPTION
### What I did

Ape no longer works when specifying a custom contracts folder because it was using unset ProjectManager to figure something out. I am not sure why this is suddenly a problem.

### How I did it

Rely on self.PROJECT_FOLDER rather than reaching out to the `project_manager`.

### How to verify it

type `ape` in a project that specifies a custom contracts folder.
e.g. https://github.com/pcaversaccio/snekmate

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
