### PR TITLE
fix: issue when using hex-str for accessList storage keys

### DIFF
--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -19,7 +19,7 @@ from ape.api import ReceiptAPI, TransactionAPI
 from ape.contracts import ContractEvent
 from ape.exceptions import OutOfGasError, SignatureError, TransactionError
 from ape.logging import logger
-from ape.types import CallTreeNode, ContractLog, ContractLogContainer, SourceTraceback
+from ape.types import AddressType, CallTreeNode, ContractLog, ContractLogContainer, SourceTraceback
 from ape.utils import ZERO_ADDRESS
 
 
@@ -50,7 +50,7 @@ class TransactionType(Enum):
 
 
 class AccessList(BaseModel):
-    address: str
+    address: AddressType
     storage_keys: List[Union[HexBytes, bytes, str, int]] = Field(
         default_factory=list, alias="storageKeys"
     )

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -51,9 +51,7 @@ class TransactionType(Enum):
 
 class AccessList(BaseModel):
     address: AddressType
-    storage_keys: List[Union[HexBytes, bytes, str, int]] = Field(
-        default_factory=list, alias="storageKeys"
-    )
+    storage_keys: List[HexBytes] = Field(default_factory=list, alias="storageKeys")
 
 
 class BaseTransaction(TransactionAPI):

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -7,6 +7,7 @@ from hexbytes import HexBytes as BaseHexBytes
 from ape.exceptions import SignatureError
 from ape_ethereum.transactions import (
     AccessList,
+    AccessListTransaction,
     DynamicFeeTransaction,
     StaticFeeTransaction,
     TransactionType,
@@ -260,6 +261,12 @@ def test_model_dump_excludes_none_values():
     assert "value" not in actual
 
 
+def test_model_dump_access_list():
+    txn = AccessListTransaction()
+    actual = txn.model_dump(exclude_none=True, by_alias=True)
+    assert actual is not None
+
+
 def test_str_when_data_is_bytes(ethereum):
     """
     Tests against a condition that would cause transactions to
@@ -322,3 +329,21 @@ def test_serialize_transaction_missing_signature_and_sender(ethereum):
     txn = ethereum.create_transaction(data=HexBytes("0x123"))
     with pytest.raises(SignatureError, match=expected):
         txn.serialize_transaction()
+
+
+class TestAccessList:
+    @pytest.mark.parametrize(
+        "address",
+        (
+            "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+            HexBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+        ),
+    )
+    def test_address(self, address):
+        actual = AccessList(address=address, storageKeys=[])
+        assert actual.address == "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+    @pytest.mark.parametrize("storage_key", (123, HexBytes(123), "0x0123"))
+    def test_storage_keys(self, storage_key, zero_address):
+        actual = AccessList(address=zero_address, storageKeys=[storage_key])
+        assert actual.storage_keys == [storage_key]

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -262,7 +262,18 @@ def test_model_dump_excludes_none_values():
 
 
 def test_model_dump_access_list():
-    txn = AccessListTransaction()
+    # Data directly from eth_createAccessList RPC
+    access_list = [
+        {
+            "address": "0x7ef8e99980da5bcedcf7c10f41e55f759f6a174b",
+            "storageKeys": [
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "0x0000000000000000000000000000000000000000000000000000000000000001",
+                "0x0000000000000000000000000000000000000000000000000000000000000002",
+            ],
+        }
+    ]
+    txn = AccessListTransaction(access_list=access_list)
     actual = txn.model_dump(exclude_none=True, by_alias=True)
     assert actual is not None
 

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -357,4 +357,4 @@ class TestAccessList:
     @pytest.mark.parametrize("storage_key", (123, HexBytes(123), "0x0123"))
     def test_storage_keys(self, storage_key, zero_address):
         actual = AccessList(address=zero_address, storageKeys=[storage_key])
-        assert actual.storage_keys == [storage_key]
+        assert actual.storage_keys == [HexBytes(storage_key)]


### PR DESCRIPTION
### What I did

For some reason, storageKeys when not bytes were no longer serializing to JSON correctly.

fixes: #1881 

### How I did it

The fix was change the type from `Union[HexBytes, bytes, int, str]` to just `HexBytes`.
This way, the validators run correctly and it actually works for int, str etc because it turns it to bytes first.

As a bonus, i changed address to be `AddressType` to fix similar, unreported issues there.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
