### PR TITLE
fix: issues with local installs

### DIFF
--- a/src/ape/plugins/_utils.py
+++ b/src/ape/plugins/_utils.py
@@ -348,13 +348,7 @@ class PluginMetadata(BaseInterfaceModel):
         if not use_cache:
             _get_distributions.cache_clear()
 
-        for dist in _get_distributions():
-            if not (name := getattr(dist, "name", "")):
-                continue
-            elif self.package_name == name:
-                return True
-
-        return False
+        return any(self.package_name == getattr(d, "name", "") for d in _get_distributions())
 
     def _prepare_install(
         self, upgrade: bool = False, skip_confirmation: bool = False

--- a/src/ape/plugins/_utils.py
+++ b/src/ape/plugins/_utils.py
@@ -344,12 +344,17 @@ class PluginMetadata(BaseInterfaceModel):
         version_key = f"=={self.version}" if self.version and self.version[0].isnumeric() else ""
         return f"{self.name}{version_key}"
 
-    def check_installed(self, use_cache: bool = True):
+    def check_installed(self, use_cache: bool = True) -> bool:
         if not use_cache:
             _get_distributions.cache_clear()
 
-        ape_packages = [n.name for n in _get_distributions()]
-        return self.package_name in ape_packages
+        for dist in _get_distributions():
+            if not (name := getattr(dist, "name", "")):
+                continue
+            elif self.package_name == name:
+                return True
+
+        return False
 
     def _prepare_install(
         self, upgrade: bool = False, skip_confirmation: bool = False


### PR DESCRIPTION
### What I did

issue where plugin install checking failed because of local dists w/o name attribute

i think related to local or editable installs of packages...

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
