### PR TITLE
feat: Adjust `SignatureError` with helpful tip on including `sender=` tx kwarg

### DIFF
--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -61,7 +61,7 @@ class BaseTransaction(TransactionAPI):
             if not self.sender:
                 message = (
                     f"{message} "
-                    "Did you forget to add the sender argument to the transaction function call?"
+                    "Did you forget to add the `sender=` kwarg to the transaction function call?"
                 )
 
             raise SignatureError(message)

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -57,10 +57,14 @@ class AccessList(BaseModel):
 class BaseTransaction(TransactionAPI):
     def serialize_transaction(self) -> bytes:
         if not self.signature:
-            raise SignatureError(
-                "The transaction is not signed. "
-                "Did you forget to add the sender argument to the transaction function call?"
-            )
+            message = "The transaction is not signed."
+            if not self.sender:
+                message = (
+                    f"{message} "
+                    "Did you forget to add the sender argument to the transaction function call?"
+                )
+
+            raise SignatureError(message)
 
         txn_data = self.model_dump(by_alias=True, exclude={"sender", "type"})
 

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -57,7 +57,7 @@ class AccessList(BaseModel):
 class BaseTransaction(TransactionAPI):
     def serialize_transaction(self) -> bytes:
         if not self.signature:
-            raise SignatureError("The transaction is not signed. Did you forget to add sender parameter to the transaction?")
+            raise SignatureError("The transaction is not signed. Did you forget to add sender argument to the transaction function call?")
 
         txn_data = self.model_dump(by_alias=True, exclude={"sender", "type"})
 

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -57,7 +57,10 @@ class AccessList(BaseModel):
 class BaseTransaction(TransactionAPI):
     def serialize_transaction(self) -> bytes:
         if not self.signature:
-            raise SignatureError("The transaction is not signed. Did you forget to add sender argument to the transaction function call?")
+            raise SignatureError(
+                "The transaction is not signed. "
+                "Did you forget to add the sender argument to the transaction function call?"
+            )
 
         txn_data = self.model_dump(by_alias=True, exclude={"sender", "type"})
 

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -57,7 +57,7 @@ class AccessList(BaseModel):
 class BaseTransaction(TransactionAPI):
     def serialize_transaction(self) -> bytes:
         if not self.signature:
-            raise SignatureError("The transaction is not signed.")
+            raise SignatureError("The transaction is not signed. Did you forget to add sender parameter to the transaction?")
 
         txn_data = self.model_dump(by_alias=True, exclude={"sender", "type"})
 

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -115,7 +115,7 @@ def test_serialize_transaction_missing_signature(ethereum, owner):
 def test_serialize_transaction_missing_signature_and_sender(ethereum):
     expected = (
         r"The transaction is not signed. "
-        r"Did you forget to add the sender argument to the transaction function call?"
+        r"Did you forget to add the `sender=` kwarg to the transaction function call?"
     )
     txn = ethereum.create_transaction(data=HexBytes("0x123"))
     with pytest.raises(SignatureError, match=expected):

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -1,6 +1,7 @@
 import pytest
 from eth_pydantic_types import HexBytes
 
+from ape.exceptions import SignatureError
 from ape_ethereum.transactions import DynamicFeeTransaction, StaticFeeTransaction, TransactionType
 
 
@@ -91,3 +92,31 @@ def test_txn_str_when_data_is_bytes(ethereum):
 def test_transaction_with_none_receipt(ethereum):
     txn = ethereum.create_transaction(data=HexBytes("0x123"))
     assert txn.receipt is None
+
+
+def test_serialize_transaction(owner, ethereum):
+    txn = ethereum.create_transaction(
+        data=HexBytes("0x123"), max_fee=0, max_priority_fee=0, nonce=0
+    )
+    txn = owner.sign_transaction(txn)
+    assert txn is not None
+
+    actual = txn.serialize_transaction()
+    assert isinstance(actual, bytes)
+
+
+def test_serialize_transaction_missing_signature(ethereum, owner):
+    expected = r"The transaction is not signed."
+    txn = ethereum.create_transaction(data=HexBytes("0x123"), sender=owner.address)
+    with pytest.raises(SignatureError, match=expected):
+        txn.serialize_transaction()
+
+
+def test_serialize_transaction_missing_signature_and_sender(ethereum):
+    expected = (
+        r"The transaction is not signed. "
+        r"Did you forget to add the sender argument to the transaction function call?"
+    )
+    txn = ethereum.create_transaction(data=HexBytes("0x123"))
+    with pytest.raises(SignatureError, match=expected):
+        txn.serialize_transaction()


### PR DESCRIPTION
### What I did

A developer experience enhancement.

When doing a transaction with Ape, if you forget `sender` parameter you get an unhelpful error message.

Adding a help tip for `SignatureError` error message to hint to the user what's probably wrong:

```
            raise SignatureError("The transaction is not signed. Did you forget to add sender argument to the transaction function call?")
```

### How I did it

Better error message.

### How to verify it



### Checklist


- [ ] All changes are completed
- [-] New test cases have been added  (no functional changes)
- [ ] Documentation has been updated (no functional changes)
