### PR TITLE
feat: add conversion for fixed ABI types

### DIFF
--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -192,9 +192,9 @@ class StringDecimalConverter(ConverterAPI):
     """
 
     def is_convertible(self, value: Any) -> bool:
-        # Matches only string-formatted floats with an optional sign character (+/-),
-        # leading and trailing zeros are optional.
-        return isinstance(value, str) and re.fullmatch("[+-]?[0-9]*[.][0-9]*", value)
+        # Matches only string-formatted floats with an optional sign character (+/-).
+        # Leading and trailing zeros are required.
+        return isinstance(value, str) and re.fullmatch("[+-]?[0-9]+[.][0-9]+", value) is not None
 
     def convert(self, value: str) -> Decimal:
         return Decimal(value)

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -194,7 +194,7 @@ class StringDecimalConverter(ConverterAPI):
     def is_convertible(self, value: Any) -> bool:
         # Matches only string-formatted floats with an optional sign character (+/-).
         # Leading and trailing zeros are required.
-        return isinstance(value, str) and re.fullmatch("[+-]?[0-9]+[.][0-9]+", value) is not None
+        return isinstance(value, str) and re.fullmatch(r"[+-]?\d+\.\d+", value) is not None
 
     def convert(self, value: str) -> Decimal:
         return Decimal(value)

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any, Dict, List, Sequence, Tuple, Type, Union
@@ -185,6 +186,20 @@ class TimestampConverter(ConverterAPI):
             raise ConversionError()
 
 
+class StringDecimalConverter(ConverterAPI):
+    """
+    Convert string-formatted floating point values to `Decimal` type.
+    """
+
+    def is_convertible(self, value: Any) -> bool:
+        # Matches only string-formatted floats with an optional sign character (+/-),
+        # leading and trailing zeros are optional.
+        return isinstance(value, str) and re.fullmatch("[+-]?[0-9]*[.][0-9]*", value)
+
+    def convert(self, value: str) -> Decimal:
+        return Decimal(value)
+
+
 class ConversionManager(BaseManager):
     """
     A singleton that manages all the converters.
@@ -219,7 +234,7 @@ class ConversionManager(BaseManager):
                 StringIntConverter(),
                 AccountIntConverter(),
             ],
-            Decimal: [],
+            Decimal: [StringDecimalConverter()],
             bool: [],
             str: [],
         }

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -194,6 +194,8 @@ class StringDecimalConverter(ConverterAPI):
     def is_convertible(self, value: Any) -> bool:
         # Matches only string-formatted floats with an optional sign character (+/-).
         # Leading and trailing zeros are required.
+        # NOTE: `re.fullmatch` will only match the full string, so "1.0 ether" and "10.0 USDC"
+        # will not be identified as convertible.
         return isinstance(value, str) and re.fullmatch(r"[+-]?\d+\.\d+", value) is not None
 
     def convert(self, value: str) -> Decimal:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -582,7 +582,7 @@ class Ethereum(EcosystemAPI):
 
         elif "int" in abi_type.type:
             return int
-        
+
         elif "fixed" in abi_type.type:
             return Decimal
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -1,5 +1,6 @@
 import re
 from copy import deepcopy
+from decimal import Decimal
 from functools import cached_property
 from typing import Any, ClassVar, Dict, Iterator, List, Optional, Sequence, Tuple, Type, Union, cast
 
@@ -581,6 +582,9 @@ class Ethereum(EcosystemAPI):
 
         elif "int" in abi_type.type:
             return int
+        
+        elif "fixed" in abi_type.type:
+            return Decimal
 
         raise ConversionError(f"Unable to convert '{abi_type}'.")
 

--- a/tests/functional/conversion/test_decimal.py
+++ b/tests/functional/conversion/test_decimal.py
@@ -1,12 +1,22 @@
 from decimal import Decimal
 
+import pytest
 
-def test_convert_float_formatted_string_to_decimal(convert):
-    test_strings = [
-        ".1",
-        "1.",
-        "1.0",
-    ]
+
+def test_converting_formatted_float_strings_to_decimal(convert):
+    test_strings = ["1.000", "1.00", "1.0", "0.1", "0.01", "0.001"]
     for test_string in test_strings:
         actual = convert(test_string, Decimal)
         assert actual == Decimal(test_string)
+
+
+def test_converting_badly_formatted_float_strings_to_decimal(convert):
+    test_strings = [
+        ".1",
+        "1.",
+        "1",
+        ".",
+    ]
+    for test_string in test_strings:
+        with pytest.raises(Exception):
+            convert(test_string, Decimal)

--- a/tests/functional/conversion/test_decimal.py
+++ b/tests/functional/conversion/test_decimal.py
@@ -1,0 +1,12 @@
+from decimal import Decimal
+
+
+def test_convert_float_formatted_string_to_decimal(convert):
+    test_strings = [
+        ".1",
+        "1.",
+        "1.0",
+    ]
+    for test_string in test_strings:
+        actual = convert(test_string, Decimal)
+        assert actual == Decimal(test_string)

