### PR TITLE
fix: raise error when attempting to deploy a contract without init-code

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -14,6 +14,7 @@ from ape.exceptions import (
     AccountsError,
     AliasAlreadyInUseError,
     MethodNonPayableError,
+    MissingDeploymentBytecodeError,
     SignatureError,
     TransactionError,
 )
@@ -238,6 +239,10 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
                 "such as 'project.MyContract' where 'MyContract' is the name of "
                 "a contract in your project."
             )
+
+        bytecode = contract.contract_type.deployment_bytecode
+        if not bytecode or bytecode.bytecode in (None, "", "0x"):
+            raise MissingDeploymentBytecodeError(contract.contract_type)
 
         txn = contract(*args, **kwargs)
         if kwargs.get("value") and not contract.contract_type.constructor.is_payable:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -23,6 +23,7 @@ from ape.exceptions import (
     ContractNotFoundError,
     CustomError,
     MethodNonPayableError,
+    MissingDeploymentBytecodeError,
     TransactionNotFoundError,
 )
 from ape.logging import logger
@@ -1343,6 +1344,10 @@ class ContractContainer(ContractTypeWrapper):
         Returns:
             :class:`~ape.contracts.base.ContractInstance`
         """
+
+        bytecode = self.contract_type.deployment_bytecode
+        if not bytecode or bytecode.bytecode in (None, "", "0x"):
+            raise MissingDeploymentBytecodeError(self.contract_type)
 
         txn = self(*args, **kwargs)
         private = kwargs.get("private", False)

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Collection, Dict, Iterator, List, Optiona
 import click
 from eth_typing import Hash32
 from eth_utils import humanize_hash
+from ethpm_types import ContractType
 from ethpm_types.abi import ConstructorABI, ErrorABI, MethodABI
 from rich import print as rich_print
 
@@ -75,6 +76,22 @@ class ContractDataError(ApeException):
     contract logic errors; it is more about ABI-related
     issues and alike.
     """
+
+
+class MissingDeploymentBytecodeError(ContractDataError):
+    """
+    Raised when trying to deploy an interface or empty data.
+    """
+
+    def __init__(self, contract_type: ContractType):
+        message = "Cannot deploy: contract"
+        if name := contract_type.name:
+            message = f"{message} '{name}'"
+
+        message = (
+            f"{message} has no deployment-bytecode. Are you attempting to deploy an interface?"
+        )
+        super().__init__(message)
 
 
 class ArgumentsLengthError(ContractDataError):

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -19,9 +19,9 @@ from ape_networks import CustomNetwork
 from tests.functional.conftest import PROJECT_WITH_LONG_CONTRACTS_FOLDER
 
 
-def test_deployments(networks, owner, project_with_contract):
+def test_deployments(networks, owner, vyper_contract_container):
     # First, obtain a "previously-deployed" contract.
