### PR TITLE
fix: threading applications using ape

### DIFF
--- a/src/ape/__init__.py
+++ b/src/ape/__init__.py
@@ -1,6 +1,9 @@
 import signal
+import threading
 
-signal.signal(signal.SIGINT, lambda s, f: _sys.exit(130))
+if threading.current_thread() is threading.main_thread():
+    # If we are in the main thread, we can safely set the signal handler
+    signal.signal(signal.SIGINT, lambda s, f: _sys.exit(130))
 
 import sys as _sys
 


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

Add signal handling for applications that use Ape using threads, this could be APIs, streamlit applications and [prefect flows](https://docs.prefect.io/latest/concepts/flows/)

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #1164 

### How I did it

<!-- Discuss the thought process behind the change -->
Checked if we are running in the main thread or not, if we are signaling is applied as usual, otherwise it won't be applied. This means more traceback for threaded applications but it will work.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->
Previously `ape` fails at import time due to signalling failing to be achieved on a child thread.

Running the following script without the change will result in an error `ValueError: signal only works in main thread of the main interpreter` :

```python
import threading

def import_ape():
    import ape

thread = threading.Thread(target=import_ape)

thread.start()
thread.join()

print("Done")
```
Once the change is applied `ape` is successfully loaded
### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
