### PR TITLE
fix: show file name instead of attr in missing source error message

### DIFF
--- a/src/ape/managers/project/manager.py
+++ b/src/ape/managers/project/manager.py
@@ -584,7 +584,7 @@ class ProjectManager(BaseManager):
                 continue
 
             message = (
-                f"{message} However, there is a source file named '{attr_name}', "
+                f"{message} However, there is a source file named '{file.name}', "
                 "did you mean to reference a contract name from this source file?"
             )
             file_check_appended = True

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -29,7 +29,7 @@ def test_missing_compilers_error_message(project_with_source_files_contract, sen
     missing_exts = project_with_source_files_contract.extensions_with_missing_compilers()
     expected = (
         r"ProjectManager has no attribute or contract named 'ContractA'\. "
-        r"However, there is a source file named 'ContractA', "
+        r"However, there is a source file named 'ContractA.sol', "
         r"did you mean to reference a contract name from this source file\? "
         r"Else, could it be from one of the missing compilers for extensions: "
         rf'{", ".join(sorted(missing_exts))}\?'

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -495,7 +495,7 @@ def test_getattr_contract_not_exists(project):
     expected = (
         r"ProjectManager has no attribute or contract named "
         r"'ThisIsNotAContractThatExists'. However, there is a source "
-        r"file named 'ThisIsNotAContractThatExists', did you mean to "
+        r"file named 'ThisIsNotAContractThatExists\.foo', did you mean to "
         r"reference a contract name from this source file\? "
         r"Else, could it be from one of the missing compilers for extensions:.*\?"
     )


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
