### PR TITLE
feat: allow contracts-folder (with hyphen) in ape-config.yaml

### DIFF
--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -190,7 +190,9 @@ class ConfigManager(BaseInterfaceModel):
         self.dependencies = configs["dependencies"]
 
         # NOTE: It is okay for this directory not to exist at this point.
-        contracts_folder = user_config.pop("contracts_folder", None)
+        contracts_folder = user_config.pop(
+            "contracts_folder", user_config.pop("contracts-folder", None)
+        )
         contracts_folder = (
             (self.PROJECT_FOLDER / Path(contracts_folder)).expanduser().resolve()
             if contracts_folder

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -284,3 +284,8 @@ def test_load_does_not_call_project_manager(temp_config, config):
             assert path.name not in [x.name for x in config.contracts_folder.parents]
     finally:
         config.project_manager.path = orig
+
+
+def test_contracts_folder_with_hyphen(temp_config):
+    with temp_config({"contracts-folder": "src"}) as project:
+        assert project.contracts_folder.name == "src"


### PR DESCRIPTION
### What I did

I noticed this user was using `contracts-folder` with a hyphen in their config, which should be fine I think.

### How I did it

if `contracts_folder` isn't there, try `contracts-folder`

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
