### PR TITLE
fix: array of structs or tuples when only 1 element would be weird

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -637,10 +637,18 @@ class Ethereum(EcosystemAPI):
             # Array of structs or tuples: don't convert to list
             # Array of anything else: convert to single list
             return (
-                ((output_values[0],),)
+                (
+                    [
+                        output_values[0],
+                    ],
+                )
                 if issubclass(type(output_values[0]), Struct)
                 else ([o for o in output_values[0]],)
             )
+
+        elif returns_array(abi):
+            # Tuple with single item as the array.
+            return (output_values,)
 
         return tuple(output_values)
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -634,7 +634,13 @@ class Ethereum(EcosystemAPI):
             and isinstance(output_values, (list, tuple))
             and len(output_values) == 1
         ):
-            return ([o for o in output_values[0]],)
+            # Array of structs or tuples: don't convert to list
+            # Array of anything else: convert to single list
+            return (
+                ((output_values[0],),)
+                if issubclass(type(output_values[0]), Struct)
+                else ([o for o in output_values[0]],)
+            )
 
         return tuple(output_values)
 

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -596,8 +596,10 @@ def test_decode_returndata_list_with_1_struct(ethereum):
     )
     actual = ethereum.decode_returndata(abi, raw_data)
 
-    # The result should still be a list.
     assert len(actual) == 1
+    # The result should still be a list.
+    # There was also a bug where it was mistakenly a tuple!
+    assert isinstance(actual[0], list)
     assert len(actual[0]) == 1
     assert actual[0][0].a == "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
     assert actual[0][0].b == HexBytes(


### PR DESCRIPTION
### What I did

fixes a bug from Discord when if you have a func return an array of a single struct, it would be all funky and not at all like if 2 structs for example.

Also fixes the issue where arrays of structs were tuples unlike arrays of addresses or other types, which were lists. now arrays are always lists.

### How I did it

Squeeze in some handling without breaking anything.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
