### PR TITLE
feat: adds compiler_cache_folder config var

### DIFF
--- a/docs/userguides/compile.md
+++ b/docs/userguides/compile.md
@@ -85,7 +85,14 @@ compile:
 ## Settings
 
 Generally, configure compiler plugins using your `ape-config.yaml` file.
-For example, when using the `vyper` plugin, you can configure settings under the `vyper` key:
+One setting that applies to many compiler plugins is `compiler_cache_folder`, which holds dependency source files the compiler uses when compiling your contracts.
+By default, the folder is in your `contracts/.cache` folder but there are times you may want to move this to another location.
+
+```yaml
+compiler_cache_folder: .cache
+```
+
+As another example, when using the `vyper` plugin, you can configure settings under the `vyper` key:
 
 ```yaml
 vyper:

--- a/docs/userguides/compile.md
+++ b/docs/userguides/compile.md
@@ -85,11 +85,20 @@ compile:
 ## Settings
 
 Generally, configure compiler plugins using your `ape-config.yaml` file.
-One setting that applies to many compiler plugins is `compiler_cache_folder`, which holds dependency source files the compiler uses when compiling your contracts.
+One setting that applies to many compiler plugins is `cache_folder`, which holds dependency source files the compiler uses when compiling your contracts.
 By default, the folder is in your `contracts/.cache` folder but there are times you may want to move this to another location.
+Paths are relative to the project directory.
+For instance, to move the dependency cahce to the root project directory:
 
 ```yaml
