### PR TITLE
refactor: `exclude` track by name instead of path

### DIFF
--- a/src/ape/cli/arguments.py
+++ b/src/ape/cli/arguments.py
@@ -110,10 +110,10 @@ class _ContractPaths(ManagerAccessMixin):
 
     def do_exclude(self, path: Union[Path, str]) -> bool:
         name = path if isinstance(path, str) else path.name
-        if path not in self.exclude_list:
-            self.exclude_list[path] = any(fnmatch(name, p) for p in self.exclude_patterns)
+        if name not in self.exclude_list:
+            self.exclude_list[name] = any(fnmatch(name, p) for p in self.exclude_patterns)
 
-        return self.exclude_list[path]
+        return self.exclude_list[name]
 
     def compiler_is_unknown(self, path: Union[Path, str]) -> bool:
         path = Path(path)
@@ -174,5 +174,4 @@ def contract_file_paths_argument():
     The return type from the callback is a flattened list of
     source file-paths.
     """
-
     return click.argument("file_paths", nargs=-1, callback=_ContractPaths.callback)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -309,6 +309,8 @@ def project_with_contract(temp_config):
     with temp_config() as project:
         copytree(str(APE_PROJECT_FOLDER), str(project.path), dirs_exist_ok=True)
         project.local_project._cached_manifest = None  # Clean manifest
+        project.config_manager.load(force_reload=True)  # Reload after copying config file.
+
         yield project
 
 

--- a/tests/functional/data/projects/ApeProject/ape-config.yaml
+++ b/tests/functional/data/projects/ApeProject/ape-config.yaml
@@ -1,1 +1,5 @@
 contracts_folder: ./contracts
+
+compile:
+  exclude:
+    - "*Excl*"

--- a/tests/functional/data/projects/ApeProject/contracts/Exclude.json
+++ b/tests/functional/data/projects/ApeProject/contracts/Exclude.json
@@ -1,0 +1,3 @@
+[
+    {"name":"ApeContract","type":"fallback", "stateMutability":"nonpayable"}
+]

--- a/tests/functional/data/projects/ApeProject/contracts/subdir/ExcludeNested.json
+++ b/tests/functional/data/projects/ApeProject/contracts/subdir/ExcludeNested.json
@@ -1,0 +1,3 @@
+[
+    {"name":"ApeContract","type":"fallback", "stateMutability":"nonpayable"}
+]

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -461,6 +461,15 @@ def test_contract_file_paths_argument_given_contracts_folder_name(
     assert f"EXPECTED {all_paths}" in result.output
 
 
+def test_contract_file_paths_handles_exclude(project_with_contract, runner, contracts_paths_cmd):
+    cfg = project_with_contract.config_manager.get_config("compile")
+    failmsg = "Setup failed - missing exclude config (set in ape-config.yaml)."
+    assert "*Excl*" in cfg.exclude, failmsg
+    result = runner.invoke(contracts_paths_cmd, "contracts")
+    assert "Exclude.json" not in result.output
+    assert "ExcludeNested.json" not in result.output
+
+
 @pytest.mark.parametrize("name", ("contracts/subdir", "subdir"))
 def test_contract_file_paths_argument_given_subdir_relative_to_path(
     project_with_contract, runner, contracts_paths_cmd, name

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -448,7 +448,7 @@ def test_contract_file_paths_argument_given_contracts_folder(
 ):
     pm = project_with_contract
     result = runner.invoke(contracts_paths_cmd, pm.contracts_folder.as_posix())
-    all_paths = ", ".join(x.name for x in sorted(pm.source_paths))
+    all_paths = ", ".join(x.name for x in sorted(pm.source_paths) if "Excl" not in x.name)
     assert f"EXPECTED {all_paths}" in result.output
 
 
@@ -457,7 +457,7 @@ def test_contract_file_paths_argument_given_contracts_folder_name(
 ):
     pm = project_with_contract
     result = runner.invoke(contracts_paths_cmd, "contracts")
-    all_paths = ", ".join(x.name for x in sorted(pm.source_paths))
+    all_paths = ", ".join(x.name for x in sorted(pm.source_paths) if "Excl" not in x.name)
     assert f"EXPECTED {all_paths}" in result.output
 
 
@@ -476,7 +476,11 @@ def test_contract_file_paths_argument_given_subdir_relative_to_path(
 ):
     pm = project_with_contract
     result = runner.invoke(contracts_paths_cmd, name)
-    all_paths = ", ".join(x.name for x in sorted(pm.source_paths) if x.parent.name == "subdir")
+    all_paths = ", ".join(
+        x.name
+        for x in sorted(pm.source_paths)
+        if x.parent.name == "subdir" and "Excl" not in x.name
+    )
     assert f"EXPECTED {all_paths}" in result.output
 
 


### PR DESCRIPTION
### What I did

* tracks exclude by name to avoid checking names twice when paths differ
* add missing test for exclude used with contract_file_paths argument type

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
