### PR TITLE
docs: fix link and spelling issues in `ape init` command

### DIFF
--- a/src/ape_init/_cli.py
+++ b/src/ape_init/_cli.py
@@ -4,40 +4,10 @@ from pathlib import Path
 import click
 
 from ape.cli import ape_cli_context
+from ape.managers.config import CONFIG_FILE_NAME
 from ape.utils import github_client
 
-
-@click.command(short_help="Initalize an ape project")
-@ape_cli_context()
-@click.option("--github", metavar="github-org/repo", help="Clone a template from Github")
-def cli(cli_ctx, github):
-    """
-    ``ape init`` allows the user to create an ape project with
-    default folders and ape-config.yaml
-
-    From more information:
-    https://docs.apeworx.io/ape/stable/userguides/config.html
-    """
-    if github:
-        github_client.clone_repo(github, Path.cwd())
-        shutil.rmtree(Path.cwd() / ".git")
-
-    else:
-        project_folder = Path.cwd()
-
-        for folder_name in ["contracts", "tests", "scripts"]:
-            # Create target Directory
-            folder = project_folder / folder_name
-            if folder.exists():
-                cli_ctx.logger.warning(f"'{folder}' exists")
-            else:
-                folder.mkdir(exist_ok=False)
-
-        git_ignore_path = project_folder / ".gitignore"
-        if git_ignore_path.is_file():
-            cli_ctx.logger.warning(f"Unable to create .gitignore: '{git_ignore_path}' file exists.")
-        else:
-            body = """
+GITIGNORE_CONTENT = """
 # Ape stuff
 .build/
 .cache/
@@ -49,13 +19,44 @@ def cli(cli_ctx, github):
 .python-version
 __pycache__
 """
-            git_ignore_path.touch()
-            git_ignore_path.write_text(body.lstrip())
 
-        ape_config = project_folder / "ape-config.yaml"
+
+@click.command(short_help="Initialize an ape project")
+@ape_cli_context()
+@click.option("--github", metavar="github-org/repo", help="Clone a template from Github")
+def cli(cli_ctx, github):
+    """
+    ``ape init`` allows the user to create an ape project with
+    default folders and ape-config.yaml
+
+    From more information:
+    https://docs.apeworx.io/ape/stable/userguides/data.html#using-the-cache
+    """
+    if github:
+        github_client.clone_repo(github, Path.cwd())
+        shutil.rmtree(Path.cwd() / ".git")
+    else:
+        project_folder = Path.cwd()
+
+        for folder_name in ("contracts", "tests", "scripts"):
+            # Create target Directory
+            folder = project_folder / folder_name
+            if folder.exists():
+                cli_ctx.logger.warning(f"'{folder}' exists")
+            else:
+                folder.mkdir()
+
+        git_ignore_path = project_folder / ".gitignore"
+        if git_ignore_path.exists():
+            cli_ctx.logger.warning(f"Unable to create .gitignore: '{git_ignore_path}' file exists.")
+        else:
+            git_ignore_path.touch()
+            git_ignore_path.write_text(GITIGNORE_CONTENT.lstrip())
+
+        ape_config = project_folder / CONFIG_FILE_NAME
         if ape_config.exists():
             cli_ctx.logger.warning(f"'{ape_config}' exists")
         else:
             project_name = click.prompt("Please enter project name")
             ape_config.write_text(f"name: {project_name}\n")
-            cli_ctx.logger.success(f"{project_name} is written in ape-config.yaml")
+            cli_ctx.logger.success(f"{project_name} is written in {CONFIG_FILE_NAME}")

--- a/src/ape_init/_cli.py
+++ b/src/ape_init/_cli.py
@@ -27,10 +27,7 @@ __pycache__
 def cli(cli_ctx, github):
     """
     ``ape init`` allows the user to create an ape project with
-    default folders and ape-config.yaml
-
-    From more information:
-    https://docs.apeworx.io/ape/stable/userguides/data.html#using-the-cache
+    default folders and ape-config.yaml.
     """
     if github:
         github_client.clone_repo(github, Path.cwd())


### PR DESCRIPTION
### What I did

cleans up this command a bit.

1. fix spelling
2. move gitignore to module level so its easier to see/ edit
3. fix link that was weirdly pointing o the config guide.. use actual cache guide now.
4. use constant for the config file
5. improve some of the file-exists logic

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
