### PR TITLE
fix: issue when contracts w/o source IDs would not enrich

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -617,6 +617,20 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
         contract_type: ContractType,
         **kwargs,
     ) -> Optional[CustomError]:
+        """
+        Decode a custom error class from an ABI defined in a contract.
+
+        Args:
+            data (HexBytes): The error data contining the selector
+              and input data.
+            contract_type (ContractType): The contract type with the
+              error ABI definition(s).
+            **kwargs: Additional init kwargs for the custom error class.
+
+        Returns:
+            Optional[CustomError]: If it able to decode one, else ``None``.
+        """
+
         selector = data[:4]
         input_data = data[4:]
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -633,7 +633,7 @@ class ProviderAPI(BaseInterfaceModel):
 
     @raises_not_implemented
     def get_transaction_trace(  # type: ignore[empty-body]
-        self, txn_hash: str
+        self, txn_hash: Union[HexBytes, str]
     ) -> Iterator[TraceFrame]:
         """
         Provide a detailed description of opcodes.

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -7,10 +7,10 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, U
 
 import click
 import pandas as pd
+from eth_pydantic_types import HexBytes
 from eth_utils import to_hex
 from ethpm_types.abi import ConstructorABI, ErrorABI, EventABI, MethodABI
 from ethpm_types.contract_type import ABI_W_SELECTOR_T, ContractType
-from hexbytes import HexBytes
 
 from ape.api import AccountAPI, Address, ReceiptAPI, TransactionAPI
 from ape.api.address import BaseAddress

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -7,9 +7,10 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, U
 
 import click
 import pandas as pd
-from eth_pydantic_types import HexBytes
+from eth_utils import to_hex
 from ethpm_types.abi import ConstructorABI, ErrorABI, EventABI, MethodABI
 from ethpm_types.contract_type import ABI_W_SELECTOR_T, ContractType
+from hexbytes import HexBytes
 
 from ape.api import AccountAPI, Address, ReceiptAPI, TransactionAPI
 from ape.api.address import BaseAddress
@@ -836,12 +837,14 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
         self,
         address: AddressType,
         contract_type: ContractType,
-        txn_hash: Optional[str] = None,
+        txn_hash: Optional[Union[str, HexBytes]] = None,
     ) -> None:
         super().__init__()
         self._address = address
         self.contract_type = contract_type
-        self.txn_hash = txn_hash
+        self.txn_hash = (
+            (txn_hash if isinstance(txn_hash, str) else to_hex(txn_hash)) if txn_hash else None
+        )
         self._cached_receipt: Optional[ReceiptAPI] = None
 
     def __call__(self, *args, **kwargs) -> ReceiptAPI:
@@ -1319,7 +1322,9 @@ class ContractContainer(ContractTypeWrapper, ExtraAttributesMixin):
 
         return self.chain_manager.contracts.get_deployments(self)
 
-    def at(self, address: AddressType, txn_hash: Optional[str] = None) -> ContractInstance:
+    def at(
+        self, address: AddressType, txn_hash: Optional[Union[str, HexBytes]] = None
+    ) -> ContractInstance:
         """
         Get a contract at the given address.
 
@@ -1334,8 +1339,8 @@ class ContractContainer(ContractTypeWrapper, ExtraAttributesMixin):
               **NOTE**: Things will not work as expected if the contract is not actually
               deployed to this address or if the contract at the given address has
               a different ABI than :attr:`~ape.contracts.ContractContainer.contract_type`.
