### PR TITLE
feat: allow `contract.source_path` from non local project

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -281,6 +281,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
             self.project_manager.track_deployment(instance)
             self.provider.network.publish_contract(address)
 
+        instance.base_path = contract.base_path or self.project_manager.contracts_folder
         return instance
 
     def declare(self, contract: "ContractContainer", *args, **kwargs) -> ReceiptAPI:

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -125,7 +125,7 @@ def test_source_path_in_project(project_with_contract):
     contract = project_with_contract.contracts["Contract"]
     contract_container = project_with_contract.get_contract("Contract")
     expected = contracts_folder / contract.source_id
-
+    assert contract_container.source_path is not None
     assert contract_container.source_path.is_file()
     assert contract_container.source_path == expected
 


### PR DESCRIPTION
### What I did

A small improvement in the process of the larger project refactor for 0.8.
Basically just changes how `contract.source_path` works. Before, it looked it up via name. Now, when deploying, it sets a base path.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
