### PR TITLE
fix: bug where could not have same field name in struct as method

### DIFF
--- a/src/ape/utils/abi.py
+++ b/src/ape/utils/abi.py
@@ -371,6 +371,15 @@ def create_struct(name: str, types: Sequence[ABIType], output_values: Sequence) 
         "values": values,
     }
 
+    if conflicts := [p for p in properties if p in methods]:
+        conflicts_str = ", ".join(conflicts)
+        logger.debug(
+            "The following methods are unavailable on the struct "
+            f"due to having the same name as a field: {conflicts_str}"
+        )
+        for conflict in conflicts:
+            del methods[conflict]
+
     struct_def = make_dataclass(
         name,
         properties,

--- a/tests/functional/utils/test_abi.py
+++ b/tests/functional/utils/test_abi.py
@@ -126,3 +126,9 @@ class TestStruct:
     def test_pickle(self, struct):
         actual = pickle.dumps(struct)
         assert isinstance(actual, bytes)
+
+    def test_field_with_same_name_as_method(self):
+        struct = create_struct(
+            "MyStruct", (ABIType(name="values", type="string"),), ("output_value_0",)
+        )
+        assert struct.values == "output_value_0"  # Is the field, not the method.


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #2008 

### How I did it

use the field name instead of the method and log the issue

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
