### PR TITLE
refactor: move missing compiler check to contract-filepaths callback

### DIFF
--- a/docs/userguides/clis.md
+++ b/docs/userguides/clis.md
@@ -217,3 +217,29 @@ def cli_1(alias):
 my_accounts = [accounts.load("me"), accounts.load("me2")]
 selected_account = get_user_selected_account(account_type=my_accounts)
 ```
+
+# Contract File Paths
+
+Does your CLI interact with contract source files?
+(Think `ape compile`).
+
+If so, use the `@contract_file_paths_argument()` decorator in your CLI.
+
+```python
+from pathlib import Path
+import click
+
+from ape.cli import contract_file_paths_argument
+
+@click.command()
+@contract_file_paths_argument()
+def cli(file_paths: set[Path]):
+   # Loop through all source files given (or all source files in the project).
+    for path in file_paths:
+        click.echo(f"Source found: {path}")
+```
+
+When using the `@contract_file_paths_argument()` decorator, you can pass any number of source files as arguments.
+When not passing any source file(s), `@contract_file_paths_argument()` defaults to all sources in the local project.
+That is why `ape compile` compiles the full project and `ape compile MySource.vy` only compiles `MySource.vy` (and whatever else it needs / imports).
+Use `@contract_file_paths_argument()` for any similar use-case involving contract source files.

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -340,18 +340,21 @@ class DependencyAPI(ExtraAttributesMixin, BaseInterfaceModel):
     The version of the dependency. Omit to use the latest.
     """
 
+    # TODO: Remove in 0.8.
     contracts_folder: str = "contracts"
     """
     The name of the dependency's ``contracts/`` directory.
     This is where ``ape`` will look for source files when compiling
     the manifest for this dependency.
 
-    **NOTE**: This must be the name of a directory in the project.
+    **Deprecated**: Use ``config_override:contracts_folder``.
     """
 
+    # TODO: Remove in 0.8.
     exclude: List[str] = ["package.json", "package-lock.json", "**/.build/**/*.json"]
     """
     A list of glob-patterns for excluding files in dependency projects.
+    **Deprecated**: Use ``config_override:compile:exclude``.
     """
 
     config_override: Dict = {}
@@ -535,13 +538,16 @@ class DependencyAPI(ExtraAttributesMixin, BaseInterfaceModel):
         elif project_path.parent.is_dir():
             project_path = project_path.parent
 
+        # TODO: In 0.8, delete self.contracts_folder and rely on cfg override.
+        contracts_folder = self.config_override.get("contracts_folder", self.contracts_folder)
+
         # NOTE: Dependencies are not compiled here. Instead, the sources are packaged
         # for later usage via imports. For legacy reasons, many dependency-esque projects
         # are not meant to compile on their own.
 
         with self.config_manager.using_project(
             project_path,
-            contracts_folder=(project_path / self.contracts_folder).expanduser().resolve(),
+            contracts_folder=(project_path / contracts_folder).expanduser().resolve(),
         ) as pm:
             project = pm.local_project
             if sources := self._get_sources(project):
@@ -578,8 +584,14 @@ class DependencyAPI(ExtraAttributesMixin, BaseInterfaceModel):
         pattern = rf".*({extension_pattern})"
         all_sources = get_all_files_in_directory(project.contracts_folder, pattern=pattern)
 
+        # TODO: In 0.8, delete self.exclude and only use config override.
+        exclude = [
+            *(self.exclude or []),
+            *(self.config_override.get("compile", {}).get("exclude", []) or []),
+        ]
+
         excluded_files = set()
-        for pattern in set(self.exclude):
+        for pattern in set(exclude):
             excluded_files.update({f for f in project.contracts_folder.glob(pattern)})
 
         return [s for s in all_sources if s not in excluded_files]

--- a/src/ape/cli/paramtype.py
+++ b/src/ape/cli/paramtype.py
@@ -21,6 +21,8 @@ class Path(click.Path):
         super().__init__(*args, **kwargs)
 
 
+# TODO: Delete for 0.8 (list of lists is weird and we
+#  are no longer using this).
 class AllFilePaths(Path):
     """
     Either all the file paths in the given directory,

--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -683,7 +683,7 @@ class ProjectManager(BaseManager):
         input_path = Path(key_contract_path)
         if input_path.is_file():
             # Already given an existing file.
-            return input_path
+            return input_path.absolute()
 
         input_stem = input_path.stem
         input_extension = get_full_extension(input_path) or None

--- a/src/ape_compile/__init__.py
+++ b/src/ape_compile/__init__.py
@@ -7,6 +7,18 @@ from ape import plugins
 from ape.api import PluginConfig
 
 DEFAULT_CACHE_FOLDER_NAME = ".cache"  # default relative to contracts/
+EXCLUDE_PATTERNS = [
+    "*package.json",
+    "*package-lock.json",
+    "*tsconfig.json",
+    "*.md",
+    "*.rst",
+    "*.txt",
+    "*.py[a-zA-Z]?",
+    "*.html",
+    "*.css",
+    "*.adoc",
+]
 
 
 class Config(PluginConfig):
@@ -21,7 +33,7 @@ class Config(PluginConfig):
     should configure ``include_dependencies`` to be ``True``.
     """
 
-    exclude: List[str] = ["*package.json", "*package-lock.json", "*tsconfig.json"]
+    exclude: List[str] = []
     """
     Source exclusion globs across all file types.
     """
@@ -41,7 +53,7 @@ class Config(PluginConfig):
         assert self.cache_folder is not None
 
         # If the dependency cache folder is configured, to be outside of the contracts dir, we want
-        # to use the projects folder to be the base dir for copmilation.
+        # to use the projects folder to be the base dir for compilation.
         if self._config_manager.contracts_folder not in self.cache_folder.parents:
             return self._config_manager.PROJECT_FOLDER
 
@@ -79,7 +91,8 @@ class Config(PluginConfig):
     @field_validator("exclude", mode="before")
     @classmethod
     def validate_exclude(cls, value):
-        return value or []
+        excl = [*(value or []), *EXCLUDE_PATTERNS]
+        return list(set(excl))
 
 
 @plugins.register(plugins.Config)

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -5,7 +5,6 @@ import click
 from ethpm_types import ContractType
 
 from ape.cli import ape_cli_context, contract_file_paths_argument
-from ape.utils.os import get_full_extension
 
 
 def _include_dependencies_callback(ctx, param, value):
@@ -51,34 +50,6 @@ def cli(cli_ctx, file_paths: Set[Path], use_cache: bool, display_size: bool, inc
     if not file_paths and sources_missing and len(cli_ctx.project_manager.dependencies) == 0:
         cli_ctx.logger.warning("Nothing to compile.")
         return
-
-    ext_given = [get_full_extension(p) for p in file_paths if p]
-
-    # Filter out common files that we know are not files you can compile anyway,
-    # like documentation files. NOTE: Nothing prevents a CompilerAPI from using these
-    # extensions, we just don't warn about missing compilers here. The warning is really
-    # meant to help guide users when the vyper, solidity, or cairo plugins are not installed.
-    general_extensions = {".md", ".rst", ".txt", ".py", ".html", ".css", ".adoc"}
-
-    ext_with_missing_compilers = {
-        x
-        for x in cli_ctx.project_manager.extensions_with_missing_compilers(ext_given)
-        if x not in general_extensions
-    }
-    if ext_with_missing_compilers:
-        if len(ext_with_missing_compilers) > 1:
-            # NOTE: `sorted` to increase reproducibility.
-            extensions_str = ", ".join(sorted(ext_with_missing_compilers))
-            message = f"Missing compilers for the following file types: '{extensions_str}'."
-        else:
-            message = f"Missing a compiler for {ext_with_missing_compilers.pop()} file types."
-
-        message = (
-            f"{message} "
-            f"Possibly, a compiler plugin is not installed "
-            f"or is installed but not loading correctly."
-        )
-        cli_ctx.logger.warning(message)
 
     contract_types = cli_ctx.project_manager.load_contracts(
         file_paths=file_paths, use_cache=use_cache

--- a/tests/functional/data/projects/ApeProject/contracts/subdir/ApeContractNested.json
+++ b/tests/functional/data/projects/ApeProject/contracts/subdir/ApeContractNested.json
@@ -1,0 +1,3 @@
+[
+    {"name":"ApeContract","type":"fallback", "stateMutability":"nonpayable"}
+]

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -462,6 +462,19 @@ def test_lookup_path_closest_match(project_with_source_files_contract):
         clean()
 
 
+def test_lookup_path_includes_contracts_prefix(project_with_source_files_contract):
+    """
+    Show we can include the `contracts/` prefix.
+    """
+    project = project_with_source_files_contract
+    actual_from_str = project.lookup_path("contracts/ContractA.sol")
+    actual_from_path = project.lookup_path(Path("contracts/ContractA.sol"))
+    expected = project.contracts_folder / "ContractA.sol"
+    assert actual_from_str == actual_from_path == expected
+    assert actual_from_str.is_absolute()
+    assert actual_from_path.is_absolute()
+
+
 def test_sources(project_with_source_files_contract):
     project = project_with_source_files_contract
     assert "ApeContract0.json" in project.sources


### PR DESCRIPTION
### What I did

**main**

refactor: move missing compiler check from `ape_compile._cli:cli` to `ape.cli.arguments.contracts_file_paths(callback)`... 
    so any usage of the argument gets the benefit.

**side quests**

feat: better error message for missing `.vy` and/or `.sol` compilers!
fix: bug with `project.lookup_source` not returning absolute paths for some cases
test: add a bunch of missing tests for `contract_file_paths_argument`

**deprecates** (will remove entirely on a new branch targeting feat/08):

chore: deprecate AllFilePaths click.ParamType (it is bad because it returns lists of lists and that is just uncalled for - no longer used in `contracts_file_paths_argument`
chore: deprecate dependencyApi.exclude and .contracts_folder (use `config_override` for all config-override`)

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [ ] Documentation has been updated
