### PR TITLE
fix: use macos-12 instead of macos-latest in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,7 +62,9 @@ jobs:
 
         strategy:
             matrix:
-                os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
+                # TODO: Replace with macos-latest when works again.
+                #   https://github.com/actions/setup-python/issues/808
+                os: [ubuntu-latest, macos-12]   # eventually add `windows-latest`
                 python-version: [3.8, 3.9, "3.10", "3.11"]
 
         env:


### PR DESCRIPTION
### What I did

The following issue seems to block python3.8-3.9 for macos arm: https://github.com/actions/setup-python/issues/808

NOTE: Anticipating things may still fail because of gacts/install-geth action

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
