### PR TITLE
feat: allow `convert(0, AddressType)` to work

### DIFF
--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -148,7 +148,7 @@ class IntAddressConverter(ConverterAPI):
     A converter that converts an integer address to an :class:`~ape.types.address.AddressType`.
     """
 
-    _cache: dict[int, Union[AddressType, bool]] = {}
+    _cache: Dict[int, Union[AddressType, bool]] = {}
 
     def is_convertible(self, value: Any) -> bool:
         if not isinstance(value, int):

--- a/tests/functional/conversion/test_address.py
+++ b/tests/functional/conversion/test_address.py
@@ -1,3 +1,5 @@
+from eth_typing import ChecksumAddress, HexAddress, HexStr
+
 from ape.types import AddressType
 
 
@@ -19,3 +21,11 @@ def test_convert_address_to_int(convert, owner):
 def test_convert_account_to_int(convert, owner):
     actual = convert(owner, int)
     assert actual == int(owner.address, 16)
+
+
+def test_convert_address_missing_padding_to_int(convert, owner):
+    # NOTE: Should be "0x0f135c529caf5abb89156b3adaa7732eace9eb0f"
+    address_str = HexStr("0xf135c529caf5abb89156b3adaa7732eace9eb0f")
+    address_missing_padded_zero = ChecksumAddress(HexAddress(address_str))
+    actual = convert(address_missing_padded_zero, int)
+    assert actual == 0xf135c529caf5abb89156b3adaa7732eace9eb0f

--- a/tests/functional/conversion/test_address.py
+++ b/tests/functional/conversion/test_address.py
@@ -1,5 +1,6 @@
-from eth_typing import ChecksumAddress, HexAddress, HexStr
+import pytest
 
+from ape.managers.converters import HexAddressConverter, IntAddressConverter
 from ape.types import AddressType
 
 
@@ -23,9 +24,42 @@ def test_convert_account_to_int(convert, owner):
     assert actual == int(owner.address, 16)
 
 
-def test_convert_address_missing_padding_to_int(convert, owner):
-    # NOTE: Should be "0x0f135c529caf5abb89156b3adaa7732eace9eb0f"
-    address_str = HexStr("0xf135c529caf5abb89156b3adaa7732eace9eb0f")
-    address_missing_padded_zero = ChecksumAddress(HexAddress(address_str))
-    actual = convert(address_missing_padded_zero, int)
-    assert actual == 0xf135c529caf5abb89156b3adaa7732eace9eb0f
+def test_convert_0_to_address(convert, zero_address):
+    assert convert(0, AddressType) == zero_address
+
+
+class TestHexAddressConverter:
+    @pytest.fixture(scope="class")
+    def converter(self):
+        return HexAddressConverter()
+
+    def test_is_convertible_hex_str(self, converter):
+        assert not converter.is_convertible("0x123")
+
+    def test_is_convertible_address(self, converter, owner):
+        # Is already an address!
+        assert not converter.is_convertible(str(owner.address))
+
+    def test_convert_not_canonical_address(self, converter):
+        actual = converter.convert("0x0ffffffaaaaaaaabbbbbbb333337777eeeeeee00")
+        expected = "0x0fFFfffAaAaAaAaBBBbBbb333337777eeeeeEe00"
+        assert actual == expected
+
+
+class TestIntAddressConverter:
+    @pytest.fixture(scope="class")
+    def converter(self):
+        return IntAddressConverter()
+
+    def test_is_convertible(self, converter, owner):
+        int_address = int(owner.address, 16)
+        assert converter.is_convertible(int_address)
+
+    def test_is_convertible_random_int(self, converter):
+        assert converter.is_convertible(0)
+
+    @pytest.mark.parametrize("val", (0, 1))
+    def test_convert_simple_int(self, converter, val, zero_address):
+        actual = converter.convert(val)
+        expected = f"{zero_address[:-1]}{val}"
+        assert actual == expected

--- a/tests/functional/conversion/test_hex.py
+++ b/tests/functional/conversion/test_hex.py
@@ -5,15 +5,14 @@ from ape.exceptions import ConversionError
 from ape.managers.converters import HexConverter, HexIntConverter
 
 
-def test_hex_str(convert):
-    hex_value = "0xA100"
-    int_str_value = "100"
-    hex_expected = 41216
-    int_expected = 100
-    assert convert(hex_value, int) == hex_expected
-    assert convert(int_str_value, int) == int_expected
-    assert convert(hex_value, bytes) == HexBytes(hex_value)
-    assert convert(int_expected, bytes) == HexBytes(int_expected)
+@pytest.mark.parametrize("val", ("0xA100", "0x0A100", "0x00a100"))
+def test_hex_str(convert, val):
+    assert convert(val, int) == 0xA100
+    assert int(convert(val, bytes).hex(), 16) == int(HexBytes(0xA100).hex(), 16)
+
+
+def test_int_str(convert):
+    assert convert("100", int) == 100
 
 
 def test_missing_prefix(convert):


### PR DESCRIPTION
### What I did

Create simple addresses a lot easier by allowing:

```
In [1]: from ape.types import AddressType

In [2]: convert(0, AddressType)
Out[2]: '0x0000000000000000000000000000000000000000'
```

### How I did it

Use `eth_pydantic_types` validator

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
