### PR TITLE
docs: revise readme and rely more on user-guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ With our **modular plugin system**, Ape supports multiple contract languages and
 
 Ape is built by [ApeWorX LTD](https://www.apeworx.io/).
 
-Join our [ApeWorX Discord server][discord-url] to stay up to date on new releases, plugins and tutorials.
+Join our [ApeWorX Discord server][discord-url] to stay up to date on new releases, plugins, and tutorials.
 
-If you want to just get started, jump down to the [Playing with Ape](#playing-with-ape).
+If you want to get started now, see the [Quickstart](#quickstart) section.
 
 ## Documentation
 
@@ -36,7 +36,7 @@ Check your python version in a terminal with `python3 --version`.
 
 There are three ways to install ape: `pipx`, `pip`, or `Docker`.
 
-### Considerations for Installing:
+### Considerations for Installing
 
 - If using `pip`, we advise using the most up-to-date version of `pip` to increase the chance of a successful installation.
 
@@ -49,13 +49,13 @@ There are three ways to install ape: `pipx`, `pip`, or `Docker`.
 
 - We advise for **macOS** users to install virtual env via [homebrew](https://formulae.brew.sh/formula/virtualenv).
 
-### via `pipx` or `pip`
+### Installing with `pipx` or `pip`
 
 1. Install `pipx` via their [installation instructions](https://pypa.github.io/pipx/) or `pip` via their [installation instructions](https://pip.pypa.io/en/stable/cli/pip_install/).
 
 2. Install **`ape`** via `pipx install eth-ape` or `pip install eth-ape`.
 
-### via `docker`
+### Installing with `docker`
 
 Ape can also run in a docker container.
 
@@ -63,148 +63,56 @@ Please visit our [Dockerhub](https://hub.docker.com/repository/docker/apeworx/ap
 
 ```bash
 docker run \
---volume $HOME/.ape:/home/harambe/.ape \
---volume $HOME/.vvm:/home/harambe/.vvm \
---volume $HOME/.solcx:/home/harambe/.solcx \
---volume $PWD:/home/harambe/project \
-apeworx/ape compile
+  --volume $HOME/.ape:/home/harambe/.ape \
+  --volume $HOME/.vvm:/home/harambe/.vvm \
+  --volume $HOME/.solcx:/home/harambe/.solcx \
+  --volume $PWD:/home/harambe/project \
+  apeworx/ape compile
 ```
 
-## Playing with Ape
+## Quickstart
 
-After you installed Ape, you can run `ape --version` to make sure it works and is the latest version.
+After you have installed Ape, run `ape --version` to verify the installation was successful.
 
-There are two ways to interact with Ape:
+Interact with Ape using either the [CLI](https://docs.apeworx.io/ape/latest/index.html) or [Python code](https://docs.apeworx.io/ape/latest/index.html).
 
-- [CLI Reference](https://docs.apeworx.io/ape/latest/index.html)
+See the following user-guides for more in-depth tutorials:
 
-- [Python Reference](https://docs.apeworx.io/ape/latest/index.html)
+- [Accounts][accounts-guide]
+- [Networks][networks-guide]
+- [Projects][projects-guide]
+- [Compiling][compile-guide]
+- [Testing][testing-guide]
+- [Console][console-guide]
+- [Scripting][scripting-guide]
+- [Logging][logging-guide]
 
-Ape is both a CLI tool and a Python SDK.
+## Plugin System
 
-The CLI tool contains all the Ape commands and the Python SDK contains the classes and types needed to compose scripts, console actions, and tests.
+Ape's modular plugin system allows users to have an interoperable experience with Web3.
 
-## **Ape Modular Plugin System:**
-
-Our modular plugin system is the best way to have the most interoperable experience with Web3.
-
-**NOTE**: If a plugin does not originate from the [ApeWorX GitHub Organization](https://github.com/ApeWorX?q=ape&type=all), you will get a warning about installing 3rd-party plugins.
-
-Install 3rd party plugins at your own risk.
-
-Additionally, plugins that come bundled with **`ape`** in the core installation cannot be removed and are part of the **`ape`** core software.
-
-- Learn more about **installing** plugins from following this [installing user guide](https://docs.apeworx.io/ape/stable/userguides/installing_plugins.html).
+- Learn about **installing** plugins from following this [installing user guide](https://docs.apeworx.io/ape/stable/userguides/installing_plugins.html).
 
 - Learn more about **developing** your own plugins from this [developing user guide](https://docs.apeworx.io/ape/stable/userguides/developing_plugins.html).
 
-### Accounts
+**NOTE**: If a plugin does not originate from the [ApeWorX GitHub Organization](https://github.com/ApeWorX?q=ape&type=all), you will get a warning about installing 3rd-party plugins.
+Install 3rd party plugins at your own risk.
 
-In Ape, you will need accounts to make transactions.
-You can import or generate accounts using the core `accounts` plugin:
-
-```bash
-ape accounts import acc0   # Will prompt for a private key
-ape accounts generate acc1
-```
-
-List all your accounts with the `list` command.
-
-```bash
-ape accounts list
-```
-
-Learn more about accounts in Ape by following the [accounts guide](https://docs.apeworx.io/ape/stable/userguides/accounts.html).
-
-### Plugins
-
-Add any plugins you may need, such as `vyper`.
-
-```bash
-ape plugins list -a
-ape plugins install vyper
-ape plugins list -a
-```
-
-## Projects
-
-When using Ape, you generally will work with a project.
-
-Learn more about smart-contract **projects** from this [projects guide](https://docs.apeworx.io/ape/stable/userguides/projects.html).
-
-### Compiling
-
-You can compile contracts within the `contracts/` directory of your project.
-The `--size` option will display you the size of the contract.
-
-```bash
-ape compile --size
-```
-
-Learn more about compiling in Ape by following the [compile guide](https://docs.apeworx.io/ape/stable/userguides/compile.html).
-
-### Testing
-
-Use Ape to test your smart-contract projects.
-Provide the same arguments to `pytest` as you would to the `ape test` command.
-
-For example:
-
-```bash
-ape test -k test_only_one_thing
-```
-
-Visit the [testing guide](https://docs.apeworx.io/ape/stable/userguides/testing.html) to learn more about testing using Ape.
-
-### Console
-
-Ape provides an `IPython` interactive console with useful pre-defined locals to interact with your project.
-To interact with a deployed contract in a local environment, start by opening the console:
-
-```bash
-ape console --network ethereum:mainnet:infura
-```
-
-Visit [Ape Console](https://docs.apeworx.io/ape/stable/commands/console.html) to learn how to use Ape Console.
-
-### Scripts
-
-If you want to run specific files in a `scripts/` directory, you can do it using the `ape run` command.
-
-```bash
-# This command will run a file named deploy in the scripts/ directory
-$ ape run deploy
-```
-
-Learn more about scripting using Ape by following the [scripting guide](https://docs.apeworx.io/ape/stable/userguides/scripts.html).
-
-### Logging
-
-To enable debug logging, run your command with the `--verbosity` flag using `DEBUG` as the value:
-
-```bash
-ape --verbosity DEBUG run
-```
-
-### Networks
-
-You can work with registered networks, providers, and blockchain ecosystems (like Ethereum):
-
-```python
-from ape import networks
-with networks.ethereum.mainnet.use_provider("infura"):
-    ...  # Work with the infura provider here
-```
-
-To learn more about networks in Ape, see [this guide](https://docs.apeworx.io/ape/stable/commands/networks.html).
-
+[accounts-guide]: https://docs.apeworx.io/ape/stable/userguides/accounts.html
 [actions-badge]: https://github.com/ApeWorX/ape/actions/workflows/test.yaml/badge.svg
 [actions-url]: https://github.com/ApeWorX/ape/actions?query=branch%3Amain+event%3Apush
+[compile-guide]: https://docs.apeworx.io/ape/stable/userguides/compile.html
+[console-guide]: https://docs.apeworx.io/ape/stable/userguides/console.html
 [discord-badge]: https://img.shields.io/discord/922917176040640612.svg?logo=discord&style=flat-square
 [discord-url]: https://discord.gg/apeworx
 [licence-badge]: https://img.shields.io/github/license/ApeWorX/ape?color=blue
 [licence-url]: https://github.com/ApeWorX/ape/blob/main/LICENSE
+[logging-guide]: https://docs.apeworx.io/ape/stable/userguides/logging.html
+[networks-guide]: https://docs.apeworx.io/ape/stable/userguides/networks.html
+[projects-guide]: https://docs.apeworx.io/ape/stable/userguides/projects.html
 [pypi-badge]: https://img.shields.io/pypi/dm/eth-ape?label=pypi.org
 [pypi-url]: https://pypi.org/project/eth-ape/
+[scripting-guide]: https://docs.apeworx.io/ape/stable/userguides/scripts.html
+[testing-guide]: https://docs.apeworx.io/ape/stable/userguides/testing.html
 [twitter-badge]: https://img.shields.io/twitter/follow/ApeFramework
 [twitter-url]: https://twitter.com/ApeFramework


### PR DESCRIPTION
### What I did

Updates some smaller things in the README and removes many sections and replaces their idea with links to the user-guides from he Quickstart section.
One of the small changes was renaming Playing with Ape to Quickstart, as many docs-viewers are looking for this.
Additionally:
* removes `:` from headers
* Avoids words like `just`
* Adds spacing for multi-line commands

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
