### PR TITLE
fix: None check in SharedBlobReceipt

### DIFF
--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -453,4 +453,6 @@ class SharedBlobReceipt(Receipt):
     @field_validator("blob_gas_used", "blob_gas_price", mode="before")
     @classmethod
     def hex_to_int(cls, value):
+        if value == None:
+            return 0
         return value if isinstance(value, int) else int(HexBytes(value).hex(), 16)

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -453,6 +453,6 @@ class SharedBlobReceipt(Receipt):
     @field_validator("blob_gas_used", "blob_gas_price", mode="before")
     @classmethod
     def hex_to_int(cls, value):
-        if value == None:
+        if value is None:
             return 0
         return value if isinstance(value, int) else int(HexBytes(value).hex(), 16)


### PR DESCRIPTION
### What I did

fixes: added a None check to hex_to_int in SharedBlobReceipt

### How I did it

added a simple None check with a 0 return

### How to verify it

Try hitting RPCs (such as tenderly's) that have not updated their returns post-Dencun.

### Checklist

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
