### PR TITLE
fix: issue with kwargs for get_logs using eth-tester

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
         "click>=8.1.6,<9",
         "ijson>=3.1.4,<4",
         "importlib-metadata",  # NOTE: Needed on 3.8 for entry_points `group=` kwarg.
-        "ipython>=8.23.0,<9",
+        "ipython>=8.5.0,<9",
         "lazyasd>=0.1.4",
         "packaging>=23.0,<24",
         "pandas>=1.3.0,<2",

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
         "click>=8.1.6,<9",
         "ijson>=3.1.4,<4",
         "importlib-metadata",  # NOTE: Needed on 3.8 for entry_points `group=` kwarg.
-        "ipython>=8.5.0,<8.23.0",  # TODO: Fix 8.23.0
+        "ipython>=8.23.0,<9",
         "lazyasd>=0.1.4",
         "packaging>=23.0,<24",
         "pandas>=1.3.0,<2",

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
         "click>=8.1.6,<9",
         "ijson>=3.1.4,<4",
         "importlib-metadata",  # NOTE: Needed on 3.8 for entry_points `group=` kwarg.
-        "ipython>=8.22.2,<8.23.0",  # TODO: Fix 8.23.0
+        "ipython>=8.5.0,<8.23.0",  # TODO: Fix 8.23.0
         "lazyasd>=0.1.4",
         "packaging>=23.0,<24",
         "pandas>=1.3.0,<2",

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
         "py-geth>=4.4.0,<5",
         "web3[tester]>=6.16.0,<7",
         # ** Dependencies maintained by ApeWorX **
-        "eip712>=0.2.3,<0.4",
+        "eip712>=0.2.7,<0.4",
         "ethpm-types>=0.6.7,<0.7",
         "eth_pydantic_types>=0.1.0a5,<0.2",
         "evmchains>=0.0.2,<0.1",

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
         "py-geth>=4.4.0,<5",
         "web3[tester]>=6.17.0,<7",
         # ** Dependencies maintained by ApeWorX **
-        "eip712>=0.2.3,<0.4",
+        "eip712>=0.2.6,<0.3",
         "ethpm-types>=0.6.7,<0.7",
         "eth_pydantic_types>=0.1.0a5,<0.2",
         "evmchains>=0.0.2,<0.1",

