### PR TITLE
feat: adds block_number arg to network.fork()

### DIFF
--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -8,7 +8,7 @@ from ape.api import EcosystemAPI, ProviderAPI, ProviderContextManager
 from ape.api.networks import NetworkAPI
 from ape.exceptions import ApeAttributeError, EcosystemNotFoundError, NetworkError
 from ape.managers.base import BaseManager
-from ape.utils.misc import dict_overlay
+from ape.utils.misc import _dict_overlay
 from ape_ethereum.provider import EthereumNodeProvider
 
 
@@ -103,7 +103,7 @@ class NetworkManager(BaseManager):
                 block_number = self.provider.get_block("latest").number + block_number
 
             # Ensure block_number is set in config for this network
-            dict_overlay(
+            _dict_overlay(
                 provider_settings,
                 {
                     "fork": {

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -8,6 +8,7 @@ from ape.api import EcosystemAPI, ProviderAPI, ProviderContextManager
 from ape.api.networks import NetworkAPI
 from ape.exceptions import ApeAttributeError, EcosystemNotFoundError, NetworkError
 from ape.managers.base import BaseManager
+from ape.utils.misc import dict_overlay
 from ape_ethereum.provider import EthereumNodeProvider
 
 
@@ -79,6 +80,7 @@ class NetworkManager(BaseManager):
         self,
         provider_name: Optional[str] = None,
         provider_settings: Optional[Dict] = None,
+        block_number: Optional[int] = None,
     ) -> ProviderContextManager:
         """
         Fork the currently connected network.
@@ -94,6 +96,21 @@ class NetworkManager(BaseManager):
         """
         forked_network = self.ecosystem.get_network(f"{self.network.name}-fork")
         provider_settings = provider_settings or {}
+
+        if block_number is not None:
+            # Negateive block_number means relative to HEAD
+            if block_number < 0:
+                block_number = self.provider.get_block("latest").number + block_number
+
+            # Ensure block_number is set in config for this network
+            dict_overlay(
+                provider_settings,
+                {
+                    "fork": {
+                        self.ecosystem.name: {self.network.name: {"block_number": block_number}}
+                    }
+                },
+            )
 
         if provider_name:
             return forked_network.use_provider(

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -98,7 +98,7 @@ class NetworkManager(BaseManager):
         provider_settings = provider_settings or {}
 
         if block_number is not None:
-            # Negateive block_number means relative to HEAD
+            # Negative block_number means relative to HEAD
             if block_number < 0:
                 block_number = self.provider.get_block("latest").number + block_number
 

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -500,7 +500,7 @@ def dict_defaults(mapping: Dict[str, Any], defaults: Dict[str, Any], depth=0):
     return mapping
 
 
-def dict_overlay(mapping: Dict[str, Any], overlay: Dict[str, Any], depth=0):
+def dict_overlay(mapping: Dict[str, Any], overlay: Dict[str, Any], depth: int=0):
     """Overlay given overlay structure on a dict"""
     for key, value in overlay.items():
         if isinstance(value, dict):

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -490,23 +490,13 @@ def is_zero_hex(address: str) -> bool:
         return False
 
 
-def dict_defaults(mapping: Dict[str, Any], defaults: Dict[str, Any], depth=0):
-    """Conditionally overlay given default on a dict if no value is set"""
-    for key, value in defaults.items():
-        if key not in mapping:
-            mapping[key] = value
-        elif isinstance(value, dict):
-            dict_defaults(mapping[key], value, depth + 1)
-    return mapping
-
-
-def dict_overlay(mapping: Dict[str, Any], overlay: Dict[str, Any], depth: int=0):
+def _dict_overlay(mapping: Dict[str, Any], overlay: Dict[str, Any], depth: int = 0):
     """Overlay given overlay structure on a dict"""
     for key, value in overlay.items():
         if isinstance(value, dict):
             if key not in mapping:
                 mapping[key] = dict()
-            dict_overlay(mapping[key], value, depth + 1)
+            _dict_overlay(mapping[key], value, depth + 1)
         else:
             mapping[key] = value
     return mapping
@@ -515,8 +505,7 @@ def dict_overlay(mapping: Dict[str, Any], overlay: Dict[str, Any], depth: int=0)
 __all__ = [
     "allow_disconnected",
     "cached_property",
-    "dict_defaults",
-    "dict_overlay",
+    "_dict_overlay",
     "extract_nested_value",
     "gas_estimation_error_message",
     "get_current_timestamp_ms",

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -490,9 +490,33 @@ def is_zero_hex(address: str) -> bool:
         return False
 
 
+def dict_defaults(mapping: Dict[str, Any], defaults: Dict[str, Any], depth=0):
+    """Conditionally overlay given default on a dict if no value is set"""
+    for key, value in defaults.items():
+        if key not in mapping:
+            mapping[key] = value
+        elif isinstance(value, dict):
+            dict_defaults(mapping[key], value, depth + 1)
+    return mapping
+
+
+def dict_overlay(mapping: Dict[str, Any], overlay: Dict[str, Any], depth=0):
+    """Overlay given overlay structure on a dict"""
+    for key, value in overlay.items():
+        if isinstance(value, dict):
+            if key not in mapping:
+                mapping[key] = dict()
+            dict_overlay(mapping[key], value, depth + 1)
+        else:
+            mapping[key] = value
+    return mapping
+
+
 __all__ = [
     "allow_disconnected",
     "cached_property",
+    "dict_defaults",
+    "dict_overlay",
     "extract_nested_value",
     "gas_estimation_error_message",
     "get_current_timestamp_ms",

--- a/tests/functional/utils/test_misc.py
+++ b/tests/functional/utils/test_misc.py
@@ -6,9 +6,8 @@ from web3.types import Wei
 from ape.exceptions import APINotImplementedError
 from ape.utils.misc import (
     ZERO_ADDRESS,
+    _dict_overlay,
     add_padding_to_strings,
-    dict_defaults,
-    dict_overlay,
     extract_nested_value,
     get_package_version,
     is_evm_precompile,
@@ -144,24 +143,9 @@ def test_pragma_str_to_specifier_set(spec, expected):
     assert pragma_str_to_specifier_set(spec) == expected
 
 
-def test_dict_defaults():
-    mapping = {
-        "a": 1,
-    }
-    dict_defaults(mapping, {"a": 2, "b": {"one": 1, "two": None}})
-
-    assert mapping["a"] == 1
-    assert "b" in mapping
-    assert isinstance(mapping["b"], dict)
-    assert "one" in mapping["b"]
-    assert mapping["b"]["one"] == 1
-    assert "two" in mapping["b"]
-    assert mapping["b"]["two"] is None
-
-
 def test_dict_overlay():
     mapping = {"a": 1, "b": {"one": 1, "two": 1}}
-    dict_overlay(mapping, {"a": 2, "b": {"two": 2, "three": None}, "c": {"four": 4}})
+    _dict_overlay(mapping, {"a": 2, "b": {"two": 2, "three": None}, "c": {"four": 4}})
 
     assert mapping["a"] == 2
     assert "b" in mapping

--- a/tests/functional/utils/test_misc.py
+++ b/tests/functional/utils/test_misc.py
@@ -7,6 +7,8 @@ from ape.exceptions import APINotImplementedError
 from ape.utils.misc import (
     ZERO_ADDRESS,
     add_padding_to_strings,
+    dict_defaults,
+    dict_overlay,
     extract_nested_value,
     get_package_version,
     is_evm_precompile,
@@ -140,3 +142,36 @@ def test_to_int(val):
 )
 def test_pragma_str_to_specifier_set(spec, expected):
     assert pragma_str_to_specifier_set(spec) == expected
+
+
+def test_dict_defaults():
+    mapping = {
+        "a": 1,
+    }
+    dict_defaults(mapping, {"a": 2, "b": {"one": 1, "two": None}})
+
+    assert mapping["a"] == 1
+    assert "b" in mapping
+    assert isinstance(mapping["b"], dict)
+    assert "one" in mapping["b"]
+    assert mapping["b"]["one"] == 1
+    assert "two" in mapping["b"]
+    assert mapping["b"]["two"] is None
+
+
+def test_dict_overlay():
+    mapping = {"a": 1, "b": {"one": 1, "two": 1}}
+    dict_overlay(mapping, {"a": 2, "b": {"two": 2, "three": None}, "c": {"four": 4}})
+
+    assert mapping["a"] == 2
+    assert "b" in mapping
+    assert isinstance(mapping["b"], dict)
+    assert "one" in mapping["b"]
+    assert mapping["b"]["one"] == 1
+    assert "two" in mapping["b"]
+    assert mapping["b"]["two"] == 2
+    assert "three" in mapping["b"]
+    assert mapping["b"]["three"] is None
+    assert "c" in mapping
+    assert isinstance(mapping["c"], dict)
+    assert "four" in mapping["c"]


### PR DESCRIPTION
### What I did

Adds `block_number` argument to `network.fork()`, including negative behind numbers.

fixes: #1740

### How I did it

When the kwarg is provided, it will update the expected config structure for the fork provider with the given block number

### How to verify it

```python
from ape import chain, networks
from ape.cli import ConnectedProviderCommand
import click


@click.command(cls=ConnectedProviderCommand)
def cli():
    live_block = chain.provider.get_block("latest")

    # with networks.fork("provider", block_number=-100):
    with networks.fork("foundry", block_number=18569420):
        block = chain.provider.get_block("latest")
        assert block.number == 18569420

    with networks.fork("foundry", block_number=-100):
        block = chain.provider.get_block("latest")
        assert block.number == live_block.number - 100
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [X] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