-            txn_hash (str): The hash of the transaction that deployed the contract, if
-              available. Defaults to ``None``.
+            txn_hash (Union[str, HexBytes]): The hash of the transaction that deployed the
+              contract, if available. Defaults to ``None``.
 
         Returns:
             :class:`~ape.contracts.ContractInstance`

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -771,6 +771,11 @@ class CustomError(ContractLogicError):
         """
         return self.abi.name
 
+    def __repr__(self) -> str:
+        name = self.__class__.__name__  # Custom error name
+        calldata = ", ".join(sorted([f"{k}={v}" for k, v in self.inputs.items()])) or ""
+        return f"{name}({calldata})"
+
 
 def _get_ape_traceback_from_tx(txn: FailedTxn) -> Optional["SourceTraceback"]:
     from ape.api.transactions import ReceiptAPI

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import time
 import traceback
+from functools import cached_property
 from inspect import getframeinfo, stack
 from pathlib import Path
 from types import CodeType, TracebackType
@@ -208,6 +209,20 @@ class TransactionError(ApeException):
             or getattr(self.txn, "receiver", None)
             or getattr(self.txn, "contract_address", None)
         )
+
+    @cached_property
+    def contract_type(self) -> Optional[ContractType]:
+        if not (address := self.address):
+            # Contract address not found.
+            return None
+
+        # Lazy import because of exceptions.py root nature.
+        from ape.utils.basemodel import ManagerAccessMixin
+
+        try:
+            return ManagerAccessMixin.chain_manager.contracts.get(address)
+        except (RecursionError, ProviderNotConnectedError):
+            return None
 
     def _set_tb(self):
         if not self.source_traceback and self.txn:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -7,6 +7,7 @@ from typing import IO, Collection, Dict, Iterator, List, Optional, Set, Type, Un
 
 import pandas as pd
 from ethpm_types import ABI, ContractType
+from hexbytes import HexBytes
 from rich import get_console
 from rich.console import Console as RichConsole
 
@@ -1074,7 +1075,7 @@ class ContractCache(BaseManager):
         self,
         address: Union[str, AddressType],
         contract_type: Optional[ContractType] = None,
-        txn_hash: Optional[str] = None,
+        txn_hash: Optional[Union[str, HexBytes]] = None,
         abi: Optional[Union[List[ABI], Dict, str, Path]] = None,
     ) -> ContractInstance:
         """
@@ -1093,8 +1094,8 @@ class ContractCache(BaseManager):
               plugin, you can also provide an ENS domain name.
             contract_type (Optional[``ContractType``]): Optionally provide the contract type
               in case it is not already known.
-            txn_hash (Optional[str]): The hash of the transaction responsible for deploying the
-              contract, if known. Useful for publishing. Defaults to ``None``.
+            txn_hash (Optional[Union[str, HexBytes]]): The hash of the transaction responsible for
+              deploying the contract, if known. Useful for publishing. Defaults to ``None``.
             abi (Optional[Union[List[ABI], Dict, str, Path]]): Use an ABI str, dict, path,
               or ethpm models to create a contract instance class.
 

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import IO, Collection, Dict, Iterator, List, Optional, Set, Type, Union, cast
 
 import pandas as pd
+from eth_pydantic_types import HexBytes
 from ethpm_types import ABI, ContractType
-from hexbytes import HexBytes
 from rich import get_console
 from rich.console import Console as RichConsole
 

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -323,10 +323,8 @@ class CompilerManager(BaseManager, ExtraAttributesMixin):
             :class:`~ape.exceptions.ContractLogicError`: The enriched exception.
         """
         # First, try enriching using their ABI.
-        if custom_err := self.get_custom_error(err):
-            return custom_err
-
-        elif not (contract_type := err.contract_type):
+        err = self.get_custom_error(err) or err
+        if not (contract_type := err.contract_type):
             return err
 
         # Delegate to compiler APIs.
@@ -340,7 +338,7 @@ class CompilerManager(BaseManager, ExtraAttributesMixin):
             compiler = self.registered_compilers[ext]
             return compiler.enrich_error(err)
 
-        # No enrichment.
+        # No further enrichment.
         return err
 
     def get_custom_error(self, err: ContractLogicError) -> Optional[CustomError]:

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -358,7 +358,7 @@ class CompilerManager(BaseManager, ExtraAttributesMixin):
         message = err.revert_message
         if not message.startswith("0x"):
             return None
-        elif not (contract_type := err.contract_type):
+        elif not (address := err.address):
             return None
 
         if provider := self.network_manager.active_provider:
@@ -369,9 +369,8 @@ class CompilerManager(BaseManager, ExtraAttributesMixin):
 
         return ecosystem.decode_custom_error(
             HexBytes(message),
-            contract_type,
+            address,
             base_err=err.base_err,
-            contract_address=err.address,
             source_traceback=err.source_traceback,
             trace=err.trace,
             txn=err.txn,

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -360,8 +360,6 @@ class CompilerManager(BaseManager, ExtraAttributesMixin):
             return None
         elif not (contract_type := err.contract_type):
             return None
-        elif not (address := err.address):
-            return None
 
         bytes_message = HexBytes(message)
         selector = bytes_message[:4]
@@ -375,8 +373,7 @@ class CompilerManager(BaseManager, ExtraAttributesMixin):
         abi = contract_type.errors[selector]
         inputs = ecosystem.decode_calldata(abi, input_data)
         container = self.chain_manager.contracts.get_container(contract_type)
-        contract = container.at(address, txn_hash=err.txn.txn_hash if err.txn else None)
-        error_class = contract.get_error_by_signature(abi.signature)
+        error_class = container._create_custom_error_type(abi)
         return error_class(
             abi,
             inputs,

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -371,7 +371,7 @@ class CompilerManager(BaseManager, ExtraAttributesMixin):
             HexBytes(message),
             contract_type,
             base_err=err.base_err,
-            contract_address=err.contract_address,
+            contract_address=err.address,
             source_traceback=err.source_traceback,
             trace=err.trace,
             txn=err.txn,

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -321,9 +321,7 @@ class CompilerManager(BaseManager, ExtraAttributesMixin):
         Returns:
             :class:`~ape.exceptions.ContractLogicError`: The enriched exception.
         """
