### PR TITLE
fix: plugin path assert

### DIFF
--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -167,7 +167,7 @@ class TestPluginMetadata:
             f"ape-available>=0.{ape_version.minor},<0.{ape_version.minor + 1}",
             "--quiet",
         ]
-        assert arguments[0].endswith("python")
+        assert "python" in arguments[0]
         assert arguments[1:] == expected
 
     def test_prepare_install_upgrade(self):
@@ -183,7 +183,7 @@ class TestPluginMetadata:
             f"ape-available>=0.{ape_version.minor},<0.{ape_version.minor + 1}",
             "--quiet",
         ]
-        assert arguments[0].endswith("python")
+        assert "python" in arguments[0]
         assert arguments[1:] == expected
 
     @mark_specifiers_less_than_ape


### PR DESCRIPTION
I was running into an issue with tests failing after creating a new virtual environment.