### PR TITLE
fix: `ape plugins update` command type error

### DIFF
--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -15,6 +15,7 @@ from ape.plugins._utils import (
     PluginMetadata,
     PluginMetadataList,
     PluginType,
+    _filter_plugins_from_dists,
     ape_version,
 )
 from ape.utils import load_config
@@ -254,6 +255,9 @@ def _install(name, spec) -> int:
         message = f"Failed to install/update {name}"
         if completed_process.stdout:
             message += f": {completed_process.stdout}"
+        if completed_process.stderr:
+            message += f": {completed_process.stderr}"
+
         logger.error(message)
         sys.exit(completed_process.returncode)
     else:
@@ -267,7 +271,7 @@ def _change_version(spec: str):
     # This will also update core Ape.
     # NOTE: It is possible plugins may depend on each other and may update in
     #   an order causing some error codes to pop-up, so we ignore those for now.
-    for plugin in _get_distributions():
+    for plugin in _filter_plugins_from_dists(_get_distributions()):
         logger.info(f"Updating {plugin} ...")
         name = plugin.split("=")[0].strip()
         _install(name, spec)

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -229,13 +229,14 @@ def change_version(version):
     _change_version(version)
 
 
-def _install(name, spec) -> int:
+def _install(name, spec, exit_on_fail: bool = True) -> int:
     """
     Helper function to install or update a Python package using pip.
 
     Args:
       name (str): The package name.
       spec (str): Version specifier, e.g., '==1.0.0', '>=1.0.0', etc.
+      exit_on_fail (bool): Set to ``False`` to not exit on fail.
 
     Returns:
         The process return-code.
@@ -259,7 +260,8 @@ def _install(name, spec) -> int:
             message += f": {completed_process.stderr}"
 
         logger.error(message)
-        sys.exit(completed_process.returncode)
+        if exit_on_fail:
+            sys.exit(completed_process.returncode)
     else:
         logger.info(f"Successfully installed/updated {name}")
 
@@ -271,13 +273,22 @@ def _change_version(spec: str):
     # This will also update core Ape.
     # NOTE: It is possible plugins may depend on each other and may update in
     #   an order causing some error codes to pop-up, so we ignore those for now.
+    plugin_retcode = 0
     for plugin in _filter_plugins_from_dists(_get_distributions()):
         logger.info(f"Updating {plugin} ...")
         name = plugin.split("=")[0].strip()
-        _install(name, spec)
+        retcode = _install(name, spec, exit_on_fail=False)
+        if retcode != 0:
+            plugin_retcode = retcode
+        # else: errors logged in _install separately
 
     # This check is for verifying the update and shouldn't actually do anything.
     logger.info("Updating Ape core ...")
-    returncode = _install("eth-ape", spec)
-    if returncode == 0:
-        logger.success("Ape and all plugins have successfully upgraded.")
+    ape_retcode = _install("eth-ape", spec)
+    if ape_retcode == 0 and plugin_retcode == 0:
+        prefix = "Ape"
+        if plugin_retcode == 0:
+            prefix = f"{prefix} and plugins"
+
+        logger.success(f"{prefix} have successfully upgraded.")
+    # else: _install logs errors already.

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -292,3 +292,5 @@ def _change_version(spec: str):
 
         logger.success(f"{prefix} have successfully upgraded.")
     # else: _install logs errors already.
+
+    sys.exit(ape_retcode | plugin_retcode)

--- a/tests/integration/cli/test_plugins.py
+++ b/tests/integration/cli/test_plugins.py
@@ -136,14 +136,14 @@ def test_list_does_not_repeat(ape_plugins_runner, installed_plugin):
 
 @pytest.mark.pip
 @run_once
-def test_upgrade(ape_plugins_runner, installed_plugin):
+def test_install_upgrade(ape_plugins_runner, installed_plugin):
     result = ape_plugins_runner.invoke(("install", TEST_PLUGIN_NAME, "--upgrade"))
     assert result.exit_code == 0
 
 
 @pytest.mark.pip
 @run_once
-def test_upgrade_failure(ape_plugins_runner):
+def test_install_upgrade_failure(ape_plugins_runner):
     result = ape_plugins_runner.invoke(("install", "NOT_EXISTS", "--upgrade"))
     assert result.exit_code == 1
 


### PR DESCRIPTION
### What I did

fixes a bug introduced here: https://github.com/ApeWorX/ape/commit/5eeec421af32ed5a34e65e731f4401bdbc370205#diff-0b86928e81aa95cc356070c25d73b92777562a9465597bf82b802e00736a1f96

where `ape plugins update` (for upgrading full ape suite) was failing because it was looking through dists instead of plugin names.

### How I did it

use `_filter_plugins_from_dists`

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
