### PR TITLE
fix: allow kwargs to flatten_contract()

### DIFF
--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -337,7 +337,7 @@ class CompilerManager(BaseManager):
         compiler = self.registered_compilers[ext]
         return compiler.enrich_error(err)
 
-    def flatten_contract(self, path: Path) -> Content:
+    def flatten_contract(self, path: Path, **kwargs) -> Content:
         """
         Get the flattened version of a contract via its source path.
         Delegates to the matching :class:`~ape.api.compilers.CompilerAPI`.
@@ -355,7 +355,7 @@ class CompilerManager(BaseManager):
             )
 
         compiler = self.registered_compilers[path.suffix]
-        return compiler.flatten_contract(path)
+        return compiler.flatten_contract(path, **kwargs)
 
     def can_trace_source(self, filename: str) -> bool:
         """


### PR DESCRIPTION
### What I did

Adds missing (?) kwargs to `CompilerManager.flatten_contract()` to match `CompilerAPI.flatten_contract()`.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
