### PR TITLE
refactor: remove and rationalize each usage of `model_dump()` with mode="json"

### DIFF
--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -24,7 +24,11 @@ def display_config(ctx, param, value):
         return
 
     click.echo("# Current configuration")
-    click.echo(yaml.dump(ManagerAccessMixin.project_manager.config_manager.model_dump(mode="json")))
+
+    # NOTE: Using json-mode as yaml.dump requires JSON-like structure.
+    model = ManagerAccessMixin.project_manager.config_manager.model_dump(mode="json")
+
+    click.echo(yaml.dump(model))
 
     ctx.exit()  # NOTE: Must exit to bypass running ApeCLI
 

--- a/src/ape/api/compiler.py
+++ b/src/ape/api/compiler.py
@@ -57,7 +57,7 @@ class CompilerAPI(BaseInterfaceModel):
         The combination of settings from ``ape-config.yaml`` and ``.compiler_settings``.
         """
         CustomConfig = self.config.__class__
-        data = {**self.config.model_dump(mode="json", by_alias=True), **self.compiler_settings}
+        data = {**self.config.model_dump(by_alias=True), **self.compiler_settings}
         return CustomConfig.model_validate(data)
 
     @abstractmethod

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -259,9 +259,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
                     f"More than one network named '{custom_net.name}' in ecosystem '{self.name}'."
                 )
 
-            network_data = custom_net.model_dump(
-                mode="json", by_alias=True, exclude=("default_provider",)
-            )
+            network_data = custom_net.model_dump(by_alias=True, exclude=("default_provider",))
             network_data["data_folder"] = self.data_folder / custom_net.name
             network_data["ecosystem"] = self
             network_type = create_network_type(custom_net.chain_id, custom_net.chain_id)

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -176,12 +176,14 @@ class TransactionAPI(BaseInterfaceModel):
 
     @log_instead_of_fail(default="<TransactionAPI>")
     def __repr__(self) -> str:
+        # NOTE: Using JSON mode for style.
         data = self.model_dump(mode="json")
         params = ", ".join(f"{k}={v}" for k, v in data.items())
         cls_name = getattr(type(self), "__name__", TransactionAPI.__name__)
         return f"<{cls_name} {params}>"
 
     def __str__(self) -> str:
+        # NOTE: Using JSON mode for style.
         data = self.model_dump(mode="json")
         if len(data["data"]) > 9:
             # only want to specify encoding if data["data"] is a string

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -833,6 +833,7 @@ class ProjectManager(BaseManager):
         return None
 
     # def publish_manifest(self):
+    #     NOTE: Using JSON mode for maximum publishing compatibility.
     #     manifest = self.manifest.model_dump(mode="json")
     #     if not manifest["name"]:
     #         raise ProjectError("Need name to release manifest")

--- a/src/ape/utils/abi.py
+++ b/src/ape/utils/abi.py
@@ -113,7 +113,7 @@ class StructParser:
             and isinstance(value, (list, tuple))
             and len(_type.components or []) > 0
         ):
-            non_array_type_data = _type.model_dump(mode="json")
+            non_array_type_data = _type.model_dump()
             non_array_type_data["type"] = "tuple"
             non_array_type = ABIType(**non_array_type_data)
             return [self._encode(non_array_type, v) for v in value]
@@ -159,7 +159,7 @@ class StructParser:
         elif has_array_of_tuples_return:
             item_type_str = str(_types[0].type).split("[")[0]
             data = {
-                **_types[0].model_dump(mode="json"),
+                **_types[0].model_dump(),
                 "type": item_type_str,
                 "internalType": item_type_str,
             }
@@ -181,7 +181,7 @@ class StructParser:
                     if item_type_str == "tuple":
                         # Either an array of structs or nested structs.
                         item_type_data = {
-                            **output_type.model_dump(mode="json"),
+                            **output_type.model_dump(),
                             "type": item_type_str,
                             "internalType": item_type_str,
                         }

--- a/src/ape_cache/query.py
+++ b/src/ape_cache/query.py
@@ -407,6 +407,7 @@ class CacheQueryProvider(QueryAPI):
     def _get_block_cache_data(
         self, query: BlockQuery, result: Iterator[BaseInterfaceModel]
     ) -> Optional[List[Dict[str, Any]]]:
+        # NOTE: Using JSON-mode for maximum DB compatibility.
         return [m.model_dump(mode="json", by_alias=False) for m in result]
 
     @_get_cache_data.register
@@ -416,6 +417,8 @@ class CacheQueryProvider(QueryAPI):
         new_result = []
         table_columns = [c.key for c in Transactions.__table__.columns]  # type: ignore
         txns: List[TransactionAPI] = cast(List[TransactionAPI], result)
+
+        # NOTE: Using JSON mode for maximum DB compatibility.
         for val in [m for m in txns]:
             new_dict = {
                 k: v
@@ -444,6 +447,7 @@ class CacheQueryProvider(QueryAPI):
     def _get_cache_events_data(
         self, query: ContractEventQuery, result: Iterator[BaseInterfaceModel]
     ) -> Optional[List[Dict[str, Any]]]:
+        # NOTE: Using JSON mode for maximum DB compatibility.
         return [m.model_dump(mode="json", by_alias=False) for m in result]
 
     def update_cache(self, query: QueryType, result: Iterator[BaseInterfaceModel]):

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -199,7 +199,7 @@ class BaseEthereumConfig(PluginConfig):
                     use_fork=True,
                     default_transaction_type=cls.DEFAULT_TRANSACTION_TYPE,
                     gas_limit=cls.DEFAULT_LOCAL_GAS_LIMIT,
-                ).model_dump(mode="json", by_alias=True)
+                ).model_dump(by_alias=True)
                 data = merge_configs(default_fork_model, obj)
                 cfg_forks[key] = ForkedNetworkConfig.model_validate(data)
 
@@ -207,7 +207,7 @@ class BaseEthereumConfig(PluginConfig):
                 # Custom network.
                 default_network_model = create_network_config(
                     default_transaction_type=cls.DEFAULT_TRANSACTION_TYPE
-                ).model_dump(mode="json", by_alias=True)
+                ).model_dump(by_alias=True)
                 data = merge_configs(default_network_model, obj)
                 custom_networks[name] = NetworkConfig.model_validate(data)
 
@@ -607,7 +607,7 @@ class Ethereum(EcosystemAPI):
 
     def decode_calldata(self, abi: Union[ConstructorABI, MethodABI], calldata: bytes) -> Dict:
         raw_input_types = [i.canonical_type for i in abi.inputs]
-        input_types = [parse_type(i.model_dump(mode="json")) for i in abi.inputs]
+        input_types = [parse_type(i.model_dump()) for i in abi.inputs]
 
         try:
             raw_input_values = decode(raw_input_types, calldata, strict=False)
@@ -644,7 +644,7 @@ class Ethereum(EcosystemAPI):
         elif not isinstance(vm_return_values, (tuple, list)):
             vm_return_values = (vm_return_values,)
 
-        output_types = [parse_type(o.model_dump(mode="json")) for o in abi.outputs]
+        output_types = [parse_type(o.model_dump()) for o in abi.outputs]
         output_values = [
             self.decode_primitive_value(v, t) for v, t in zip(vm_return_values, output_types)
         ]

--- a/src/ape_geth/__init__.py
+++ b/src/ape_geth/__init__.py
@@ -13,7 +13,7 @@ def config_class():
 
 @plugins.register(plugins.ProviderPlugin)
 def providers():
-    networks_dict = GethNetworkConfig().model_dump(mode="json")
+    networks_dict = GethNetworkConfig().model_dump()
     networks_dict.pop(LOCAL_NETWORK_NAME)
     for network_name in networks_dict:
         yield "ethereum", network_name, GethProvider

--- a/src/ape_geth/provider.py
+++ b/src/ape_geth/provider.py
@@ -258,6 +258,7 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
             self.start()
 
     def start(self, timeout: int = 20):
+        # NOTE: Using JSON mode to ensure types can be passed as CLI args.
         test_config = self.config_manager.get_config("test").model_dump(mode="json")
 
         # Allow configuring a custom executable besides your $PATH geth.

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -127,6 +127,7 @@ class TestAccount(TestAccountAPI):
 
     def sign_transaction(self, txn: TransactionAPI, **signer_options) -> Optional[TransactionAPI]:
         # Signs anything that's given to it
+        # NOTE: Using JSON mode since used as request data.
         tx_data = txn.model_dump(mode="json", by_alias=True)
 
         try:

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -110,7 +110,10 @@ class LocalProvider(TestProviderAPI, Web3Provider):
             return self.network.gas_limit
 
         estimate_gas = self.web3.eth.estimate_gas
+
+        # NOTE: Using JSON mode since used as request data.
         txn_dict = txn.model_dump(mode="json")
+
         txn_dict.pop("gas", None)
         txn_data = cast(TxParams, txn_dict)
 
@@ -125,7 +128,10 @@ class LocalProvider(TestProviderAPI, Web3Provider):
                 # and then set it back.
                 expected_nonce, actual_nonce = gas_match.groups()
                 txn.nonce = int(expected_nonce)
+
+                # NOTE: Using JSON mode since used as request data.
                 txn_params: TxParams = cast(TxParams, txn.model_dump(by_alias=True, mode="json"))
+
                 value = estimate_gas(txn_params, block_identifier=block_id)
                 txn.nonce = int(actual_nonce)
                 return value
@@ -141,7 +147,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
     @property
     def settings(self) -> EthTesterProviderConfig:
         return EthTesterProviderConfig.model_validate(
-            {**self.config.provider.model_dump(mode="json"), **self.provider_settings}
+            {**self.config.provider.model_dump(), **self.provider_settings}
         )
 
     @cached_property
@@ -177,7 +183,9 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         state: Optional[Dict] = None,
         **kwargs,
     ) -> HexBytes:
+        # NOTE: Using JSON mode since used as request data.
         data = txn.model_dump(mode="json", exclude_none=True)
+
         state = kwargs.pop("state_override", None)
         call_kwargs: Dict = {"block_identifier": block_id, "state_override": state}
 
@@ -214,7 +222,9 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         self.chain_manager.history.append(receipt)
 
         if receipt.failed:
+            # NOTE: Using JSON mode since used as request data.
             txn_dict = txn.model_dump(mode="json")
+
             txn_dict["nonce"] += 1
             txn_params = cast(TxParams, txn_dict)
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -308,6 +308,7 @@ def ds_note_test_contract(eth_tester_provider, vyper_contract_type, owner, get_c
 def project_with_contract(temp_config):
     with temp_config() as project:
         copy_tree(str(APE_PROJECT_FOLDER), str(project.path))
+        project.local_project._cached_manifest = None  # Clean manifest
         yield project
 
 

--- a/tests/functional/test_block.py
+++ b/tests/functional/test_block.py
@@ -7,7 +7,7 @@ def block(chain):
 
 
 def test_block_dict(block):
-    actual = block.model_dump(mode="json")
+    actual = block.model_dump()
     expected = {
         "baseFeePerGas": 1000000000,
         "difficulty": 0,

--- a/tests/functional/test_contract.py
+++ b/tests/functional/test_contract.py
@@ -23,7 +23,7 @@ def test_Contract_from_abi(contract_instance):
 def test_Contract_from_abi_list(contract_instance):
     contract = Contract(
         contract_instance.address,
-        abi=[abi.model_dump(mode="json") for abi in contract_instance.contract_type.abi],
+        abi=[abi.model_dump() for abi in contract_instance.contract_type.abi],
     )
 
     assert isinstance(contract, ContractInstance)
@@ -34,9 +34,7 @@ def test_Contract_from_abi_list(contract_instance):
 def test_Contract_from_json_str(contract_instance):
     contract = Contract(
         contract_instance.address,
-        abi=json.dumps(
-            [abi.model_dump(mode="json") for abi in contract_instance.contract_type.abi]
-        ),
+        abi=json.dumps([abi.model_dump() for abi in contract_instance.contract_type.abi]),
     )
 
     assert isinstance(contract, ContractInstance)

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -799,7 +799,7 @@ def test_value_to_non_payable_fallback_and_no_receive(
     and you try to send a value, it fails.
     """
     # Hack to set fallback as non-payable.
