### PR TITLE
fix: ignore debug-logging regular `AttributeError`s

### DIFF
--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -109,7 +109,7 @@ def only_raise_attribute_error(fn: Callable) -> Any:
         try:
             return fn(*args, **kwargs)
         except AttributeError:
-            raise  # Don't modify or log normal already attr errors.
+            raise  # Don't modify or log attr errors.
         except Exception as err:
             # Wrap the exception in AttributeError
             logger.log_debug_stack_trace()

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -108,10 +108,12 @@ def only_raise_attribute_error(fn: Callable) -> Any:
     def wrapper(*args, **kwargs):
         try:
             return fn(*args, **kwargs)
-        except Exception as e:
+        except AttributeError:
+            raise  # Don't modify or log normal already attr errors.
+        except Exception as err:
             # Wrap the exception in AttributeError
             logger.log_debug_stack_trace()
-            raise ApeAttributeError(f"{e}") from e
+            raise ApeAttributeError(f"{err}") from err
 
     return wrapper
 


### PR DESCRIPTION
### What I did

fixes: #2053 

the problem is we are debug logging every atttr error when we shouldnt be

### How I did it

dont debug log attribute errors when they are acually attribute errors

### How to verify it

```
ape -v debug
```
with and w/o

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
