### PR TITLE
fix: various bugs regarding `AccessList` usage in transactions (type 1 and 2)

### DIFF
--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -837,6 +837,7 @@ class Web3Provider(ProviderAPI, ABC):
             if txn.max_fee is None:
                 multiplier = self.network.base_fee_multiplier
                 txn.max_fee = int(self.base_fee * multiplier + txn.max_priority_fee)
+
             # else: Assume user specified the correct amount or txn will fail and waste gas
 
         gas_limit = self.network.gas_limit if txn.gas_limit is None else txn.gas_limit

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -51,7 +51,9 @@ class TransactionType(Enum):
 
 class AccessList(BaseModel):
     address: str
-    storage_keys: List[Union[str, bytes, int]] = Field(default_factory=list, alias="storageKeys")
+    storage_keys: List[Union[HexBytes, bytes, str, int]] = Field(
+        default_factory=list, alias="storageKeys"
+    )
 
 
 class BaseTransaction(TransactionAPI):

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -74,6 +74,21 @@ class BaseTransaction(TransactionAPI):
         if txn_data.get("to") == ZERO_ADDRESS:
             del txn_data["to"]
 
+        # Adjust bytes in the access list if necessary.
+        if "accessList" in txn_data:
+            adjusted_access_list = []
+
+            for item in txn_data["accessList"]:
+                adjusted_item = {**item}
+                storage_keys_corrected = [HexBytes(k).hex() for k in item.get("storageKeys", [])]
+
+                if storage_keys_corrected:
+                    adjusted_item["storageKeys"] = storage_keys_corrected
+
+                adjusted_access_list.append(adjusted_item)
+
+            txn_data["accessList"] = adjusted_access_list
+
         unsigned_txn = serializable_unsigned_transaction_from_dict(txn_data)
         signature = (self.signature.v, to_int(self.signature.r), to_int(self.signature.s))
         signed_txn = encode_transaction(unsigned_txn, signature)

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -441,6 +441,13 @@ def test_create_transaction_with_none_values(ethereum, eth_tester_provider):
     assert dynamic.max_priority_fee is None
 
 
+@pytest.mark.parametrize("kwarg_name", ("max_fee", "max_fee_per_gas", "maxFee", "maxFeePerGas"))
+def test_create_transaction_max_fee_per_gas(kwarg_name, ethereum):
+    fee = 1_000_000_000
+    tx = ethereum.create_transaction(**{kwarg_name: fee})
+    assert tx.max_fee == fee
+
+
 @pytest.mark.parametrize("tx_type", TransactionType)
 def test_encode_transaction(tx_type, ethereum, vyper_contract_instance, owner, eth_tester_provider):
     abi = vyper_contract_instance.contract_type.methods[0]

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -2,7 +2,112 @@ import pytest
 from eth_pydantic_types import HexBytes
 
 from ape.exceptions import SignatureError
