### PR TITLE
fix: issues with custom and forked network config parsing

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -1,6 +1,6 @@
 import re
 from copy import deepcopy
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Type, Union, cast, ClassVar
+from typing import Any, ClassVar, Dict, Iterator, List, Optional, Sequence, Tuple, Type, Union, cast
 
 from eth_abi import decode, encode
 from eth_abi.exceptions import InsufficientDataBytes, NonEmptyPaddingBytes

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -1,6 +1,6 @@
 import re
 from copy import deepcopy
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Type, Union, cast
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Type, Union, cast, ClassVar
 
 from eth_abi import decode, encode
 from eth_abi.exceptions import InsufficientDataBytes, NonEmptyPaddingBytes
@@ -164,7 +164,11 @@ class BaseEthereumConfig(PluginConfig):
     L2 plugins should use this as their config base-class.
     """
 
-    local: NetworkConfig = create_local_network_config(default_provider="test")
+    DEFAULT_TRANSACTION_TYPE: ClassVar[TransactionType] = TransactionType.DYNAMIC
+
+    local: NetworkConfig = create_local_network_config(
+        default_provider="test", default_transaction_type=DEFAULT_TRANSACTION_TYPE
+    )
     default_network: str = LOCAL_NETWORK_NAME
     _forked_configs: Dict[str, ForkedNetworkConfig] = {}
     _custom_networks: Dict[str, NetworkConfig] = {}
@@ -184,9 +188,9 @@ class BaseEthereumConfig(PluginConfig):
             key = net_name.replace("_fork", "")
             if net_name.endswith("_fork"):
                 key = net_name.replace("_fork", "")
-                default_fork_model = create_local_network_config(use_fork=True).model_dump(
-                    mode="json", by_alias=True
-                )
+                default_fork_model = create_local_network_config(
+                    use_fork=True, default_transaction_type=cls.DEFAULT_TRANSACTION_TYPE
+                ).model_dump(mode="json", by_alias=True)
                 cfg_forks[key] = ForkedNetworkConfig.model_validate({**default_fork_model, **obj})
 
             elif key != LOCAL_NETWORK_NAME and key not in NETWORKS and isinstance(obj, dict):

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -4,6 +4,7 @@ import pytest
 
 from ape.api import ProviderAPI
 from ape.exceptions import NetworkError, ProviderNotFoundError
+from ape_ethereum.transactions import TransactionType
 
 
 def test_get_provider_when_not_found(ethereum):
@@ -69,9 +70,17 @@ def test_forked_networks(ethereum):
     assert mainnet_fork.upstream_chain_id == 1
     # Just make sure it doesn't fail when trying to access.
     assert mainnet_fork.upstream_provider
+    # Ensure has default configurations.
+    cfg = mainnet_fork.config.mainnet_fork
+    assert cfg.default_transaction_type == TransactionType.DYNAMIC
+    assert cfg.block_time == 0
+    assert cfg.default_provider is None
 
 
 def test_data_folder_custom_network(custom_network, ethereum, custom_network_name_0):
     actual = custom_network.data_folder
     expected = ethereum.data_folder / custom_network_name_0
     assert actual == expected
+
+
+#def test_configuring_forked_networks(temp_config)

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -1,3 +1,4 @@
+import copy
 from pathlib import Path
 
 import pytest
@@ -75,6 +76,23 @@ def test_forked_networks(ethereum):
     assert cfg.default_transaction_type == TransactionType.DYNAMIC
     assert cfg.block_time == 0
     assert cfg.default_provider is None
+    assert cfg.base_fee_multiplier == 1.0
+    assert cfg.transaction_acceptance_timeout == 20
+    assert cfg.max_receipt_retries == 20
+
+
+def test_forked_network_with_config(temp_config, ethereum):
+    data = {
+        "ethereum": {"mainnet_fork": {"default_transaction_type": TransactionType.STATIC.value}}
+    }
+    with temp_config(data):
+        cfg = ethereum.mainnet_fork.config.mainnet_fork
+        assert cfg.default_transaction_type == TransactionType.STATIC
+        assert cfg.block_time == 0
+        assert cfg.default_provider is None
+        assert cfg.base_fee_multiplier == 1.0
+        assert cfg.transaction_acceptance_timeout == 20
+        assert cfg.max_receipt_retries == 20
 
 
 def test_data_folder_custom_network(custom_network, ethereum, custom_network_name_0):
@@ -83,4 +101,30 @@ def test_data_folder_custom_network(custom_network, ethereum, custom_network_nam
     assert actual == expected
 
 
-#def test_configuring_forked_networks(temp_config)
+def test_config_custom_networks_default(ethereum, custom_networks_config):
+    """
+    Shows you don't get AttributeError when custom network config is not
+    present.
+    """
+    network = ethereum.apenet
+    cfg = network.config.apenet
+    assert cfg.default_transaction_type == TransactionType.DYNAMIC
+
+
+def test_config_custom_networks(
+    ethereum, custom_networks_config_dict, temp_config, custom_network_name_0
+):
+    data = copy.deepcopy(custom_networks_config_dict)
+    data["ethereum"] = {
+        custom_network_name_0: {"default_transaction_type": TransactionType.STATIC.value}
+    }
+    with temp_config(data):
+        network = ethereum.apenet
+        ethereum_config = network.config
+        cfg_by_attr = ethereum_config.apenet
+        assert cfg_by_attr.default_transaction_type == TransactionType.STATIC
+
+        assert "apenet" in ethereum_config
+        cfg_by_get = ethereum_config.get("apenet")
+        assert cfg_by_get is not None
+        assert cfg_by_get.default_transaction_type == TransactionType.STATIC


### PR DESCRIPTION
### What I did

fix: issue where forked networks config didnt have the expected defaults
fix: now, if you reference a config for a non-existent network, youll get an empty network config instead of an attribute error 
fix: issue where custom network configs were not parsed and remained as dictionaries.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
