### PR TITLE
fix: remove mnemonic from error message

### DIFF
--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -22,6 +22,7 @@ logging.addLevelName(LogLevel.SUCCESS.value, LogLevel.SUCCESS.name)
 logging.SUCCESS = LogLevel.SUCCESS.value  # type: ignore
 DEFAULT_LOG_LEVEL = LogLevel.INFO.name
 DEFAULT_LOG_FORMAT = "%(levelname)s%(plugin)s: %(message)s"
+HIDDEN_MESSAGE = "[hidden]"
 
 
 def success(self, message, *args, **kws):
@@ -278,7 +279,7 @@ def sanitize_url(url: str) -> str:
 
     # If there is a path, hide it but show that you are hiding it.
     # Use string interpolation to prevent URL-character encoding.
-    return f"{url_obj.with_path('')}/[hidden]" if url_obj.path else f"{url}"
+    return f"{url_obj.with_path('')}/{HIDDEN_MESSAGE}" if url_obj.path else f"{url}"
 
 
 logger = ApeLogger.create()

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -7,6 +7,7 @@ from eth_account.hdaccount import ETHEREUM_DEFAULT_PATH
 from eth_utils import to_checksum_address
 
 from ape.cli import ape_cli_context, existing_alias_argument, non_existing_alias_argument
+from ape.logging import HIDDEN_MESSAGE
 from ape.utils.basemodel import ManagerAccessMixin
 from ape_accounts import (
     AccountContainer,
@@ -150,7 +151,8 @@ def _import(cli_ctx, alias, import_from_mnemonic, custom_hd_path):
             passphrase = ask_for_passphrase()
             account = import_account_from_mnemonic(alias, passphrase, mnemonic, custom_hd_path)
         except Exception as error:
-            cli_ctx.abort(f"Seed phrase can't be imported: {error}")
+            error_msg = f"{error}".replace(mnemonic, HIDDEN_MESSAGE)
+            cli_ctx.abort(f"Seed phrase can't be imported: {error_msg}")
 
     else:
         key = click.prompt("Enter Private Key", hide_input=True)

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -6,6 +6,7 @@ import pytest
 from eth_account import Account
 from eth_account.hdaccount import ETHEREUM_DEFAULT_PATH
 
+from ape.logging import HIDDEN_MESSAGE
 from tests.integration.cli.utils import assert_failure, run_once
 
 ALIAS = "test"
@@ -158,7 +159,7 @@ def test_import_mnemonic_default_hdpath(
     result = runner.invoke(
         ape_cli,
         ["accounts", "import", "--use-mnemonic", ALIAS],
-        input="\n".join([f"{MNEMONIC}", PASSWORD, PASSWORD]),
+        input="\n".join([MNEMONIC, PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
     assert temp_account_mnemonic_default_hdpath.address in result.output
@@ -175,7 +176,7 @@ def test_import_mnemonic_custom_hdpath(
     result = runner.invoke(
         ape_cli,
         ["accounts", "import", ALIAS, "--use-mnemonic", "--hd-path", CUSTOM_HDPATH],
-        input="\n".join([f"{MNEMONIC}", PASSWORD, PASSWORD]),
+        input="\n".join([MNEMONIC, PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
     assert temp_account_mnemonic_custom_hdpath.address in result.output
@@ -205,14 +206,12 @@ def test_import_invalid_mnemonic(ape_cli, runner):
     result = runner.invoke(
         ape_cli,
         ["accounts", "import", "--use-mnemonic", ALIAS],
-        input="\n".join([f"{INVALID_MNEMONIC}", PASSWORD, PASSWORD]),
+        input="\n".join([INVALID_MNEMONIC, PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 1, result.output
-    assert_failure(
-        result,
-        f"Seed phrase can't be imported: Provided words: '{INVALID_MNEMONIC}'"
-        + ", are not a valid BIP39 mnemonic phrase!",
-    )
+    assert_failure(result, "Seed phrase can't be imported")
+    assert HIDDEN_MESSAGE in result.output
+    assert INVALID_MNEMONIC not in result.output
 
 
 @run_once


### PR DESCRIPTION
### What I did

3rd party lib revealed a bad mnemonic (which is likely very close to the real one).
Remove for security reasons.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