--- a/tests/functional/conversion/test_decimal.py
+++ b/tests/functional/conversion/test_decimal.py
@@ -3,19 +3,53 @@ from decimal import Decimal
 import pytest
 
 
-def test_converting_formatted_float_strings_to_decimal(convert):
+def test_convert_formatted_float_strings_to_decimal(convert):
     test_strings = ["1.000", "1.00", "1.0", "0.1", "0.01", "0.001"]
     for test_string in test_strings:
         actual = convert(test_string, Decimal)
         assert actual == Decimal(test_string)
 
 
-def test_converting_badly_formatted_float_strings_to_decimal(convert):
+def test_convert_badly_formatted_float_strings_to_decimal(convert):
     test_strings = [
         ".1",
         "1.",
-        "1",
         ".",
+    ]
+    for test_string in test_strings:
+        with pytest.raises(Exception):
+            convert(test_string, Decimal)
+
+
+def test_convert_int_strings(convert):
+    test_strings = ["1", "10", "100"]
+    for test_string in test_strings:
+        with pytest.raises(Exception):
+            convert(test_string, Decimal)
+
+
+def test_convert_alphanumeric_strings(convert):
+    test_strings = ["a", "H", "XYZ"]
+    for test_string in test_strings:
+        with pytest.raises(Exception):
+            convert(test_string, Decimal)
+
+
+def test_convert_strings_with_token_names(convert):
+    test_strings = [
+        "0.999 DAI",
+        "10.0 USDC",
+    ]
+    for test_string in test_strings:
+        with pytest.raises(Exception):
+            convert(test_string, Decimal)
+
+
+def test_convert_strings_with_ether_alias(convert):
+    test_strings = [
+        "0 wei",
+        "999 gwei",
+        "1.0 ether",
     ]
     for test_string in test_strings:
         with pytest.raises(Exception):

--- a/tests/functional/conversion/test_decimal.py
+++ b/tests/functional/conversion/test_decimal.py
@@ -2,9 +2,18 @@ from decimal import Decimal
 
 import pytest
 
+from ape.exceptions import ConversionError
+
 
 def test_convert_formatted_float_strings_to_decimal(convert):
-    test_strings = ["1.000", "1.00", "1.0", "0.1", "0.01", "0.001"]
+    test_strings = [
+        "1.000",
+        "1.00",
+        "1.0",
+        "0.1",
+        "0.01",
+        "0.001",
+    ]
     for test_string in test_strings:
         actual = convert(test_string, Decimal)
         assert actual == Decimal(test_string)
@@ -17,21 +26,35 @@ def test_convert_badly_formatted_float_strings_to_decimal(convert):
         ".",
     ]
     for test_string in test_strings:
-        with pytest.raises(Exception):
+        with pytest.raises(
+            ConversionError, match=f"No conversion registered to handle '{test_string}'"
+        ):
             convert(test_string, Decimal)
 
 
 def test_convert_int_strings(convert):
-    test_strings = ["1", "10", "100"]
+    test_strings = [
+        "1",
+        "10",
+        "100",
+    ]
     for test_string in test_strings:
-        with pytest.raises(Exception):
+        with pytest.raises(
+            ConversionError, match=f"No conversion registered to handle '{test_string}'"
+        ):
             convert(test_string, Decimal)
 
 
 def test_convert_alphanumeric_strings(convert):
-    test_strings = ["a", "H", "XYZ"]
+    test_strings = [
+        "a",
+        "H",
+        "XYZ",
+    ]
     for test_string in test_strings:
-        with pytest.raises(Exception):
+        with pytest.raises(
+            ConversionError, match=f"No conversion registered to handle '{test_string}'"
+        ):
             convert(test_string, Decimal)
 
 
@@ -41,7 +64,9 @@ def test_convert_strings_with_token_names(convert):
         "10.0 USDC",
     ]
     for test_string in test_strings:
-        with pytest.raises(Exception):
+        with pytest.raises(
+            ConversionError, match=f"No conversion registered to handle '{test_string}'"
+        ):
             convert(test_string, Decimal)
 
 
@@ -52,5 +77,7 @@ def test_convert_strings_with_ether_alias(convert):
         "1.0 ether",
     ]
     for test_string in test_strings:
-        with pytest.raises(Exception):
+        with pytest.raises(
+            ConversionError, match=f"No conversion registered to handle '{test_string}'"
+        ):
             convert(test_string, Decimal)


### PR DESCRIPTION
### What I did

Ape has no converter to handle Vyper's `decimal` type, which is translated to the `fixed168x10` ABI type. Testing a contract function with a `decimal` type argument will fail with a `ConversionError`.

### How I did it

#### `ape_ethereum` plugin:
- Add `Decimal` as the native Python type for ABI types with "fixed" in the name.

#### `ape` base:
- Add a converter to support using string-formatted float values instead of requiring a strictly `Decimal` value. This converter will translate a "1.0" string in-place. Did not add a `float` converter, because floating-point accuracy will cause subtle errors. 

#### Tests:
- Added simple string -> Decimal converter test.

### Checklist:
- [ ] All changes are completed
- [x] New test cases have been added
- [ ] Documentation has been updated
