### PR TITLE
fix: ecosystem-level default in config for local gas limit

### DIFF
--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -93,6 +93,7 @@ def test_forked_network_with_config(temp_config, ethereum):
         assert cfg.base_fee_multiplier == 1.0
         assert cfg.transaction_acceptance_timeout == 20
         assert cfg.max_receipt_retries == 20
+        assert cfg.gas_limit == "max"
 
 
 def test_data_folder_custom_network(custom_network, ethereum, custom_network_name_0):


### PR DESCRIPTION
### What I did

this helps Arbitrum utilize the new base class and others who may change the default utilize the base class

```python

class ArbitrumConfig(BaseEthereumConfig):
    DEFAULT_TRANSACTION_TYPE: ClassVar[int] = EthTransactionType.STATIC.value
    DEFAULT_LOCAL_GAS_LIMIT: ClassVar[GasLimit] = LOCAL_GAS_LIMIT
    mainnet: NetworkConfig = _create_config()
    goerli: NetworkConfig = _create_config()
    sepolia: NetworkConfig = _create_config()
```

see Arby PR: https://github.com/ApeWorX/ape-arbitrum/pull/27

### How I did it

classvar default

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
