### PR TITLE
fix: bug where `project.lookup_source` didn't return most exact match

### DIFF
--- a/src/ape/cli/paramtype.py
+++ b/src/ape/cli/paramtype.py
@@ -32,6 +32,12 @@ class AllFilePaths(Path):
     ) -> List[PathLibPath]:
         path = super().convert(value, param, ctx)
         assert isinstance(path, PathLibPath)  # For mypy
+
+        if not path.is_file() and path.is_absolute():
+            # Don't do absolute non-existent paths.
+            # Let it resolve elsewhere.
+            path = PathLibPath(value)
+
         return get_all_files_in_directory(path) if path.is_dir() else [path]
 
 

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -680,27 +680,57 @@ class ProjectManager(BaseManager):
             pathlib.Path: The path if it exists, else ``None``.
         """
 
-        path = Path(key_contract_path)
-        ext = get_full_extension(path) or None
+        input_path = Path(key_contract_path)
+        if input_path.is_file():
+            # Already given an existing file.
+            return input_path
 
-        def find_in_dir(dir_path: Path) -> Optional[Path]:
-            if not dir_path.is_dir():
-                return None
+        input_stem = input_path.stem
+        input_extension = get_full_extension(input_path) or None
 
-            for file_path in dir_path.iterdir():
-                if file_path.is_dir() and (result := find_in_dir(file_path)):
-                    return result
+        def find_in_dir(dir_path: Path, path_id: Path) -> Optional[Path]:
+            # Try exact match with or without extension
+            possible_matches = []
 
-                # If the user provided an extension, it has to match.
-                ext_okay = ext == get_full_extension(file_path) if ext is not None else True
+            if path_id.is_absolute():
+                full_path = path_id
+            else:
+                # Check if a file with an exact match exists.
+                full_path = dir_path / path_id
 
-                # File found
-                if file_path.stem == path.stem and ext_okay:
-                    return file_path
+            if full_path.is_file():
+                return full_path
+
+            # Check for exact match with no given extension.
+            if input_extension is None:
+                if full_path.parent.is_dir():
+                    for file in full_path.parent.iterdir():
+                        if not file.is_file():
+                            continue
+                        elif not (file_ext := get_full_extension(file)):
+                            continue
+
+                        # Check exact match w/o extension.
+                        prefix = file_ext.join(str(file).split(file_ext)[:-1])
+                        if str(full_path) == prefix:
+                            return file
+
+                # Look for stem-only matches (last resort).
+                for file_path in dir_path.rglob("*"):
+                    if file_path.stem == input_stem:
+                        possible_matches.append(file_path)
+
+            # If we have possible matches, return the one with the closest relative path
+            if possible_matches:
+                # Prioritize the exact relative path or first match in the list
+                possible_matches.sort(key=lambda p: len(str(p.relative_to(dir_path))))
+                return possible_matches[0]
 
             return None
 
-        return find_in_dir(self.contracts_folder)
+        # Derive the relative path from the given key_contract_path.
+        relative_path = input_path.relative_to(input_path.anchor)
+        return find_in_dir(self.contracts_folder, relative_path)
 
     def load_contracts(
         self, file_paths: Optional[Union[Iterable[Path], Path]] = None, use_cache: bool = True

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -143,6 +143,12 @@ def test_compile_when_sources_change(ape_cli, runner, project, clean_cache):
 def test_compile_when_contract_type_collision(ape_cli, runner, project, clean_cache):
     source_path = project.contracts_folder / "Interface.json"
     temp_dir = project.contracts_folder / "temp"
+
+    def clean():
+        if temp_dir.is_dir():
+            shutil.rmtree(temp_dir)
+
+    clean()
     source_copy = temp_dir / "Interface.json"
     expected = (
         r"ERROR: \(CompilerError\) ContractType collision between sources '"
@@ -161,8 +167,7 @@ def test_compile_when_contract_type_collision(ape_cli, runner, project, clean_ca
         assert {groups[0], groups[1]} == {"Interface.json", "temp/Interface.json"}
 
     finally:
-        if temp_dir.is_dir():
-            shutil.rmtree(temp_dir)
+        clean()
 
 
 @skip_projects_except("multiple-interfaces")


### PR DESCRIPTION
### What I did

When you have a file a structure like:

```
contracts/
  - foo.jules
  - helpers/
       - foo.jules
```

`project.lookup_source("helpers/foo")` and `project.lookup_source("helpers/foo.jules")` would return the Path to `contracts/foo.jules` instead of the expected `contracts/helpers/foo.jules`

### How to verify it

Test cases I added:

```
# For root foo.jules file
Path("path/to/contracts/foo.jules")
"path/to/contracts/foo.jules"
"foo.jules"
"foo"

# For sub foo.jules file
Path("path/to/contracts/helpers/foo.jules")
"path/to/contracts/helpers/foo.jules"
"helpers/foo.jules"
"helpers/foo"

# For super sub foo.jules file
Path("path/to/contracts/helpers/foo.jules")
"path/to/contracts/helpers/foo.jules"
"helpers/abstract/foo.jules"
"helpers/abstract/foo"
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
