### PR TITLE
feat: remove setuptools dependence

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ extras_require["dev"] = (
 with open("./README.md") as readme:
     long_description = readme.read()
 
+
 setup(
     name="eth-ape",
     use_scm_version=True,
@@ -106,10 +107,10 @@ setup(
         "pydantic-settings>=2.0.3,<3",
         "PyGithub>=1.59,<2",
         "pytest>=6.0,<8.0",
-        "python-dateutil>=2.8.2",
+        "python-dateutil>=2.8.2,<3",
         "PyYAML>=5.0,<7",
         "requests>=2.28.1,<3",
-        "rich>=12.5.1",
+        "rich>=12.5.1,<14",
         "SQLAlchemy>=1.4.35",
         "tqdm>=4.62.3,<5.0",
         "traitlets>=5.3.0",
@@ -120,7 +121,7 @@ setup(
         "eth-account>=0.11.2,<0.12",
         "eth-tester @ git+https://github.com/wakamex/eth-tester.git",
         "eth-typing>=3.5.2,<4",
-        "eth-utils>=2.3.1",
+        "eth-utils>=2.3.1,<3",
         "py-geth>=4.4.0,<5",
         "web3[tester]>=6.17.2,<7",
         # ** Dependencies maintained by ApeWorX **

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ extras_require["dev"] = (
 with open("./README.md") as readme:
     long_description = readme.read()
 
-
 setup(
     name="eth-ape",
     use_scm_version=True,
@@ -101,16 +100,16 @@ setup(
         "ipython>=8.5.0,<9",
         "lazyasd>=0.1.4",
         "packaging>=23.0,<24",
-        "pandas>=1.3.0,<2",
+        "pandas>=2",
         "pluggy>=1.3,<2",
         "pydantic>=2.5.2,<3",
         "pydantic-settings>=2.0.3,<3",
         "PyGithub>=1.59,<2",
         "pytest>=6.0,<8.0",
-        "python-dateutil>=2.8.2,<3",
+        "python-dateutil>=2.8.2",
         "PyYAML>=5.0,<7",
         "requests>=2.28.1,<3",
-        "rich>=12.5.1,<14",
+        "rich>=12.5.1",
         "SQLAlchemy>=1.4.35",
         "tqdm>=4.62.3,<5.0",
         "traitlets>=5.3.0",
@@ -119,8 +118,9 @@ setup(
         # ** Dependencies maintained by Ethereum Foundation **
         "eth-abi>=5.1.0,<6",
         "eth-account>=0.11.2,<0.12",
+        "eth-tester @ git+https://github.com/wakamex/eth-tester.git",
         "eth-typing>=3.5.2,<4",
-        "eth-utils>=2.3.1,<3",
+        "eth-utils>=2.3.1",
         "py-geth>=4.4.0,<5",
         "web3[tester]>=6.17.2,<7",
         # ** Dependencies maintained by ApeWorX **

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
         # ** Dependencies maintained by Ethereum Foundation **
         "eth-abi>=5.1.0,<6",
         "eth-account>=0.11.2,<0.12",
-        "eth-tester @ git+https://github.com/wakamex/eth-tester.git",
+        "eth-tester>=0.11.0-beta.2,<0.12",
         "eth-typing>=3.5.2,<4",
         "eth-utils>=2.3.1,<3",
         "py-geth>=4.4.0,<5",

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         "ipython>=8.5.0,<9",
         "lazyasd>=0.1.4",
         "packaging>=23.0,<24",
-        "pandas>=2",
+        "pandas>=1.3.0,<2",
         "pluggy>=1.3,<2",
         "pydantic>=2.5.2,<3",
         "pydantic-settings>=2.0.3,<3",


### PR DESCRIPTION
### What I did

spun out from #2000, remove setuptools dependency

### How I did it

two ways:
1. remove dependency caps. recent versions of some dependencies have removed usage of pkg_resources.
2. for those dependencies that haven't, fork them to remove usage of pkg_resources, and point to that fork.

### How to verify it

install with `uv` then run `ape plugins list` and see if it errors out complaining about pkg_resources.

### Checklist

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
