### PR TITLE
fix: issue with selecting first network from an ecosystem as default

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -401,16 +401,16 @@ class AccountContainerAPI(BaseInterfaceModel):
     instances.
     """
 
+    data_folder: Path
     """
     The path to the account's data.
     """
-    data_folder: Path
 
+    account_type: Type[AccountAPI]
     """
     The type of account in this container.
     See :class:`~ape.api.accounts.AccountAPI`.
     """
-    account_type: Type[AccountAPI]
 
     @property
     @abstractmethod

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -320,7 +320,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
             str
         """
         if network := self._default_network:
-            # Was set programatically.
+            # Was set programmatically.
             return network
 
         elif network := self.config.get("default_network"):
@@ -333,7 +333,8 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
 
         elif len(self.networks) >= 1:
             # Use the first network.
-            return self.networks[0]
+            key = next(iter(self.networks.keys()))
+            return self.networks[key].name
 
         # Very unlikely scenario.
         raise NetworkError("No networks found.")
@@ -809,14 +810,10 @@ class NetworkAPI(BaseInterfaceModel):
             if cfg := self.config.get(opt):
                 if isinstance(cfg, dict):
                     return cfg
-
                 elif isinstance(cfg, PluginConfig):
                     return cfg
-
                 else:
                     raise TypeError(f"Network config must be a dictionary. Received '{type(cfg)}'.")
-
-                return cfg
 
         return PluginConfig()
 
@@ -1112,7 +1109,7 @@ class NetworkAPI(BaseInterfaceModel):
 
         provider_from_config: str
         if provider := self._default_provider:
-            # Was set programatically.
+            # Was set programmatically.
             return provider
 
         elif provider_from_config := self._network_config.get("default_provider"):

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -101,7 +101,7 @@ class ProviderAPI(BaseInterfaceModel):
     """The settings for the provider, as overrides to the configuration."""
 
     data_folder: Path
-    """The path to the  ``.ape`` directory."""
+    """The path to the ``.ape`` directory."""
 
     request_header: Dict
     """A header to set on HTTP/RPC requests."""

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -340,7 +340,10 @@ class Ethereum(EcosystemAPI):
 
         for name in networks_to_check:
             network = self.get_network(name)
-            ecosystem_default = network.config.DEFAULT_TRANSACTION_TYPE
+            ecosystem_config = network.config
+            ecosystem_default = ecosystem_config.get(
+                "default_transaction_type", DEFAULT_TRANSACTION_TYPE
+            )
             result: int = network._network_config.get("default_transaction_type", ecosystem_default)
             return TransactionType(result)
 

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -941,6 +941,7 @@ def test_default_network_name_from_config(config, ethereum):
     orig = config._plugin_configs["ethereum"]
     data = {"default_network": "testnet"}
     config._plugin_configs["ethereum"] = EthereumConfig.model_validate(data)
+    ethereum._default_network = None
     assert ethereum.default_network_name == "testnet"
     config._plugin_configs["ethereum"] = orig
 
@@ -951,6 +952,7 @@ def test_default_network_name_when_not_set_uses_local(config, ethereum):
     data = {k: v for k, v in data.items() if k not in ("default_network",)}
     data["default_network"] = None
     config._plugin_configs["ethereum"] = data
+    ethereum._default_network = None
     assert ethereum.default_network_name == LOCAL_NETWORK_NAME
     config._plugin_configs["ethereum"] = orig
 

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -962,6 +962,7 @@ def test_default_network_name_when_not_set_and_no_local_uses_only(mocker, config
     mock_net.name = net_name
     mock_pm.networks = ((None, ("ethereum", net_name, lambda *args, **kwargs: mock_net)),)
     Ethereum.plugin_manager = mock_pm
+    ethereum._default_network = None
 
     try:
         assert ethereum.default_network_name == net_name

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -11,7 +11,13 @@ from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI
 from ape.exceptions import DecodingError, NetworkError, NetworkNotFoundError
 from ape.types import AddressType
 from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
-from ape_ethereum.ecosystem import BLUEPRINT_HEADER, BaseEthereumConfig, Block, Ethereum
+from ape_ethereum.ecosystem import (
+    BLUEPRINT_HEADER,
+    BaseEthereumConfig,
+    Block,
+    Ethereum,
+    EthereumConfig,
+)
 from ape_ethereum.transactions import (
     DynamicFeeTransaction,
     Receipt,
@@ -933,7 +939,8 @@ def test_default_network_name_set_programmatically(ethereum):
 
 def test_default_network_name_from_config(config, ethereum):
     orig = config._plugin_configs["ethereum"]
-    config._plugin_configs["ethereum"] = {"default_network": "testnet"}
+    data = {"default_network": "testnet"}
+    config._plugin_configs["ethereum"] = EthereumConfig.model_validate(data)
     assert ethereum.default_network_name == "testnet"
     config._plugin_configs["ethereum"] = orig
 
@@ -942,6 +949,7 @@ def test_default_network_name_when_not_set_uses_local(config, ethereum):
     orig = config._plugin_configs["ethereum"]
     data = orig if isinstance(orig, dict) else orig.model_dump()
     data = {k: v for k, v in data.items() if k not in ("default_network",)}
+    data["default_network"] = None
     config._plugin_configs["ethereum"] = data
     assert ethereum.default_network_name == LOCAL_NETWORK_NAME
     config._plugin_configs["ethereum"] = orig


### PR DESCRIPTION
### What I did

When an ecosystem has no default network, the logic says to pick the first network. However, you get a `KeyError` in that case because it mistakenly tries `0` instead of the the first key.

### How I did it

Use `next` to get the key and use that instead of `0`.

### How to verify it

Install an ecosystem plugin with no `local` network and have the default be unset in the config.
Try it out.
Notice KeyError.

Try with this PR
Notice no KeyError and it actually selects the correct one.

Also added tests.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
