### PR TITLE
fix: provider settings RPC was not being used when it was the default

### DIFF
--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -447,6 +447,7 @@ class NetworkManager(BaseManager):
             return default_network.get_provider(provider_settings=provider_settings)
 
         elif _is_custom_network(network_choice):
+            # Custom network w/o ecosystem & network spec.
             return self.create_custom_provider(network_choice)
 
         selections = network_choice.split(":")

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -14,7 +14,6 @@ from eth_utils import is_0x_prefixed
 from importlib_metadata import PackageNotFoundError, distributions, packages_distributions
 from importlib_metadata import version as version_metadata
 from packaging.specifiers import SpecifierSet
-from requests import head
 from tqdm.auto import tqdm  # type: ignore
 
 from ape.exceptions import APINotImplementedError, ProviderNotConnectedError

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -14,6 +14,7 @@ from eth_utils import is_0x_prefixed
 from importlib_metadata import PackageNotFoundError, distributions, packages_distributions
 from importlib_metadata import version as version_metadata
 from packaging.specifiers import SpecifierSet
+from requests import head
 from tqdm.auto import tqdm  # type: ignore
 
 from ape.exceptions import APINotImplementedError, ProviderNotConnectedError

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -473,7 +473,7 @@ class Geth(EthereumNodeProvider):
     @property
     def uri(self) -> str:
         if "uri" in self.provider_settings:
-            # If specifying in Python, user no matter what.
+            # If specifying in Python, use no matter what.
             return self.provider_settings["uri"]
 
         uri = super().uri
@@ -484,7 +484,7 @@ class Geth(EthereumNodeProvider):
         if not uri or uri == DEFAULT_SETTINGS["uri"]:
             # Do not override explicit configuration
             if ecosystem in self.config:
-                # Shape of this is odd.  Pydantic model containing dicts
+                # Shape of this is odd. Pydantic model containing dicts
                 if network_config := self.config[ecosystem].get(network):
                     if "uri" in network_config:
                         return network_config["uri"]

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -472,6 +472,10 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
 class Geth(EthereumNodeProvider):
     @property
     def uri(self) -> str:
+        if "uri" in self.provider_settings:
+            # If specifying in Python, user no matter what.
+            return self.provider_settings["uri"]
+
         uri = super().uri
         ecosystem = self.network.ecosystem.name
         network = self.network.name

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -23,7 +23,7 @@ from ape_ethereum.transactions import (
     TransactionStatusEnum,
     TransactionType,
 )
-from ape_geth.provider import GethDevProcess, GethNotInstalledError
+from ape_geth.provider import GethDevProcess, GethNotInstalledError, _RPCFactory
 from tests.conftest import GETH_URI, geth_process_test
 
 
@@ -40,7 +40,7 @@ def test_uri(geth_provider):
 
 
 @geth_process_test
-def test_default_public_uri(config):
+def test_uri_localhost_not_running_uses_random_default(config):
     cfg = config.get_config("geth").ethereum.mainnet
     assert cfg["uri"] in PUBLIC_CHAIN_META["ethereum"]["mainnet"]["rpc"]
     cfg = config.get_config("geth").ethereum.sepolia

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -61,10 +61,9 @@ def test_uri_when_configured(geth_provider, temp_config, ethereum):
 
             # Assert provider settings takes precedence.
             expected = DEFAULT_SETTINGS["uri"]
-            for name in ("local", "mainnet"):
-                network = ethereum.get_network(name)
-                provider = network.get_provider("geth", provider_settings={"uri": expected})
-                assert provider.uri == expected
+            network = ethereum.get_network("mainnet")
+            provider = network.get_provider("geth", provider_settings={"uri": expected})
+            assert provider.uri == expected
 
     finally:
         geth_provider.provider_settings = settings


### PR DESCRIPTION
### What I did

In ape-geth, if was given a provdider-settings URI, use that no matter what
Also, when generating config defaults, if something is running on the local, still use that as the default just in case.
Then, finally, if the default is available, use that instead of again checking for random public

fixes: #1917 

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
