### PR TITLE
fix: issue when forking past genesis

### DIFF
--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -6,7 +6,12 @@ import yaml
 
 from ape.api import EcosystemAPI, ProviderAPI, ProviderContextManager
 from ape.api.networks import NetworkAPI
-from ape.exceptions import ApeAttributeError, EcosystemNotFoundError, NetworkError
+from ape.exceptions import (
+    ApeAttributeError,
+    EcosystemNotFoundError,
+    NetworkError,
+    NetworkNotFoundError,
+)
 from ape.managers.base import BaseManager
 from ape.utils.misc import _dict_overlay
 from ape_ethereum.provider import EthereumNodeProvider
@@ -90,17 +95,24 @@ class NetworkManager(BaseManager):
               When ``None``, returns the default provider.
             provider_settings (dict, optional): Settings to apply to the provider. Defaults to
               ``None``.
+            block_number (Optional[int]): Optionally specify the block number you wish to fork.
+              Negative block numbers are relative to HEAD. Defaults to the configured fork
+              block number or HEAD.
 
         Returns:
             :class:`~ape.api.networks.ProviderContextManager`
         """
-        forked_network = self.ecosystem.get_network(f"{self.network.name}-fork")
+        try:
+            forked_network = self.ecosystem.get_network(f"{self.network.name}-fork")
+        except NetworkNotFoundError as err:
+            raise NetworkError(f"Unable to fork network '{self.network.name}'.") from err
+
         provider_settings = provider_settings or {}
 
         if block_number is not None:
             # Negative block_number means relative to HEAD
             if block_number < 0:
-                block_number = self.provider.get_block("latest").number + block_number
+                block_number = max(0, self.provider.get_block("latest").number)
 
             # Ensure block_number is set in config for this network
             _dict_overlay(
@@ -112,12 +124,12 @@ class NetworkManager(BaseManager):
                 },
             )
 
-        if provider_name:
-            return forked_network.use_provider(
-                provider_name, provider_settings, disconnect_after=True
-            )
-
-        return forked_network.use_default_provider(provider_settings, disconnect_after=True)
+        shared_kwargs: dict = {"provider_settings": provider_settings, "disconnect_after": True}
+        return (
+            forked_network.use_provider(provider_name, **shared_kwargs)
+            if provider_name
+            else forked_network.use_default_provider(**shared_kwargs)
+        )
 
     @property
     def ecosystem_names(self) -> Set[str]:

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -112,7 +112,8 @@ class NetworkManager(BaseManager):
         if block_number is not None:
             # Negative block_number means relative to HEAD
             if block_number < 0:
-                block_number = self.provider.get_block("latest").number + block_number
+                latest_block_number = self.provider.get_block("latest").number or 0
+                block_number = latest_block_number + block_number
                 if block_number < 0:
                     # If the block number is still negative, they have forked past genesis.
                     raise NetworkError("Unable to fork past genesis block.")

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -112,7 +112,10 @@ class NetworkManager(BaseManager):
         if block_number is not None:
             # Negative block_number means relative to HEAD
             if block_number < 0:
-                block_number = max(0, self.provider.get_block("latest").number)
+                block_number = self.provider.get_block("latest").number + block_number
+                if block_number < 0:
+                    # If the block number is still negative, they have forked past genesis.
+                    raise NetworkError("Unable to fork past genesis block.")
 
             # Ensure block_number is set in config for this network
             _dict_overlay(

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -735,7 +735,7 @@ def mock_fork_provider(mocker, ethereum):
     mock_provider.name = "mock"
     mock_provider.network = ethereum.sepolia_fork
 
-    # Have to this because providers are partials.
+    # Have to do this because providers are partials.
     def fake_partial(*args, **kwargs):
         mock_provider.partial_call = (args, kwargs)
         return mock_provider

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -699,12 +699,15 @@ def mock_compiler(mocker):
 
 
 @pytest.fixture
-def mock_sepolia(ethereum, eth_tester_provider):
+def mock_sepolia(ethereum, eth_tester_provider, vyper_contract_instance):
     """
     Temporarily tricks Ape into thinking the local network
     is Sepolia so we can test features that require a live
     network.
     """
+    # Ensuring contract exists before hack.
+    # This allow the nework to be past genesis which is more realistic.
+    _ = vyper_contract_instance
     eth_tester_provider.network.name = "sepolia"
     yield eth_tester_provider.network
     eth_tester_provider.network.name = LOCAL_NETWORK_NAME


### PR DESCRIPTION
### What I did

The error when trying to fork a non-forkable network was not quite good enough for me, so I fixed it.

Also, adds missing tests for `netowork.fork` context stuff.

### How I did it

Catch the network error and raise a different one with a more custom message for the `.fork()` method use-case.

### How to verify it

connect to `local` and then do:

```python
with networks.fork():
   ...
```

it should fail something like 

```
NetworkError: Unable to fork network local
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
