### PR TITLE
fix: issue where could not create an access-list transaction

### DIFF
--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -825,7 +825,7 @@ class Web3Provider(ProviderAPI, ABC):
 
         txn_type = TransactionType(txn.type)
         if (
-            txn_type == TransactionType.STATIC
+            txn_type in (TransactionType.STATIC, TransactionType.ACCESS_LIST)
             and isinstance(txn, StaticFeeTransaction)
             and txn.gas_price is None
         ):

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -128,9 +128,10 @@ class DynamicFeeTransaction(BaseTransaction):
         return value.value if isinstance(value, TransactionType) else value
 
 
-class AccessListTransaction(BaseTransaction):
+class AccessListTransaction(StaticFeeTransaction):
     """
-    EIP-2930 transactions are similar to legacy transaction with an added access list functionality.
+    `EIP-2930 <https://eips.ethereum.org/EIPS/eip-2930>`__
+    transactions are similar to legacy transaction with an added access list functionality.
     """
 
     gas_price: Optional[int] = Field(None, alias="gasPrice")

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -122,7 +122,9 @@ class TestAccount(TestAccountAPI):
 
     def sign_transaction(self, txn: TransactionAPI, **signer_options) -> Optional[TransactionAPI]:
         # Signs anything that's given to it
-        signature = EthAccount.sign_transaction(txn.model_dump(mode="json"), self.private_key)
+        signature = EthAccount.sign_transaction(
+            txn.model_dump(mode="json", by_alias=True), self.private_key
+        )
         txn.signature = TransactionSignature(
             v=signature.v,
             r=to_bytes(signature.r),

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -45,8 +45,12 @@ def test_create_dynamic_fee_kwargs(ethereum, fee_kwargs):
         assert txn.max_fee == int(100e9)
 
 
-def test_txn_hash_and_receipt(owner, eth_tester_provider, ethereum):
-    txn = ethereum.create_transaction()
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"type": 0}, {"type": 1}, {"type": 2, "max_fee": 1_000_000_000}],
+)
+def test_txn_hash_and_receipt(owner, eth_tester_provider, ethereum, kwargs):
+    txn = ethereum.create_transaction(**kwargs)
     txn = owner.prepare_transaction(txn)
     txn = owner.sign_transaction(txn)
     assert txn


### PR DESCRIPTION
### What I did

https://eips.ethereum.org/EIPS/eip-2930
It says it is the same as the legacy types, so the fixes here make that happen.

### How I did it

* Issue where gasPrice was not automatically set during `prepare_transaction` for Access-list transactions
* Issue where Access list transactions failed when you didn't set a `max_fee`, which doesn't make sense because they ain't EIP-1559 transactions
* Issue where signing a tx, access list was in `snake_case` instead of `camelCase`

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
