### PR TITLE
feat: add `--config-override` option for `ape pm install`

### DIFF
--- a/docs/userguides/dependencies.md
+++ b/docs/userguides/dependencies.md
@@ -141,6 +141,15 @@ For `npm` dependencies, you use an `npm:` prefix.
 For local dependencies, you give it a path to the local dependency.
 `--version` is not required when using a local dependency.
 
+To change the config of a dependency when installing, use the `--config-override` CLI option:
+
+```shell
+ape pm install gh:OpenZeppelin/openzeppelin-contracts \
+  --name openzeppelin \
+  --version "4.6.0" \
+  --config-override '{"solidity": {"version": "0.8.12"}}'
+```
+
 ### remove
 
 Remove previously installed packages using the `remove` command:

--- a/src/ape/cli/__init__.py
+++ b/src/ape/cli/__init__.py
@@ -19,6 +19,7 @@ from ape.cli.options import (
     NetworkOption,
     account_option,
     ape_cli_context,
+    config_override_option,
     contract_option,
     incompatible_with,
     network_option,
@@ -26,7 +27,7 @@ from ape.cli.options import (
     skip_confirmation_option,
     verbosity_option,
 )
-from ape.cli.paramtype import AllFilePaths, Path
+from ape.cli.paramtype import JSON, AllFilePaths, Path
 
 __all__ = [
     "account_option",
@@ -35,12 +36,14 @@ __all__ = [
     "AllFilePaths",
     "ape_cli_context",
     "ApeCliContextObject",
+    "config_override_option",
     "ConnectedProviderCommand",
     "contract_file_paths_argument",
     "contract_option",
     "existing_alias_argument",
     "get_user_selected_account",
     "incompatible_with",
+    "JSON",
     "network_option",
     "NetworkBoundCommand",
     "NetworkChoice",

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -7,7 +7,6 @@ from click import Option
 from ethpm_types import ContractType
 
 from ape.api import ProviderAPI
-from ape.cli import ConnectedProviderCommand
 from ape.cli.choices import (
     _ACCOUNT_TYPE_FILTER,
     _NONE_NETWORK,
@@ -16,6 +15,8 @@ from ape.cli.choices import (
     OutputFormat,
     output_format_choice,
 )
+from ape.cli.commands import ConnectedProviderCommand
+from ape.cli.paramtype import JSON
 from ape.exceptions import Abort, ProjectError
 from ape.logging import DEFAULT_LOG_LEVEL, ApeLogger, LogLevel, logger
 from ape.utils.basemodel import ManagerAccessMixin
@@ -438,3 +439,17 @@ def incompatible_with(incompatible_opts) -> Type[click.Option]:
             return super().handle_parse_result(ctx, opts, args)
 
     return IncompatibleOption
+
+
+def _json_option(name, help, **kwargs):
+    return click.option(
+        name,
+        help=help,
+        type=JSON(),
+        metavar='{"KEY": "VAL"}',
+        **kwargs,
+    )
+
+
+def config_override_option(**kwargs):
+    return _json_option("--config-override", help="Config override mappings", **kwargs)

--- a/src/ape/cli/paramtype.py
+++ b/src/ape/cli/paramtype.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path as PathLibPath
 from typing import Any, List, Optional
 
@@ -32,3 +33,22 @@ class AllFilePaths(Path):
         path = super().convert(value, param, ctx)
         assert isinstance(path, PathLibPath)  # For mypy
         return get_all_files_in_directory(path) if path.is_dir() else [path]
+
+
+class JSON(click.ParamType):
+    """
+    A type that accepts a raw-JSON str
+    and loads it into a dictionary.
+    """
+
+    def convert(self, value, param, ctx):
+        if not value:
+            return {}
+
+        elif isinstance(value, str):
+            try:
+                return json.loads(value)
+            except ValueError as err:
+                self.fail(f"Invalid JSON string: {err}", param, ctx)
+
+        return value  # Good already.

--- a/src/ape/managers/project/dependency.py
+++ b/src/ape/managers/project/dependency.py
@@ -294,6 +294,10 @@ class LocalDependency(DependencyAPI):
         if value.get("contracts_folder") not in (None, "contracts"):
             return value
 
+        elif cfg_value := value.get("config_override", {}).get("contracts_folder"):
+            value["contracts_folder"] = cfg_value
+            return value
+
         # If using default value, check if exists
         local_path_value = value.get("local") or os.getcwd()
         local_project_path = Path(local_path_value)

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -35,8 +35,8 @@ def cli():
 
 # Different name because `list` is a keyword
 @cli.command(name="list", short_help="List available local accounts")
-@click.option("--all", "show_all_plugins", help="Output accounts from all plugins", is_flag=True)
 @ape_cli_context()
+@click.option("--all", "show_all_plugins", help="Output accounts from all plugins", is_flag=True)
 def _list(cli_ctx, show_all_plugins):
     if "accounts" not in cli_ctx.account_manager.containers:
         cli_ctx.abort("Accounts plugin unexpectedly failed to load.")
@@ -75,6 +75,7 @@ def _list(cli_ctx, show_all_plugins):
 
 
 @cli.command(short_help="Create an account with a random mnemonic seed phrase")
+@ape_cli_context()
 @click.option(
     "--hide-mnemonic",
     help="Hide the newly generated mnemonic from the terminal",
@@ -94,7 +95,6 @@ def _list(cli_ctx, show_all_plugins):
     show_default=True,
 )
 @non_existing_alias_argument()
-@ape_cli_context()
 def generate(cli_ctx, alias, hide_mnemonic, word_count, custom_hd_path):
     click.prompt(
         "Enhance the security of your account by adding additional random input",
@@ -122,6 +122,7 @@ def generate(cli_ctx, alias, hide_mnemonic, word_count, custom_hd_path):
 
 # Different name because `import` is a keyword
 @cli.command(name="import", short_help="Import an account by private key or seed phrase")
+@ape_cli_context()
 @click.option(
     "--use-mnemonic", "import_from_mnemonic", help="Import a key from a mnemonic", is_flag=True
 )
@@ -133,7 +134,6 @@ def generate(cli_ctx, alias, hide_mnemonic, word_count, custom_hd_path):
     show_default=True,
 )
 @non_existing_alias_argument()
-@ape_cli_context()
 def _import(cli_ctx, alias, import_from_mnemonic, custom_hd_path):
     account: Optional[KeyfileAccount] = None
 
@@ -183,8 +183,8 @@ def export(cli_ctx, alias):
 
 
 @cli.command(short_help="Change the password of an existing account")
-@existing_alias_argument(account_type=KeyfileAccount)
 @ape_cli_context()
+@existing_alias_argument(account_type=KeyfileAccount)
 def change_password(cli_ctx, alias):
     account = cli_ctx.account_manager.load(alias)
     assert isinstance(account, KeyfileAccount)
@@ -193,8 +193,8 @@ def change_password(cli_ctx, alias):
 
 
 @cli.command(short_help="Delete an existing account")
-@existing_alias_argument(account_type=KeyfileAccount)
 @ape_cli_context()
+@existing_alias_argument(account_type=KeyfileAccount)
 def delete(cli_ctx, alias):
     account = cli_ctx.account_manager.load(alias)
     assert isinstance(account, KeyfileAccount)

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -13,6 +13,7 @@ def _include_dependencies_callback(ctx, param, value):
 
 
 @click.command(short_help="Compile select contract source files")
+@ape_cli_context()
 @contract_file_paths_argument()
 @click.option(
     "-f",
@@ -37,7 +38,6 @@ def _include_dependencies_callback(ctx, param, value):
     help="Also compile dependencies",
     callback=_include_dependencies_callback,
 )
-@ape_cli_context()
 def cli(cli_ctx, file_paths: Set[Path], use_cache: bool, display_size: bool, include_dependencies):
     """
     Compiles the manifest for this project and saves the results

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -93,6 +93,7 @@ def _display_all_callback(ctx, param, value):
 
 
 @cli.command(name="list", short_help="Display plugins")
+@ape_cli_context()
 @click.option(
     "-a",
     "--all",
@@ -102,7 +103,6 @@ def _display_all_callback(ctx, param, value):
     callback=_display_all_callback,
     help="Display all plugins installed and available (including Core)",
 )
-@ape_cli_context()
 def _list(cli_ctx, to_display):
     metadata = PluginMetadataList.load(cli_ctx.plugin_manager)
     if output := metadata.to_str(include=to_display):
@@ -156,8 +156,8 @@ def install(cli_ctx, plugins: List[PluginMetadata], skip_confirmation: bool, upg
 
 
 @cli.command()
-@plugins_argument()
 @ape_cli_context()
+@plugins_argument()
 @skip_confirmation_option("Don't ask for confirmation to install the plugins")
 def uninstall(cli_ctx, plugins, skip_confirmation):
     """Uninstall plugins"""

--- a/src/ape_pm/_cli.py
+++ b/src/ape_pm/_cli.py
@@ -131,7 +131,7 @@ def _package_callback(ctx, param, value):
         return None
 
     elif isinstance(value, Path):
-        return _handle_package_path(value, original_value=value)
+        return _handle_package_path(value)
 
     elif value.startswith("gh:"):
         # Is a GitHub style dependency

--- a/src/ape_pm/_cli.py
+++ b/src/ape_pm/_cli.py
@@ -180,7 +180,7 @@ def install(cli_ctx, package, name, version, ref, force, config_override):
 
     if not package or package == ".":
         if config_override:
-            # NOTE: Handled correctly on feat/0.8
+            # TODO: Handle correctly in project-refactor for feat/08
             cli_ctx.abort("Cannot provide 'config_override' option without specific package(s).")
 
         # `ape pm install`: Load all dependencies from current package.

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -150,7 +150,7 @@ def test_compile_with_config_override(dependency_manager, project):
     #  for this test to test against a previous bug where we got multiple values.
     override = {"contracts_folder": "src"}
     path = "__test_path__"
-    contracts_path = project.path / path / "contracts"
+    contracts_path = project.path / path / "src"
     contracts_path.mkdir(exist_ok=True, parents=True)
     (contracts_path / "contract.json").write_text('{"abi": []}')
     data = {"name": "FooBar", "local": path, "config_override": override}

--- a/tests/functional/test_logging.py
+++ b/tests/functional/test_logging.py
@@ -21,7 +21,7 @@ def test_info(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.info("this is a test")
 
-    result = simple_runner.invoke(group_for_testing, ["cmd"])
+    result = simple_runner.invoke(group_for_testing, "cmd")
     assert "INFO" in result.output
     assert "this is a test" in result.output
 
@@ -32,7 +32,7 @@ def test_info_level_higher(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.info("this is a test")
 
-    result = simple_runner.invoke(group_for_testing, ["cmd", "-v", "WARNING"])
+    result = simple_runner.invoke(group_for_testing, ("cmd", "-v", "WARNING"))
 
     # You don't get INFO log when log level is higher
     assert "INFO" not in result.output
@@ -45,7 +45,7 @@ def test_warning(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.warning("this is a test")
 
-    result = simple_runner.invoke(group_for_testing, ["cmd"])
+    result = simple_runner.invoke(group_for_testing, "cmd")
     assert "WARNING" in result.output
     assert "this is a test" in result.output
 
@@ -56,7 +56,7 @@ def test_warning_level_higher(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.warning("this is a test")
 
-    result = simple_runner.invoke(group_for_testing, ["cmd", "-v", "ERROR"])
+    result = simple_runner.invoke(group_for_testing, ("cmd", "-v", "ERROR"))
     assert "WARNING" not in result.output
     assert "this is a test" not in result.output
 
@@ -70,7 +70,7 @@ def test_success(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.success("this is a test")
 
-    result = simple_runner.invoke(group_for_testing, ["cmd"])
+    result = simple_runner.invoke(group_for_testing, "cmd")
     assert "SUCCESS" in result.output
     assert "this is a test" in result.output
 
@@ -81,7 +81,7 @@ def test_success_level_higher(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.success("this is a test")
 
-    result = simple_runner.invoke(group_for_testing, ["cmd", "-v", "WARNING"])
+    result = simple_runner.invoke(group_for_testing, ("cmd", "-v", "WARNING"))
     assert "SUCCESS" not in result.output
     assert "this is a test" not in result.output
 
@@ -96,5 +96,5 @@ def test_format(simple_runner):
         finally:
             cli_ctx.logger.format()
 
-    result = simple_runner.invoke(group_for_testing, ["cmd", "-v", "SUCCESS"])
+    result = simple_runner.invoke(group_for_testing, ("cmd", "-v", "SUCCESS"))
     assert "SUCCESS" not in result.output

--- a/tests/integration/cli/test_accounts.py
+++ b/tests/integration/cli/test_accounts.py
@@ -72,7 +72,7 @@ def test_import_valid_private_key(ape_cli, runner, temp_account, temp_keyfile_pa
     # Add account from valid private key
     result = runner.invoke(
         ape_cli,
-        ["accounts", "import", ALIAS],
+        ("accounts", "import", ALIAS),
         input="\n".join([f"0x{PRIVATE_KEY}", PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
@@ -87,7 +87,7 @@ def test_import_alias_is_private_key(ape_cli, runner):
     key_alias = f"0x{PRIVATE_KEY}"
     result = runner.invoke(
         ape_cli,
-        ["accounts", "import", key_alias],
+        ("accounts", "import", key_alias),
         input="\n".join([f"0x{PRIVATE_KEY}", PASSWORD, PASSWORD]),
     )
     assert result.exit_code != 0, result.output
@@ -105,7 +105,7 @@ def test_import_alias_is_really_long(ape_cli, runner):
     long_alias = "this is a long alias that i am going to use and you cant stop me"
     result = runner.invoke(
         ape_cli,
-        ["accounts", "import", long_alias],
+        ("accounts", "import", long_alias),
         input="\n".join([f"0x{PRIVATE_KEY}", PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0
@@ -116,7 +116,7 @@ def test_import_invalid_private_key(ape_cli, runner):
     # Add account from invalid private key
     result = runner.invoke(
         ape_cli,
-        ["accounts", "import", ALIAS],
+        ("accounts", "import", ALIAS),
         input="\n".join(["0xhello", PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 1, result.output
@@ -128,7 +128,7 @@ def test_import_alias_already_in_use(ape_cli, runner):
     def invoke_import():
         return runner.invoke(
             ape_cli,
-            ["accounts", "import", ALIAS],
+            ("accounts", "import", ALIAS),
             input="\n".join([f"0x{PRIVATE_KEY}", PASSWORD, PASSWORD]),
         )
 
@@ -144,7 +144,7 @@ def test_import_account_instantiation_failure(mocker, ape_cli, runner):
     eth_account_from_key_patch.side_effect = Exception("Can't instantiate this account!")
     result = runner.invoke(
         ape_cli,
-        ["accounts", "import", ALIAS],
+        ("accounts", "import", ALIAS),
         input="\n".join([f"0x{PRIVATE_KEY}", PASSWORD, PASSWORD]),
     )
     assert_failure(result, "Key can't be imported: Can't instantiate this account!")
@@ -158,7 +158,7 @@ def test_import_mnemonic_default_hdpath(
     # Add account from mnemonic with default hdpath of ETHEREUM_DEFAULT_PATH
     result = runner.invoke(
         ape_cli,
-        ["accounts", "import", "--use-mnemonic", ALIAS],
+        ("accounts", "import", "--use-mnemonic", ALIAS),
         input="\n".join([MNEMONIC, PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
@@ -175,7 +175,7 @@ def test_import_mnemonic_custom_hdpath(
     # Add account from mnemonic with custom hdpath
     result = runner.invoke(
         ape_cli,
-        ["accounts", "import", ALIAS, "--use-mnemonic", "--hd-path", CUSTOM_HDPATH],
+        ("accounts", "import", ALIAS, "--use-mnemonic", "--hd-path", CUSTOM_HDPATH),
         input="\n".join([MNEMONIC, PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
@@ -189,7 +189,7 @@ def test_export(ape_cli, runner, temp_keyfile, keyfile_account, test_accounts):
     # export key
     result = runner.invoke(
         ape_cli,
-        ["accounts", "export", ALIAS],
+        ("accounts", "export", ALIAS),
         input="\n".join([PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
@@ -205,7 +205,7 @@ def test_import_invalid_mnemonic(ape_cli, runner):
     # Add account from invalid mnemonic
     result = runner.invoke(
         ape_cli,
-        ["accounts", "import", "--use-mnemonic", ALIAS],
+        ("accounts", "import", "--use-mnemonic", ALIAS),
         input="\n".join([INVALID_MNEMONIC, PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 1, result.output
@@ -221,7 +221,7 @@ def test_generate_default(ape_cli, runner, temp_keyfile_path):
     show_mnemonic = ""
     result = runner.invoke(
         ape_cli,
-        ["accounts", "generate", ALIAS],
+        ("accounts", "generate", ALIAS),
         input="\n".join(["random entropy", show_mnemonic, PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
@@ -241,7 +241,7 @@ def test_generate_hide_mnemonic_prompt(ape_cli, runner, temp_keyfile_path):
     show_mnemonic = "n"
     result = runner.invoke(
         ape_cli,
-        ["accounts", "generate", ALIAS],
+        ("accounts", "generate", ALIAS),
         input="\n".join(["random entropy", show_mnemonic, PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
@@ -257,7 +257,7 @@ def test_generate_hide_mnemonic_option(ape_cli, runner, temp_keyfile_path):
     # Generate new private key
     result = runner.invoke(
         ape_cli,
-        ["accounts", "generate", ALIAS, "--hide-mnemonic"],
+        ("accounts", "generate", ALIAS, "--hide-mnemonic"),
         input="\n".join(["random entropy", PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
@@ -275,7 +275,7 @@ def test_generate_24_words(ape_cli, runner, temp_keyfile_path):
     word_count = 24
     result = runner.invoke(
         ape_cli,
-        ["accounts", "generate", ALIAS, "--word-count", word_count],
+        ("accounts", "generate", ALIAS, "--word-count", word_count),
         input="\n".join(["random entropy", show_mnemonic, PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
@@ -295,7 +295,7 @@ def test_generate_custom_hdpath(ape_cli, runner, temp_keyfile_path):
     show_mnemonic = ""
     result = runner.invoke(
         ape_cli,
-        ["accounts", "generate", ALIAS, "--hd-path", CUSTOM_HDPATH],
+        ("accounts", "generate", ALIAS, "--hd-path", CUSTOM_HDPATH),
         input="\n".join(["random entropy", show_mnemonic, PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
@@ -316,7 +316,7 @@ def test_generate_24_words_and_custom_hdpath(ape_cli, runner, temp_keyfile_path)
     word_count = 24
     result = runner.invoke(
         ape_cli,
-        ["accounts", "generate", ALIAS, "--word-count", word_count, "--hd-path", CUSTOM_HDPATH],
+        ("accounts", "generate", ALIAS, "--word-count", word_count, "--hd-path", CUSTOM_HDPATH),
         input="\n".join(["random entropy", show_mnemonic, PASSWORD, PASSWORD]),
     )
     assert result.exit_code == 0, result.output
@@ -335,7 +335,7 @@ def test_generate_alias_already_in_use(ape_cli, runner):
         show_mnemonic = ""
         return runner.invoke(
             ape_cli,
-            ["accounts", "generate", ALIAS],
+            ("accounts", "generate", ALIAS),
             input="\n".join(["random entropy", show_mnemonic, PASSWORD, PASSWORD]),
         )
 
@@ -347,14 +347,14 @@ def test_generate_alias_already_in_use(ape_cli, runner):
 
 @run_once
 def test_list(ape_cli, runner, keyfile_account):
-    result = runner.invoke(ape_cli, ["accounts", "list"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, ("accounts", "list"), catch_exceptions=False)
     assert keyfile_account.alias in result.output
     assert keyfile_account.address in result.output
 
 
 @run_once
 def test_list_all(ape_cli, runner, keyfile_account):
-    result = runner.invoke(ape_cli, ["accounts", "list", "--all"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, ("accounts", "list", "--all"), catch_exceptions=False)
     assert keyfile_account.alias in result.output
     assert keyfile_account.address in result.output
 
@@ -366,7 +366,7 @@ def test_change_password(ape_cli, runner, temp_keyfile):
     valid_input = [PASSWORD, "N", "password2", "password2"]
     result = runner.invoke(
         ape_cli,
-        ["accounts", "change-password", ALIAS],
+        ("accounts", "change-password", ALIAS),
         input="\n".join(valid_input) + "\n",
     )
     assert result.exit_code == 0, result.output
@@ -376,6 +376,6 @@ def test_change_password(ape_cli, runner, temp_keyfile):
 def test_delete(ape_cli, runner, temp_keyfile):
     assert temp_keyfile.is_file()
     # Delete Account
-    result = runner.invoke(ape_cli, ["accounts", "delete", ALIAS], input=f"{PASSWORD}\n")
+    result = runner.invoke(ape_cli, ("accounts", "delete", ALIAS), input=f"{PASSWORD}\n")
     assert result.exit_code == 0, result.output
     assert not temp_keyfile.is_file()

--- a/tests/integration/cli/test_cache.py
+++ b/tests/integration/cli/test_cache.py
@@ -6,5 +6,5 @@ def test_cache_init_purge(ape_cli, runner):
     cmd = ("cache", "init", "--network", "ethereum:goerli")
     result = runner.invoke(ape_cli, cmd)
     assert result.output == "SUCCESS: Caching database initialized for ethereum:goerli.\n"
-    result = runner.invoke(ape_cli, ["cache", "purge", "--network", "ethereum:goerli"])
+    result = runner.invoke(ape_cli, ("cache", "purge", "--network", "ethereum:goerli"))
     assert result.output == "SUCCESS: Caching database purged for ethereum:goerli.\n"

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -29,7 +29,7 @@ skip_non_compilable_projects = skip_projects(
     "with-contracts",
 )
 def test_compile_missing_contracts_dir(ape_cli, runner, project):
-    arg_lists = [["compile"], ["compile", "--include-dependencies"]]
+    arg_lists = [("compile",), ("compile", "--include-dependencies")]
     for arg_list in arg_lists:
         result = runner.invoke(ape_cli, arg_list)
         assert result.exit_code == 0, result.output
@@ -39,7 +39,7 @@ def test_compile_missing_contracts_dir(ape_cli, runner, project):
 
 @skip_projects_except("bad-contracts")
 def test_skip_contracts_and_missing_compilers(ape_cli, runner, project, switch_config):
-    result = runner.invoke(ape_cli, ["compile", "--force"])
+    result = runner.invoke(ape_cli, ("compile", "--force"))
     assert "INFO: Compiling 'subdir/tsconfig.json'." not in result.output
     assert "INFO: Compiling 'package.json'." not in result.output
 
@@ -56,13 +56,13 @@ def test_skip_contracts_and_missing_compilers(ape_cli, runner, project, switch_c
         - "*package.json"
     """
     with switch_config(project, content):
-        result = runner.invoke(ape_cli, ["compile", "--force"])
+        result = runner.invoke(ape_cli, ("compile", "--force"))
         assert "INFO: Compiling 'subdir/tsconfig.json'." in result.output
 
 
 @skip_non_compilable_projects
 def test_compile(ape_cli, runner, project, clean_cache):
-    result = runner.invoke(ape_cli, ["compile"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, "compile", catch_exceptions=False)
     assert result.exit_code == 0, result.output
 
     # First time it compiles, it compiles the files with registered compilers successfully.
@@ -106,7 +106,7 @@ def test_compile(ape_cli, runner, project, clean_cache):
     shutil.copytree(project.path / ".build", project.contracts_folder / ".build")
 
     try:
-        result = runner.invoke(ape_cli, ["compile"], catch_exceptions=False)
+        result = runner.invoke(ape_cli, "compile", catch_exceptions=False)
         assert result.exit_code == 0, result.output
         # First time it compiles, it caches
         for file in project.path.glob("contracts/**/*"):
@@ -118,7 +118,7 @@ def test_compile(ape_cli, runner, project, clean_cache):
 
 @skip_projects_except("multiple-interfaces")
 def test_compile_when_sources_change(ape_cli, runner, project, clean_cache):
-    result = runner.invoke(ape_cli, ["compile"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, "compile", catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert "Compiling 'Interface.json'" in result.output
 
@@ -129,12 +129,12 @@ def test_compile_when_sources_change(ape_cli, runner, project, clean_cache):
     source_path.touch()
     source_path.write_text(modified_source_text)
 
-    result = runner.invoke(ape_cli, ["compile"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, "compile", catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert "Compiling 'Interface.json'" in result.output
 
     # Verify that the next time, it does not need to recompile (no changes)
-    result = runner.invoke(ape_cli, ["compile"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, "compile", catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert "Compiling 'Interface.json'" not in result.output
 
@@ -152,7 +152,7 @@ def test_compile_when_contract_type_collision(ape_cli, runner, project, clean_ca
     try:
         source_copy.touch()
         source_copy.write_text(source_path.read_text())
-        result = runner.invoke(ape_cli, ["compile"], catch_exceptions=False)
+        result = runner.invoke(ape_cli, "compile", catch_exceptions=False)
         assert result.exit_code == 1
         actual = result.output
         search_result = re.search(expected, actual)
@@ -179,12 +179,12 @@ def test_compile_when_source_contains_return_characters(ape_cli, runner, project
     source_path.touch()
     source_path.write_text(modified_source_text)
 
-    result = runner.invoke(ape_cli, ["compile"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, "compile", catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert "Compiling 'Interface.json'" in result.output
 
     # Verify that the next time, it does not need to recompile (no changes)
-    result = runner.invoke(ape_cli, ["compile"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, "compile", catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert "Compiling 'Interface.json'" not in result.output
 
@@ -202,17 +202,17 @@ def test_can_access_contracts(project, clean_cache):
     ("Interface", "Interface.json", "contracts/Interface", "contracts/Interface.json"),
 )
 def test_compile_specified_contracts(ape_cli, runner, project, contract_path, clean_cache):
-    result = runner.invoke(ape_cli, ["compile", contract_path], catch_exceptions=False)
+    result = runner.invoke(ape_cli, ("compile", contract_path), catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert "Compiling 'Interface.json'" in result.output
 
     # Already compiled.
-    result = runner.invoke(ape_cli, ["compile", contract_path], catch_exceptions=False)
+    result = runner.invoke(ape_cli, ("compile", contract_path), catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert "Compiling 'Interface.json'" not in result.output
 
     # Force recompile.
-    result = runner.invoke(ape_cli, ["compile", contract_path, "--force"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, ("compile", contract_path, "--force"), catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert "Compiling 'Interface.json'" in result.output
 
@@ -220,7 +220,7 @@ def test_compile_specified_contracts(ape_cli, runner, project, contract_path, cl
 @skip_projects_except("multiple-interfaces")
 def test_compile_unknown_extension_does_not_compile(ape_cli, runner, project, clean_cache):
     result = runner.invoke(
-        ape_cli, ["compile", "Interface.js"], catch_exceptions=False
+        ape_cli, ("compile", "Interface.js"), catch_exceptions=False
     )  # Suffix to existing extension
     assert result.exit_code == 2, result.output
     assert "Error: Contract 'Interface.js' not found." in result.output
@@ -228,7 +228,7 @@ def test_compile_unknown_extension_does_not_compile(ape_cli, runner, project, cl
 
 @skip_projects_except()
 def test_compile_contracts(ape_cli, runner, project):
-    result = runner.invoke(ape_cli, ["compile", "--size"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, ("compile", "--size"), catch_exceptions=False)
     assert result.exit_code == 0, result.output
     # Still caches but displays bytecode size
     for file in project.path.glob("contracts/**/*"):
@@ -263,7 +263,7 @@ def test_compile_with_dependency(ape_cli, runner, project, contract_path):
 
 @skip_projects_except("with-dependencies")
 def test_compile_individual_contract_excludes_other_contract(ape_cli, runner, project):
-    result = runner.invoke(ape_cli, ["compile", "Project", "--force"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, ("compile", "Project", "--force"), catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert "Other" not in result.output
 
@@ -275,7 +275,7 @@ def test_compile_non_ape_project_deletes_ape_config_file(ape_cli, runner, projec
         # Corrupted from a previous test.
         ape_config.unlink()
 
-    result = runner.invoke(ape_cli, ["compile", "Project", "--force"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, ("compile", "Project", "--force"), catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert "ape-config.yaml" not in [f.name for f in (project.path / "default").iterdir()]
 
@@ -287,7 +287,7 @@ def test_compile_only_dependency(ape_cli, runner, project, clean_cache, caplog):
     if dependency_cache.is_dir():
         shutil.rmtree(str(dependency_cache))
 
-    result = runner.invoke(ape_cli, ["compile", "--force"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, ("compile", "--force"), catch_exceptions=False)
     assert result.exit_code == 0, result.output
 
     # Dependencies are not compiled automatically
@@ -315,7 +315,7 @@ def test_compile_only_dependency(ape_cli, runner, project, clean_cache, caplog):
 
     # Force a re-compile and trigger the dependency to compile via CLI
     result = runner.invoke(
-        ape_cli, ["compile", "--force", "--include-dependencies"], catch_exceptions=False
+        ape_cli, ("compile", "--force", "--include-dependencies"), catch_exceptions=False
     )
     assert result.exit_code == 0, result.output
     assert expected_log_message in result.output
@@ -328,7 +328,7 @@ def test_compile_only_dependency(ape_cli, runner, project, clean_cache, caplog):
         config_file.unlink()
         config_file.write_text(text)
         project.config_manager.load(force_reload=True)
-        result = runner.invoke(ape_cli, ["compile", "--force"], catch_exceptions=False)
+        result = runner.invoke(ape_cli, ("compile", "--force"), catch_exceptions=False)
         assert result.exit_code == 0, result.output
         assert expected_log_message in result.output
     finally:
@@ -354,6 +354,6 @@ def test_compile_after_deleting_cache_file(project):
 
 @skip_projects_except("with-contracts")
 def test_compile_exclude(ape_cli, runner):
-    result = runner.invoke(ape_cli, ["compile", "--force"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, ("compile", "--force"), catch_exceptions=False)
     assert "Compiling 'Exclude.json'" not in result.output
     assert "Compiling 'exclude_dir/UnwantedContract.json'" not in result.output

--- a/tests/integration/cli/test_console.py
+++ b/tests/integration/cli/test_console.py
@@ -74,12 +74,12 @@ def clean_console_rc_write(project):
 @skip_projects("geth")
 @pytest.mark.parametrize("item", __all__)
 def test_console(ape_cli, runner, item):
-    result = runner.invoke(ape_cli, ["console"], input=f"{item}\nexit\n", catch_exceptions=False)
+    result = runner.invoke(ape_cli, "console", input=f"{item}\nexit\n", catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert no_console_error(result), result.output
     result = runner.invoke(
         ape_cli,
-        ["console", "-v", "debug"],
+        ("console", "-v", "debug"),
         input=f"{item}\nexit\n",
         catch_exceptions=False,
     )
@@ -94,7 +94,7 @@ def test_console_extras(project, folder, ape_cli, runner):
 
     result = runner.invoke(
         ape_cli,
-        ["console"],
+        "console",
         input="\n".join(["assert A == 1", "exit"]) + "\n",
         catch_exceptions=False,
     )
@@ -103,7 +103,7 @@ def test_console_extras(project, folder, ape_cli, runner):
 
     result = runner.invoke(
         ape_cli,
-        ["console"],
+        "console",
         input="\n".join(["assert a() == 1", "exit"]) + "\n",
         catch_exceptions=False,
     )
@@ -117,7 +117,7 @@ def test_console_init_extras(project, folder, ape_cli, runner):
     write_ape_console_extras(project, folder, EXTRAS_SCRIPT_2)
     result = runner.invoke(
         ape_cli,
-        ["console"],
+        "console",
         input="print('a:', A)\nassert A == 2\nexit\n",
         catch_exceptions=False,
     )
@@ -130,7 +130,7 @@ def test_console_init_extras(project, folder, ape_cli, runner):
 def test_console_init_extras_kwargs(project, folder, ape_cli, runner):
     write_ape_console_extras(project, folder, EXTRAS_SCRIPT_3)
 
-    result = runner.invoke(ape_cli, ["console"], input="exit\n", catch_exceptions=False)
+    result = runner.invoke(ape_cli, "console", input="exit\n", catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert no_console_error(result), result.output
 
@@ -143,7 +143,7 @@ def test_console_init_extras_return(project, folder, ape_cli, runner):
     # Test asserts returned A exists and B is not overwritten
     result = runner.invoke(
         ape_cli,
-        ["console"],
+        "console",
         input="\n".join(
             [
                 "assert A == 1, 'unexpected A'",
@@ -163,7 +163,7 @@ def test_console_init_extras_return(project, folder, ape_cli, runner):
 def test_console_import_local_path(project, ape_cli, runner):
     result = runner.invoke(
         ape_cli,
-        ["console"],
+        "console",
         input="\n".join(["from dependency_in_project_only.importme import import_me", "exit"])
         + "\n",
     )
@@ -177,7 +177,7 @@ def test_console_import_local_path_in_extras_file(project, ape_cli, runner):
 
     result = runner.invoke(
         ape_cli,
-        ["console"],
+        "console",
         input="exit\n",
         catch_exceptions=False,
     )
@@ -189,7 +189,7 @@ def test_console_import_local_path_in_extras_file(project, ape_cli, runner):
 def test_console_ape_magic(ape_cli, runner):
     result = runner.invoke(
         ape_cli,
-        ["console"],
+        ("console",),
         input="%load_ext ape_console.plugin\n%ape--help\nexit\n",
         catch_exceptions=False,
     )
@@ -210,7 +210,7 @@ def test_console_bal_magic(ape_cli, runner, keyfile_account):
     cmd_str = "\n".join(cmd_ls)
     result = runner.invoke(
         ape_cli,
-        ["console"],
+        ("console",),
         input=f"{cmd_str}\n",
         catch_exceptions=False,
     )
@@ -233,7 +233,7 @@ def test_uncaught_txn_err(ape_cli, runner, mocker):
     cmd_str = "\n".join(cmd_ls)
     runner.invoke(
         ape_cli,
-        ["console"],
+        ("console",),
         input=f"{cmd_str}\n",
         catch_exceptions=False,
     )
@@ -243,6 +243,6 @@ def test_uncaught_txn_err(ape_cli, runner, mocker):
 
 def test_console_none_network(ape_cli, runner):
     result = runner.invoke(
-        ape_cli, ["console", "--network", "None"], input="exit\n", catch_exceptions=False
+        ape_cli, ("console", "--network", "None"), input="exit\n", catch_exceptions=False
     )
     assert result.exit_code == 0

--- a/tests/integration/cli/test_misc.py
+++ b/tests/integration/cli/test_misc.py
@@ -8,11 +8,11 @@ from tests.integration.cli.utils import run_once
 @run_once
 @pytest.mark.parametrize(
     "args",
-    (
-        [],
-        ["--version"],
-        ["--config"],
-    ),
+    [
+        (),
+        ("--version",),
+        ("--config",),
+    ],
 )
 def test_invocation(ape_cli, runner, args):
     result = runner.invoke(ape_cli, args)

--- a/tests/integration/cli/test_plugins.py
+++ b/tests/integration/cli/test_plugins.py
@@ -91,7 +91,12 @@ def installed_plugin(ape_plugins_runner):
     plugin_installed = TEST_PLUGIN_NAME in ape_plugins_runner.invoke_list().installed_plugins
     did_install = False
     if not plugin_installed:
-        install_result = ape_plugins_runner.invoke(["install", TEST_PLUGIN_NAME])
+        install_result = ape_plugins_runner.invoke(
+            (
+                "install",
+                TEST_PLUGIN_NAME,
+            )
+        )
         list_result = ape_plugins_runner.invoke_list()
         plugins_list_output = list_result.installed_plugins
         did_install = TEST_PLUGIN_NAME in plugins_list_output
@@ -101,7 +106,7 @@ def installed_plugin(ape_plugins_runner):
     yield
 
     if did_install:
-        ape_plugins_runner.invoke(["uninstall", TEST_PLUGIN_NAME])
+        ape_plugins_runner.invoke(("uninstall", TEST_PLUGIN_NAME))
 
 
 @github_xfail()
@@ -123,7 +128,7 @@ def test_list_include_version(ape_plugins_runner, installed_plugin):
 
 @github_xfail()
 def test_list_does_not_repeat(ape_plugins_runner, installed_plugin):
-    result = ape_plugins_runner.invoke_list(["--all"])
+    result = ape_plugins_runner.invoke_list(("--all",))
     assert "ethereum" in result.core_plugins
     assert "ethereum" not in result.installed_plugins
     assert "ethereum" not in result.available_plugins
@@ -132,21 +137,21 @@ def test_list_does_not_repeat(ape_plugins_runner, installed_plugin):
 @pytest.mark.pip
 @run_once
 def test_upgrade(ape_plugins_runner, installed_plugin):
-    result = ape_plugins_runner.invoke(["install", TEST_PLUGIN_NAME, "--upgrade"])
+    result = ape_plugins_runner.invoke(("install", TEST_PLUGIN_NAME, "--upgrade"))
     assert result.exit_code == 0
 
 
 @pytest.mark.pip
 @run_once
 def test_upgrade_failure(ape_plugins_runner):
-    result = ape_plugins_runner.invoke(["install", "NOT_EXISTS", "--upgrade"])
+    result = ape_plugins_runner.invoke(("install", "NOT_EXISTS", "--upgrade"))
     assert result.exit_code == 1
 
 
 @pytest.mark.pip
 @run_once
 def test_install_multiple_in_one_str(ape_plugins_runner):
-    result = ape_plugins_runner.invoke(["install", f"{TEST_PLUGIN_NAME} {TEST_PLUGIN_NAME_2}"])
+    result = ape_plugins_runner.invoke(("install", f"{TEST_PLUGIN_NAME} {TEST_PLUGIN_NAME_2}"))
     assert result.exit_code == 0
 
 
@@ -155,7 +160,7 @@ def test_install_multiple_in_one_str(ape_plugins_runner):
 def test_install_from_config_file(ape_cli, runner, temp_config):
     plugins_config = {"plugins": [{"name": TEST_PLUGIN_NAME}]}
     with temp_config(plugins_config):
-        result = runner.invoke(ape_cli, ["plugins", "install", "."], catch_exceptions=False)
+        result = runner.invoke(ape_cli, ("plugins", "install", "."), catch_exceptions=False)
         assert result.exit_code == 0, result.output
         assert TEST_PLUGIN_NAME in result.stdout
 
@@ -164,7 +169,7 @@ def test_install_from_config_file(ape_cli, runner, temp_config):
 @run_once
 def test_uninstall(ape_cli, runner, installed_plugin):
     result = runner.invoke(
-        ape_cli, ["plugins", "uninstall", TEST_PLUGIN_NAME, "--yes"], catch_exceptions=False
+        ape_cli, ("plugins", "uninstall", TEST_PLUGIN_NAME, "--yes"), catch_exceptions=False
     )
     assert result.exit_code == 0, result.output
     assert TEST_PLUGIN_NAME in result.output

--- a/tests/integration/cli/test_pm.py
+++ b/tests/integration/cli/test_pm.py
@@ -91,7 +91,7 @@ def test_install_github_dependency_with_ref(ape_cli, runner):
 def test_install_config_override(ape_cli, runner, project):
     config_override = '{"contracts_folder": "src"}'
     dep_path = project.path / "dep"
-    name = "foodep"
+    name = "foodep2"
     result = runner.invoke(
         ape_cli,
         (
@@ -102,10 +102,11 @@ def test_install_config_override(ape_cli, runner, project):
             name,
             "--config-override",
             config_override,
+            "--force",
         ),
     )
     assert (
-        "No source files found in dependency 'foodep'. "
+        f"No source files found in dependency '{name}'. "
         "Try adjusting its config using `config_override`"
     ) in result.output
 

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -7,14 +7,14 @@ BAD_COMMAND = "not-a-name"
 
 @skip_projects_except("script")
 def test_run_unknown_script(ape_cli, runner, project):
-    result = runner.invoke(ape_cli, ["run", BAD_COMMAND])
+    result = runner.invoke(ape_cli, ("run", BAD_COMMAND))
     assert result.exit_code == 2
     assert f"No such command '{BAD_COMMAND}'." in result.output
 
 
 @skip_projects_except("script")
 def test_run(ape_cli, runner, project):
-    result = runner.invoke(ape_cli, ["run"])
+    result = runner.invoke(ape_cli, "run")
     assert result.exit_code == 0, result.output
     # By default, no commands are run
     assert "Super secret script output" not in result.output
@@ -26,7 +26,7 @@ def test_run(ape_cli, runner, project):
         if not s.name.startswith("error") and s.stem not in not_part_of_test
     ]
     for script_file in scripts:
-        result = runner.invoke(ape_cli, ["run", script_file.stem], catch_exceptions=False)
+        result = runner.invoke(ape_cli, ("run", script_file.stem), catch_exceptions=False)
         assert (
             result.exit_code == 0
         ), f"Unexpected exit code for '{script_file.name}'\n{result.output}"
@@ -40,13 +40,13 @@ def test_run(ape_cli, runner, project):
 
 @skip_projects_except("script")
 def test_run_with_verbosity(ape_cli, runner, project):
-    result = runner.invoke(ape_cli, ["run", "click", "--verbosity", "DEBUG"])
+    result = runner.invoke(ape_cli, ("run", "click", "--verbosity", "DEBUG"))
     assert result.exit_code == 0, result.output
 
 
 @skip_projects_except("script")
 def test_run_subdirectories(ape_cli, runner, project):
-    result = runner.invoke(ape_cli, ["run"])
+    result = runner.invoke(ape_cli, "run")
     assert result.exit_code == 0, result.output
     # By default, no commands are run
     assert "Super secret script output" not in result.output
@@ -56,14 +56,14 @@ def test_run_subdirectories(ape_cli, runner, project):
         if not s.name.startswith("error")
     ]
     for each in subdirectory_scripts:
-        result = runner.invoke(ape_cli, ["run", "subdirectory", each.stem])
+        result = runner.invoke(ape_cli, ("run", "subdirectory", each.stem))
         assert result.exit_code == 0
         assert "Super secret script output" in result.output
 
 
 @skip_projects_except("only-script-subdirs")
 def test_run_only_subdirs(ape_cli, runner, project):
-    result = runner.invoke(ape_cli, ["run"])
+    result = runner.invoke(ape_cli, "run")
     assert result.exit_code == 0, result.output
     # By default, no commands are run
     assert "Super secret script output" not in result.output
@@ -73,7 +73,7 @@ def test_run_only_subdirs(ape_cli, runner, project):
         if not s.name.startswith("error")
     ]
     for each in subdirectory_scripts:
-        result = runner.invoke(ape_cli, ["run", "subdirectory", each.stem])
+        result = runner.invoke(ape_cli, ("run", "subdirectory", each.stem))
         assert result.exit_code == 0, f"Unexpected exit code for '{each.name}'"
         assert "Super secret script output" in result.output
 
@@ -86,7 +86,7 @@ def test_run_when_script_errors(ape_cli, runner, project):
         if s.name.startswith("error") and not s.name.endswith("forgot_click.py")
     ]
     for script_file in scripts:
-        result = runner.invoke(ape_cli, ["run", script_file.stem])
+        result = runner.invoke(ape_cli, ("run", script_file.stem))
         assert (
             result.exit_code != 0
         ), f"Unexpected exit code for '{script_file.name}'.\n{result.output}"
@@ -102,7 +102,7 @@ def test_run_interactive(ape_cli, runner, project):
     # Show that the variable namespace from the script is available in the console.
     user_input = "local_variable\nape.chain.provider.mine()\nape.chain.blocks.head\nexit\n"
 
-    result = runner.invoke(ape_cli, ["run", "--interactive", scripts[0].stem], input=user_input)
+    result = runner.invoke(ape_cli, ("run", "--interactive", scripts[0].stem), input=user_input)
     assert result.exit_code == 0, result.output
 
     # From script: local_variable = "test foo bar"
@@ -114,7 +114,7 @@ def test_run_interactive(ape_cli, runner, project):
 def test_run_custom_provider(ape_cli, runner, project):
     result = runner.invoke(
         ape_cli,
-        ["run", "deploy", "--network", "ethereum:mainnet:http://127.0.0.1:9545"],
+        ("run", "deploy", "--network", "ethereum:mainnet:http://127.0.0.1:9545"),
         catch_exceptions=False,
     )
 
@@ -125,7 +125,7 @@ def test_run_custom_provider(ape_cli, runner, project):
 
 @skip_projects_except("script")
 def test_run_custom_network(ape_cli, runner, project):
-    result = runner.invoke(ape_cli, ["run", "deploy", "--network", "http://127.0.0.1:9545"])
+    result = runner.invoke(ape_cli, ("run", "deploy", "--network", "http://127.0.0.1:9545"))
 
     # Show that it attempts to connect
     assert result.exit_code == 1, result.output
@@ -140,13 +140,13 @@ def test_try_run_script_missing_cli_decorator(ape_cli, runner, project):
     a usage error.
     """
 
-    result = runner.invoke(ape_cli, ["run", "error_forgot_click"])
+    result = runner.invoke(ape_cli, ("run", "error_forgot_click"))
     assert "Usage: cli run" in result.output
 
 
 @skip_projects_except("with-contracts")
 def test_uncaught_tx_err(ape_cli, runner, project):
-    result = runner.invoke(ape_cli, ["run", "txerr"])
+    result = runner.invoke(ape_cli, ("run", "txerr"))
     assert '/scripts/txerr.py", line 12, in main' in result.output
     assert "contract.setNumber(5, sender=account)" in result.output
     assert "ERROR: (ContractLogicError) Transaction failed." in result.output
@@ -165,7 +165,7 @@ def test_scripts_module_already_installed(ape_cli, runner, project, mocker):
     mock_scripts.__path__ = mock_path
     sys.modules["scripts"] = mock_scripts
 
-    result = runner.invoke(ape_cli, ["run"])
+    result = runner.invoke(ape_cli, ("run",))
     assert result.exit_code == 0, result.output
 
     del sys.modules["scripts"]
@@ -178,7 +178,7 @@ def test_run_recompiles_if_needed(ape_cli, runner, project):
     when we run a script, it re-compiles the script first.
     """
     # Ensure we begin compiled.
-    runner.invoke(ape_cli, ["compile", "--force"])
+    runner.invoke(ape_cli, ("compile", "--force"))
 
     # Make a change to the contract
     contract = project.contracts_folder / "VyperContract.json"


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

feat: adds new `config_override_option` and `JSON` CLI param type
fix: when decoding a dependency, checks config override for contracts folder instead of using default
(only a problem when contracts/ exists but changing it to something else anyway)
chore: move `@ape_cli_conext` to top of every cli impl usage list of decors, as a better standard for its placement.
feat: allow package callback in `ape pm` command to work if given a Path (only happens during testing)
test(refactor): for all usage of `runner.invoke` use either `str` or `tuple` if possible for arguments. `str` works for single commands and `tuple` works if you are not building up commands... less chance of mutability accidents and is just better practice.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
