### PR TITLE
fix: handle `None` blob-receipt gas values

### DIFF
--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -466,12 +466,12 @@ class SharedBlobReceipt(Receipt):
     blob transaction.
     """
 
-    blob_gas_used: int
+    blob_gas_used: Optional[int] = None
     """
     The total amount of blob gas consumed by the transactions within the block.
     """
 
-    blob_gas_price: int
+    blob_gas_price: Optional[int] = None
     """
     The blob-gas price, independent from regular gas price.
     """
@@ -479,7 +479,7 @@ class SharedBlobReceipt(Receipt):
     @field_validator("blob_gas_used", "blob_gas_price", mode="before")
     @classmethod
     def validate_hex(cls, value):
-        return cls._hex_to_int(value or 0)
+        return None if value is None else cls._hex_to_int(value)
 
     @classmethod
     def _hex_to_int(cls, value) -> int:

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -461,10 +461,26 @@ class Receipt(ReceiptAPI):
 
 
 class SharedBlobReceipt(Receipt):
+    """
+    An `EIP-4844 <https://eips.ethereum.org/EIPS/eip-4844#blob-transaction>`__"
+    blob transaction.
+    """
+
     blob_gas_used: int
+    """
+    The total amount of blob gas consumed by the transactions within the block.
+    """
+
     blob_gas_price: int
+    """
+    The blob-gas price, independent from regular gas price.
+    """
 
     @field_validator("blob_gas_used", "blob_gas_price", mode="before")
     @classmethod
-    def hex_to_int(cls, value):
+    def validate_hex(cls, value):
+        return cls._hex_to_int(value or 0)
+
+    @classmethod
+    def _hex_to_int(cls, value) -> int:
         return value if isinstance(value, int) else int(HexBytes(value).hex(), 16)

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -466,12 +466,12 @@ class SharedBlobReceipt(Receipt):
     blob transaction.
     """
 
-    blob_gas_used: Optional[int] = None
+    blob_gas_used: int
     """
     The total amount of blob gas consumed by the transactions within the block.
     """
 
-    blob_gas_price: Optional[int] = None
+    blob_gas_price: int
     """
     The blob-gas price, independent from regular gas price.
     """
@@ -479,7 +479,7 @@ class SharedBlobReceipt(Receipt):
     @field_validator("blob_gas_used", "blob_gas_price", mode="before")
     @classmethod
     def validate_hex(cls, value):
-        return None if value is None else cls._hex_to_int(value)
+        return cls._hex_to_int(value or 0)
 
     @classmethod
     def _hex_to_int(cls, value) -> int:

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -597,9 +597,11 @@ def test_decode_receipt_shared_blob(ethereum, blob_gas_used):
 
     if blob_gas_used:
         assert actual.blob_gas_used == 131072
+    elif blob_gas_used is None:
+        assert actual.blob_gas_used is None
     else:
-        assert actual.blob_gas_used == 0
-
+        # Must be int.
+        assert actual.blob_gas_used == blob_gas_used
 
 
 def test_default_transaction_type_not_connected_used_default_network(

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -596,12 +596,11 @@ def test_decode_receipt_shared_blob(ethereum, blob_gas_used):
     assert actual.blob_gas_price == int(blob_gas_price, 16)
 
     if blob_gas_used:
+        # all test-values are this when they exist.
         assert actual.blob_gas_used == 131072
-    elif blob_gas_used is None:
-        assert actual.blob_gas_used is None
     else:
-        # Must be int.
-        assert actual.blob_gas_used == blob_gas_used
+        # when None, should also default to 0.
+        assert actual.blob_gas_used == 0
 
 
 def test_default_transaction_type_not_connected_used_default_network(

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -548,9 +548,9 @@ def test_decode_receipt_from_etherscan(eth_tester_provider, ethereum):
     assert receipt.gas_price == 1499999989
 
 
-def test_decode_receipt_shared_blob(ethereum):
+@pytest.mark.parametrize("blob_gas_used", ("0x20000", 131072, 0, None))
+def test_decode_receipt_shared_blob(ethereum, blob_gas_used):
     blob_gas_price = "0x4d137e31b"
-    blob_gas_used = "0x20000"
 
     data = {
         "required_confirmations": 0,
@@ -593,8 +593,13 @@ def test_decode_receipt_shared_blob(ethereum):
     }
     actual = ethereum.decode_receipt(data)
     assert isinstance(actual, SharedBlobReceipt)
-    assert actual.blob_gas_used == int(blob_gas_used, 16)
     assert actual.blob_gas_price == int(blob_gas_price, 16)
+
+    if blob_gas_used:
+        assert actual.blob_gas_used == 131072
+    else:
+        assert actual.blob_gas_used == 0
+
 
 
 def test_default_transaction_type_not_connected_used_default_network(


### PR DESCRIPTION
### What I did

Running into this problem here: https://github.com/ApeWorX/ape-foundry/actions/runs/8939795074/job/24556545952?pr=101

It seems like `None` should be allowed.

Looking at this PR: https://github.com/foundry-rs/foundry/pull/7242/files, they also seem to allow `nil` here.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
