### PR TITLE
test: auto mine functionality to eth-tester

### DIFF
--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -93,7 +93,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         self._web3 = Web3(self.tester)
         # Handle disabling auto-mine if the user requested via config.
         if self.config.provider.auto_mine is False:
-            self.auto_mine = False  # NOTE: set via __setattr__
+            self.auto_mine = False  # type: ignore[misc]
 
     def disconnect(self):
         # NOTE: This type ignore seems like a bug in pydantic.
@@ -269,13 +269,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
             raise ProviderError(f"Failed to time travel: {err}") from err
 
     def mine(self, num_blocks: int = 1):
-        if self.auto_mine:
-            # Are able to use the better method.
-            self.evm_backend.mine_blocks(num_blocks)
-        else:
-            # Have to use this method for some reason.
-            for _ in range(num_blocks):
-                self.tester.ethereum_tester.mine_block()
+        self.evm_backend.mine_blocks(num_blocks)
 
     def get_virtual_machine_error(self, exception: Exception, **kwargs) -> VirtualMachineError:
         if isinstance(exception, ValidationError):

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -74,17 +74,14 @@ class LocalProvider(TestProviderAPI, Web3Provider):
     def auto_mine(self) -> bool:
         return self.tester.ethereum_tester.auto_mine_transactions
 
-    def __setattr__(self, attr: str, value: Any) -> None:
-        # NOTE: Need to do this until https://github.com/pydantic/pydantic/pull/2625 is figured out
-        if attr == "auto_mine":
-            if value is True:
-                self.tester.ethereum_tester.enable_auto_mine_transactions()
-            elif value is False:
-                self.tester.ethereum_tester.disable_auto_mine_transactions()
-            else:
-                raise TypeError("Expecting bool-value for auto_mine setter.")
+    @auto_mine.setter
+    def auto_mine(self, value: Any) -> None:
+        if value is True:
+            self.tester.ethereum_tester.enable_auto_mine_transactions()
+        elif value is False:
+            self.tester.ethereum_tester.disable_auto_mine_transactions()
         else:
-            super().__setattr__(attr, value)
+            raise TypeError("Expecting bool-value for auto_mine setter.")
 
     def connect(self):
         if "tester" in self.__dict__:

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -269,7 +269,13 @@ class LocalProvider(TestProviderAPI, Web3Provider):
             raise ProviderError(f"Failed to time travel: {err}") from err
 
     def mine(self, num_blocks: int = 1):
-        self.evm_backend.mine_blocks(num_blocks)
+        if self.auto_mine:
+            # Are able to use the better method.
+            self.evm_backend.mine_blocks(num_blocks)
+        else:
+            # Have to use this method for some reason.
+            for _ in range(num_blocks):
+                self.tester.ethereum_tester.mine_block()
 
     def get_virtual_machine_error(self, exception: Exception, **kwargs) -> VirtualMachineError:
         if isinstance(exception, ValidationError):

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -402,5 +402,12 @@ def test_create_access_list(eth_tester_provider, vyper_contract_instance, owner)
 def test_auto_mine(eth_tester_provider):
     eth_tester_provider.auto_mine = False
     assert not eth_tester_provider.auto_mine
+
+    # Ensure can still manually mine.
+    block = eth_tester_provider.get_block("latest").number
+    eth_tester_provider.mine()
+    next_block = eth_tester_provider.get_block("latest").number
+    assert next_block > block
+
     eth_tester_provider.auto_mine = True
     assert eth_tester_provider.auto_mine

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -397,3 +397,10 @@ def test_create_access_list(eth_tester_provider, vyper_contract_instance, owner)
     tx = vyper_contract_instance.setNumber.as_transaction(123, sender=owner)
     with pytest.raises(APINotImplementedError):
         eth_tester_provider.create_access_list(tx)
+
+
+def test_auto_mine(eth_tester_provider):
+    eth_tester_provider.auto_mine = False
+    assert not eth_tester_provider.auto_mine
+    eth_tester_provider.auto_mine = True
+    assert eth_tester_provider.auto_mine


### PR DESCRIPTION
### What I did

fixes: #1968

### How I did it

does the same as https://github.com/ApeWorX/ape-foundry/pull/59/files but for ape-test

thought: maybe need to squeeze this into the api class to keep things uniform, but i implemented the same as ape-foundry's just in case.

### How to verify it

connect to ape-test provider which uses eth-tester, and then you can do this

```python
from ape import chain

chain.provider.automine = True
...
chain.provider.automine = False
```

by default, it is on.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
