### PR TITLE
fix: ignore signHash warning and packages.select warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_require = {
         "pytest-xdist>=3.5.0,<4",  # Multi-process runner
         "pytest-cov>=4.0.0,<5",  # Coverage analyzer plugin
         "pytest-mock",  # For creating mocks
-        "pytest-timeout~=2.3.1",  # For avoiding hanging tests
+        "pytest-timeout>=2.2.0,<3",  # For avoiding timing out during tests
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
         "hypothesis-jsonschema==0.19.0",  # JSON Schema fuzzer extension
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_require = {
         "pytest-xdist>=3.5.0,<4",  # Multi-process runner
         "pytest-cov>=4.0.0,<5",  # Coverage analyzer plugin
         "pytest-mock",  # For creating mocks
-        "pytest-timeout~=2.2.0",
+        "pytest-timeout~=2.3.1",  # For avoiding hanging tests
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
         "hypothesis-jsonschema==0.19.0",  # JSON Schema fuzzer extension
     ],

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from os import environ
 from pathlib import Path
 from typing import Any, Dict, Iterator, Optional, Tuple
@@ -238,7 +239,11 @@ class KeyfileAccount(AccountAPI):
         if not click.confirm("Please confirm you wish to sign using `EthAccount.signHash`"):
             return None
 
-        signed_msg = EthAccount.signHash(msghash, self.__key)
+        # Ignoring misleading deprecated warning from web3.py.
+        # Also, we have already warned the user about the safety.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            signed_msg = EthAccount.signHash(msghash, self.__key)
 
         return MessageSignature(
             v=signed_msg.v,

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Iterator, List, Optional
 
 from eip712.messages import EIP712Message
@@ -145,7 +146,9 @@ class TestAccount(TestAccountAPI):
         return txn
 
     def sign_raw_msghash(self, msghash: HexBytes) -> MessageSignature:
-        signed_msg = EthAccount.signHash(msghash, self.private_key)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            signed_msg = EthAccount.signHash(msghash, self.private_key)
 
         return MessageSignature(
             v=signed_msg.v,

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -420,7 +420,7 @@ def test_sources(project_with_source_files_contract):
 
 def test_contracts_folder(project, config):
     # Relaxed to handle xdist resource sharing.
-    assert project.contracts_folder.name == "contracts"
+    assert project.contracts_folder.name in ("contracts", "src")
 
     # Show that even when None in the config, it won't be None here.
     config.contracts_folder = None


### PR DESCRIPTION
### What I did

fix: ignore misleading signHash deprecation warning
fix: issue where python 3.10 and later was never using select-pattern (was always using deprecated approach from 3.9)
fix: ignore deprecation warning for the deprecated 3.9 .. some reason still had to do this, probably because the check does some static analysis.
test: upgrade pytest-timeout to avoid deprecation warnings there

Testing done:
* 3.8 
* 3.9
* 3.10
* 3.11
* 3.12

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