--- a/setup.py
+++ b/setup.py
@@ -122,13 +122,13 @@ setup(
         "eth-typing>=3.5.2,<4",
         "eth-utils>=2.3.1,<3",
         "py-geth>=4.4.0,<5",
-        "web3[tester]>=6.16.0,<7",
+        "web3[tester]>=6.17.1,<7",
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.2.7,<0.4",
         "ethpm-types>=0.6.7,<0.7",
         "eth_pydantic_types>=0.1.0a5,<0.2",
         "evmchains>=0.0.2,<0.1",
-        "evm-trace>=0.1.2",
+        "evm-trace>=0.1.5",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
         "eth-typing>=3.5.2,<4",
         "eth-utils>=2.3.1,<3",
         "py-geth>=4.4.0,<5",
-        "web3[tester]>=6.16.0,<7",
+        "web3[tester]>=6.17.0,<7",
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.2.3,<0.4",
         "ethpm-types>=0.6.7,<0.7",

--- a/setup.py
+++ b/setup.py
@@ -119,17 +119,17 @@ setup(
         "watchdog>=3.0,<4",
         # ** Dependencies maintained by Ethereum Foundation **
         "eth-abi>=5.1.0,<6",
-        "eth-account>=0.11.2,<0.12",
+        "eth-account>=0.10.0,<0.11",
         "eth-typing>=3.5.2,<4",
         "eth-utils>=2.3.1,<3",
         "py-geth>=4.4.0,<5",
-        "web3[tester]>=6.17.1,<7",
+        "web3[tester]>=6.16.0,<6.17.1",
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.2.7,<0.3",
         "ethpm-types>=0.6.9,<0.7",
         "eth_pydantic_types>=0.1.0,<0.2",
         "evmchains>=0.0.6,<0.1",
-        "evm-trace>=0.1.5,<0.2",
+        "evm-trace>=0.1.3,<0.2",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],

--- a/setup.py
+++ b/setup.py
@@ -118,17 +118,17 @@ setup(
         "watchdog>=3.0,<4",
         # ** Dependencies maintained by Ethereum Foundation **
         "eth-abi>=5.1.0,<6",
-        "eth-account>=0.10.0,<0.11",
+        "eth-account>=0.11.2,<0.12",
         "eth-typing>=3.5.2,<4",
         "eth-utils>=2.3.1,<3",
         "py-geth>=4.4.0,<5",
         "web3[tester]>=6.17.1,<7",
         # ** Dependencies maintained by ApeWorX **
-        "eip712>=0.2.7,<0.4",
-        "ethpm-types>=0.6.7,<0.7",
-        "eth_pydantic_types>=0.1.0a5,<0.2",
-        "evmchains>=0.0.2,<0.1",
-        "evm-trace>=0.1.5",
+        "eip712>=0.2.7,<0.3",
+        "ethpm-types>=0.6.9,<0.7",
+        "eth_pydantic_types>=0.1.0,<0.2",
+        "evmchains>=0.0.6,<0.1",
+        "evm-trace>=0.1.5,<0.2",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],

--- a/setup.py
+++ b/setup.py
@@ -118,17 +118,17 @@ setup(
         "watchdog>=3.0,<4",
         # ** Dependencies maintained by Ethereum Foundation **
         "eth-abi>=5.1.0,<6",
-        "eth-account>=0.10.0,<0.11",
+        "eth-account>=0.11.2,<0.12",
         "eth-typing>=3.5.2,<4",
         "eth-utils>=2.3.1,<3",
         "py-geth>=4.4.0,<5",
         "web3[tester]>=6.17.0,<7",
         # ** Dependencies maintained by ApeWorX **
-        "eip712>=0.2.6,<0.3",
+        "eip712>=0.2.7,<0.3",
         "ethpm-types>=0.6.7,<0.7",
         "eth_pydantic_types>=0.1.0a5,<0.2",
         "evmchains>=0.0.2,<0.1",
-        "evm-trace>=0.1.2",
+        "evm-trace>=0.1.4,<=0.2",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
         "click>=8.1.6,<9",
         "ijson>=3.1.4,<4",
         "importlib-metadata",  # NOTE: Needed on 3.8 for entry_points `group=` kwarg.
-        "ipython>=8.5.0,<9",
+        "ipython>=8.22.2,<8.23.0",  # TODO: Fix 8.23.0
         "lazyasd>=0.1.4",
         "packaging>=23.0,<24",
         "pandas>=1.3.0,<2",
@@ -118,17 +118,17 @@ setup(
         "watchdog>=3.0,<4",
         # ** Dependencies maintained by Ethereum Foundation **
         "eth-abi>=5.1.0,<6",
-        "eth-account>=0.11.2,<0.12",
+        "eth-account>=0.10.0,<0.11",
         "eth-typing>=3.5.2,<4",
         "eth-utils>=2.3.1,<3",
         "py-geth>=4.4.0,<5",
-        "web3[tester]>=6.17.0,<7",
+        "web3[tester]>=6.16.0,<7",
         # ** Dependencies maintained by ApeWorX **
-        "eip712>=0.2.7,<0.3",
+        "eip712>=0.2.3,<0.4",
         "ethpm-types>=0.6.7,<0.7",
         "eth_pydantic_types>=0.1.0a5,<0.2",
         "evmchains>=0.0.2,<0.1",
-        "evm-trace>=0.1.4,<=0.2",
+        "evm-trace>=0.1.2",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -935,14 +935,14 @@ class Ethereum(EcosystemAPI):
                     converted_arguments[key] = value
 
             yield ContractLog(
-                block_hash=log["blockHash"],
-                block_number=log["blockNumber"],
+                block_hash=log.get("blockHash", log.get("block_hash")),
+                block_number=log.get("blockNumber", log.get("block_number")),
                 contract_address=self.decode_address(log["address"]),
                 event_arguments=converted_arguments,
                 event_name=abi.event_name,
-                log_index=log["logIndex"],
-                transaction_hash=log["transactionHash"],
-                transaction_index=log["transactionIndex"],
+                log_index=log.get("logIndex", log.get("log_index")),
+                transaction_hash=log.get("transactionHash", log.get("transaction_hash")),
+                transaction_index=log.get("transactionIndex", log.get("transaction_index")),
             )
 
     def enrich_calltree(self, call: CallTreeNode, **kwargs) -> CallTreeNode:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -942,7 +942,11 @@ class Ethereum(EcosystemAPI):
                 event_name=abi.event_name,
                 log_index=log.get("logIndex") or log.get("log_index") or 0,
                 transaction_hash=log.get("transactionHash") or log.get("transaction_hash") or "",
-                transaction_index=log.get("transactionIndex") or log.get("transaction_index"),
+                transaction_index=(
+                    log.get("transactionIndex")
+                    if "transactionIndex" in log
+                    else log.get("transaction_index")
+                ),
             )
 
     def enrich_calltree(self, call: CallTreeNode, **kwargs) -> CallTreeNode:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -935,14 +935,14 @@ class Ethereum(EcosystemAPI):
                     converted_arguments[key] = value
 
             yield ContractLog(
-                block_hash=log.get("blockHash", log.get("block_hash")),
-                block_number=log.get("blockNumber", log.get("block_number")),
+                block_hash=log.get("blockHash") or log.get("block_hash") or "",
+                block_number=log.get("blockNumber") or log.get("block_number") or 0,
                 contract_address=self.decode_address(log["address"]),
                 event_arguments=converted_arguments,
                 event_name=abi.event_name,
-                log_index=log.get("logIndex", log.get("log_index")),
-                transaction_hash=log.get("transactionHash", log.get("transaction_hash")),
-                transaction_index=log.get("transactionIndex", log.get("transaction_index")),
+                log_index=log.get("logIndex") or log.get("log_index") or 0,
+                transaction_hash=log.get("transactionHash") or log.get("transaction_hash") or "",
+                transaction_index=log.get("transactionIndex") or log.get("transaction_index"),
             )
 
     def enrich_calltree(self, call: CallTreeNode, **kwargs) -> CallTreeNode:

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -863,7 +863,8 @@ class Web3Provider(ProviderAPI, ABC):
             start, stop = block_range
             update = {"start_block": start, "stop_block": stop}
             page_filter = log_filter.model_copy(update=update)
-            logs = self._make_request("eth_getLogs", [page_filter])
+            filter_params = page_filter.model_dump(mode="json")
+            logs = self._make_request("eth_getLogs", [filter_params])
             return self.network.ecosystem.decode_logs(logs, *log_filter.events)
 
         with ThreadPoolExecutor(self.concurrency) as pool:

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -863,20 +863,12 @@ class Web3Provider(ProviderAPI, ABC):
             start, stop = block_range
             update = {"start_block": start, "stop_block": stop}
             page_filter = log_filter.model_copy(update=update)
-            # eth-tester expects a different format, let web3 handle the conversions for it.
-            raw = "EthereumTester" not in self.client_version
-            logs = self._get_logs(page_filter.model_dump(mode="json"), raw)
+            logs = self._make_request("eth_getLogs", [page_filter])
             return self.network.ecosystem.decode_logs(logs, *log_filter.events)
 
         with ThreadPoolExecutor(self.concurrency) as pool:
             for page in pool.map(fetch_log_page, block_ranges):
                 yield from page
-
-    def _get_logs(self, filter_params, raw=True) -> List[Dict]:
-        if not raw:
-            return [vars(d) for d in self.web3.eth.get_logs(filter_params)]
-
-        return self._make_request("eth_getLogs", [filter_params])
 
     def prepare_transaction(self, txn: TransactionAPI) -> TransactionAPI:
         # NOTE: Use "expected value" for Chain ID, so if it doesn't match actual, we raise

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -269,9 +269,19 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         self.evm_backend.mine_blocks(num_blocks)
 
     def get_contract_logs(self, log_filter: LogFilter) -> Iterator[ContractLog]:
+        from_block = max(0, log_filter.start_block)
+
+        if log_filter.stop_block is None:
+            to_block = None
+        else:
+            latest_block = self.get_block("latest").number
+            to_block = (
+                min(latest_block, log_filter.stop_block)
+                if latest_block is not None
+                else log_filter.stop_block
+            )
+
         for address in log_filter.addresses:
-            from_block = max(0, log_filter.start_block)
-            to_block = min(self.get_block("latest").number, log_filter.stop_block)
             log_gen = self.tester.ethereum_tester.get_logs(
                 address=address,
                 from_block=from_block,

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -281,14 +281,13 @@ class LocalProvider(TestProviderAPI, Web3Provider):
                 else log_filter.stop_block
             )
 
-        for address in log_filter.addresses:
-            log_gen = self.tester.ethereum_tester.get_logs(
-                address=address,
-                from_block=from_block,
-                to_block=to_block,
-                topics=log_filter.topic_filter,
-            )
-            yield from self.network.ecosystem.decode_logs(log_gen, *log_filter.events)
+        log_gen = self.tester.ethereum_tester.get_logs(
+            address=log_filter.addresses,
+            from_block=from_block,
+            to_block=to_block,
+            topics=log_filter.topic_filter,
+        )
+        yield from self.network.ecosystem.decode_logs(log_gen, *log_filter.events)
 
     def get_virtual_machine_error(self, exception: Exception, **kwargs) -> VirtualMachineError:
         if isinstance(exception, ValidationError):

--- a/tests/functional/test_block.py
+++ b/tests/functional/test_block.py
@@ -17,7 +17,7 @@ def test_block_dict(block):
         "num_transactions": 0,
         "number": 0,
         "parentHash": block.parent_hash.hex(),
-        "size": 548,
+        "size": block.size,
         "timestamp": block.timestamp,
         "totalDifficulty": 0,
         "transactions": [],
@@ -32,7 +32,7 @@ def test_block_json(block):
         f'"hash":"{block.hash.hex()}",'
         '"num_transactions":0,"number":0,'
         f'"parentHash":"{block.parent_hash.hex()}",'
-        f'"size":548,"timestamp":{block.timestamp},'
+        f'"size":{block.size},"timestamp":{block.timestamp},'
         f'"totalDifficulty":0,"transactions":[]}}'
     )
     assert actual == expected

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -124,7 +124,7 @@ def test_contract_logs_range(chain, contract_instance, owner, assert_log_values)
 def test_contract_logs_range_by_address(
     mocker, chain, eth_tester_provider, test_accounts, contract_instance, owner, assert_log_values
 ):
-    get_logs_spy = mocker.spy(eth_tester_provider.web3.eth, "get_logs")
+    get_logs_spy = mocker.spy(eth_tester_provider.tester.ethereum_tester, "get_logs")
     contract_instance.setAddress(test_accounts[1], sender=owner)
     height = chain.blocks.height
     logs = [
@@ -137,18 +137,18 @@ def test_contract_logs_range_by_address(
     # NOTE: This spy assertion tests against a bug where address queries were not
     # 0x-prefixed. However, this was still valid in EthTester and thus was not causing
     # test failures.
-    height_arg = to_hex(chain.blocks.height)
-    get_logs_spy.assert_called_once_with(
-        {
-            "address": [contract_instance.address],
-            "fromBlock": height_arg,
-            "toBlock": height_arg,
-            "topics": [
-                "0x7ff7bacc6cd661809ed1ddce28d4ad2c5b37779b61b9e3235f8262be529101a9",
-                "0x00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8",
-            ],
-        }
-    )
+    height_arg = chain.blocks.height
+    actual = get_logs_spy.call_args[-1]
+    expected = {
+        "address": [contract_instance.address],
+        "from_block": height_arg,
+        "to_block": height_arg,
+        "topics": [
+            "0x7ff7bacc6cd661809ed1ddce28d4ad2c5b37779b61b9e3235f8262be529101a9",
+            "0x00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8",
+        ],
+    }
+    assert actual == expected
     assert logs == [contract_instance.AddressChange(newAddress=test_accounts[1])]
 
 

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import pytest
 from eth_pydantic_types import HexBytes
-from eth_utils import to_hex
 from ethpm_types import ContractType
 
 from ape.api import ReceiptAPI


### PR DESCRIPTION
### What I did

somehow the latest web3.py causes intermittent failures with eth-tester get_logs kwargs.
this should take care of it

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