-compiler_cache_folder: .cache
+compile:
+   cache_folder: .cache
+```
+
+```{caution}
+Changing the location of the dependency cache folder may alter the the output bytecode of your contracts from some compilers.
+Specifically, the [solc compiler will apend a hash of the input metadata to the contract bytecode](https://docs.soliditylang.org/en/latest/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode) which will change with contract path or compiler settings changes.
+This may impact things like contract verification on existing projects.
 ```
 
 As another example, when using the `vyper` plugin, you can configure settings under the `vyper` key:

--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -1,8 +1,11 @@
 from enum import Enum
-from typing import Any, Dict, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Optional, TypeVar
 
 from pydantic import ConfigDict
 from pydantic_settings import BaseSettings
+
+if TYPE_CHECKING:
+    from ape.managers.config import ConfigManager
 
 ConfigItemType = TypeVar("ConfigItemType")
 
@@ -33,8 +36,14 @@ class PluginConfig(BaseSettings):
     a config API must register a subclass of this class.
     """
 
+    # NOTE: This is probably partially initialized at the time of assignment
+    _config_manager: Optional["ConfigManager"]
+
     @classmethod
-    def from_overrides(cls, overrides: Dict) -> "PluginConfig":
+    def from_overrides(
+        cls, overrides: Dict, config_manager: Optional["ConfigManager"] = None
+    ) -> "PluginConfig":
+        cls._config_manager = config_manager
         default_values = cls().model_dump()
 
         def update(root: Dict, value_map: Dict):

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -161,7 +161,9 @@ class CompilerManager(BaseManager):
                 # For mypy - should not be possible.
                 raise ValueError("Compiler should not be None")
 
-            compiled_contracts = compiler.compile(paths_to_compile, base_path=contracts_folder)
+            compiled_contracts = compiler.compile(
+                paths_to_compile, base_path=self.config_manager.get_config("compile").base_dir
+            )
 
             # Validate some things about the compile contracts.
             for contract_type in compiled_contracts:

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -162,7 +162,7 @@ class CompilerManager(BaseManager):
                 raise ValueError("Compiler should not be None")
 
             compiled_contracts = compiler.compile(
-                paths_to_compile, base_path=self.config_manager.get_config("compile").base_dir
+                paths_to_compile, base_path=self.config_manager.get_config("compile").base_path
             )
 
             # Validate some things about the compile contracts.

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -216,9 +216,12 @@ class ConfigManager(BaseInterfaceModel):
             # `or {}` to handle the case when the empty config is `None`.
             user_override = user_config.pop(plugin_name, {}) or {}
             if config_class != ConfigDict:
-                # NOTE: Will raise if improperly provided keys
                 config = config_class.from_overrides(  # type: ignore
-                    user_override, config_manager=self
+                    # NOTE: Will raise if improperly provided keys
+                    user_override,
+                    # NOTE: Sending ourselves in case the PluginConfig needs access to the root
+                    #       config vars.
+                    config_manager=self,
                 )
             else:
                 # NOTE: Just use it directly as a dict if `ConfigDict` is passed

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -101,9 +101,9 @@ class ProjectManager(BaseManager):
         The path to the project's compiler source cache folder.
         """
         # NOTE: as long as config has come up properly, this should not be None
-        if self.config_manager.compiler_cache_folder is None:
-            raise ProjectError("Compiler cache folder not set in config.")
-        return self.config_manager.compiler_cache_folder
+        compile_conf = self.config_manager.get_config("compile")
+        assert compile_conf.cache_folder is not None
+        return compile_conf.cache_folder
 
     @property
     def source_paths(self) -> List[Path]:

--- a/src/ape_compile/__init__.py
+++ b/src/ape_compile/__init__.py
@@ -32,7 +32,7 @@ class Config(PluginConfig):
     """
 
     @property
-    def base_dir(self) -> Path:
+    def base_path(self) -> Path:
         """The base directory for compilation file path references"""
 
         # These should be initialized by plugin config loading and pydantic validators before the

--- a/src/ape_compile/__init__.py
+++ b/src/ape_compile/__init__.py
@@ -68,8 +68,13 @@ class Config(PluginConfig):
 
         # Do not allow escape of the project folder for security and functionality reasons. Paths
         # outside the relative compilation root are not portable and will cause bytecode changes.
-        if project_folder not in self.cache_folder.resolve().parents:
-            raise ValueError("cache_folder must be a child of the project directory")
+        project_resolved = project_folder.resolve()
+        cache_resolved = self.cache_folder.resolve()
+        if project_resolved not in cache_resolved.parents:
+            raise ValueError(
+                f"cache_folder must be a child of the project directory. "
+                f"{project_resolved} not in {cache_resolved}"
+            )
 
     @field_validator("exclude", mode="before")
     @classmethod

--- a/src/ape_compile/__init__.py
+++ b/src/ape_compile/__init__.py
@@ -1,9 +1,12 @@
-from typing import List
+from pathlib import Path
+from typing import List, Optional
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 
 from ape import plugins
 from ape.api import PluginConfig
+
+DEFAULT_CACHE_FOLDER_NAME = ".cache"  # default relative to contracts/
 
 
 class Config(PluginConfig):
@@ -22,6 +25,23 @@ class Config(PluginConfig):
     """
     Source exclusion globs across all file types.
     """
+
+    cache_folder: Optional[Path] = None
+    """
+    Path to contract dependency cache directory (e.g. `contracts/.cache`)
+    """
+
+    @model_validator(mode="after")
+    def validate_cache_folder(self):
+        if self._config_manager is None:
+            return  # Not enough information to continue at this time
+
+        # Handle setting default
+        if self.cache_folder is None:
+            contracts_folder = self._config_manager.contracts_folder
+            self.cache_folder = contracts_folder / DEFAULT_CACHE_FOLDER_NAME
+        elif not self.cache_folder.is_absolute():
+            self.cache_folder = self.cache_folder.expanduser().resolve()
 
     @field_validator("exclude", mode="before")
     @classmethod

--- a/src/ape_compile/__init__.py
+++ b/src/ape_compile/__init__.py
@@ -68,7 +68,7 @@ class Config(PluginConfig):
 
         # Do not allow escape of the project folder for security and functionality reasons. Paths
         # outside the relative compilation root are not portable and will cause bytecode changes.
-        if project_folder not in self.cache_folder.parents:
+        if project_folder not in self.cache_folder.resolve().parents:
             raise ValueError("cache_folder must be a child of the project directory")
 
     @field_validator("exclude", mode="before")

--- a/src/ape_compile/__init__.py
+++ b/src/ape_compile/__init__.py
@@ -72,7 +72,7 @@ class Config(PluginConfig):
         cache_resolved = self.cache_folder.resolve()
         if project_resolved not in cache_resolved.parents:
             raise ValueError(
-                f"cache_folder must be a child of the project directory. "
+                "cache_folder must be a child of the project directory. "
                 f"{project_resolved} not in {cache_resolved}"
             )
 

--- a/src/ape_compile/__init__.py
+++ b/src/ape_compile/__init__.py
@@ -31,17 +31,45 @@ class Config(PluginConfig):
     Path to contract dependency cache directory (e.g. `contracts/.cache`)
     """
 
+    @property
+    def base_dir(self) -> Path:
+        """The base directory for compilation file path references"""
+
+        # These should be initialized by plugin config loading and pydantic validators before the
+        # time this prop is accessed.
+        assert self._config_manager is not None
+        assert self.cache_folder is not None
+
+        # If the dependency cache folder is configured, to be outside of the contracts dir, we want
+        # to use the projects folder to be the base dir for copmilation.
+        if self._config_manager.contracts_folder not in self.cache_folder.parents:
+            return self._config_manager.PROJECT_FOLDER
+
+        # Otherwise, we're defaulting to contracts folder for backwards compatibility. Chaning this
+        # will cause existing projects to compile to different bytecode.
+        return self._config_manager.contracts_folder
+
     @model_validator(mode="after")
     def validate_cache_folder(self):
         if self._config_manager is None:
             return  # Not enough information to continue at this time
 
-        # Handle setting default
+        contracts_folder = self._config_manager.contracts_folder
+        project_folder = self._config_manager.PROJECT_FOLDER
+
+        # Set unconfigured default
         if self.cache_folder is None:
-            contracts_folder = self._config_manager.contracts_folder
             self.cache_folder = contracts_folder / DEFAULT_CACHE_FOLDER_NAME
+
+        # If we get a relative path, assume it's relative to project root (where the config file
+        # lives)
         elif not self.cache_folder.is_absolute():
-            self.cache_folder = self.cache_folder.expanduser().resolve()
+            self.cache_folder = project_folder / self.cache_folder
+
+        # Do not allow escape of the project folder for security and functionality reasons. Paths
+        # outside the relative compilation root are not portable and will cause bytecode changes.
+        if project_folder not in self.cache_folder.parents:
+            raise ValueError("cache_folder must be a child of the project directory")
 
     @field_validator("exclude", mode="before")
     @classmethod

--- a/src/ape_compile/__init__.py
+++ b/src/ape_compile/__init__.py
@@ -45,7 +45,7 @@ class Config(PluginConfig):
         if self._config_manager.contracts_folder not in self.cache_folder.parents:
             return self._config_manager.PROJECT_FOLDER
 
-        # Otherwise, we're defaulting to contracts folder for backwards compatibility. Chaning this
+        # Otherwise, we're defaulting to contracts folder for backwards compatibility. Changing this
         # will cause existing projects to compile to different bytecode.
         return self._config_manager.contracts_folder
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,7 +298,7 @@ def temp_config(config):
     def func(data: Optional[Dict] = None):
         data = data or {}
         with tempfile.TemporaryDirectory() as temp_dir_str:
-            temp_dir = Path(temp_dir_str)
+            temp_dir = Path(temp_dir_str).resolve()
             config._cached_configs = {}
             config_file = temp_dir / CONFIG_FILE_NAME
             config_file.touch()

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -315,7 +315,9 @@ def test_contracts_folder_with_hyphen(temp_config):
 
 
 def test_compiler_cache_folder(temp_config):
-    with temp_config({"contracts_folder": "smarts", "compiler_cache_folder": ".cash"}) as project:
+    with temp_config(
+        {"contracts_folder": "smarts", "compile": {"cache_folder": ".cash"}}
+    ) as project:
         assert project.contracts_folder.name == "smarts"
         assert project.compiler_cache_folder.name == ".cash"
         assert str(project.contracts_folder) not in str(project.compiler_cache_folder)

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -314,6 +314,13 @@ def test_contracts_folder_with_hyphen(temp_config):
         assert project.contracts_folder.name == "src"
 
 
+def test_compiler_cache_folder(temp_config):
+    with temp_config({"contracts_folder": "smarts", "compiler_cache_folder": ".cash"}) as project:
+        assert project.contracts_folder.name == "smarts"
+        assert project.compiler_cache_folder.name == ".cash"
+        assert str(project.contracts_folder) not in str(project.compiler_cache_folder)
+
+
 def test_custom_network():
     chain_id = 11191919191991918223773
     data = {


### PR DESCRIPTION
### What I did

Adds the `cache_folder` config var for ape_compile. Compiler plugins will leverage this for various temporary build-storage (mostly dependency sources).

Ref: #1335

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
