### PR TITLE
fix: issue preventing docs CI workflow from updating `gh-pages` branch

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,6 +12,9 @@ jobs:
     docs:
         runs-on: ubuntu-latest
 
+        permissions:
+          contents: write
+
         steps:
         - uses: actions/checkout@v4
 

--- a/.github/workflows/draft.yaml
+++ b/.github/workflows/draft.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
### What I did

looks a classic case of permissions suddenly being required.
we usually see this in the drafter, so i added it there too just to be safe.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
