### PR TITLE
perf: make `ape --help` faster

### DIFF
--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -52,11 +52,14 @@ class ApeCLI(click.MultiCommand):
                 "Plugin": [],
                 "3rd-Party Plugin": [],
             }
-            metadata = PluginMetadataList.load(ManagerAccessMixin.plugin_manager)
+
+            pl_metadata = PluginMetadataList.load(
+                ManagerAccessMixin.plugin_manager, include_available=False
+            )
 
             for cli_name, cmd in commands:
                 help = cmd.get_short_help_str(limit)
-                plugin = metadata.get_plugin(cli_name)
+                plugin = pl_metadata.get_plugin(cli_name)
                 if not plugin:
                     continue
 


### PR DESCRIPTION
### How I did it

* cache `is_installed` instead of checking multiple times
* don't call github available plugins during `--help` as it is not used and is a waste of internet

The performance gains I saw were close to twice as fast when doing `ape --help`... still feels slow but is better.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
