### PR TITLE
fix: multicall allow failure

### DIFF
--- a/src/ape_ethereum/multicall/handlers.py
+++ b/src/ape_ethereum/multicall/handlers.py
@@ -93,7 +93,7 @@ class BaseMulticall(ManagerAccessMixin):
         self,
         call: ContractMethodHandler,
         *args,
-        allow_failure: bool = True,
+        allowFailure: bool = True,
         value: int = 0,
     ) -> "BaseMulticall":
         """
@@ -107,7 +107,7 @@ class BaseMulticall(ManagerAccessMixin):
             call (:class:`~ape_ethereum.multicall.handlers.ContractMethodHandler`):
               The method to call.
             *args: The arguments to invoke the method with.
-            allow_failure (bool): Whether the call is allowed to fail.
+            allowFailure (bool): Whether the call is allowed to fail.
             value (int): The amount of ether to forward with the call.
 
         Returns:
@@ -121,7 +121,7 @@ class BaseMulticall(ManagerAccessMixin):
         self.calls.append(
             {
                 "target": call.contract.address,
-                "allowFailure": allow_failure,
+                "allowFailure": allowFailure,
                 "value": value,
                 "callData": call.encode_input(*args),
             }

--- a/src/ape_ethereum/multicall/handlers.py
+++ b/src/ape_ethereum/multicall/handlers.py
@@ -21,7 +21,7 @@ from .constants import (
     MULTICALL3_CONTRACT_TYPE,
     SUPPORTED_CHAINS,
 )
-from .exceptions import InvalidOption, NotExecutedError, UnsupportedChainError, ValueRequired
+from .exceptions import InvalidOption, UnsupportedChainError, ValueRequired
 
 
 class BaseMulticall(ManagerAccessMixin):
@@ -87,17 +87,13 @@ class BaseMulticall(ManagerAccessMixin):
         if any(call["value"] > 0 for call in self.calls):
             return self.contract.aggregate3Value
 
-        elif any(call["allowFailure"] for call in self.calls):
-            return self.contract.aggregate3
-
-        else:
-            return self.contract.aggregate
+        return self.contract.aggregate3
 
     def add(
         self,
         call: ContractMethodHandler,
         *args,
-        allowFailure: bool = False,
+        allow_failure: bool = True,
         value: int = 0,
     ) -> "BaseMulticall":
         """
@@ -111,7 +107,7 @@ class BaseMulticall(ManagerAccessMixin):
             call (:class:`~ape_ethereum.multicall.handlers.ContractMethodHandler`):
               The method to call.
             *args: The arguments to invoke the method with.
-            allowFailure (bool): Whether the call is allowed to fail.
+            allow_failure (bool): Whether the call is allowed to fail.
             value (int): The amount of ether to forward with the call.
 
         Returns:
