### PR TITLE
fix: add dateutil stubs to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     -   id: mypy
         additional_dependencies: [
                 types-PyYAML,
+                types-python-dateutil,
                 types-requests,
                 types-setuptools,
                 pydantic,


### PR DESCRIPTION
### What I did

Fixes a problem with the pre-commit hook by adding dateutil stubs.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [X] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
