### PR TITLE
fix: circular import issues from accounts plugins

### DIFF
--- a/src/ape/cli/arguments.py
+++ b/src/ape/cli/arguments.py
@@ -3,16 +3,16 @@ from itertools import chain
 import click
 from eth_utils import is_hex
 
-from ape import accounts, project
 from ape.cli.choices import _ACCOUNT_TYPE_FILTER, Alias
 from ape.cli.paramtype import AllFilePaths
 from ape.exceptions import AccountsError, AliasAlreadyInUseError
+from ape.utils.basemodel import ManagerAccessMixin
 
 _flatten = chain.from_iterable
 
 
 def _alias_callback(ctx, param, value):
-    if value in accounts.aliases:
+    if value in ManagerAccessMixin.account_manager.aliases:
         # Alias cannot be used.
         raise AliasAlreadyInUseError(value)
 
@@ -59,7 +59,7 @@ def _create_contracts_paths(ctx, param, value):
     resolved_contract_paths = set()
     for contract_path in contract_paths:
         # Adds missing absolute path as well as extension.
-        if resolved_contract_path := project.lookup_path(contract_path):
+        if resolved_contract_path := ManagerAccessMixin.project_manager.lookup_path(contract_path):
             resolved_contract_paths.add(resolved_contract_path)
         else:
             _raise_bad_arg(contract_path.name)

--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -5,10 +5,10 @@ from typing import Any, List, Optional
 import click
 from click import Context
 
-from ape import networks
 from ape.api import ProviderAPI, ProviderContextManager
 from ape.cli.choices import _NONE_NETWORK, NetworkChoice
 from ape.exceptions import NetworkError
+from ape.utils.basemodel import ManagerAccessMixin
 
 
 def get_param_from_ctx(ctx: Context, param: str) -> Optional[Any]:
@@ -33,10 +33,13 @@ def parse_network(ctx: Context) -> Optional[ProviderContextManager]:
     provider = get_param_from_ctx(ctx, "network")
     if provider is not None and isinstance(provider, ProviderAPI):
         return provider.network.use_provider(provider, disconnect_on_exit=not interactive)
+
     elif provider not in (None, _NONE_NETWORK) and isinstance(provider, str):
-        return networks.parse_network_choice(provider, disconnect_on_exit=not interactive)
+        return ManagerAccessMixin.network_manager.parse_network_choice(
+            provider, disconnect_on_exit=not interactive
+        )
     elif provider is None:
-        ecosystem = networks.default_ecosystem
+        ecosystem = ManagerAccessMixin.network_manager.default_ecosystem
         network = ecosystem.default_network
         if provider_name := network.default_provider_name:
             return network.use_provider(provider_name, disconnect_on_exit=not interactive)


### PR DESCRIPTION
### What I did

Replace top-level imports with ManagerAccessMixin to prevent circular imports in account plugins.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
