### PR TITLE
fix: fail gracefully trying to fetch contract type in Web3Provider.estimate_gas_cost()

### DIFF
--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -294,8 +294,13 @@ class Web3Provider(ProviderAPI, ABC):
             tb = None
             if call_trace and txn_params.get("to"):
                 traces = (self._create_trace_frame(t) for t in call_trace[1])
-                if contract_type := self.chain_manager.contracts.get(txn_params["to"]):
-                    tb = SourceTraceback.create(contract_type, traces, HexBytes(txn_params["data"]))
+                try:
+                    if contract_type := self.chain_manager.contracts.get(txn_params["to"]):
+                        tb = SourceTraceback.create(
+                            contract_type, traces, HexBytes(txn_params["data"])
+                        )
+                except ProviderNotConnectedError:
+                    pass
 
             tx_error = self.get_virtual_machine_error(
                 err,


### PR DESCRIPTION
### What I did

Fixes issue fetching contract type in a disconnected provider by failing gracefully.  Issue discovered when running tests in ape-alchemy.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [X] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
