### PR TITLE
feat(AccountAPI): sign raw hash32

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -58,6 +58,18 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         return None
 
     def sign_raw_msghash(self, msghash: HexBytes) -> Optional[MessageSignature]:
+        """
+        Sign a raw message hash.
+
+        Args:
+          msghash (:class:`~eth_pydantic_types.HexBytes`):
+            The message hash to sign. Plugins may or may not support this operation.
+            Default implementation is to raise ``NotImplementedError``.
+
+        Returns:
+          :class:`~ape.types.signatures.MessageSignature` (optional):
+            The signature corresponding to the message.
+        """
         raise NotImplementedError(
             f"Raw message signing is not supported by '{self.__class__.__name__}'"
         )

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -6,7 +6,7 @@ from eip712.messages import EIP712Message
 from eip712.messages import SignableMessage as EIP712SignableMessage
 from eth_account import Account
 from eth_account.messages import encode_defunct
-from hexbytes import HexBytes
+from eth_pydantic_types import HexBytes
 
 from ape.api.address import BaseAddress
 from ape.api.transactions import ReceiptAPI, TransactionAPI

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -2,8 +2,8 @@ from typing import Iterator, Optional, Union
 
 from eth_account import Account
 from eth_account.messages import SignableMessage
+from eth_pydantic_types import HexBytes
 from eth_utils import to_bytes, to_hex
-from hexbytes import HexBytes
 from pydantic.dataclasses import dataclass
 
 try:

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -3,8 +3,8 @@ from typing import Any, Iterator, List, Optional
 from eip712.messages import EIP712Message
 from eth_account import Account as EthAccount
 from eth_account.messages import SignableMessage, encode_defunct
+from eth_pydantic_types import HexBytes
 from eth_utils import to_bytes
-from hexbytes import HexBytes
 
 from ape.api import TestAccountAPI, TestAccountContainerAPI, TransactionAPI
 from ape.exceptions import SignatureError

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -142,3 +142,12 @@ class TestAccount(TestAccountAPI):
         )
 
         return txn
+
+    def sign_raw_msghash(self, msghash: HexBytes) -> MessageSignature:
+        signed_msg = EthAccount.signHash(msghash, self.private_key)
+
+        return MessageSignature(
+            v=signed_msg.v,
+            r=to_bytes(signed_msg.r),
+            s=to_bytes(signed_msg.s),
+        )

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -116,6 +116,21 @@ def test_sign_message_with_prompts(runner, keyfile_account, message):
     assert start_nonce == end_nonce
 
 
+def test_sign_raw_hash(runner, keyfile_account):
+    # NOTE: `message` is a 32 byte raw hash, which is treated specially
+    message = b"\xAB" * 32
+
+    # "y\na\ny": yes sign raw hash, password, yes keep unlocked
+    with runner.isolation(input=f"y\n{PASSPHRASE}\ny"):
+        signature = keyfile_account.sign_raw_msghash(message)
+        assert keyfile_account.check_signature(message, signature, recover_using_eip191=False)
+
+    # "n\nn": no sign raw hash: don't sign
+    with runner.isolation(input="n"):
+        signature = keyfile_account.sign_message(message)
+        assert signature is None
+
+
 def test_transfer(sender, receiver, eth_tester_provider, convert):
     initial_receiver_balance = receiver.balance
     initial_sender_balance = sender.balance


### PR DESCRIPTION
### What I did

Add a new path to `AccountAPI` called `.sign_raw_msghash` that allows signing a raw 32 byte hash without treating it as an EIP191 `SignableMessage` type

fixes: #1962

### How I did it

I needed this for work I was doing on ape safe, but it is a really dangerous thing to allow, so I added a warning message and additionally disallowed autosigning for it. For `AccountAPI.recover_message` I added an additional kwarg `recover_using_eip191=True` that can be set false if you want to opt-in for that behavior for verifying a signature.

### How to verify it

Try the experience locally, I have added tests for it. Ultimately, when installled alongside the delegate feature for ape safe (https://github.com/ApeWorX/ape-safe/pull/41) you should now be able to use it to directly sign something with the API

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