-
-        address = err.address
-        if not address:
+        if not (address := err.address):
             # Contract address not found.
             return err
 

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -367,14 +367,17 @@ class CompilerManager(BaseManager, ExtraAttributesMixin):
             # Default to Ethereum.
             ecosystem = self.network_manager.ethereum
 
-        return ecosystem.decode_custom_error(
-            HexBytes(message),
-            address,
-            base_err=err.base_err,
-            source_traceback=err.source_traceback,
-            trace=err.trace,
-            txn=err.txn,
-        )
+        try:
+            return ecosystem.decode_custom_error(
+                HexBytes(message),
+                address,
+                base_err=err.base_err,
+                source_traceback=err.source_traceback,
+                trace=err.trace,
+                txn=err.txn,
+            )
+        except NotImplementedError:
+            return None
 
     def flatten_contract(self, path: Path, **kwargs) -> Content:
         """

--- a/src/ape/types/signatures.py
+++ b/src/ape/types/signatures.py
@@ -65,7 +65,7 @@ def _left_pad_bytes(val: bytes, num_bytes: int) -> bytes:
 class _Signature:
     v: int
     """
-    The version byte (``v``) in an Ethereum-style ECDSA signture.
+    The version byte (``v``) in an Ethereum-style ECDSA signature.
     """
 
     r: bytes

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -130,8 +130,8 @@ class Web3Provider(ProviderAPI, ABC):
         return super().__new__(cls)  # pydantic v2 doesn't want args
 
     def __init__(self, *args, **kwargs):
-        logger.create_logger("web3.RequestManager", handlers=(_sanitize_web3_url,))
-        logger.create_logger("web3.providers.HTTPProvider", handlers=(_sanitize_web3_url,))
+        # logger.create_logger("web3.RequestManager", handlers=(_sanitize_web3_url,))
+        # logger.create_logger("web3.providers.HTTPProvider", handlers=(_sanitize_web3_url,))
         super().__init__(*args, **kwargs)
 
     @property

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1357,7 +1357,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
 
     def get_transaction_trace(self, txn_hash: Union[HexBytes, str]) -> Iterator[TraceFrame]:
         if isinstance(txn_hash, HexBytes):
-            txn_hash_str = to_hex(txn_hash)
+            txn_hash_str = str(to_hex(txn_hash))
         else:
             txn_hash_str = txn_hash
 

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1355,9 +1355,16 @@ class EthereumNodeProvider(Web3Provider, ABC):
         self._web3 = None
         self._client_version = None
 
-    def get_transaction_trace(self, txn_hash: str) -> Iterator[TraceFrame]:
+    def get_transaction_trace(self, txn_hash: Union[HexBytes, str]) -> Iterator[TraceFrame]:
+        if isinstance(txn_hash, HexBytes):
+            txn_hash_str = to_hex(txn_hash)
+        else:
+            txn_hash_str = txn_hash
+
         frames = self._stream_request(
-            "debug_traceTransaction", [txn_hash, {"enableMemory": True}], "result.structLogs.item"
+            "debug_traceTransaction",
+            [txn_hash_str, {"enableMemory": True}],
+            "result.structLogs.item",
         )
         for frame in create_trace_frames(frames):
             yield self._create_trace_frame(frame)

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -130,8 +130,8 @@ class Web3Provider(ProviderAPI, ABC):
         return super().__new__(cls)  # pydantic v2 doesn't want args
 
     def __init__(self, *args, **kwargs):
-        # logger.create_logger("web3.RequestManager", handlers=(_sanitize_web3_url,))
-        # logger.create_logger("web3.providers.HTTPProvider", handlers=(_sanitize_web3_url,))
+        logger.create_logger("web3.RequestManager", handlers=(_sanitize_web3_url,))
+        logger.create_logger("web3.providers.HTTPProvider", handlers=(_sanitize_web3_url,))
         super().__init__(*args, **kwargs)
 
     @property

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -294,8 +294,12 @@ class Receipt(ReceiptAPI):
                     # Default to Ethereum.
                     ecosystem = self.network_manager.ethereum
 
-                instance = ecosystem.decode_custom_error(returndata, address)
-                revert_message = repr(instance)
+                try:
+                    instance = ecosystem.decode_custom_error(returndata, address)
+                except NotImplementedError:
+                    pass
+                else:
+                    revert_message = repr(instance)
 
         self.chain_manager._reports.show_trace(
             call_tree,

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -150,13 +150,14 @@ def test_compile_source(compilers):
     assert isinstance(actual, ContractContainer)
 
 
-def test_enrich_error_custom_error(compilers):
+def test_enrich_error_custom_error(chain, compilers):
     abi = [ErrorABI(type="error", name="InsufficientETH", inputs=[])]
     contract_type = ContractType(abi=abi)
     addr = cast(AddressType, "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD")
     err = ContractLogicError("0x6a12f104", contract_address=addr)
+
     # Hack in contract-type.
-    err.__dict__["contract_type"] = contract_type
+    chain.contracts._local_contract_types[addr] = contract_type
 
     # Enriching the error should produce a custom error from the ABI.
     actual = compilers.enrich_error(err)
@@ -165,7 +166,7 @@ def test_enrich_error_custom_error(compilers):
     assert actual.__class__.__name__ == "InsufficientETH"
 
 
-def test_enrich_error_custom_error_with_inputs(compilers):
+def test_enrich_error_custom_error_with_inputs(chain, compilers):
     abi = [
         ErrorABI(
             type="error",
@@ -183,7 +184,7 @@ def test_enrich_error_custom_error_with_inputs(compilers):
         contract_address=addr,
     )
     # Hack in contract-type.
-    err.__dict__["contract_type"] = contract_type
+    chain.contracts._local_contract_types[addr] = contract_type
 
     # Enriching the error should produce a custom error from the ABI.
     actual = compilers.enrich_error(err)

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -191,4 +191,4 @@ def test_enrich_error_custom_error_with_inputs(compilers):
     assert isinstance(actual, CustomError)
     assert actual.__class__.__name__ == "AllowanceExpired"
     assert actual.inputs["deadline"] == deadline
-    assert repr(actual) == f"AllowanceExpired('deadline={deadline}')"
+    assert repr(actual) == f"AllowanceExpired(deadline={deadline})"


### PR DESCRIPTION
### What I did

fixes: #2035 

Enrichment was skipped for contracts missing source IDs. This adds it.

bonuses that are not needed but were still part of the fun:

* https://github.com/ApeWorX/ape-foundry/pull/100
* https://github.com/ApeWorX/ape-solidity/pull/141

TODO: Refactor CompilerAPI plugins to use new helper method (instead of re-implementing n-places) `compiler_manager.get_custom_error()`

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
