### PR TITLE
docs: exclude `model_` prefixed methods appearing in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,6 +79,11 @@ html_css_files = ["custom.css"]
 # since not all links are available in the markdown files pre-build.
 myst_all_links_external = True
 
+# Set some default to avoid unnecessary repetitious directives.
+autodoc_default_options = {
+    "exclude-members": "__repr__,__weakref__,__metaclass__,__init__,model_config,model_fields,model_post_init"
+}
+
 
 def fixpath(path: str) -> str:
     """

--- a/docs/methoddocs/api.md
+++ b/docs/methoddocs/api.md
@@ -7,7 +7,6 @@
     :members:
     :show-inheritance:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ## Address
@@ -33,7 +32,6 @@
     :members:
     :show-inheritance:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ## Convert
@@ -59,7 +57,6 @@
     :members:
     :show-inheritance:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ## Projects
@@ -84,14 +81,12 @@
 .. autoclass:: ape.api.transactions.ReceiptAPI
     :members:
     :show-inheritance:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ```{eval-rst}
 .. autoclass:: ape.api.transactions.TransactionAPI
     :members:
     :show-inheritance:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ## Query
@@ -101,5 +96,4 @@
     :members:
     :show-inheritance:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```

--- a/docs/methoddocs/contracts.md
+++ b/docs/methoddocs/contracts.md
@@ -5,7 +5,6 @@
     :members:
     :show-inheritance:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ```{eval-rst}
@@ -13,7 +12,6 @@
     :members:
     :show-inheritance:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ```{eval-rst}
@@ -21,7 +19,6 @@
     :members:
     :show-inheritance:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __call__, __init__
 ```
 
 ```{eval-rst}
@@ -29,5 +26,4 @@
     :members:
     :show-inheritance:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __call__, __init__
 ```

--- a/docs/methoddocs/managers.md
+++ b/docs/methoddocs/managers.md
@@ -6,7 +6,6 @@
 .. automodule:: ape.managers.accounts
     :members:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ## Compilers
@@ -22,35 +21,30 @@
 .. autoclass:: ape.managers.chain.TransactionHistory
     :members:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ```{eval-rst}
 .. autoclass:: ape.managers.chain.AccountHistory
     :members:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ```{eval-rst}
 .. autoclass:: ape.managers.chain.ContractCache
     :members:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ```{eval-rst}
 .. autoclass:: ape.managers.chain.BlockContainer
     :members:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ```{eval-rst}
 .. autoclass:: ape.managers.chain.ChainManager
     :members:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ## Config
@@ -59,7 +53,6 @@
 .. automodule:: ape.managers.config
     :members:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ## Converters
@@ -82,35 +75,30 @@
 .. automodule:: ape.managers.project.manager
     :members:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ```{eval-rst}
 .. automodule:: ape.managers.project.dependency
     :members:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ```{eval-rst}
 .. autoclass:: ape.managers.project.types.BaseProject
     :members:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ```{eval-rst}
 .. autoclass:: ape.managers.project.types.ApeProject
     :members:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ```{eval-rst}
 .. autoclass:: ape.managers.project.types.BrownieProject
     :members:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```
 
 ## Query
@@ -119,5 +107,4 @@
 .. automodule:: ape.managers.query
     :members:
     :special-members:
-    :exclude-members: __repr__, __weakref__, __metaclass__, __init__
 ```


### PR DESCRIPTION
### What I did

These are related to pydantic integration are not meant to be public.

### How I did it

I found a way to share the code by setting a default value in `conf.py`
yay deleting code!

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
