### PR TITLE
test: adds timeout and skips some breaking integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ addopts = "-p no:ape_test"  # NOTE: Prevents the ape plugin from activating on o
 python_files = "test_*.py"
 testpaths = "tests"
 markers = "fuzzing: Run Hypothesis fuzz test suite"
+timeout = 300
 
 [tool.isort]
 line_length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ norecursedirs = "projects"
 addopts = "-p no:ape_test"  # NOTE: Prevents the ape plugin from activating on our tests
 python_files = "test_*.py"
 testpaths = "tests"
-markers = "fuzzing: Run Hypothesis fuzz test suite"
+markers = """fuzzing: Run Hypothesis fuzz test suite
+pip: tests that rely on pip install operations"""
 timeout = 300
 
 [tool.isort]

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ extras_require = {
         "pytest-xdist",  # Multi-process runner
         "pytest-cov>=4.0.0,<5",  # Coverage analyzer plugin
         "pytest-mock",  # For creating mocks
+        "pytest-timeout~=2.2.0",
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
         "hypothesis-jsonschema==0.19.0",  # JSON Schema fuzzer extension
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,17 @@ geth_process_test = pytest.mark.xdist_group(name="geth-tests")
 explorer_test = pytest.mark.xdist_group(name="explorer-tests")
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--includepip", action="store_true", help="run tests that depend on pip install operations"
+    )
+
+
+def pytest_runtest_setup(item):
+    if "pip" in item.keywords and not item.config.getoption("--includepip"):
+        pytest.skip("need --includepip option to run this test")
+
+
 @pytest.fixture(autouse=True)
 def setenviron(monkeypatch):
     """

--- a/tests/integration/cli/test_plugins.py
+++ b/tests/integration/cli/test_plugins.py
@@ -129,29 +129,25 @@ def test_list_does_not_repeat(ape_plugins_runner, installed_plugin):
     assert "ethereum" not in result.available_plugins
 
 
-@pytest.mark.skip(reason="Installation may replace local packages with unwanted versions")
-@github_xfail()
+@pytest.mark.pip
 def test_upgrade(ape_plugins_runner, installed_plugin):
     result = ape_plugins_runner.invoke(["install", TEST_PLUGIN_NAME, "--upgrade"])
     assert result.exit_code == 0
 
 
-@pytest.mark.skip(reason="Installation may replace local packages with unwanted versions")
-@github_xfail()
+@pytest.mark.pip
 def test_upgrade_failure(ape_plugins_runner):
     result = ape_plugins_runner.invoke(["install", "NOT_EXISTS", "--upgrade"])
     assert result.exit_code == 1
 
 
-@pytest.mark.skip(reason="Installation may replace local packages with unwanted versions")
-@github_xfail()
+@pytest.mark.pip
 def test_install_multiple_in_one_str(ape_plugins_runner):
     result = ape_plugins_runner.invoke(["install", f"{TEST_PLUGIN_NAME} {TEST_PLUGIN_NAME_2}"])
     assert result.exit_code == 0
 
 
-@pytest.mark.skip(reason="Installation may replace local packages with unwanted versions")
-@github_xfail()
+@pytest.mark.pip
 def test_install_from_config_file(ape_cli, runner, temp_config):
     plugins_config = {"plugins": [{"name": TEST_PLUGIN_NAME}]}
     with temp_config(plugins_config):
@@ -160,8 +156,7 @@ def test_install_from_config_file(ape_cli, runner, temp_config):
         assert TEST_PLUGIN_NAME in result.stdout
 
 
-@pytest.mark.skip(reason="Installation may replace local packages with unwanted versions")
-@github_xfail()
+@pytest.mark.pip
 def test_uninstall(ape_cli, runner, installed_plugin):
     result = runner.invoke(
         ape_cli, ["plugins", "uninstall", TEST_PLUGIN_NAME, "--yes"], catch_exceptions=False

--- a/tests/integration/cli/test_plugins.py
+++ b/tests/integration/cli/test_plugins.py
@@ -129,24 +129,28 @@ def test_list_does_not_repeat(ape_plugins_runner, installed_plugin):
     assert "ethereum" not in result.available_plugins
 
 
+@pytest.mark.skip(reason="Installation b0rks local packages")
 @github_xfail()
 def test_upgrade(ape_plugins_runner, installed_plugin):
     result = ape_plugins_runner.invoke(["install", TEST_PLUGIN_NAME, "--upgrade"])
     assert result.exit_code == 0
 
 
+@pytest.mark.skip(reason="Installation b0rks local packages")
 @github_xfail()
 def test_upgrade_failure(ape_plugins_runner):
     result = ape_plugins_runner.invoke(["install", "NOT_EXISTS", "--upgrade"])
     assert result.exit_code == 1
 
 
+@pytest.mark.skip(reason="Installation b0rks local packages")
 @github_xfail()
 def test_install_multiple_in_one_str(ape_plugins_runner):
     result = ape_plugins_runner.invoke(["install", f"{TEST_PLUGIN_NAME} {TEST_PLUGIN_NAME_2}"])
     assert result.exit_code == 0
 
 
+@pytest.mark.skip(reason="Installation b0rks local packages")
 @github_xfail()
 def test_install_from_config_file(ape_cli, runner, temp_config):
     plugins_config = {"plugins": [{"name": TEST_PLUGIN_NAME}]}
@@ -156,6 +160,7 @@ def test_install_from_config_file(ape_cli, runner, temp_config):
         assert TEST_PLUGIN_NAME in result.stdout
 
 
+@pytest.mark.skip(reason="Installation b0rks local packages")
 @github_xfail()
 def test_uninstall(ape_cli, runner, installed_plugin):
     result = runner.invoke(

--- a/tests/integration/cli/test_plugins.py
+++ b/tests/integration/cli/test_plugins.py
@@ -2,7 +2,7 @@ from typing import List, Tuple
 
 import pytest
 
-from tests.integration.cli.utils import github_xfail
+from tests.integration.cli.utils import github_xfail, run_once
 
 TEST_PLUGIN_NAME = "tokens"
 TEST_PLUGIN_NAME_2 = "optimism"
@@ -130,24 +130,28 @@ def test_list_does_not_repeat(ape_plugins_runner, installed_plugin):
 
 
 @pytest.mark.pip
+@run_once
 def test_upgrade(ape_plugins_runner, installed_plugin):
     result = ape_plugins_runner.invoke(["install", TEST_PLUGIN_NAME, "--upgrade"])
     assert result.exit_code == 0
 
 
 @pytest.mark.pip
+@run_once
 def test_upgrade_failure(ape_plugins_runner):
     result = ape_plugins_runner.invoke(["install", "NOT_EXISTS", "--upgrade"])
     assert result.exit_code == 1
 
 
 @pytest.mark.pip
+@run_once
 def test_install_multiple_in_one_str(ape_plugins_runner):
     result = ape_plugins_runner.invoke(["install", f"{TEST_PLUGIN_NAME} {TEST_PLUGIN_NAME_2}"])
     assert result.exit_code == 0
 
 
 @pytest.mark.pip
+@run_once
 def test_install_from_config_file(ape_cli, runner, temp_config):
     plugins_config = {"plugins": [{"name": TEST_PLUGIN_NAME}]}
     with temp_config(plugins_config):
@@ -157,6 +161,7 @@ def test_install_from_config_file(ape_cli, runner, temp_config):
 
 
 @pytest.mark.pip
+@run_once
 def test_uninstall(ape_cli, runner, installed_plugin):
     result = runner.invoke(
         ape_cli, ["plugins", "uninstall", TEST_PLUGIN_NAME, "--yes"], catch_exceptions=False

--- a/tests/integration/cli/test_plugins.py
+++ b/tests/integration/cli/test_plugins.py
@@ -129,28 +129,28 @@ def test_list_does_not_repeat(ape_plugins_runner, installed_plugin):
     assert "ethereum" not in result.available_plugins
 
 
-@pytest.mark.skip(reason="Installation b0rks local packages")
+@pytest.mark.skip(reason="Installation may replace local packages with unwanted versions")
 @github_xfail()
 def test_upgrade(ape_plugins_runner, installed_plugin):
     result = ape_plugins_runner.invoke(["install", TEST_PLUGIN_NAME, "--upgrade"])
     assert result.exit_code == 0
 
 
-@pytest.mark.skip(reason="Installation b0rks local packages")
+@pytest.mark.skip(reason="Installation may replace local packages with unwanted versions")
 @github_xfail()
 def test_upgrade_failure(ape_plugins_runner):
     result = ape_plugins_runner.invoke(["install", "NOT_EXISTS", "--upgrade"])
     assert result.exit_code == 1
 
 
-@pytest.mark.skip(reason="Installation b0rks local packages")
+@pytest.mark.skip(reason="Installation may replace local packages with unwanted versions")
 @github_xfail()
 def test_install_multiple_in_one_str(ape_plugins_runner):
     result = ape_plugins_runner.invoke(["install", f"{TEST_PLUGIN_NAME} {TEST_PLUGIN_NAME_2}"])
     assert result.exit_code == 0
 
 
-@pytest.mark.skip(reason="Installation b0rks local packages")
+@pytest.mark.skip(reason="Installation may replace local packages with unwanted versions")
 @github_xfail()
 def test_install_from_config_file(ape_cli, runner, temp_config):
     plugins_config = {"plugins": [{"name": TEST_PLUGIN_NAME}]}
@@ -160,7 +160,7 @@ def test_install_from_config_file(ape_cli, runner, temp_config):
         assert TEST_PLUGIN_NAME in result.stdout
 
 
-@pytest.mark.skip(reason="Installation b0rks local packages")
+@pytest.mark.skip(reason="Installation may replace local packages with unwanted versions")
 @github_xfail()
 def test_uninstall(ape_cli, runner, installed_plugin):
     result = runner.invoke(


### PR DESCRIPTION
### What I did

- Adds pytest-timeout to prevent some failing tests from running forever.
- Skips plugin installation integration tests because they will often re-install ape (and dependencies), which means the following tests run against an unwanted versions of packages.

@antazoey we spoke about the latter a bit the other day.  I think I narrowed the behavior down to these tests.  I'm not entirely sure if it's only local test runs or if it may affect CI as well.  Slight suspicion it might be related to my local `src/ape/version.py` file but not sure.  I'd be happy skipping on local only if we'd prefer.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