-from ape_ethereum.transactions import DynamicFeeTransaction, StaticFeeTransaction, TransactionType
+from ape_ethereum.transactions import (
+    AccessList,
+    DynamicFeeTransaction,
+    StaticFeeTransaction,
+    TransactionType,
+)
+
+ACCESS_LIST = [{"address": "0x0000000000000000000000000000000000000004", "storageKeys": []}]
+LONG_ACCESS_LIST = [
+    {
+        "address": "0x5Ab952D45d33ba32DBAA3Da85b0738aC9DF24626",
+        "storageKeys": [
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000000"),
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000004"),
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000001"),
+            HexBytes("0x9c04773acff4c5c42718bd0120c72761f458e43068a3961eb935577d1ed4effb"),
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000008"),
+        ],
+    },
+    {
+        "address": "0x60594a405d53811d3BC4766596EFD80fd545A270",
+        "storageKeys": [
+            HexBytes("0x2e7eb34672b18adb9244b4932b747ae4bcb4f839a51cd3b2e72e6113c9d4d285"),
+            HexBytes("0x000000000000000000000000000000000000000000000000000000000000005c"),
+            HexBytes("0x000000000000000000000000000000000000000000000000000000000000005d"),
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000000"),
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000004"),
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000002"),
+        ],
+    },
+    {
+        "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        "storageKeys": [
+            HexBytes("0x29cb8bd4e192d16f51155329ce8b0f5eb88a1d9e4d3b93ce07efbac9e1c4d175"),
+            HexBytes("0x995f3b129dd3291868ddb9cf202c75cd985227d50e309847fbab0f8da403b19c"),
+        ],
+    },
+    {
+        "address": "0x709b80deC74CA88e9394DEaB45840d861BD5398d",
+        "storageKeys": [
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000006"),
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000007"),
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000009"),
+            HexBytes("0x000000000000000000000000000000000000000000000000000000000000000a"),
+            HexBytes("0x000000000000000000000000000000000000000000000000000000000000000c"),
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000008"),
+        ],
+    },
+    {
+        "address": "0x45E412E1878080815D6D51d47B83D17869433459",
+        "storageKeys": [
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000005"),
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000008"),
+            HexBytes("0x3a8870f40d200d252a256529d1f22c4f977b6e09dc78c6ebdeffd3f8651c4719"),
+            HexBytes("0x2d027208e382c51007968756a0988c06fc25a78a1ef13c193023db7354fa6ea9"),
+            HexBytes("0xc247e5713292da7b6b8145ca699e5c90c1257a929a9b107aa7c7d211bc3a369c"),
+            HexBytes("0x50164d12bd200c7817ac53416fd234974ec726930dca7760174d351e0e29af6a"),
+            HexBytes("0x000000000000000000000000000000000000000000000000000000000000000f"),
+            HexBytes("0xb8e6a40a2729c4eca72da15a47bea21de47ee5b868eb98a2a3966fe05bc777c6"),
+            HexBytes("0x1e4e2ca44a4ccf068a5ab14ea9a4d61e97a8b5395bf782d9b2032e0ee8487c29"),
+            HexBytes("0x000000000000000000000000000000000000000000000000000000000000000b"),
+            HexBytes("0x5de84563fdc81a8663ce72466e3e1e667da5e6c8834c90c011812476ee214f3c"),
+            HexBytes("0xb39e9ba92c3c47c76d4f70e3bc9c3270ab78d2592718d377c8f5433a34d3470a"),
+            HexBytes("0x86853267f2534b9eec92fd7a80680d7481e5e740ce8d21c54361341b3a3c1f14"),
+            HexBytes("0xa78b521343fce79b129d9bbe9bff921a08c8a8fde6ae24a7e159847b3ba54bb7"),
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000010"),
+            HexBytes("0x000000000000000000000000000000000000000000000000000000000000000a"),
+            HexBytes("0x000000000000000000000000000000000000000000000000000000000000001d"),
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000009"),
+            HexBytes("0x21c632ec26149a6f0282e6b24bf8cb49cdf334cfb6e21a8f4001c5e39c858863"),
+        ],
+    },
+    {
+        "address": "0xFb76CD5e9Fb9351137C3CE0aC1C23212C46995A7",
+        "storageKeys": [
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000002"),
+            HexBytes("0x9c04773acff4c5c42718bd0120c72761f458e43068a3961eb935577d1ed4effb"),
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000008"),
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000000"),
+            HexBytes("0x0000000000000000000000000000000000000000000000000000000000000004"),
+        ],
+    },
+    {
+        "address": "0x3005003BDA885deE7c74182e5FE336e9E3Df87bB",
+        "storageKeys": [
+            HexBytes("0x23d376ed44ad443baf938cf24280e50027474804f2cdc01ec9195cdc123467a5"),
+            HexBytes("0x577b913a3c8810dd10161c9ae11e2ee31042564c62114c83b0bc5d3a3e71b362"),
+            HexBytes("0x04421adc6f4dd2e52160b542e3ea06d21bd261fae596660765cf3964443fa2b7"),
+        ],
+    },
+    {
+        "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        "storageKeys": [
+            HexBytes("0xbb0d37a1af2c606132ece9f63118a24cfb959e4791cb65d639217bd82f7282b3"),
+            HexBytes("0xf762dfe765e313d39f5dd6e34e29a9ef0af51578e67f7f482bb4f8efd984976b"),
+            HexBytes("0xa3303497cfb83efa67ca4f88b647c0dc6639b10da44cd96ac8b3488d155cf935"),
+            HexBytes("0xb73247ebb5deb7b0fcdb78323c538aca3746ddf79808af84f3cf760fcb915185"),
+            HexBytes("0x12231cd4c753cb5530a43a74c45106c24765e6f81dc8927d4f4be7e53315d5a8"),
+        ],
+    },
+]
+
+
+@pytest.fixture
+def access_list():
+    return ACCESS_LIST
 
 
 @pytest.mark.parametrize("type_kwarg", (0, "0x0", b"\x00", "0", HexBytes("0x0"), HexBytes("0x00")))
@@ -21,6 +126,12 @@ def test_create_access_list_transaction(ethereum, type_kwarg):
 def test_create_dynamic_fee_transaction(ethereum, type_kwarg):
     txn = ethereum.create_transaction(type=type_kwarg)
     assert txn.type == TransactionType.DYNAMIC.value
+
+
+def test_create_dynamic_fee_transaction_with_access_lists(ethereum, access_list):
+    txn = ethereum.create_transaction(type=2, accessList=access_list)
+    assert txn.type == TransactionType.DYNAMIC.value
+    assert txn.access_list == [AccessList.model_validate(x) for x in access_list]
 
 
 @pytest.mark.parametrize(
@@ -47,7 +158,14 @@ def test_create_dynamic_fee_kwargs(ethereum, fee_kwargs):
 
 @pytest.mark.parametrize(
     "kwargs",
-    [{"type": 0}, {"type": 1}, {"type": 2, "max_fee": 1_000_000_000}],
+    [
+        {"type": 0},
+        {"type": 1},
+        {"type": 1, "accessList": ACCESS_LIST},
+        {"type": 1, "accessList": LONG_ACCESS_LIST},
+        {"type": 2, "max_fee": 1_000_000_000},
+        {"type": 2, "accessList": ACCESS_LIST},
+    ],
 )
 def test_txn_hash_and_receipt(owner, eth_tester_provider, ethereum, kwargs):
     txn = ethereum.create_transaction(**kwargs)


### PR DESCRIPTION
### What I did

* fix: issue where didnt create access list tx by default when excluding type 2 and including access list stuff
* feat: allow more alias-keys in create_transaction Ethereum method
* fix: issue where could not init a storage key of bytes type
* issue where if hacked in a raw access list using bytes type, serializing the tx would fail
  **NOTE**: This is the issue the user was seeing. However, I could never actually hit this state myself without
   doing a weird hack. Nonetheless, am confident this issue is even more impossible to happen now in Ape.
* fix: issue where `prepare_transaction` did not set `gasPrice` for AccessLisTransaction (type 1)

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
