### PR TITLE
feat: hide home dir in project.path and all paths in `ape console`

### DIFF
--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -24,7 +24,7 @@ from ape.managers.base import BaseManager
 from ape.managers.project.types import ApeProject, BrownieProject
 from ape.utils import get_relative_path, log_instead_of_fail
 from ape.utils.basemodel import _assert_not_ipython_check, only_raise_attribute_error
-from ape.utils.os import get_full_extension
+from ape.utils.os import clean_path, get_full_extension
 
 
 class ProjectManager(BaseManager):
@@ -63,11 +63,11 @@ class ProjectManager(BaseManager):
             self.path = self.path.parent
 
     def __str__(self) -> str:
-        return f'Project("{self.path}")'
+        return f'Project("{clean_path(self.path)}")'
 
     @log_instead_of_fail(default="<ProjectManager>")
     def __repr__(self) -> str:
-        path = f" {self.path}" if self.path else ""
+        path = f" {clean_path(self.path)}" if self.path else ""
         return f"<ProjectManager{path}>"
 
     @property

--- a/src/ape/utils/os.py
+++ b/src/ape/utils/os.py
@@ -218,6 +218,6 @@ def run_in_tempdir(
 def clean_path(path: Path) -> str:
     home = Path.home()
     if path.is_relative_to(home):
-        return f"{path.relative_to(home)}"
+        return f"$HOME{os.path.sep}{path.relative_to(home)}"
 
     return f"{path}"

--- a/src/ape/utils/os.py
+++ b/src/ape/utils/os.py
@@ -206,11 +206,18 @@ def run_in_tempdir(
     Args:
         fn (Callable): A function that takes a path. It gets called
           with the resolved path to the temporary directory.
-        name (Optional[str]): Optionally provide a name for the temporary
-          directory.
+        name (Optional[str]): Optionally name the temporary directory.
 
     Returns:
         Any: The result of the function call.
     """
     with create_tempdir(name=name) as temp_dir:
         return fn(temp_dir)
+
+
+def clean_path(path: Path) -> str:
+    home = Path.home()
+    if path.is_relative_to(home):
+        return f"{path.relative_to(home)}"
+
+    return f"{path}"

--- a/src/ape_console/plugin.py
+++ b/src/ape_console/plugin.py
@@ -1,10 +1,12 @@
 import shlex
+from pathlib import Path
 
 import click
 from click.testing import CliRunner
 from eth_utils import is_hex
 from IPython import get_ipython
 from IPython.core.magic import Magics, line_magic, magics_class
+from rich import print as rich_print
 
 import ape
 from ape._cli import cli
@@ -12,6 +14,7 @@ from ape.exceptions import Abort, ApeException, handle_ape_exception
 from ape.logging import logger
 from ape.types import AddressType
 from ape.utils import cached_property
+from ape.utils.os import clean_path
 
 
 @magics_class
@@ -82,3 +85,9 @@ def custom_exception_handler(self, etype, value, tb, tb_offset=None):
 def load_ipython_extension(ipython):
     ipython.register_magics(ApeConsoleMagics)
     ipython.set_custom_exc((ApeException,), custom_exception_handler)
+
+    # This prevents displaying a user's home directory
+    # ever when using `ape console`.
+    ipython.display_formatter.formatters["text/plain"].for_type(
+        Path, lambda x, *args, **kwargs: rich_print(clean_path(x))
+    )

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -680,3 +680,10 @@ def test_add_compiler_data(project_with_dependency_config):
     compiler_5 = Compiler(name="test456", version="9.0.0", contractTypes=["bar"])
     with pytest.raises(ProjectError, match=r".*'bar' collision across compilers.*"):
         proj.add_compiler_data([compiler_4, compiler_5])
+
+
+def test_repr(project):
+    actual = repr(project)
+    # NOTE: tmp path is NOT relative to home.
+    expected = f"<ProjectManager {project.path}>"
+    assert actual == expected

--- a/tests/functional/utils/test_os.py
+++ b/tests/functional/utils/test_os.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from ape.utils.os import (
+    clean_path,
     create_tempdir,
     get_all_files_in_directory,
     get_full_extension,
@@ -117,3 +118,17 @@ def test_run_in_tempdir(name):
     assert arguments[0].resolve() == arguments[0]
     if name is not None:
         assert arguments[0].name == name
+
+
+def test_clean_path_relative_to_home():
+    name = "__canary_ape_test__"
+    path = Path.home() / name
+    actual = clean_path(path)
+    assert actual == name
+
+
+def test_clean_path_not_relative_to_home():
+    name = "__canary_ape_test__"
+    path = Path(name)
+    actual = clean_path(path)
+    assert actual == name

--- a/tests/functional/utils/test_os.py
+++ b/tests/functional/utils/test_os.py
@@ -124,7 +124,8 @@ def test_clean_path_relative_to_home():
     name = "__canary_ape_test__"
     path = Path.home() / name
     actual = clean_path(path)
-    assert actual == name
+    expected = f"$HOME/{name}"
+    assert actual == expected
 
 
 def test_clean_path_not_relative_to_home():


### PR DESCRIPTION
### What I did

* `project` repr and str now hide the Home dir to be less doxy
* `ape console` won't display any home dir for path's repr now -- all hidden

### How I did it

* make new clean path util
* use it in project repr
* customize the IPython integration to use it for showing paths: 

```
    ipython.display_formatter.formatters["text/plain"].for_type(
        Path, lambda x, *args, **kwargs: rich_print(clean_path(x))
    )
```

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