-    contract_type_data = vyper_fallback_contract_type.model_dump(mode="json")
+    contract_type_data = vyper_fallback_contract_type.model_dump()
     for abi in contract_type_data["abi"]:
         if abi.get("type") == "fallback":
             abi["stateMutability"] = "non-payable"

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -246,7 +246,7 @@ def test_block_handles_snake_case_parent_hash(eth_tester_provider, sender, recei
 
     # Replace 'parentHash' key with 'parent_hash'
     latest_block = eth_tester_provider.get_block("latest")
-    latest_block_dict = eth_tester_provider.get_block("latest").model_dump(mode="json")
+    latest_block_dict = eth_tester_provider.get_block("latest").model_dump()
     latest_block_dict["parent_hash"] = latest_block_dict.pop("parentHash")
 
     redefined_block = Block.model_validate(latest_block_dict)

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -265,10 +265,10 @@ def test_data_when_contains_whitespace():
 def test_model_dump_excludes_none_values():
     txn = StaticFeeTransaction()
     txn.value = 1000000
-    actual = txn.model_dump(mode="json")
+    actual = txn.model_dump()
     assert "value" in actual
     txn.value = None  # type: ignore
-    actual = txn.model_dump(mode="json")
+    actual = txn.model_dump()
     assert "value" not in actual
 
 

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -75,7 +75,7 @@ def signature(owner, signable_message):
 
 
 def test_contract_log_serialization(log, zero_address):
-    obj = ContractLog.model_validate(log.model_dump(mode="json"))
+    obj = ContractLog.model_validate(log.model_dump())
     assert obj.contract_address == zero_address
     assert obj.block_hash == BLOCK_HASH
     assert obj.block_number == BLOCK_NUMBER
@@ -86,7 +86,7 @@ def test_contract_log_serialization(log, zero_address):
 
 
 def test_contract_log_serialization_with_hex_strings_and_non_checksum_addresses(log, zero_address):
-    data = log.model_dump(mode="json")
+    data = log.model_dump()
     data["log_index"] = to_hex(log.log_index)
     data["transaction_index"] = to_hex(log.transaction_index)
     data["block_number"] = to_hex(log.block_number)
@@ -104,12 +104,12 @@ def test_contract_log_serialization_with_hex_strings_and_non_checksum_addresses(
 
 
 def test_contract_log_str(log):
-    obj = ContractLog.model_validate(log.model_dump(mode="json"))
+    obj = ContractLog.model_validate(log.model_dump())
     assert str(obj) == "MyEvent(foo=0 bar=1)"
 
 
 def test_contract_log_repr(log):
-    obj = ContractLog.model_validate(log.model_dump(mode="json"))
+    obj = ContractLog.model_validate(log.model_dump())
     assert repr(obj) == "<MyEvent foo=0 bar=1>"
 
 


### PR DESCRIPTION
### What I did

* removes `mode="json"` where is not needed.
* rationalizes every usage of `mode="json"` with a comment.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
