### PR TITLE
feat: `NetworkNotFoundError` handle case when no networks

### DIFF
--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -357,12 +357,19 @@ class NetworkNotFoundError(NetworkError):
         options: Optional[Collection[str]] = None,
     ):
         self.network = network
-        message = (
-            f"No network in '{ecosystem}' named '{network}'."
-            if ecosystem
-            else f"No network named '{network}'."
-        )
+        options = options or []
+        if network in options:
+            # Only seen in testing scenarios. Not realistic.
+            raise ValueError(
+                f"{network} found in options. Should not have gotten `NetworkNotFoundError`."
+            )
+
         if options:
+            message = (
+                f"No network in '{ecosystem}' named '{network}'."
+                if ecosystem
+                else f"No network named '{network}'."
+            )
             close_matches = difflib.get_close_matches(network, options, cutoff=0.6)
             if close_matches:
                 message = f"{message} Did you mean '{', '.join(close_matches)}'?"
@@ -370,6 +377,12 @@ class NetworkNotFoundError(NetworkError):
                 # No close matches - show all options.
                 options_str = "\n".join(sorted(options))
                 message = f"{message} Options:\n{options_str}"
+
+        elif ecosystem:
+            message = f"'{ecosystem}' has no networks."
+
+        else:
+            message = "No networks found."
 
         super().__init__(message)
 

--- a/tests/functional/test_exceptions.py
+++ b/tests/functional/test_exceptions.py
@@ -1,7 +1,7 @@
 import re
 
 from ape.api import ReceiptAPI
-from ape.exceptions import Abort, TransactionError
+from ape.exceptions import Abort, NetworkNotFoundError, TransactionError
 from ape_ethereum.transactions import Receipt
 
 
@@ -25,3 +25,35 @@ def test_transaction_error_when_receipt_is_subclass(vyper_contract_instance, own
 
     err = TransactionError(txn=sub_receipt)
     assert isinstance(err.txn, ReceiptAPI)  # Same check used.
+
+
+def test_network_not_found_error_close_match():
+    net = "sepolai"
+    error = NetworkNotFoundError(net, ecosystem="ethereum", options=("sepolia",))
+    actual = str(error)
+    expected = f"No network in 'ethereum' named '{net}'. Did you mean 'sepolia'?"
+    assert actual == expected
+
+
+def test_network_not_found_error_no_close_matches():
+    net = "madeup"
+    error = NetworkNotFoundError(net, ecosystem="ethereum", options=("sepolia",))
+    actual = str(error)
+    expected = f"No network in 'ethereum' named '{net}'. Options:\nsepolia"
+    assert actual == expected
+
+
+def test_network_with_ecosystem_not_found_no_options():
+    net = "madeup"
+    error = NetworkNotFoundError(net, ecosystem="ethereum", options=())
+    actual = str(error)
+    expected = "'ethereum' has no networks."
+    assert actual == expected
+
+
+def test_network_without_ecosystem_not_found_no_options():
+    net = "madeup"
+    error = NetworkNotFoundError(net, options=())
+    actual = str(error)
+    expected = "No networks found."
+    assert actual == expected


### PR DESCRIPTION
### What I did

This exception made no sense when it came up in a situation where a custom ecosystem existed with no networks (was in a test so maybe not realistic, but this is better and fixes those cases if they ever happened)

**part of project refactor stuff**

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
