### PR TITLE
fix: issue with networks that started PoA but currently are not

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -1031,9 +1031,10 @@ class NetworkAPI(BaseInterfaceModel):
 
         if provider_name in self.providers:
             provider = self.providers[provider_name](provider_settings=provider_settings)
-            if provider.connection_id in ProviderContextManager.connected_providers:
+            connection_id = provider.connection_id
+            if connection_id in ProviderContextManager.connected_providers:
                 # Likely multi-chain testing or utilizing multiple on-going connections.
-                return ProviderContextManager.connected_providers[provider.connection_id]
+                return ProviderContextManager.connected_providers[connection_id]
 
             return provider
 

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -8,7 +8,7 @@ from copy import copy
 from functools import cached_property
 from itertools import tee
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Literal, Optional, Union, cast
+from typing import Any, Dict, Iterator, List, Optional, Union, cast
 
 import ijson  # type: ignore
 import requests


### PR DESCRIPTION
### What I did

I could not fetch blocks before the consensus changed.
`get_block("earliest")` would be fail because the middleware was only added via a check from the latest block.
(could have swore i already fixed this bug before...)

fixes: https://github.com/ApeWorX/ape-foundry/issues/78


additionally fixes a weird race condition in network context

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
