### PR TITLE
fix: bug where couldn't put `contracts_folder` in dependency `config_override` config

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -477,9 +477,11 @@ class DependencyAPI(ExtraAttributesMixin, BaseInterfaceModel):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir)
             contracts_folder = path / config_data.get("contracts_folder", "contracts")
-            with self.config_manager.using_project(
-                path, contracts_folder=contracts_folder, **config_data
-            ) as project:
+
+            if "contracts_folder" not in config_data:
+                config_data["contracts_folder"] = contracts_folder
+
+            with self.config_manager.using_project(path, **config_data) as project:
                 manifest.unpack_sources(contracts_folder)
                 compiled_manifest = project.local_project.create_manifest()
 

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -150,7 +150,7 @@ def test_compile_with_config_override(dependency_manager, project):
     override = {"contracts_folder": "src"}
     path = "__test_path__"
     contracts_path = project.path / path / "contracts"
-    contracts_path.mkdir(parents=True)
+    contracts_path.mkdir(exist_ok=True, parents=True)
     (contracts_path / "contract.json").write_text('{"abi": []}')
     data = {"name": "FooBar", "local": path, "config_override": override}
     dependency = dependency_manager.decode_dependency(data)

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -123,15 +123,7 @@ def test_npm_dependency(mock_home_directory):
             shutil.rmtree(package_folder)
 
 
-def test_compile(project_with_downloaded_dependencies):
-    name = "OpenZeppelin"
-    oz_442 = project_with_downloaded_dependencies.dependencies[name]["4.4.2"]
-    # NOTE: the test data is pre-compiled because the ape-solidity plugin is required.
-    actual = oz_442.compile()
-    assert len(actual.contract_types) > 0
-
-
-def test_compile_with_extra_settings(dependency_manager, project):
+def test_decode_with_config_override(dependency_manager, project):
     settings = {".json": {"evm_version": "paris"}}
     path = "__test_path__"
     base_path = project.path / path
@@ -142,6 +134,29 @@ def test_compile_with_extra_settings(dependency_manager, project):
     data = {"name": "FooBar", "local": path, "config_override": settings}
     dependency = dependency_manager.decode_dependency(data)
     assert dependency.config_override == settings
+
+
+def test_compile(project_with_downloaded_dependencies):
+    name = "OpenZeppelin"
+    oz_442 = project_with_downloaded_dependencies.dependencies[name]["4.4.2"]
+    # NOTE: the test data is pre-compiled because the ape-solidity plugin is required.
+    actual = oz_442.compile()
+    assert len(actual.contract_types) > 0
+
+
+def test_compile_with_config_override(dependency_manager, project):
+    # NOTE: It is important that `contracts_folder` is present in settings
+    #  for this test to test against a previous bug where we got multiple values.
+    override = {"contracts_folder": "src"}
+    path = "__test_path__"
+    contracts_path = project.path / path / "contracts"
+    contracts_path.mkdir(parents=True)
+    (contracts_path / "contract.json").write_text('{"abi": []}')
+    data = {"name": "FooBar", "local": path, "config_override": override}
+    dependency = dependency_manager.decode_dependency(data)
+
+    actual = dependency.compile()
+    assert len(actual.contract_types) > 0
 
 
 def test_github_dependency_ref_or_version_is_required():


### PR DESCRIPTION
### What I did

dependencies let you specify `contracts_folder` as a key but also offer a `config_override`.
however, when putting `contracts_folder` in `config_override` (which should be valid because `contracts_folder` is also a project's top-level config item), it fails with `got multiple args for keyword 'contracts_folder'`, so this fixes that.

### How I did it

check if `contracts_folder` is in config override. if no, then put the one you were gonna put else, leave it be.

### How to verify it

```yaml
dependencies:
  - name: solmate
    github: transmissions11/solmate
    ref: "v6"
    #contracts_folder: src
    config_override:
      contracts_folder: src
      compile:
        exclude: 
          - ./test/utils/*
```

run `ape pm compile`

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
