### PR TITLE
fix: Issue preventing `ContractContainer.source_id` from working

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 24.4.1
+    rev: 24.4.2
     hooks:
       - id: black
         name: black

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require = {
         "hypothesis-jsonschema==0.19.0",  # JSON Schema fuzzer extension
     ],
     "lint": [
-        "black>=24.4.1,<25",  # Auto-formatter and linter
+        "black>=24.4.2,<25",  # Auto-formatter and linter
         "mypy>=1.10.0,<2",  # Static type analyzer
         "types-PyYAML",  # Needed due to mypy typeshed
         "types-requests",  # Needed due to mypy typeshed

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -158,3 +158,10 @@ def test_decode_input(contract_container, calldata):
 def test_declare(contract_container, sender):
     receipt = contract_container.declare(sender=sender)
     assert not receipt.failed
+
+
+def test_source_id(contract_container):
+    actual = contract_container.source_id
+    expected = contract_container.contract_type.source_id
+    # Is just a pass-through (via extras-model), but making sure it works.
+    assert actual == expected


### PR DESCRIPTION
### What I did

Fixes an issue preventing `ContractContainer.source_id` from working

### How I did it

* fix an issue with attr-lookup returning None and never processing down the extras-chain.
* fix an issue models w/o `__contains__` from working as extra's attributes
* documents attributes more.
* tests that container.source_id works

### How to verify it

```python
project.MyContract.source_id
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
