### PR TITLE
feat: add convenience methods for selector identifiers to ContractInstance

### DIFF
--- a/docs/userguides/contracts.md
+++ b/docs/userguides/contracts.md
@@ -362,6 +362,32 @@ bytes_value = contract.encode_input(0, 1, 2, 4, 5)
 method_id, input_dict = contract.decode_input(bytes_value)
 ```
 
+## Contract Interface Introspection
+
+There may be times you need to figure out ABI selectors and method or event identifiers for a contract.
+A contract instance provides properties to make this easy.
+For instance, if you have a 4-byte hex method ID, you can return the ABI type for that method:
+
+```python
+import ape
+
+usdc = ape.Contract("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+
+# ABI type for a hex method ID
+assert usdc.identifier_lookup['0x70a08231'].selector == 'balanceOf(address)'
+
+# Also, selectors from method and event signatures
+assert usdc.selector_identifiers["balances(address)"] == "0x27e235e3"
+
+# Or dump all selectors and IDs
+for identifier, abi_type in usdc.identifier_lookup.items():
+    print(identifier, abi_type)
+    # 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef type='event' name='Transfer' inputs=...
+    # ...
+```
+
+These include methods and error IDs, as well as event topics.
+
 ## Multi-Call and Multi-Transaction
 
 The `ape_ethereum` core plugin comes with a `multicall` module containing tools for interacting with the [multicall3 smart contract](https://github.com/mds1/multicall).

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -713,10 +713,18 @@ class ContractTypeWrapper(ManagerAccessMixin):
 
     @property
     def selector_identifiers(self) -> Dict[str, str]:
+        """
+        Provides a mapping of function signatures (pre-hashed selectors) to
+        selector identifiers.
+        """
         return self.contract_type.selector_identifiers
 
     @property
     def identifier_lookup(self) -> Dict[str, ABI_W_SELECTOR_T]:
+        """
+        Provides a mapping of method, error, and event selector identifiers to
+        ABI Types.
+        """
         return self.contract_type.identifier_lookup
 
     @cached_property

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -8,8 +8,8 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, U
 import click
 import pandas as pd
 from eth_pydantic_types import HexBytes
-from ethpm_types import ContractType
 from ethpm_types.abi import ConstructorABI, ErrorABI, EventABI, MethodABI
+from ethpm_types.contract_type import ABI_W_SELECTOR_T, ContractType
 
 from ape.api import AccountAPI, Address, ReceiptAPI, TransactionAPI
 from ape.api.address import BaseAddress
@@ -710,6 +710,14 @@ class ContractEvent(BaseInterfaceModel):
 
 class ContractTypeWrapper(ManagerAccessMixin):
     contract_type: ContractType
+
+    @property
+    def selector_identifiers(self) -> Dict[str, str]:
+        return self.contract_type.selector_identifiers
+
+    @property
+    def identifier_lookup(self) -> Dict[str, ABI_W_SELECTOR_T]:
+        return self.contract_type.identifier_lookup
 
     @cached_property
     def source_path(self) -> Optional[Path]:

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -725,6 +725,28 @@ def test_get_error_by_signature(error_contract):
     assert actual == expected
 
 
+def test_selector_identifiers(vyper_contract_instance):
+    assert len(vyper_contract_instance.selector_identifiers.keys()) == 52
+    assert vyper_contract_instance.selector_identifiers["balances(address)"] == "0x27e235e3"
+    assert vyper_contract_instance.selector_identifiers["owner()"] == "0x8da5cb5b"
+    assert (
+        vyper_contract_instance.selector_identifiers["FooHappened(uint256)"]
+        == "0x1a7c56fae0af54ebae73bc4699b9de9835e7bb86b050dff7e80695b633f17abd"
+    )
+
+
+def test_identifier_lookup(vyper_contract_instance):
+    assert len(vyper_contract_instance.identifier_lookup.keys()) == 52
+    assert vyper_contract_instance.identifier_lookup["0x27e235e3"].selector == "balances(address)"
+    assert vyper_contract_instance.identifier_lookup["0x8da5cb5b"].selector == "owner()"
+    assert (
+        vyper_contract_instance.identifier_lookup[
+            "0x1a7c56fae0af54ebae73bc4699b9de9835e7bb86b050dff7e80695b633f17abd"
+        ].selector
+        == "FooHappened(uint256)"
+    )
+
+
 def test_source_path(project_with_contract, owner):
     contracts_folder = project_with_contract.contracts_folder
     contract = project_with_contract.contracts["Contract"]


### PR DESCRIPTION
### What I did

Adds convenience method/props `selector_identifiers` and `identifier_lookup` to `ContractInstance` for easy selector/identifier lookups.

fixes: #1682

### How I did it

Pass through methods to the underlying `ContractType`

### How to verify it

See tests?

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [X] All changes are completed
- [X] New test cases have been added
- [x] Documentation has been updated
