### PR TITLE
fix: remove double caching for `ProviderAPI.config`

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -226,7 +226,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
             :class:`~ape.api.providers.BlockAPI`
         """
 
-    @cached_property
+    @property
     def config(self) -> PluginConfig:
         """
         The configuration of the ecosystem. See :class:`ape.managers.config.ConfigManager`
@@ -821,7 +821,6 @@ class NetworkAPI(BaseInterfaceModel):
         The configuration of the network. See :class:`~ape.managers.config.ConfigManager`
         for more information on plugin configurations.
         """
-
         return self.config_manager.get_config(self.ecosystem.name)
 
     @property


### PR DESCRIPTION
### What I did

noticed this is an unnecessary cached property, as config is essentially cached already. thus this PR removes an instance of double caching

**part of project refactor - believe it or not**

### How I did it

@cached_property -> @property

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
