### PR TITLE
fix: custom ecosystem work and custom network fixes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,7 +86,7 @@ jobs:
         - name: Install Geth
           uses: gacts/install-geth-tools@v1
           with:
-            version: 1.12.2
+            version: 1.13.10
 
         - name: Install Dependencies
           run: |

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -131,13 +131,13 @@ Read more on the network option [here](#selecting-a-network).
 **chain_id**: The chain ID is required for config-based custom networks.
 It ensures you are on the correct network when making transactions and is very important!
 
-**ecosystem**: You can optionally tell Ape what ecosystem a custom network is part of.
-Without specifying, custom networks appear in the `"ethereum"` ecosystem.
-Recall, you refer to your network via the network-triplet `ecosystem:network:provider`.
-The ecosystem system class is largely responsible for decoding and encoding data to-and-fro the blockchain.
+**ecosystem**: Configure your custom network's ecosystem.
+By default, custom networks appear in the `"ethereum"` ecosystem.
+Recall, you refer to your network via the network-triplet `ecosystem:network:provider` option-str.
+The ecosystem class is largely responsible for decoding and encoding data to-and-fro the blockchain.
 More information about the EcosystemAPI can be found [here](../methoddocs/api.html#ape.api.networks.EcosystemAPI).
-The default ecosystem is `ethereum`, which is the base class to most other L2 ecosystems and is defined in the core plugin `ape-ethereum`.
-If your custom network is part of a new ecosystem, such as Shibarium, use a new name as your ecosystem, e.g. `"shibarium"`.
+The default ecosystem is `ethereum`, which is the base class to most other L2 ecosystems and is defined in the Ape core plugin `ape-ethereum`.
+If your custom network is part of a new ecosystem, such as Shibarium, use the name of the new ecosystem, e.g. `"shibarium"`.
 However, if your ecosystem is not an existing plugin-based ecosystem, you may want to also adjust the `base_ecosystem_plugin` config to change the base-class used.
 
 **base_ecosystem_plugin**: The plugin that defines the base-class to your custom ecosystem containing your custom network(s).

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -116,10 +116,11 @@ To add custom networks to your `ape-config.yaml` file, follow this pattern:
 ```yaml
 networks:
   custom:
-     - name: apenet             # Required
-       chain_id: 9867733322210  # Required
-       ecosysem: ethereum       # Defaults to your default ecosystem
-       default_provider: geth   # Default is the generic node provider
+     - name: apenet                    # Required
+       chain_id: 9867733322210         # Required
+       ecosystem: shibarium            # Defaults to your default ecosystem
+       base_ecosystem_plugin: polygon  # Change the base-class
+       default_provider: geth          # Default is the generic node provider
 ```
 
 The following paragraphs explain the different parameters of the custom network config.
@@ -130,13 +131,19 @@ Read more on the network option [here](#selecting-a-network).
 **chain_id**: The chain ID is required for config-based custom networks.
 It ensures you are on the correct network when making transactions and is very important!
 
-**ecosystem**: You can optionally change the ecosystem class Ape uses.
+**ecosystem**: You can optionally tell Ape what ecosystem a custom network is part of.
+Without specifying, custom networks appear in the `"ethereum"` ecosystem.
+Recall, you refer to your network via the network-triplet `ecosystem:network:provider`.
 The ecosystem system class is largely responsible for decoding and encoding data to-and-fro the blockchain.
 More information about the EcosystemAPI can be found [here](../methoddocs/api.html#ape.api.networks.EcosystemAPI).
 The default ecosystem is `ethereum`, which is the base class to most other L2 ecosystems and is defined in the core plugin `ape-ethereum`.
-If your custom network's ecosystem matches closer to another L2 instead of Ethereum, use that ecosystem name as your `ecosystem` in your custom network config.
+If your custom network is part of a new ecosystem, such as Shibarium, use a new name as your ecosystem, e.g. `"shibarium"`.
+However, if your ecosystem is not an existing plugin-based ecosystem, you may want to also adjust the `base_ecosystem_plugin` config to change the base-class used.
+
+**base_ecosystem_plugin**: The plugin that defines the base-class to your custom ecosystem containing your custom network(s).
+If your custom network's ecosystem matches closer to another L2 instead of Ethereum, use that ecosystem name as your `base_ecosystem_plugin` in your custom network config.
 For example, take note that `"ethereum"` assumes EIP-1559 exists (unless configured otherwise).
-If your custom network is closer to Fantom, Polygon, Avalanche, or any other L2, you may want to consider using one of those plugins as the `ecosystem` to your custom network.
+If your custom network is closer to Fantom, Polygon, Avalanche, or any other L2, you may want to consider using one of those plugins as the `base_ecosystem_plugin` to your custom network.
 Alternatively, you can configure your custom network the same way you configure any other network in the config (see [this section](#block-time-transaction-type-and-more-config)).
 
 **default_provider**: The default provider is the provider class used for making the connection to your custom network, unless you specify a different provider (hence the `default_`).
@@ -222,7 +229,7 @@ Ape also lets you connect to custom networks on-the-fly!
 If you would like to connect to a URI using an existing ecosystem plugin, you can specify a URI in the provider-section for the `--network` option:
 
 ```bash
-ape run script --network <ecosysem-name>:<network-name>:https://foo.bar
+ape run script --network <ecosystem-name>:<network-name>:https://foo.bar
 ```
 
 Additionally, if you want to connect to an unknown ecosystem or network, you can use the URI by itself.

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -116,10 +116,10 @@ To add custom networks to your `ape-config.yaml` file, follow this pattern:
 ```yaml
 networks:
   custom:
-     - name: apenet                    # Required
-       chain_id: 9867733322210         # Required
-       ecosystem: shibarium            # Defaults to your default ecosystem
-       base_ecosystem_plugin: polygon  # Change the base-class
+     - name: mainnet                   # Required
+       chain_id: 109                   # Required
+       ecosystem: shibarium            # The ecosystem name, can either be new or an existing
+       base_ecosystem_plugin: polygon  # The ecosystem base-class, defaults to the default ecosystem
        default_provider: geth          # Default is the generic node provider
 ```
 
@@ -131,14 +131,13 @@ Read more on the network option [here](#selecting-a-network).
 **chain_id**: The chain ID is required for config-based custom networks.
 It ensures you are on the correct network when making transactions and is very important!
 
-**ecosystem**: Configure your custom network's ecosystem.
-By default, custom networks appear in the `"ethereum"` ecosystem.
+**ecosystem**: Specify your custom network's ecosystem.
+This can either be an existing ecosystem or a new name entirely.
 Recall, you refer to your network via the network-triplet `ecosystem:network:provider` option-str.
-The ecosystem class is largely responsible for decoding and encoding data to-and-fro the blockchain.
+The ecosystem class is largely responsible for decoding and encoding data to-and-fro the blockchain but also contains all the networks.
 More information about the EcosystemAPI can be found [here](../methoddocs/api.html#ape.api.networks.EcosystemAPI).
-The default ecosystem is `ethereum`, which is the base class to most other L2 ecosystems and is defined in the Ape core plugin `ape-ethereum`.
 If your custom network is part of a new ecosystem, such as Shibarium, use the name of the new ecosystem, e.g. `"shibarium"`.
-However, if your ecosystem is not an existing plugin-based ecosystem, you may want to also adjust the `base_ecosystem_plugin` config to change the base-class used.
+You may want to also adjust the `base_ecosystem_plugin` config to change the base-class used.
 
 **base_ecosystem_plugin**: The plugin that defines the base-class to your custom ecosystem containing your custom network(s).
 If your custom network's ecosystem matches closer to another L2 instead of Ethereum, use that ecosystem name as your `base_ecosystem_plugin` in your custom network config.
@@ -160,19 +159,19 @@ To configure the RPC URL for a custom network, use the configuration of the prov
 For example, if the RPC URL is `https://apenet.example.com/rpc`, configure it by doing:
 
 ```yaml
-default_ecosystem: ethereum  # Is default, but including for clarity.
+default_ecosystem: shibarium
 
 networks:
   custom:
-     - name: apenet
-       chain_id: 9867733322210
-       default_provider: geth  # Is default, but including for clarity.
+    - name: mainnet
+      ecosystem: shibarium
+      base_ecosystem_plugin: polygon  # Closest base class.
+      chain_id: 109  # This must be correct or txns will fail.
 
 geth:
-  ethereum:
-    # NOTE: Use your custom network as the key!
-    apenet:
-      uri: https://apenet.example.com/rpc
+  shibarium:
+    mainnet:
+      uri: https://www.shibrpc.com
 ```
 
 Now, when using `ethereum:apenet:geth`, it will connect to the RPC URL `https://apenet.example.com/rpc`.

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -268,9 +268,6 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
             network_api._is_custom = True
             networks[custom_net.name] = network_api
 
-        if not networks:
-            raise NetworkError("No networks found")
-
         return networks
 
     @cached_property

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -975,8 +975,7 @@ class NetworkAPI(BaseInterfaceModel):
             if (
                 self.is_adhoc
                 or (self.ecosystem.name == ecosystem_name and self.name == network_name)
-                or self._is_custom
-                and self.default_provider_name == provider_name
+                or (self._is_custom and self.default_provider_name == provider_name)
             ):
                 # NOTE: Lazily load provider config
                 providers[provider_name] = partial(

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -244,12 +244,12 @@ class ProviderAPI(BaseInterfaceModel):
         """
         The connected network choice string.
         """
-        if self.network.name == "custom" and self.connection_str:
+        if self.network.is_adhoc and self.connection_str:
             # `custom` is not a real network and is same
             # as using raw connection str
             return self.connection_str
 
-        elif self.network.name == "custom":
+        elif self.network.is_adhoc:
             raise ProviderError("Custom network provider missing `connection_str`.")
 
         return f"{self.network.choice}:{self.name}"

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -108,7 +108,7 @@ class NetworkManager(BaseManager):
         The set of all ecosystem names in ``ape``.
         """
 
-        return {e[0] for e in self.plugin_manager.ecosystems}
+        return set(self.ecosystems)
 
     @property
     def network_names(self) -> Set[str]:
@@ -116,12 +116,7 @@ class NetworkManager(BaseManager):
         The set of all network names in ``ape``.
         """
 
-        names = set()
-        for ecosystem in self.ecosystems.values():
-            for network in ecosystem.networks.keys():
-                names.add(network)
-
-        return names
+        return {n for e in self.ecosystems.values() for n in e.networks}
 
     @property
     def provider_names(self) -> Set[str]:
@@ -136,12 +131,32 @@ class NetworkManager(BaseManager):
             for provider in network.providers
         )
 
-    @cached_property
+    @property
     def ecosystems(self) -> Dict[str, EcosystemAPI]:
         """
         All the registered ecosystems in ``ape``, such as ``ethereum``.
         """
+        ecosystem_objs = self._plugin_ecosystems
 
+        # Load config.
+        custom_networks: List = self.config_manager.get_config("networks").get("custom", [])
+        for custom_network in custom_networks:
+            ecosystem_name = custom_network.ecosystem or "ethereum"
+            if ecosystem_name in ecosystem_objs:
+                # Already included in previous network.
+                continue
+
+            base_ecosystem_name = custom_network.get("base_ecosystem_plugin") or "ethereum"
+            existing_cls = ecosystem_objs[base_ecosystem_name]
+            ecosystem_cls = existing_cls.model_copy(
+                update={"name": ecosystem_name}, cache_clear=("_networks_from_plugins",)
+            )
+            ecosystem_objs[ecosystem_name] = ecosystem_cls
+
+        return ecosystem_objs
+
+    @cached_property
+    def _plugin_ecosystems(self) -> Dict[str, EcosystemAPI]:
         def to_kwargs(name: str) -> Dict:
             return {
                 "name": name,
@@ -149,8 +164,9 @@ class NetworkManager(BaseManager):
                 "request_header": self.config_manager.REQUEST_HEADER,
             }
 
-        ecosystems = self.plugin_manager.ecosystems
-        return {n: cls(**to_kwargs(n)) for n, cls in ecosystems}  # type: ignore
+        # Load plugins.
+        plugins = self.plugin_manager.ecosystems
+        return {n: cls(**to_kwargs(n)) for n, cls in plugins}  # type: ignore[operator]
 
     def create_custom_provider(
         self,
@@ -253,17 +269,13 @@ class NetworkManager(BaseManager):
             eth = networks.ethereum
         """
 
-        if attr_name not in self.ecosystems:
-            # First try alternating the hyphen and underscores.
-            attr_name_fix = (
-                attr_name.replace("_", "-") if "_" in attr_name else attr_name.replace("-", "_")
-            )
-            if attr_name_fix in self.ecosystems:
-                return self.ecosystems[attr_name_fix]
+        options = {attr_name, attr_name.replace("-", "_"), attr_name.replace("_", "-")}
+        ecosystems = self.ecosystems
+        for opt in options:
+            if opt in ecosystems:
+                return ecosystems[opt]
 
-            raise ApeAttributeError(f"{NetworkManager.__name__} has no attribute '{attr_name}'.")
-
-        return self.ecosystems[attr_name]
+        raise ApeAttributeError(f"{NetworkManager.__name__} has no attribute '{attr_name}'.")
 
     def get_network_choices(
         self,

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -585,8 +585,9 @@ class NetworkManager(BaseManager):
             ecosystem_data["isDefault"] = True
 
         ecosystem_data["networks"] = []
+        networks = getattr(self, ecosystem_name).networks
 
-        for network_name in getattr(self, ecosystem_name).networks:
+        for network_name in networks:
             if network_filter and network_name not in network_filter:
                 continue
 

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -1,5 +1,16 @@
 from abc import ABC
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, List, Optional, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Union,
+    cast,
+)
 
 from ethpm_types import BaseModel as EthpmTypesBaseModel
 from pydantic import BaseModel as RootBaseModel
@@ -9,6 +20,8 @@ from ape.exceptions import ApeAttributeError, ApeIndexError, ProviderNotConnecte
 from ape.logging import logger
 
 if TYPE_CHECKING:
+    from pydantic.main import Model
+
     from ape.api.providers import ProviderAPI
     from ape.managers.accounts import AccountManager
     from ape.managers.chain import ChainManager
@@ -217,6 +230,22 @@ class BaseModel(EthpmTypesBaseModel):
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def model_copy(
+        self: "Model",
+        *,
+        update: dict[str, Any] | None = None,
+        deep: bool = False,
+        cache_clear: Optional[Sequence[str]] = None,
+    ) -> "Model":
+        result = super().model_copy(update=update, deep=deep)
+
+        # Clear @cached_properties
+        for cached_item in cache_clear or []:
+            if cached_item in result.__dict__:
+                del result.__dict__[cached_item]
+
+        return result
 
 
 class ExtraAttributesMixin:

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -234,7 +234,7 @@ class BaseModel(EthpmTypesBaseModel):
     def model_copy(
         self: "Model",
         *,
-        update: dict[str, Any] | None = None,
+        update: Optional[Dict[str, Any]] = None,
         deep: bool = False,
         cache_clear: Optional[Sequence[str]] = None,
     ) -> "Model":

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1012,7 +1012,7 @@ class Web3Provider(ProviderAPI, ABC):
                 new_err_msg, base_err=exception, code=err_data.get("code"), **kwargs
             )
 
-        elif "out of gas" in str(err_msg):
+        elif "out of gas" in str(err_msg) or "intrinsic gas too low":
             return OutOfGasError(code=err_data.get("code"), base_err=exception, **kwargs)
 
         return VirtualMachineError(str(err_msg), code=(err_data or {}).get("code"), **kwargs)

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1169,7 +1169,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
             self.block_page_size = 50_000
         else:
             client_name = client_version.split("/")[0]
-            logger.warning(f"Connecting Geth plugin to non-Geth client '{client_name}'.")
+            logger.info(f"Connecting to a '{client_name}' node.")
 
         self.web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
 

--- a/src/ape_networks/__init__.py
+++ b/src/ape_networks/__init__.py
@@ -9,22 +9,22 @@ class CustomNetwork(PluginConfig):
     A custom network config.
     """
 
-    """Name of the network e.g. mainnet"""
+    """Name of the network e.g. mainnet."""
     name: str
 
-    """Chain ID (required)"""
+    """Chain ID (required)."""
     chain_id: int
 
-    """The name of the ecosystem"""
-    ecosystem: Optional[str] = None
+    """The name of the ecosystem."""
+    ecosystem: str
 
-    """The base ecosystem plugin to use, when applicable"""
+    """The base ecosystem plugin to use, when applicable. Defaults to the default ecosystem."""
     base_ecosystem_plugin: Optional[str] = None
 
-    """The default provider plugin to use"""
-    default_provider: str = "geth"  # Default node.
+    """The default provider plugin to use. Default is the default node provider."""
+    default_provider: str = "geth"
 
-    """The HTTP request header"""
+    """The HTTP request header."""
     request_header: Dict = {}
 
 

--- a/src/ape_networks/__init__.py
+++ b/src/ape_networks/__init__.py
@@ -5,10 +5,26 @@ from ape.api import PluginConfig
 
 
 class CustomNetwork(PluginConfig):
+    """
+    A custom network config.
+    """
+
+    """Name of the network e.g. mainnet"""
     name: str
+
+    """Chain ID (required)"""
     chain_id: int
+
+    """The name of the ecosystem"""
     ecosystem: Optional[str] = None
+
+    """The base ecosystem plugin to use, when applicable"""
+    base_ecosystem_plugin: Optional[str] = None
+
+    """The default provider plugin to use"""
     default_provider: str = "geth"  # Default node.
+
+    """The HTTP request header"""
     request_header: Dict = {}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -526,7 +526,7 @@ CUSTOM_BLOCK_TIME = 123
 
 
 def _make_net(name: str, chain_id: int, **kwargs) -> Dict:
-    return {"name": name, "chain_id": chain_id, **kwargs}
+    return {"name": name, "chain_id": chain_id, "ecosystem": "ethereum", **kwargs}
 
 
 CUSTOM_NETWORKS_CONFIG = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -525,8 +525,8 @@ CUSTOM_NETWORK_CHAIN_ID_1 = 944898498948934528629
 CUSTOM_BLOCK_TIME = 123
 
 
-def _make_net(name: str, chain_id: int) -> Dict:
-    return {"name": name, "chain_id": chain_id}
+def _make_net(name: str, chain_id: int, **kwargs) -> Dict:
+    return {"name": name, "chain_id": chain_id, **kwargs}
 
 
 CUSTOM_NETWORKS_CONFIG = {

--- a/tests/functional/geth/test_contract.py
+++ b/tests/functional/geth/test_contract.py
@@ -80,9 +80,7 @@ def test_out_of_gas_error(geth_contract, geth_account, geth_provider):
     Attempt to transact with not quite enough gas. We should get an error saying
     we ran out of gas.
     """
-    txn = geth_contract.setNumber.as_transaction(333, sender=geth_account)
-    gas = geth_provider.estimate_gas_cost(txn)
-    txn.gas_limit = gas - 1
+    txn = geth_contract.setNumber.as_transaction(333, sender=geth_account, gas_limit=1)
     with pytest.raises(OutOfGasError) as err:
         geth_account.call(txn)
 

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -43,10 +43,6 @@ def custom_ecosystem_config(custom_networks_config_dict, temp_config, networks):
     with temp_config(data):
         yield
 
-    # Remove cached ecosystem.
-    if "_plugin_ecosystems" in networks.__dict__:
-        del networks.__dict__["_plugin_ecosystems"]
-
 
 def test_name(ethereum):
     assert ethereum.name == "ethereum"

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from ape.api import ProviderAPI
 from ape.exceptions import NetworkError, ProviderNotFoundError
 
 
@@ -28,6 +29,13 @@ def test_get_provider_ipc(ethereum):
     actual = network.get_provider(path)
     assert actual.ipc_path == Path(path)
     assert actual.network.name == "goerli"
+
+
+def test_get_provider_custom_network(custom_networks_config, ethereum):
+    network = ethereum.apenet
+    actual = network.get_provider("geth")
+    assert isinstance(actual, ProviderAPI)
+    assert actual.name == "geth"
 
 
 def test_block_times(ethereum):

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -161,7 +161,7 @@ def test_get_provider_from_choice_custom_provider(networks_connected_to_tester):
     assert provider.network.ecosystem.name == "ethereum"
 
 
-def test_get_provider_from_choice_custom_ecosystem(networks_connected_to_tester):
+def test_get_provider_from_choice_custom_adhoc_ecosystem(networks_connected_to_tester):
     uri = "https://geth:1234567890abcdef@geth.foo.bar/"
     provider = networks_connected_to_tester.get_provider_from_choice(uri)
     assert provider.name == "geth"

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -1,7 +1,9 @@
+import copy
 from pathlib import Path
 
 import pytest
 
+from ape.api import EcosystemAPI
 from ape.exceptions import NetworkError
 from ape.utils import DEFAULT_TEST_CHAIN_ID
 
@@ -87,6 +89,7 @@ def network_with_no_providers(ethereum):
 def test_get_network_choices(networks, ethereum, mocker):
     # Simulate having a provider like foundry installed.
     mock_provider = mocker.MagicMock()
+    mock_provider.name = "mock"
     ethereum.networks["mainnet-fork"].providers["mock"] = mock_provider
     ethereum.networks["local"].providers["mock"] = mock_provider
 
@@ -205,7 +208,7 @@ def test_parse_network_choice_new_chain_id(get_provider_with_unused_chain_id, ge
 
 
 @pytest.mark.xdist_group(name="multiple-eth-testers")
-def test_disconnect_after(get_provider_with_unused_chain_id):
+def test_parse_network_choice_disconnect_after(get_provider_with_unused_chain_id):
     context = get_provider_with_unused_chain_id()
     with context as provider:
         connection_id = provider.connection_id
@@ -243,6 +246,15 @@ def test_getattr_ecosystem_with_hyphenated_name(networks, ethereum):
     del networks.ecosystems["hyphen-in-name"]
 
 
+def test_getattr_custom_ecosystem(networks, custom_networks_config_dict, temp_config):
+    data = copy.deepcopy(custom_networks_config_dict)
+    data["networks"]["custom"][0]["ecosystem"] = "custom-ecosystem"
+
+    with temp_config(data):
+        actual = getattr(networks, "custom_ecosystem")
+        assert isinstance(actual, EcosystemAPI)
+
+
 @pytest.mark.parametrize("scheme", ("http", "https"))
 def test_create_custom_provider_http(networks, scheme):
     provider = networks.create_custom_provider(f"{scheme}://example.com")
@@ -262,3 +274,18 @@ def test_create_custom_provider_ipc(networks):
     # The IPC path should not be in URI field, different parts
     # of codebase may expect an actual URI.
     assert provider.uri != provider.ipc_path
+
+
+def test_ecosystems(networks):
+    actual = networks.ecosystems
+    assert "ethereum" in actual
+    assert actual["ethereum"].name == "ethereum"
+
+
+def test_ecosystems_include_custom(networks, custom_networks_config_dict, temp_config):
+    data = copy.deepcopy(custom_networks_config_dict)
+    data["networks"]["custom"][0]["ecosystem"] = "custom-ecosystem"
+    with temp_config(data):
+        actual = networks.ecosystems
+
+    assert "custom-ecosystem" in actual

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 from eth_pydantic_types import HexBytes
 from hexbytes import HexBytes as BaseHexBytes
@@ -234,7 +236,10 @@ def test_txn_hash_when_access_list_is_raw(ethereum, owner):
     # to this state, but somehow they have.
     txn.access_list = ACCESS_LIST_HEXBYTES
 
-    actual = txn.txn_hash.hex()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        actual = txn.txn_hash.hex()
+
     assert actual.startswith("0x")
 
 

--- a/tests/integration/cli/projects/geth/ape-config.yaml
+++ b/tests/integration/cli/projects/geth/ape-config.yaml
@@ -27,5 +27,7 @@ networks:
   custom:
     - name: apenet
       chain_id: 944898498948934528628
+      ecosystem: ethereum
     - name: apenet1
       chain_id: 944898498948934528629
+      ecosystem: ethereum


### PR DESCRIPTION
### What I did

The custom networks for new ecosystems kinda made no sense, so this PR fixes that.

Before:

```yaml
networks:
  custom:
    - name: shibarium-mainnet
      ecosystem: polygon
      chain_id: 109
      
geth:
  polygon:
    shibarium-mainnet:
      uri: https://www.shibrpc.com
```
used via `--network polygon:shibarium-mainnet:geth` which makes less sense.

After:

```yaml
networks:
  custom:
    - name: mainnet
      ecosystem: shibarium
      base_ecosystem_plugin: polygon  # Closest base class.
      chain_id: 109

geth:
  shibarium:
    mainnet:
      uri: https://www.shibrpc.com
```
used via `--network shibarium:mainnet:geth` which makes more sense.

### How I did it

* Change `ecosystem` to be allowed to be any str and advise users to put custom names here when it makes sense
* Add new config option `base_ecosystem_plugin` to refer to the base-class to use.
* Fix issues where custom networks had the wrong networks
* Fix issues with default provider in custom networks.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
