### PR TITLE
fix: issue where couldn't use  scripts with `cls=ConnectedProviderCommand, use_cls_types=False)`

### DIFF
--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -66,6 +66,7 @@ class ConnectedProviderCommand(click.Command):
         super().__init__(*args, **kwargs)
 
     def parse_args(self, ctx: Context, args: List[str]) -> List[str]:
+        arguments = args  # Renamed for better pdb support.
         base_type = ProviderAPI if self._use_cls_types else str
         if existing_option := next(
             iter(
@@ -87,7 +88,7 @@ class ConnectedProviderCommand(click.Command):
             option = NetworkOption(base_type=base_type, callback=self._network_callback)
             self.params.append(option)
 
-        return super().parse_args(ctx, args)
+        return super().parse_args(ctx, arguments)
 
     def invoke(self, ctx: Context) -> Any:
         if self.callback is None:

--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -127,7 +127,7 @@ class ConnectedProviderCommand(click.Command):
                     ctx.params[name] = options.get(name)
 
         elif not self._use_cls_types and provider is not None:
-            # Legacy behavior, but may have a purpose.
+            # Keep choice-str instead of parsing to objects.
             ctx.params["network"] = provider.network_choice
 
         return ctx.invoke(self.callback or (lambda: None), **ctx.params)

--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -35,9 +35,11 @@ def parse_network(ctx: Context) -> Optional[ProviderContextManager]:
         return provider.network.use_provider(provider, disconnect_on_exit=not interactive)
 
     elif provider not in (None, _NONE_NETWORK) and isinstance(provider, str):
+        # Is using a choice-str network param value instead of the network object instances.
         return ManagerAccessMixin.network_manager.parse_network_choice(
             provider, disconnect_on_exit=not interactive
         )
+
     elif provider is None:
         ecosystem = ManagerAccessMixin.network_manager.default_ecosystem
         network = ecosystem.default_network

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -211,14 +211,14 @@ def network_option(
         user_callback = kwargs.pop("callback", None)
 
         def callback(ctx, param, value):
-            is_legacy = param.type.base_type is str
-            use_default = default == "auto"
+            keep_as_choice_str = param.type.base_type is str
+            use_default = value is None and default == "auto"
 
-            if not is_legacy and value is None and use_default:
+            if not keep_as_choice_str and use_default:
                 default_ecosystem = ManagerAccessMixin.network_manager.default_ecosystem
                 provider_obj = default_ecosystem.default_network.default_provider
 
-            elif value is None or is_legacy:
+            elif value is None or keep_as_choice_str:
                 provider_obj = None
 
             elif isinstance(value, ProviderAPI):

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -261,6 +261,13 @@ def network_option(
                                 "with non key-settable context object."
                             )
 
+            elif keep_as_choice_str:
+                # Add raw choice to object context.
+                ctx.obj = ctx.obj or {}
+                ctx.params = ctx.params or {}
+                ctx.obj["network"] = value
+                ctx.params["network"] = value
+
             # else: provider is None, meaning not connected intentionally.
 
             return value if user_callback is None else user_callback(ctx, param, value)

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -667,6 +667,23 @@ def test_connected_provider_command_with_network_option(runner, geth_provider):
     assert "geth" in res.output
 
 
+@geth_process_test
+def test_connected_provider_command_with_network_option_and_cls_types_false(runner, geth_provider):
+    _ = geth_provider  # Ensure already running, to avoid clashing later on.
+
+    @click.command(cls=ConnectedProviderCommand, use_cls_types=False)
+    @network_option()
+    def cmd(network):
+        assert isinstance(network, str)
+        assert network == "ethereum:local:geth"
+
+    # NOTE: Must use a network that is not the default.
+    spec = ("--network", "ethereum:local:geth")
+    res = runner.invoke(cmd, spec, catch_exceptions=False)
+    assert res.exit_code == 0, res.output
+    assert "geth" in res.output
+
+
 def test_connected_provider_command_none_network(runner):
     @click.command(cls=ConnectedProviderCommand)
     def cmd(network, provider):

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -681,7 +681,6 @@ def test_connected_provider_command_with_network_option_and_cls_types_false(runn
     spec = ("--network", "ethereum:local:geth")
     res = runner.invoke(cmd, spec, catch_exceptions=False)
     assert res.exit_code == 0, res.output
-    assert "geth" in res.output
 
 
 def test_connected_provider_command_none_network(runner):


### PR DESCRIPTION
### What I did

fixes: #2055

Issue where could not use `raw` type for network param (which is what legacy mode uses).

### How I did it

when using legacy, add the param in manually in callback and ctx manually.

### How to verify it

```python
@command(cls=ConnectedProviderCommand, use_cls_types=False)
@network_option()
```

or

(what use was doing in reported issue)

```python
@command(cls=NetworkBoundCommand)
@network_option()
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
