### PR TITLE
fix: support auto URLs in _sanitize_web3_url() helper func

### DIFF
--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -275,6 +275,8 @@ def _get_level(level: Optional[Union[str, int]] = None) -> str:
 
 
 def sanitize_url(url: str) -> str:
+    """Removes sensitive information from given URL"""
+
     url_obj = URL(url).with_user(None).with_password(None)
 
     # If there is a path, hide it but show that you are hiding it.

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -78,7 +78,10 @@ DEFAULT_SETTINGS = {"uri": f"http://{DEFAULT_HOSTNAME}:{DEFAULT_PORT}"}
 
 
 def _sanitize_web3_url(msg: str) -> str:
-    if "URI: " not in msg:
+    """Sanitize RPC URI from given log string"""
+
+    # `auto` used by some providers to figure it out automatically
+    if "URI: " not in msg or "URI: auto" in msg:
         return msg
 
     parts = msg.split("URI: ")


### PR DESCRIPTION
### What I did

Fixes an issue caused by the `host: auto` setting in ape-hardhat's config.

### How I did it

Does not try and sanitize auto URLs

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [X] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
