### PR TITLE
feat: CLI help plugin organization

### DIFF
--- a/src/ape/plugins/__init__.py
+++ b/src/ape/plugins/__init__.py
@@ -13,7 +13,8 @@ from .compiler import CompilerPlugin
 from .config import Config
 from .converter import ConversionPlugin
 from .network import EcosystemPlugin, ExplorerPlugin, NetworkPlugin, ProviderPlugin
-from .pluggy_patch import PluginType, hookimpl, plugin_manager
+from .pluggy_patch import PluginType, hookimpl
+from .pluggy_patch import plugin_manager as pluggy_manager
 from .project import DependencyPlugin, ProjectPlugin
 from .query import QueryPlugin
 
@@ -40,7 +41,7 @@ class AllPluginHooks(
 
 
 # All hookspecs are registered
-plugin_manager.add_hookspecs(AllPluginHooks)
+pluggy_manager.add_hookspecs(AllPluginHooks)
 
 
 def clean_plugin_name(name: str) -> str:
@@ -131,11 +132,11 @@ class PluginManager:
         #  plugin registration occurs. Registration only happens once.
         self._register_plugins()
 
-        if not hasattr(plugin_manager.hook, attr_name):
+        if not hasattr(pluggy_manager.hook, attr_name):
             raise ApeAttributeError(f"{PluginManager.__name__} has no attribute '{attr_name}'.")
 
         # Do this to get access to the package name
-        hook_fn = getattr(plugin_manager.hook, attr_name)
+        hook_fn = getattr(pluggy_manager.hook, attr_name)
         hookimpls = hook_fn.get_hookimpls()
 
         def get_plugin_name_and_hookfn(h):
@@ -157,7 +158,7 @@ class PluginManager:
     @property
     def registered_plugins(self) -> Set[str]:
         self._register_plugins()
-        return {x[0] for x in plugin_manager.list_name_plugin()}
+        return {x[0] for x in pluggy_manager.list_name_plugin()}
 
     @functools.cached_property
     def _plugin_modules(self) -> Tuple[str, ...]:
@@ -185,7 +186,7 @@ class PluginManager:
         for module_name in self._plugin_modules:
             try:
                 module = importlib.import_module(module_name)
-                plugin_manager.register(module)
+                pluggy_manager.register(module)
             except Exception as err:
                 if module_name in __modules__:
                     # Always raise core plugin registration errors.

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -40,26 +40,39 @@ def plugins_argument():
         if file_path.is_file():
             config = load_config(file_path)
             if plugins := config.get("plugins"):
-                return [PluginMetadata.model_validate(d) for d in plugins]
+                res = [PluginMetadata.model_validate(d) for d in plugins]
+                for itm in res:
+                    itm._use_subprocess_pip_freeze = True
+
+                return res
 
         ctx.obj.logger.warning(f"No plugins found at '{file_path}'.")
         return []
 
     def callback(ctx, param, value: Tuple[str]):
+        res = []
         if not value:
             ctx.obj.abort("You must give at least one requirement to install.")
 
         elif len(value) == 1:
             # User passed in a path to a file.
             file_path = Path(value[0]).expanduser().resolve()
-            return (
+            res = (
                 load_from_file(ctx, file_path)
                 if file_path.exists()
-                else [PluginMetadata(name=v) for v in value[0].split(" ")]
+                else [
+                    PluginMetadata(name=v, _use_subprocess_pip_freeze=True)
+                    for v in value[0].split(" ")
+                ]
             )
 
         else:
-            return [PluginMetadata(name=v) for v in value]
+            res = [PluginMetadata(name=v, _use_subprocess_pip_freeze=True) for v in value]
+
+        for itm in res:
+            itm._use_subprocess_pip_freeze = True
+
+        return res
 
     return click.argument(
         "plugins",
@@ -229,7 +242,7 @@ def _change_version(spec: str):
     # This will also update core Ape.
     # NOTE: It is possible plugins may depend on each other and may update in
     #   an order causing some error codes to pop-up, so we ignore those for now.
-    for plugin in _pip_freeze.get_plugins():
+    for plugin in _pip_freeze.get_plugins(use_process=True):
         logger.info(f"Updating {plugin} ...")
         name = plugin.split("=")[0].strip()
         subprocess.call([sys.executable, "-m", "pip", "install", f"{name}{spec}", "--quiet"])

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -9,8 +9,7 @@ from packaging.version import Version
 from ape.cli import ape_cli_context, skip_confirmation_option
 from ape.logging import logger
 from ape.managers.config import CONFIG_FILE_NAME
-from ape.utils import github_client, load_config
-from ape_plugins.utils import (
+from ape.plugins._utils import (
     ModifyPluginResultHandler,
     PluginMetadata,
     PluginMetadataList,
@@ -18,6 +17,7 @@ from ape_plugins.utils import (
     _pip_freeze,
     ape_version,
 )
+from ape.utils import load_config
 
 
 @click.group(short_help="Manage ape plugins")
@@ -100,9 +100,7 @@ def _display_all_callback(ctx, param, value):
 )
 @ape_cli_context()
 def _list(cli_ctx, to_display):
-    registered_plugins = cli_ctx.plugin_manager.registered_plugins
-    available_plugins = github_client.available_plugins
-    metadata = PluginMetadataList.from_package_names(registered_plugins.union(available_plugins))
+    metadata = PluginMetadataList.load(cli_ctx.plugin_manager)
     if output := metadata.to_str(include=to_display):
         click.echo(output)
         if not metadata.installed and not metadata.third_party:

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -3,8 +3,7 @@ from unittest import mock
 
 import pytest
 
-from ape_plugins.exceptions import PluginVersionError
-from ape_plugins.utils import (
+from ape.plugins._utils import (
     ApePluginsRepr,
     ModifyPluginResultHandler,
     PluginGroup,
@@ -14,6 +13,7 @@ from ape_plugins.utils import (
     _PipFreeze,
     ape_version,
 )
+from ape_plugins.exceptions import PluginVersionError
 
 CORE_PLUGINS = ("run",)
 AVAILABLE_PLUGINS = ("available", "installed")
@@ -34,7 +34,7 @@ def get_pip_freeze_output(version: str):
 @pytest.fixture(autouse=True)
 def mock_pip_freeze(mocker):
     def fn(version: str):
-        patch = mocker.patch("ape_plugins.utils._check_pip_freeze")
+        patch = mocker.patch("ape.plugins._utils._check_pip_freeze")
         patch.return_value = get_pip_freeze_output(version)
         return patch
 
@@ -43,7 +43,7 @@ def mock_pip_freeze(mocker):
 
 @pytest.fixture(autouse=True)
 def plugin_test_env(mocker, mock_pip_freeze):
-    root = "ape_plugins.utils"
+    root = "ape.plugins._utils"
 
     # Prevent calling out to GitHub
     gh_mock = mocker.patch(f"{root}._get_available_plugins")
@@ -258,7 +258,7 @@ class TestPluginGroup:
         """
         Exceptions CANNOT happen in a repr!
         """
-        patch = mocker.patch("ape_plugins.utils.PluginGroup.name", new_callable=mock.PropertyMock)
+        patch = mocker.patch("ape.plugins._utils.PluginGroup.name", new_callable=mock.PropertyMock)
         patch.side_effect = ValueError("repr fail test")
         group = PluginGroup(plugin_type=PluginType.INSTALLED)
 

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -267,7 +267,7 @@ class TestPluginGroup:
 
 def test_pip_freeze_includes_version_when_available():
     pip_freeze = _PipFreeze()
-    actual = pip_freeze.get_plugins()
+    actual = pip_freeze.get_plugins(use_process=True)
     expected = {f"ape-{INSTALLED_PLUGINS[0]}", f"ape-{THIRD_PARTY[0]}==0.{ape_version.minor}.0"}
     assert actual == expected
 

--- a/tests/integration/cli/test_misc.py
+++ b/tests/integration/cli/test_misc.py
@@ -1,9 +1,10 @@
+import re
+
 import pytest
 
 from tests.integration.cli.utils import run_once
 
 
-# NOTE: test all the things without a direct test elsewhere
 @run_once
 @pytest.mark.parametrize(
     "args",
@@ -11,13 +12,21 @@ from tests.integration.cli.utils import run_once
         [],
         ["--version"],
         ["--config"],
-        ["--help"],
-        ["accounts"],
-        ["networks"],
-        ["networks", "list"],
-        ["plugins"],
     ),
 )
 def test_invocation(ape_cli, runner, args):
     result = runner.invoke(ape_cli, args)
     assert result.exit_code == 0, result.output
+
+
+@run_once
+def test_help(ape_cli, runner):
+    result = runner.invoke(ape_cli, "--help")
+    assert result.exit_code == 0, result.output
+    anything = r"[.\n\s\w`/\-,\)\(:\]\[]*"
+    expected = (
+        rf"{anything}Core Commands:\n  accounts  "
+        rf"Manage local accounts{anything}  "
+        rf"test\s*Launches pytest{anything}"
+    )
+    assert re.match(expected.strip(), result.output)


### PR DESCRIPTION
### What I did

refactor: move some plugin utils to core for sharing purposes
perf: make `ape plugins list`  faster by only using pip-freeze subprocess checking for modifications, not list
feat: organize ape help by plugins (made possibly by the above too)

fixes: #337 

so really, I wanted the first items but they afforded the 3rd which we had an issue for.

### How to verify it

this is roughly the same performance, but probably a smidge slower

```sh
ape --help
```

this is now faster!

```sh
ape plugins list
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
