### PR TITLE
feat: EIP-4844 (type 3) transactions initial support

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -62,6 +62,8 @@ from ape_ethereum.transactions import (
     BaseTransaction,
     DynamicFeeTransaction,
     Receipt,
+    SharedBlobReceipt,
+    SharedBlobTransaction,
     StaticFeeTransaction,
     TransactionStatusEnum,
     TransactionType,
@@ -480,7 +482,7 @@ class Ethereum(EcosystemAPI):
 
     def decode_receipt(self, data: Dict) -> ReceiptAPI:
         status = data.get("status")
-        if status:
+        if status is not None:
             status = self.conversion_manager.convert(status, int)
             status = TransactionStatusEnum(status)
 
@@ -505,7 +507,7 @@ class Ethereum(EcosystemAPI):
         if block_number is None:
             raise ValueError("Missing block number.")
 
-        receipt = Receipt(
+        receipt_kwargs = dict(
             block_number=block_number,
             contract_address=data.get("contract_address") or data.get("contractAddress"),
             gas_limit=data.get("gas", data.get("gas_limit", data.get("gasLimit"))) or 0,
@@ -516,7 +518,19 @@ class Ethereum(EcosystemAPI):
             txn_hash=txn_hash,
             transaction=self.create_transaction(**data),
         )
-        return receipt
+
+        receipt_cls: Type[Receipt]
+        if any(
+            x in data
+            for x in ("blobGasPrice", "blobGasUsed", "blobVersionedHashes", "maxFeePerBlobGas")
+        ):
+            receipt_cls = SharedBlobReceipt
+            receipt_kwargs["blob_gas_price"] = data.get("blob_gas_price", data.get("blobGasPrice"))
+            receipt_kwargs["blob_gas_used"] = data.get("blob_gas_used", data.get("blobGasUsed"))
+        else:
+            receipt_cls = Receipt
+
+        return receipt_cls.model_validate(receipt_kwargs)
 
     def decode_block(self, data: Dict) -> BlockAPI:
         data["hash"] = HexBytes(data["hash"]) if data.get("hash") else None
@@ -768,6 +782,8 @@ class Ethereum(EcosystemAPI):
             tx_data,
             ("txType", "tx_type", "txnType", "txn_type", "transactionType", "transaction_type"),
         )
+        tx_data = _correct_key("maxFeePerBlobGas", tx_data, ("max_fee_per_blob_gas",))
+        tx_data = _correct_key("blobVersionedHashes", tx_data, ("blob_versioned_hashes",))
 
         # Handle unique value specifications, such as "1 ether".
         if "value" in tx_data and not isinstance(tx_data["value"], int):
@@ -781,8 +797,9 @@ class Ethereum(EcosystemAPI):
         # Deduce the transaction type.
         transaction_types: Dict[TransactionType, Type[TransactionAPI]] = {
             TransactionType.STATIC: StaticFeeTransaction,
-            TransactionType.DYNAMIC: DynamicFeeTransaction,
             TransactionType.ACCESS_LIST: AccessListTransaction,
+            TransactionType.DYNAMIC: DynamicFeeTransaction,
+            TransactionType.SHARED_BLOB: SharedBlobTransaction,
         }
         if "type" in tx_data:
             # May be None in data.
@@ -803,6 +820,8 @@ class Ethereum(EcosystemAPI):
             version = TransactionType.DYNAMIC
         elif "access_list" in tx_data or "accessList" in tx_data:
             version = TransactionType.ACCESS_LIST
+        elif "maxFeePerBlobGas" in tx_data or "blobVersionedHashes" in tx_data:
+            version = TransactionType.SHARED_BLOB
         else:
             version = self.default_transaction_type
 

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -830,7 +830,8 @@ class Web3Provider(ProviderAPI, ABC):
             and txn.gas_price is None
         ):
             txn.gas_price = self.gas_price
-        elif txn_type is TransactionType.DYNAMIC:
+
+        elif txn_type in (TransactionType.DYNAMIC, TransactionType.SHARED_BLOB):
             if txn.max_priority_fee is None:
                 txn.max_priority_fee = self.priority_fee
 

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -278,6 +278,7 @@ def test_prepare_transaction_with_max_gas(tx_type, eth_tester_provider, ethereum
 
     actual = eth_tester_provider.prepare_transaction(tx)
     assert actual.gas_limit == eth_tester_provider.max_gas
+    assert actual.max_fee is not None
 
 
 def test_no_comma_in_rpc_url():


### PR DESCRIPTION
### What I did

This allows us to decode transactions and receipts from EIP-4844

There are still some issues however that will require updating eth-account and other eth-prefixed python packages.
For example, the hash calculation fails because of an unknown type (3).

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
