### PR TITLE
docs: updates for payable method calls in user-guides

### DIFF
--- a/docs/userguides/contracts.md
+++ b/docs/userguides/contracts.md
@@ -213,7 +213,7 @@ The following sub-sections show how, using Ape, we can invoke or call the method
 
 The following example demonstrates invoking a contract's method in Ape as a transaction.
 Remember: transactions cost money, whether they are payable or not.
-Payable transactions cost more money, because the contract-logic accepts additional value (e.g. Ether).
+Payable transactions cost more money, because the contract-logic requires additional value (e.g. Ether) to be forwarded with the call.
 
 Before continuing, take note that there is a [separate guide](./transactions.html) which fully covers transactions in Ape at a more granular level.
 For this guide, assume we are using the default transaction type in Ape for Ethereum-based networks.

--- a/docs/userguides/contracts.md
+++ b/docs/userguides/contracts.md
@@ -237,6 +237,11 @@ To provider additional value to a payable method, use the `value=` kwarg:
 ```python
 receipt = contract.withdraw(sender=account, value=123)
 print(receipt.gas_used)
+
+# NOTE: You can also use "smart" values such as `"0.1 ether"` or `"100 gwei"`:
+_ = contract.withdraw(sender=account, value="0.1 ether")
+_ = contract.withdraw(sender=account, value="100 gwei")
+_ = contract.withdraw(sender=account, value="1 wei")
 ```
 
 Notice that transacting returns a [ReceiptAPI](../methoddocs/api.html#ape.api.transactions.ReceiptAPI) object which contains all the receipt data, such as `gas_used`.

--- a/docs/userguides/transactions.md
+++ b/docs/userguides/transactions.md
@@ -92,7 +92,7 @@ Static-fee transactions are the transactions that Ethereum used before the Londo
 One way to use a static-fee transaction is by specifying the `gas_price` as a key-value argument:
 
 ```python
-contract.fundMyContract(value="1 gwei", gas_price="100 gwei", sender=sender)
+contract.startAuction(gas_price="100 gwei", sender=sender)
 ```
 
 **NOTE**: Miners prioritize static-fee transactions based on the highest `gas_price`.
@@ -101,7 +101,7 @@ Another way to use a static-fee transaction (without having to provide `gas_pric
 argument `type` equal to `0x00`.
 
 ```python
-contract.fundMyContract(value="1 gwei", type="0x0", sender=sender)
+contract.startAuction(type="0x0", sender=sender)
 ```
 
 When declaring `type="0x0"` and _not_ specifying a `gas_price`, the `gas_price` gets set using the provider's estimation.
@@ -116,7 +116,7 @@ You can also use Access-lists in Dynamic-fee transactions.
 To automatically use access-list (type 1) transactions in Ape, specify `type=1` in your call:
 
 ```python
-contract.fundMyContract(value="1 gwei", type=1, sender=sender)
+contract.startAuction(type=1, sender=sender)
 ```
 
 When specifying `type=1`, Ape uses `eth_createAccessList` RPC to attach an access list to the transaction automatically.
@@ -124,8 +124,19 @@ When specifying `type=1`, Ape uses `eth_createAccessList` RPC to attach an acces
 You can also specify the access-list directly:
 
 ```python
-contract.fundMyContract(value="1 gwei", type=1, sender=sender, access_list=MY_ACCESS_LIST)
+contract.fundMyContract(type=1, sender=sender, access_list=MY_ACCESS_LIST)
 ```
+
+## Payable Transactions
+
+To add value to a transaction, use the `value=` kwarg when transacting in Ape.
+
+```python
+contract.fundMyContract(value="1 ether", sender=sender)
+```
+
+The `value="1 ether"` part is sending 1 ETH to the contract.
+You would do this if `fundMyContract` was a `"payable"` method, e.g. marked `@payable` in Vyper.
 
 ## Transaction Logs
 


### PR DESCRIPTION
### What I did

Clarifies and adds some examples invoking payable methods from contracts using Ape in a couple user-guides.

### How I did it

* Add part to contract guide contract-interaction example
* add short section in transactions guide and make that make sense with some other edits

### How to verify it

read through

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
