### PR TITLE
fix: `is_convertible` error handling

### DIFF
--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -20,6 +20,7 @@ from ethpm_types import ConstructorABI, EventABI, MethodABI
 from ape.api import ConverterAPI, TransactionAPI
 from ape.api.address import BaseAddress
 from ape.exceptions import ConversionError
+from ape.logging import logger
 from ape.types import AddressType
 from ape.utils import cached_property, log_instead_of_fail
 
@@ -320,7 +321,17 @@ class ConversionManager(BaseManager):
             return value
 
         for converter in self._converters[type]:
-            if not converter.is_convertible(value):
+            try:
+                is_convertible = converter.is_convertible(value)
+            except Exception as err:
+                # If errors while checking if we can convert, log the error
+                # and assume it's not convertible.
+                converter_name = converter.__class__.__name__
+                msg = f"Issue while checking `{converter_name}.is_convertible()`: {err}"
+                logger.error(msg)
+                continue
+
+            if not is_convertible:
                 continue
 
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,8 +63,13 @@ def config():
 
 
 @pytest.fixture(scope="session")
-def convert(chain):
-    return chain.conversion_manager.convert
+def conversion_manager(chain):
+    return chain.conversion_manager
+
+
+@pytest.fixture(scope="session")
+def convert(conversion_manager):
+    return conversion_manager.convert
 
 
 @pytest.fixture(scope="session")

--- a/tests/functional/conversion/test_misc.py
+++ b/tests/functional/conversion/test_misc.py
@@ -1,0 +1,29 @@
+from typing import Any
+
+import pytest
+
+from ape.api import ConverterAPI
+from ape.exceptions import ConversionError
+
+
+def test_convert_logs_and_passes_errors_from_is_convertible(conversion_manager, ape_caplog):
+    """
+    When checking if something is convertible, and is_convertible errors
+    for whatever reason, log the error and consider it "not convertible".
+    More than likely, it isn't by that converter and is a plugin-error.
+    """
+    error_msg = "Unexpected error!"
+
+    class ProblematicConverter(ConverterAPI):
+        def is_convertible(self, value: Any) -> bool:
+            raise ValueError(error_msg)
+
+        def convert(self, value: Any) -> Any:
+            return value
+
+    conversion_manager._converters[dict] = (ProblematicConverter(),)
+    expected = f"Issue while checking `ProblematicConverter.is_convertible()`: {error_msg}"
+    with pytest.raises(ConversionError):
+        _ = conversion_manager.convert(123, dict)
+
+    assert expected in ape_caplog.head


### PR DESCRIPTION
### What I did

I have since fixed the real problem in ape-ens https://github.com/ApeWorX/ape-ens/pull/33
but it is annoying that if an irrelevant `is_convertible()` check fails in Ape, it breaks the whole application when it would have succeeded if just logging the error and continuing... so that is what this PR does!

### How I did it

log the error and continue when `is_convertible` fails

### How to verify it

force a converter plugin to fail, like ape-ens, and run anything using an address.
dont use or rely on actual ens
but  before, just having the plugin installed causes failure! now, it should be ok and still tell you something is wrong (the bug in ape-ens)

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