@@ -125,7 +121,7 @@ class BaseMulticall(ManagerAccessMixin):
         self.calls.append(
             {
                 "target": call.contract.address,
-                "allowFailure": allowFailure,
+                "allowFailure": allow_failure,
                 "value": value,
                 "callData": call.encode_input(*args),
             }
@@ -164,8 +160,7 @@ class Call(BaseMulticall):
         super().__init__(address=address, supported_chains=supported_chains)
 
         self.abis: List[MethodABI] = []
-        self._result: Union[None, Tuple[int, List[HexBytes]], List[Tuple[bool, HexBytes]]] = None
-        self._failed_results: List[HexBytes] = []
+        self._result: Union[None, List[Tuple[bool, HexBytes]]] = None
 
     @property
     def handler(self) -> ContractCallHandler:  # type: ignore[override]
@@ -182,30 +177,13 @@ class Call(BaseMulticall):
     @property
     def returnData(self) -> List[HexBytes]:
         # NOTE: this property is kept camelCase to align with the raw EVM struct
+        print(self._result)
         result = self._result  # Declare for typing reasons.
-        if not result:
-            raise NotExecutedError()
-
-        elif (
-            isinstance(result, (tuple, list))
-            and len(result) >= 2
-            and type(result[0]) is bool
-            and isinstance(result[1], bytes)
-        ):
-            # Call3[] or Call3Value[] when only single call.
-            return [result[1]]
-
-        elif isinstance(result, tuple):
-            # Call3[] or Call3Value[] when multiple calls.
-            return list(r[1] for r in self._result)  # type: ignore
-
-        else:
-            # blockNumber: uint256, returnData: Call[]
-            return result.returnData  # type: ignore
+        return [res.returnData if res.success else None for res in result]  # type: ignore
 
     def _decode_results(self) -> Iterator[Any]:
         for abi, data in zip(self.abis, self.returnData):
-            if data in self._failed_results:
+            if data is None:
                 # The call failed.
                 yield data
                 continue

--- a/src/ape_ethereum/multicall/handlers.py
+++ b/src/ape_ethereum/multicall/handlers.py
@@ -177,7 +177,6 @@ class Call(BaseMulticall):
     @property
     def returnData(self) -> List[HexBytes]:
         # NOTE: this property is kept camelCase to align with the raw EVM struct
-        print(self._result)
         result = self._result  # Declare for typing reasons.
         return [res.returnData if res.success else None for res in result]  # type: ignore
 

--- a/tests/functional/test_multicall.py
+++ b/tests/functional/test_multicall.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import NamedTuple
 
 import pytest
 from eth_pydantic_types import HexBytes
@@ -6,20 +6,23 @@ from ethpm_types import ContractType
 
 from ape.exceptions import APINotImplementedError
 from ape_ethereum.multicall import Call
-from ape_ethereum.multicall.constants import MULTICALL3_ADDRESS, MULTICALL3_CONTRACT_TYPE
+from ape_ethereum.multicall.constants import (
+    MULTICALL3_ADDRESS,
+    MULTICALL3_CONTRACT_TYPE,
+)
 from ape_ethereum.multicall.exceptions import UnsupportedChainError
 
 RETURNDATA = HexBytes("0x4a821464")
 
 
-class ReturndataClass:
-    returnData: List[HexBytes] = [RETURNDATA]
+class ReturnData(NamedTuple):
+    success: bool
+    returnData: bytes
 
 
 RETURNDATA_PARAMS = {
-    "result": ReturndataClass(),
-    # Happens when using Call() for a single call.
-    "result_single": [False, RETURNDATA],
+    "result_ok": (ReturnData(True, RETURNDATA), RETURNDATA),
+    "result_fail": (ReturnData(False, RETURNDATA), None),
 }
 
 
@@ -53,7 +56,10 @@ def test_unsupported_chain(call_handler_with_struct_input, struct_input_for_call
 
 
 def test_aggregate3_input(
-    aggregate3, call_handler_with_struct_input, struct_input_for_call, vyper_contract_instance
+    aggregate3,
+    call_handler_with_struct_input,
+    struct_input_for_call,
+    vyper_contract_instance,
 ):
     call = Call()
 
@@ -67,7 +73,7 @@ def test_aggregate3_input(
 
 @pytest.mark.parametrize("returndata_key", RETURNDATA_PARAMS)
 def test_returndata(returndata_key):
-    returndata = RETURNDATA_PARAMS[returndata_key]
+    result, output = RETURNDATA_PARAMS[returndata_key]
     call = Call()
-    call._result = returndata  # type: ignore
-    assert call.returnData[0] == HexBytes("0x4a821464")
+    call._result = [result]  # type: ignore
+    assert call.returnData[0] == output

--- a/tests/functional/test_multicall.py
+++ b/tests/functional/test_multicall.py
@@ -6,10 +6,7 @@ from ethpm_types import ContractType
 
 from ape.exceptions import APINotImplementedError
 from ape_ethereum.multicall import Call
-from ape_ethereum.multicall.constants import (
-    MULTICALL3_ADDRESS,
-    MULTICALL3_CONTRACT_TYPE,
-)
+from ape_ethereum.multicall.constants import MULTICALL3_ADDRESS, MULTICALL3_CONTRACT_TYPE
 from ape_ethereum.multicall.exceptions import UnsupportedChainError
 
 RETURNDATA = HexBytes("0x4a821464")


### PR DESCRIPTION
### What I did

`allowFailure` was broken in multicall when a call actually failed

```
AttributeError: 'list' object has no attribute 'returnData'
```

### How I did it

- massively simplified the handler by moving to using multicall 3 only. this allows us to have one handler for the result value.
- fixed handling of partially failed calls. such calls would return `None`.
- allow partial failures by default, which is probably what the user want when reading a lot of data.
- (edit: reverted this one) rename `allowFailure` to `allow_failure` when adding individual calls.


### How to verify it

```python
$ ape console --network blast:mainnet:geth

In [1]: pos_manager = Contract('0x434575EaEa081b735C985FA9bf63CD7b87e227F9')

In [2]: from ape_ethereum.multicall import Call

In [3]: call = Call()
   ...: for i in range(5):
   ...:     call.add(pos_manager.ownerOf, i, allow_failure=True)
   ...:

In [4]: list(call())
Out[4]:
[None,
 '0xd6b64E44aae0938118aD0dAE251b859D85351c22',
 '0x121B5ac4De4a3E6F4171956BC26ceda40Cb61a56',
 '0xd6b64E44aae0938118aD0dAE251b859D85351c22',
 '0x0B78e02dB3626BF29a291549e875EfEE929Ea85e']

In [5]: call = Call()
   ...: for i in range(5):
   ...:     call.add(pos_manager.ownerOf, i, allow_failure=False)
   ...:

In [6]: list(call())
ERROR: (ContractLogicError) call failed
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
