### PR TITLE
chore: update dockerfile to python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # See LICENSE in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
-ARG PYTHON_VERSION="3.10"
+ARG PYTHON_VERSION="3.11"
 ARG PLUGINS_FILE="./recommended-plugins.txt"
 
 FROM python:${PYTHON_VERSION} as builder


### PR DESCRIPTION
### What I did

Updates the `Dockerfile` python version to 3.11 because features.

Any reason not to do this?  Will this roll the docker hub versions automagically?

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
