### PR TITLE
perf: lazy model extras and IPython canary short-circuitry

### DIFF
--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, Optional, TypeVar
 from pydantic import ConfigDict
 from pydantic_settings import BaseSettings
 
+from ape.utils.basemodel import _assert_not_ipython_check
+
 ConfigItemType = TypeVar("ConfigItemType")
 
 
@@ -49,6 +51,8 @@ class PluginConfig(BaseSettings):
         return cls(**update(default_values, overrides))
 
     def __getattr__(self, attr_name: str) -> Any:
+        _assert_not_ipython_check(attr_name)
+
         # Allow hyphens in plugin config files.
         attr_name = attr_name.replace("-", "_")
         extra = self.__pydantic_extra__ or {}

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -290,7 +290,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
     def __ape_extra_attributes__(self) -> Iterator[ExtraModelAttributes]:
         yield ExtraModelAttributes(
             name="networks",
-            attributes=self.networks,
+            attributes=lambda : self.networks,
             include_getattr=True,
             include_getitem=True,
         )

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -290,7 +290,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
     def __ape_extra_attributes__(self) -> Iterator[ExtraModelAttributes]:
         yield ExtraModelAttributes(
             name="networks",
-            attributes=lambda : self.networks,
+            attributes=lambda: self.networks,
             include_getattr=True,
             include_getitem=True,
         )

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -366,7 +366,7 @@ class DependencyAPI(ExtraAttributesMixin, BaseInterfaceModel):
     def __ape_extra_attributes__(self) -> Iterator[ExtraModelAttributes]:
         yield ExtraModelAttributes(
             name=self.name,
-            attributes=self.contracts,
+            attributes=lambda: self.contracts,
             include_getattr=True,
             include_getitem=True,
             additional_error_message="Do you have the necessary compiler plugins installed?",

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -275,7 +275,7 @@ class ReceiptAPI(ExtraAttributesMixin, BaseInterfaceModel):
         return f"<{cls_name} {self.txn_hash}>"
 
     def __ape_extra_attributes__(self) -> Iterator[ExtraModelAttributes]:
-        yield ExtraModelAttributes(name="transaction", attributes=lambda : vars(self.transaction))
+        yield ExtraModelAttributes(name="transaction", attributes=lambda: vars(self.transaction))
 
     @field_validator("transaction", mode="before")
     @classmethod

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -275,7 +275,7 @@ class ReceiptAPI(ExtraAttributesMixin, BaseInterfaceModel):
         return f"<{cls_name} {self.txn_hash}>"
 
     def __ape_extra_attributes__(self) -> Iterator[ExtraModelAttributes]:
-        yield ExtraModelAttributes(name="transaction", attributes=vars(self.transaction))
+        yield ExtraModelAttributes(name="transaction", attributes=lambda : vars(self.transaction))
 
     @field_validator("transaction", mode="before")
     @classmethod

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -30,6 +30,7 @@ from ape.logging import logger
 from ape.types import AddressType, ContractLog, LogFilter, MockContractLog
 from ape.utils import BaseInterfaceModel, ManagerAccessMixin, cached_property, singledispatchmethod
 from ape.utils.abi import StructParser
+from ape.utils.basemodel import _assert_not_ipython_check
 
 
 class ContractConstructor(ManagerAccessMixin):
@@ -1163,7 +1164,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
         Returns:
             Any: The return value from the contract call, or a transaction receipt.
         """
-
+        _assert_not_ipython_check(attr_name)
         if attr_name in set(super(BaseAddress, self).__dir__()):
             return super(BaseAddress, self).__getattribute__(attr_name)
 
@@ -1252,7 +1253,7 @@ class ContractContainer(ContractTypeWrapper):
             :class:`~ape.types.ContractEvent` or a subclass of :class:`~ape.exceptions.CustomError`
             or any real attribute of the class.
         """
-
+        _assert_not_ipython_check(name)
         try:
             # First, check if requesting a regular attribute on this class.
             return self.__getattribute__(name)
@@ -1464,6 +1465,7 @@ class ContractNamespace:
             Union[:class:`~ape.contracts.base.ContractContainer`,
             :class:`~ape.contracts.base.ContractNamespace`]
         """
+        _assert_not_ipython_check(item)
 
         def _get_name(cc: ContractContainer) -> str:
             return cc.contract_type.name or ""

--- a/src/ape/managers/base.py
+++ b/src/ape/managers/base.py
@@ -7,9 +7,9 @@ class BaseManager(ManagerAccessMixin):
     """
 
     def _repr_mimebundle_(self, include=None, exclude=None):
-        # This work's better than AttributeError for Ape.
+        # This works better than AttributeError for Ape.
         raise NotImplementedError("This manager does not implement '_repr_mimebundle_'.")
 
     def _ipython_display_(self, include=None, exclude=None):
-        # This work's better than AttributeError for Ape.
+        # This works better than AttributeError for Ape.
         raise NotImplementedError("This manager does not implement '_ipython_display_'.")

--- a/src/ape/managers/base.py
+++ b/src/ape/managers/base.py
@@ -5,3 +5,11 @@ class BaseManager(ManagerAccessMixin):
     """
     Base manager that allows us to add other IPython integration features
     """
+
+    def _repr_mimebundle_(self, include=None, exclude=None):
+        # This work's better than AttributeError for Ape.
+        raise NotImplementedError("This manager does not implement '_repr_mimebundle_'.")
+
+    def _ipython_display_(self, include=None, exclude=None):
+        # This work's better than AttributeError for Ape.
+        raise NotImplementedError("This manager does not implement '_ipython_display_'.")

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -9,7 +9,8 @@ from ape.contracts import ContractContainer
 from ape.exceptions import ApeAttributeError, CompilerError, ContractLogicError
 from ape.logging import logger
 from ape.managers.base import BaseManager
-from ape.utils import get_relative_path
+from ape.utils.basemodel import _assert_not_ipython_check
+from ape.utils.os import get_relative_path
 
 
 class CompilerManager(BaseManager):
@@ -33,6 +34,8 @@ class CompilerManager(BaseManager):
         return f"<{cls_name} len(registered_compilers)={num_compilers}>"
 
     def __getattr__(self, name: str) -> Any:
+        _assert_not_ipython_check(name)
+
         try:
             return self.__getattribute__(name)
         except AttributeError:

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -13,6 +13,7 @@ from ape.exceptions import (
     NetworkNotFoundError,
 )
 from ape.managers.base import BaseManager
+from ape.utils.basemodel import _assert_not_ipython_check
 from ape.utils.misc import _dict_overlay
 from ape_ethereum.provider import EthereumNodeProvider
 
@@ -303,7 +304,7 @@ class NetworkManager(BaseManager):
 
             eth = networks.ethereum
         """
-
+        _assert_not_ipython_check(attr_name)
         options = {attr_name, attr_name.replace("-", "_"), attr_name.replace("_", "-")}
         ecosystems = self.ecosystems
         for opt in options:

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -536,7 +536,12 @@ class ProjectManager(BaseManager):
         try:
             return self.__getattribute__(attr_name)
         except AttributeError:
-            if not self._getattr_contracts:
+            # NOTE: Also handles IPython attributes such as _ipython_display_
+            if (
+                not self._getattr_contracts
+                or attr_name.startswith("_ipython_")
+                or attr_name.startswith("_repr_")
+            ):
                 # Raise the attribute error as if this method didn't exist.
                 raise
 

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -537,14 +537,10 @@ class ProjectManager(BaseManager):
             return self.__getattribute__(attr_name)
         except AttributeError:
             # NOTE: Also handles IPython attributes such as _ipython_display_
-            if (
-                not self._getattr_contracts
-                or attr_name.startswith("_ipython_")
-                or attr_name.startswith("_repr_")
-            ):
+            if not self._getattr_contracts:
                 # Raise the attribute error as if this method didn't exist.
                 raise
-
+        breakpoint()
         try:
             # NOTE: Will compile project (if needed)
             if contract := self._get_contract(attr_name):

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -16,6 +16,7 @@ from ape.logging import logger
 from ape.managers.base import BaseManager
 from ape.managers.project.types import ApeProject, BrownieProject
 from ape.utils import get_relative_path
+from ape.utils.basemodel import _assert_not_ipython_check
 
 
 class ProjectManager(BaseManager):
@@ -55,6 +56,9 @@ class ProjectManager(BaseManager):
 
     def __str__(self) -> str:
         return f'Project("{self.path}")'
+
+    def __repr__(self):
+        return "<ProjectManager>"
 
     @property
     def dependencies(self) -> Dict[str, Dict[str, DependencyAPI]]:
@@ -481,7 +485,7 @@ class ProjectManager(BaseManager):
             :class:`~ape.contracts.ContractContainer`,
             a :class:`~ape.contracts.ContractNamespace`, or any attribute.
         """
-
+        _assert_not_ipython_check(attr_name)
         result = self._get_attr(attr_name)
         if result:
             return result

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -540,7 +540,7 @@ class ProjectManager(BaseManager):
             if not self._getattr_contracts:
                 # Raise the attribute error as if this method didn't exist.
                 raise
-        breakpoint()
+
         try:
             # NOTE: Will compile project (if needed)
             if contract := self._get_contract(attr_name):

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -58,7 +58,13 @@ class ProjectManager(BaseManager):
         return f'Project("{self.path}")'
 
     def __repr__(self):
-        return "<ProjectManager>"
+        try:
+            path = f" {self.path}"
+        except Exception:
+            # Disallow exceptions in __repr__
+            path = ""
+
+        return f"<ProjectManager{path}>"
 
     @property
     def dependencies(self) -> Dict[str, Dict[str, DependencyAPI]]:

--- a/src/ape/plugins/__init__.py
+++ b/src/ape/plugins/__init__.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Generator, Iterator, List, Optional, Set, Tupl
 from ape.__modules__ import __modules__
 from ape.exceptions import ApeAttributeError
 from ape.logging import logger
+from ape.utils.basemodel import _assert_not_ipython_check
 
 from .account import AccountPlugin
 from .compiler import CompilerPlugin
@@ -128,6 +129,8 @@ class PluginManager:
         return f"<{PluginManager.__name__}>"
 
     def __getattr__(self, attr_name: str) -> Iterator[Tuple[str, Tuple]]:
+        _assert_not_ipython_check(attr_name)
+
         # NOTE: The first time this method is called, the actual
         #  plugin registration occurs. Registration only happens once.
         self._register_plugins()

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -262,11 +262,11 @@ class BaseModel(EthpmTypesBaseModel):
         return result
 
     def _repr_mimebundle_(self, include=None, exclude=None):
-        # This work's better than AttributeError for Ape.
+        # This works better than AttributeError for Ape.
         raise NotImplementedError("This model does not implement '_repr_mimebundle_'.")
 
     def _ipython_display_(self, include=None, exclude=None):
-        # This work's better than AttributeError for Ape.
+        # This works better than AttributeError for Ape.
         raise NotImplementedError("This model does not implement '_ipython_display_'.")
 
 

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -261,6 +261,14 @@ class BaseModel(EthpmTypesBaseModel):
 
         return result
 
+    def _repr_mimebundle_(self, include=None, exclude=None):
+        # This work's better than AttributeError for Ape.
+        raise NotImplementedError("This model does not implement '_repr_mimebundle_'.")
+
+    def _ipython_display_(self, include=None, exclude=None):
+        # This work's better than AttributeError for Ape.
+        raise NotImplementedError("This model does not implement '_ipython_display_'.")
+
 
 def _assert_not_ipython_check(key):
     # Perf: IPython expects AttributeError here.

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -264,6 +264,12 @@ class BaseModel(EthpmTypesBaseModel):
         return result
 
 
+def _assert_not_ipython_check(key):
+    # Perf: IPython expects AttributeError here.
+    if isinstance(key, str) and key == "_ipython_canary_method_should_not_exist_":
+        raise AttributeError()
+
+
 class ExtraAttributesMixin:
     """
     A mixin to use on models that provide ``ExtraModelAttributes``.
@@ -287,7 +293,7 @@ class ExtraAttributesMixin:
         An overridden ``__getattr__`` implementation that takes into
         account :meth:`~ape.utils.basemodel.ExtraAttributesMixin.__ape_extra_attributes__`.
         """
-
+        _assert_not_ipython_check(name)
         private_attrs = self.__pydantic_private__ or {}
         if name in private_attrs:
             _recursion_checker.reset()

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -231,13 +231,11 @@ class ExtraModelAttributes(EthpmTypesBaseModel):
         if isinstance(self.attributes, dict):
             return self.attributes
         elif isinstance(self.attributes, RootBaseModel):
-            self.attributes = self.attributes.model_dump(by_alias=False)
-            return self.attributes
+            return self.attributes.model_dump(by_alias=False)
 
         # Lazy extras.
-        attrs = self.attributes()
-        self.attributes = attrs if isinstance(attrs, dict) else attrs.model_dump(by_alias=False)
-        return self.attributes
+        result = self.attributes()
+        return result if isinstance(result, dict) else result.model_dump(by_alias=False)
 
 
 class BaseModel(EthpmTypesBaseModel):

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -48,6 +48,7 @@ from ape.utils import (
     returns_array,
     to_int,
 )
+from ape.utils.basemodel import _assert_not_ipython_check
 from ape.utils.misc import DEFAULT_MAX_RETRIES_TX, DEFAULT_TRANSACTION_TYPE
 from ape_ethereum.proxies import (
     IMPLEMENTATION_ABI,
@@ -220,6 +221,7 @@ class BaseEthereumConfig(PluginConfig):
         )
 
     def __getattr__(self, key: str) -> Any:
+        _assert_not_ipython_check(key)
         net_key = key.replace("-", "_")
         if net_key.endswith("_fork"):
             return self._get_forked_config(net_key)

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -443,6 +443,23 @@ def test_getattr_contract_not_exists(project):
         _ = project.ThisIsNotAContractThatExists
 
 
+@pytest.mark.parametrize("iypthon_attr_name", ("_repr_mimebundle_", "_ipython_display_"))
+def test_getattr_ipython(mocker, project, iypthon_attr_name):
+    spy = mocker.spy(project, "_get_contract")
+    getattr(project, iypthon_attr_name)
+    # Ensure it does not try to do anything with contracts.
+    assert spy.call_count == 0
+
+
+def test_getattr_ipython_canary_check(mocker, project):
+    spy = mocker.spy(project, "_get_contract")
+    with pytest.raises(AttributeError):
+        getattr(project, "_ipython_canary_method_should_not_exist_")
+
+    # Ensure it does not try to do anything with contracts.
+    assert spy.call_count == 0
+
+
 def test_build_file_only_modified_once(project_with_contract):
     project = project_with_contract
     artifact = project.path / ".build" / "__local__.json"


### PR DESCRIPTION
### What I did

perf: evaluates extras lazily
perf: short-circuit during IPython canary check

the combo of these makes it not compile at weird times! people kept saying ape always compiles so much, I think this was the cause.

watch this:

go to ape main branch in an uncompiled projet and launch a console:

```sh
ape console

# THEN TYPE `project`
[1] project
```

it immediately starts compiling the project :[ but why doh

### How I did it

* first i tried __repr__ in project manager, didnt matter though :/ but it seemed like it helped kinda
* then i added the lazy eval for the extras. this is great. now, itll calculate the extras if you ask it to making ape seem a lot faster
* finally, what the heck ipython was triggering stuff in Ape it shouldnt have, like compiling, via this canary attribute: https://stackoverflow.com/questions/56068348/what-is-ipython-canary-method-should-not-exist
so to handle this, I short-circuit with what it actually wants. It just wants to make sure we are not saying we have all the full attribute name space because that would crash IPython, so it just wants an attribute error. by raising early, we avoid all the stuff we thought we were to begin with!

for example, when you do `project.MyContract`, if the contract is not found, Ape will compile the missing sources and then check again. So `ape console` then typing `project`, IPython sends this canary message and ape is like "whattttt this aint something i know, but i realize there are uncompiled contracts here so lemme just go away and compile dose and then check again.... ok, i still didnd find `_ipython_canary_bullshit_` so ima just raise AttributeError. and then IPython is like "wow thanks, i was just making sure you ain't bat-shit nuts and claiming you have all these random attributes because that would be really bad for me" and then Ape is like "we gooooood"... and so me as a dev is like, why not just formalize our little chat, skip the check for uncompiled sources because we know it aint in there, we have done this every single time we launch `ape console` for the past 3 years or whatever, so heyyy, performance me upppp. happy friday.
