### PR TITLE
feat: Use `eth_createAccessList` RPC in type=1 prepared transaction

### DIFF
--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -106,6 +106,27 @@ contract.fundMyContract(value="1 gwei", type="0x0", sender=sender)
 
 When declaring `type="0x0"` and _not_ specifying a `gas_price`, the `gas_price` gets set using the provider's estimation.
 
+## Access List Transactions
+
+Utilizing [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930), you can also make access-list transactions using Ape.
+Access-list transactions are static-fee transactions except you can optionally specify an access list.
+Access-lists make contract-interaction more predictable and optimized.
+You can also use Access-lists in Dynamic-fee transactions.
+
+To automatically use access-list (type 1) transactions in Ape, specify `type=1` in your call:
+
+```python
+contract.fundMyContract(value="1 gwei", type=1, sender=sender)
+```
+
+When specifying `type=1`, Ape uses `eth_createAccessList` RPC to attach an access list to the transaction automatically.
+
+You can also specify the access-list directly:
+
+```python
+contract.fundMyContract(value="1 gwei", type=1, sender=sender, access_list=MY_ACCESS_LIST)
+```
+
 ## Transaction Logs
 
 In Ape, you can easily get all the events on a receipt.

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1022,6 +1022,10 @@ class Web3Provider(ProviderAPI, ABC):
             else:
                 tx_dict_converted[key] = val
 
+        if not tx_dict_converted.get("to") and tx_dict.get("data") in (None, "0x"):
+            # Contract creation with no data, can skip.
+            return []
+
         arguments: list = [tx_dict_converted]
         if block_id is not None:
             arguments.append(block_id)

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -409,8 +409,8 @@ def test_prepare_transaction_access_list_from_rpc(geth_provider, geth_contract, 
     prepared_tx = geth_provider.prepare_transaction(tx)
     assert isinstance(prepared_tx, AccessListTransaction)
     actual = prepared_tx.access_list
-    assert isinstance(actual, AccessList)
     assert len(actual) > 0
+    assert isinstance(actual[0], AccessList)
     assert len(actual[0].storage_keys) > 0
 
 

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -15,7 +15,7 @@ from ape.exceptions import (
     TransactionNotFoundError,
 )
 from ape_ethereum.ecosystem import Block
-from ape_ethereum.transactions import TransactionStatusEnum, TransactionType
+from ape_ethereum.transactions import AccessList, TransactionStatusEnum, TransactionType
 from ape_geth.provider import GethDevProcess, GethNotInstalledError
 from tests.conftest import GETH_URI, geth_process_test
 
@@ -393,3 +393,10 @@ def test_prepare_tx_with_max_gas(tx_type, geth_provider, ethereum, geth_account)
     # NOTE: The local network by default uses max_gas.
     actual = geth_provider.prepare_transaction(tx)
     assert actual.gas_limit == geth_provider.max_gas
+
+
+def test_get_access_list(geth_provider, geth_contract, geth_account):
+    tx = geth_contract.setNumber.as_transaction(123, sender=geth_account, type=1)
+    actual = geth_provider.get_access_list(tx)
+    assert isinstance(actual, AccessList)
+    assert len(actual.storage_keys) > 0

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -19,7 +19,7 @@ from ape.exceptions import (
 from ape.types import LogFilter
 from ape.utils import DEFAULT_TEST_CHAIN_ID
 from ape_ethereum.provider import _sanitize_web3_url
-from ape_ethereum.transactions import AccessListTransaction, TransactionStatusEnum, TransactionType
+from ape_ethereum.transactions import TransactionStatusEnum, TransactionType
 
 
 def test_uri(eth_tester_provider):
@@ -280,14 +280,6 @@ def test_prepare_transaction_with_max_gas(tx_type, eth_tester_provider, ethereum
     assert actual.gas_limit == eth_tester_provider.max_gas
 
 
-def test_prepare_transaction_access_list_from_rpc(eth_tester_provider, ethereum, owner):
-    tx = ethereum.create_transaction(type=TransactionType.ACCESS_LIST, sender=owner.address)
-    prepared_tx = eth_tester_provider.prepare_transaction(tx)
-    assert isinstance(prepared_tx, AccessListTransaction)
-    actual = prepared_tx.access_list
-    assert actual == [1]
-
-
 def test_no_comma_in_rpc_url():
     test_url = "URI: http://127.0.0.1:8545,"
     sanitised_url = _sanitize_web3_url(test_url)
@@ -400,7 +392,7 @@ def test_base_fee(eth_tester_provider):
         _ = eth_tester_provider._get_fee_history(0)
 
 
-def test_get_access_list(eth_tester_provider, vyper_contract_instance, owner):
+def test_create_access_list(eth_tester_provider, vyper_contract_instance, owner):
     tx = vyper_contract_instance.setNumber.as_transaction(123, sender=owner)
     with pytest.raises(APINotImplementedError):
-        eth_tester_provider.get_access_list(tx)
+        eth_tester_provider.create_access_list(tx)

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -372,7 +372,7 @@ def test_make_request_not_exists_dev_nodes(eth_tester_provider, mock_web3, msg):
         if rpc == "ape_thisDoesNotExist":
             return {"error": {"message": msg}}
 
-        return real_web3.make_request(rpc, params)
+        return real_web3.provider.make_request(rpc, params)
 
     mock_web3.provider.make_request.side_effect = custom_make_request
     with pytest.raises(


### PR DESCRIPTION
### What I did

now when using type=1, access lists are automatically prepared on the tx

**question**: should we automatically set access list on type=2? I am too afraid to make that change I think but there isnt really a good way to do in Ape otherwise

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