-    instance = project_with_contract.ApeContract0.deploy(sender=owner)
+    instance = vyper_contract_container.deploy(1000200000, sender=owner)
 
     # Create a config using this new contract for a "later time".
     data = {
@@ -33,7 +33,7 @@ def test_deployments(networks, owner, project_with_contract):
     assert config.root["ethereum"]["local"][0]["address"] == instance.address
 
     # Ensure we can reference the deployment on the project.
-    deployment = project_with_contract.ApeContract0.deployments[0]
+    deployment = vyper_contract_container.deployments[0]
     assert deployment.address == instance.address
 
 

--- a/tests/functional/test_contracts_cache.py
+++ b/tests/functional/test_contracts_cache.py
@@ -9,13 +9,13 @@ from tests.conftest import explorer_test, skip_if_plugin_installed
 
 
 @pytest.fixture
-def contract_0(project_with_contract):
-    return project_with_contract.ApeContract0
+def contract_0(vyper_contract_container):
+    return vyper_contract_container
 
 
 @pytest.fixture
-def contract_1(project_with_contract):
-    return project_with_contract.ApeContract1
+def contract_1(solidity_contract_container):
+    return solidity_contract_container
 
 
 def test_instance_at(chain, contract_instance):
@@ -173,8 +173,8 @@ def test_get_deployments_local(chain, owner, contract_0, contract_1):
     chain.contracts._local_contract_types = {}
     starting_contracts_list_0 = chain.contracts.get_deployments(contract_0)
     starting_contracts_list_1 = chain.contracts.get_deployments(contract_1)
-    deployed_contract_0 = owner.deploy(contract_0)
-    deployed_contract_1 = owner.deploy(contract_1)
+    deployed_contract_0 = owner.deploy(contract_0, 900000000)
+    deployed_contract_1 = owner.deploy(contract_1, 900000001)
 
     # Act
     contracts_list_0 = chain.contracts.get_deployments(contract_0)
@@ -195,8 +195,8 @@ def test_get_deployments_local(chain, owner, contract_0, contract_1):
 def test_get_deployments_live(
     chain, owner, contract_0, contract_1, remove_disk_writes_deployments, dummy_live_network
 ):
-    deployed_contract_0 = owner.deploy(contract_0, required_confirmations=0)
-    deployed_contract_1 = owner.deploy(contract_1, required_confirmations=0)
+    deployed_contract_0 = owner.deploy(contract_0, 8000000, required_confirmations=0)
+    deployed_contract_1 = owner.deploy(contract_1, 8000001, required_confirmations=0)
 
     # Act
     my_contracts_list_0 = chain.contracts.get_deployments(contract_0)
@@ -214,12 +214,12 @@ def test_get_multiple_deployments_live(
 ):
     starting_contracts_list_0 = chain.contracts.get_deployments(contract_0)
     starting_contracts_list_1 = chain.contracts.get_deployments(contract_1)
-    initial_deployed_contract_0 = owner.deploy(contract_0, required_confirmations=0)
-    initial_deployed_contract_1 = owner.deploy(contract_1, required_confirmations=0)
-    owner.deploy(contract_0, required_confirmations=0)
-    owner.deploy(contract_1, required_confirmations=0)
-    final_deployed_contract_0 = owner.deploy(contract_0, required_confirmations=0)
-    final_deployed_contract_1 = owner.deploy(contract_1, required_confirmations=0)
+    initial_deployed_contract_0 = owner.deploy(contract_0, 700000, required_confirmations=0)
+    initial_deployed_contract_1 = owner.deploy(contract_1, 700001, required_confirmations=0)
+    owner.deploy(contract_0, 700002, required_confirmations=0)
+    owner.deploy(contract_1, 700003, required_confirmations=0)
+    final_deployed_contract_0 = owner.deploy(contract_0, 600000, required_confirmations=0)
+    final_deployed_contract_1 = owner.deploy(contract_1, 600001, required_confirmations=0)
     contracts_list_0 = chain.contracts.get_deployments(contract_0)
     contracts_list_1 = chain.contracts.get_deployments(contract_1)
     contract_type_map = {
@@ -239,11 +239,11 @@ def test_get_multiple_deployments_live(
 def test_cache_updates_per_deploy(owner, chain, contract_0, contract_1):
     # Arrange / Act
     initial_contracts = chain.contracts.get_deployments(contract_0)
-    expected_first_contract = owner.deploy(contract_0)
+    expected_first_contract = owner.deploy(contract_0, 6787678)
 
-    owner.deploy(contract_0)
-    owner.deploy(contract_0)
-    expected_last_contract = owner.deploy(contract_0)
+    owner.deploy(contract_0, 6787679)
+    owner.deploy(contract_0, 6787680)
+    expected_last_contract = owner.deploy(contract_0, 6787681)
 
     actual_contracts = chain.contracts.get_deployments(contract_0)
     first_index = len(initial_contracts)  # next index before deploys from this test
@@ -294,7 +294,8 @@ def test_get_non_contract_address(chain, owner):
 
 def test_get_attempts_to_convert(chain):
     with pytest.raises(ConversionError):
-        chain.contracts.get("test.eth")
+        # NOTE: using eth2 suffix so still works if ape-ens is installed.
+        chain.contracts.get("test.eth2")
 
 
 def test_cache_non_checksum_address(chain, vyper_contract_instance):


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1904

### How I did it

1. Check for no deploy bytecode before deploy
2. if not found, raise custom exception. the custom exception helps share the code between account deploy and container deploy

### How to verify it

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
