### PR TITLE
fix: raise error when installing a dependency results in zero sources

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -541,21 +541,29 @@ class DependencyAPI(ExtraAttributesMixin, BaseInterfaceModel):
             contracts_folder=(project_path / self.contracts_folder).expanduser().resolve(),
         ) as pm:
             project = pm.local_project
-            sources = self._get_sources(project)
-            dependencies = self.project_manager._extract_manifest_dependencies()
+            if sources := self._get_sources(project):
+                dependencies = self.project_manager._extract_manifest_dependencies()
 
-            extras: Dict = {}
-            if dependencies:
-                extras["dependencies"] = dependencies
+                extras: Dict = {}
+                if dependencies:
+                    extras["dependencies"] = dependencies
 
-            project.update_manifest_sources(
-                sources,
-                project.contracts_folder,
-                {},
-                name=project.name,
-                version=project.version,
-                **extras,
-            )
+                project.update_manifest_sources(
+                    sources,
+                    project.contracts_folder,
+                    {},
+                    name=project.name,
+                    version=project.version,
+                    **extras,
+                )
+            else:
+                raise ProjectError(
+                    f"No source files found in dependency '{self.name}'. "
+                    "Try adjusting its config using `config_override` to "
+                    "get Ape to recognize the project. "
+                    "\nMore information: "
+                    "http://127.0.0.1:1337/ape/latest/userguides/dependencies.html#config-override"
+                )
 
         # Replace the dependency's manifest with the temp project's.
         self.replace_manifest(project.manifest)


### PR DESCRIPTION
### What I did

Right now, if you have a dependency configured wrong and it produces no sources, you get absolutely no warning or error in Ape, leading to much greater confusion and messed up state down the line.

This PR makes dependency installation completely fail in that case.
I think that makes the most sense because no matter what, you are going to be forced to re-install to fix it.
It is simpler to just not cache then and also just throw an exception.
At the very least, some sort of warning must be shown to the user because right now you just get a "SUCCESS" which even threw me off on the issue!

fixes: #1817 

### How I did it

Raise a `ProjectError` with a helpful tip on using `config_override` when a dependency is completely source-less after installation. Typically, you just need to set a contracts_folder or something, but who really knows all the cases.

### How to verify it

```yaml
dependencies:
  - name: solmate
    github: transmissions11/solmate
    ref: "v6"
    # contracts_folder: src
    # config_override:
    #   compile:
    #     exclude: 
    #       - ./test/utils/*
```

If you install as-is, it fails.
then uncomment and install and it works.

before, you had to do `ape pm install . --force` to override the bad one and you also didnt get an indicator that it was bad.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
