### PR TITLE
fix: supress signHash deprecation warning from eth-account

### DIFF
--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from os import environ
 from pathlib import Path
 from typing import Any, Dict, Iterator, Optional, Tuple
@@ -244,7 +245,9 @@ class KeyfileAccount(AccountAPI):
         if not click.confirm("Please confirm you wish to sign using `EthAccount.signHash`"):
             return None
 
-        signed_msg = EthAccount.signHash(msghash, self.__key)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            signed_msg = EthAccount.signHash(msghash, self.__key)
 
         return MessageSignature(
             v=signed_msg.v,

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Iterator, List, Optional
 
 from eip712.messages import EIP712Message
@@ -144,7 +145,9 @@ class TestAccount(TestAccountAPI):
         return txn
 
     def sign_raw_msghash(self, msghash: HexBytes) -> MessageSignature:
-        signed_msg = EthAccount.signHash(msghash, self.private_key)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            signed_msg = EthAccount.signHash(msghash, self.private_key)
 
         return MessageSignature(
             v=signed_msg.v,


### PR DESCRIPTION
### What I did

suppresses a deprecation warning when calling `signHash`.

Reasons:

1. We are already extensively warning out user.
2. We are warning our user is a more accurate way (not saying it is deprecated but instead saying it is dangerous)
3. the method is not actually deprecated imo, more info: https://github.com/ethereum/eth-account/issues/85

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
