### PR TITLE
refactor: use manager._make_request instead of provider

### DIFF
--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -68,7 +68,7 @@ from ape.types import (
     SourceTraceback,
     TraceFrame,
 )
-from ape.utils import gas_estimation_error_message, run_until_complete, to_int
+from ape.utils import gas_estimation_error_message, to_int
 from ape.utils.misc import DEFAULT_MAX_RETRIES_TX
 from ape_ethereum._print import CONSOLE_CONTRACT_ID, console_contract
 from ape_ethereum.transactions import AccessList, AccessListTransaction
@@ -230,7 +230,7 @@ class Web3Provider(ProviderAPI, ABC):
         if self._web3 is None:
             return False
 
-        return run_until_complete(self._web3.is_connected())
+        return self._web3.is_connected()
 
     @property
     def max_gas(self) -> int:
@@ -1048,8 +1048,7 @@ class Web3Provider(ProviderAPI, ABC):
 
     def _make_request(self, endpoint: str, parameters: Optional[List] = None) -> Any:
         parameters = parameters or []
-        coroutine = self.web3.provider.make_request(RPCEndpoint(endpoint), parameters)
-        result = run_until_complete(coroutine)
+        result = self.web3.provider.make_request(RPCEndpoint(endpoint), parameters)
 
         if "error" in result:
             error = result["error"]

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1348,6 +1348,9 @@ class EthereumNodeProvider(Web3Provider, ABC):
         if is_likely_poa and geth_poa_middleware not in self.web3.middleware_onion:
             self.web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
+        # Some things within ape don't handle AttributeDict outputs very well.
+        self.web3.middleware_onion.remove("attrdict")
+
         self.network.verify_chain_id(chain_id)
 
     def disconnect(self):

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1048,7 +1048,10 @@ class Web3Provider(ProviderAPI, ABC):
 
     def _make_request(self, endpoint: str, parameters: Optional[List] = None) -> Any:
         parameters = parameters or []
-        result = self.web3.provider.make_request(RPCEndpoint(endpoint), parameters)
+
+        # request_func() essentially returns make_request() wrapped with middleware
+        request_func = self.web3.provider.request_func(self.web3, self.web3.middleware_onion)
+        result = request_func(RPCEndpoint(endpoint), parameters)
 
         if "error" in result:
             error = result["error"]


### PR DESCRIPTION
### What I did

Refactored to use `_make_request()` on the web3.py manager rather than `make_request()` on the web3.py provider.  This makes sure middleware are run.

I'm curious what anyone else thinks about this.  It's a private method I'm leveraging (not ideal) but skipping middleware *probably* isn't the play either.

Another option might be to just implement the internals of this function which applies middleware and calls `request_func()`.  I don't have any strong feelings, this PR is mainly the most minimal change to do what I'm looking for.  Maybe we don't even want to leverage any of the middleware and I'm off base here anyway.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
