### PR TITLE
docs: document explorer URL in custom networks

### DIFF
--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -170,6 +170,35 @@ geth:
 
 Now, when using `ethereum:apenet:geth`, it will connect to the RPC URL `https://apenet.example.com/rpc`.
 
+#### Explorer URL
+
+To configure explorer URLs for your custom network, use the explorer's plugin config.
+For example, let's say you added the following network:
+
+```yaml
+networks:
+  custom:
+    - name: customnetwork
+      chain_id: 31337
+      default_provider: geth
+```
+
+To add a corresponding entry in `ape-etherscan` (assuming you are using `ape-etherscan` as your explorer plugin), add the following to your `ape-config.yaml` file:
+
+```yaml
+etherscan:
+  ethereum:
+    rate_limit: 15  # Configure a rate limit that makes sense for retry logic.
+    
+    # The name of the entry is the same as your custom network!
+    customnetwork:
+      uri: https://custom.scan              # URL used for showing transactions
+      api_uri: https://api.custom.scan/api  # URL used for making API requests.
+```
+
+**NOTE**: Every explorer plugin may be different in how you configure custom networks.
+Consult the plugin's README to clarify.
+
 #### Block time, transaction type, and more config
 
 Configuring network properties in Ape is the same regardless of whether it is custom or not.

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 from typing import Any, Callable, Iterator, List, Optional, Sequence, Type, Union
 
 import click
-from click import BadOptionUsage, BadParameter, Choice, Context, Parameter
+from click import BadParameter, Choice, Context, Parameter
 
 from ape import accounts, networks
 from ape.api.accounts import AccountAPI
@@ -358,13 +358,6 @@ class NetworkChoice(click.Choice):
         elif self.is_custom_value(value):
             # By-pass choice constraints when using custom network.
             choice = value
-
-        elif "custom" in value:
-            raise BadOptionUsage(
-                "--network",
-                "Custom network options must include connection str as well, "
-                "such as the URI. Check `provider.network_choice` (if possible).",
-            )
 
         else:
             # Regular conditions.


### PR DESCRIPTION
### What I did

including how to configure explorer URL before someone opens issues about it being missing from the docs.
Refers to this com/ApeWorX/ape-etherscan/pull/112

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
