### PR TITLE
refactor: use `@raises_not_implemented()` instead of `raise` statements in `BaseManager` ipython methods

### DIFF
--- a/src/ape/managers/base.py
+++ b/src/ape/managers/base.py
@@ -1,4 +1,4 @@
-from ape.utils import ManagerAccessMixin
+from ape.utils import ManagerAccessMixin, raises_not_implemented
 
 
 class BaseManager(ManagerAccessMixin):
@@ -6,10 +6,12 @@ class BaseManager(ManagerAccessMixin):
     Base manager that allows us to add other IPython integration features
     """
 
+    @raises_not_implemented
     def _repr_mimebundle_(self, include=None, exclude=None):
         # This works better than AttributeError for Ape.
-        raise NotImplementedError("This manager does not implement '_repr_mimebundle_'.")
+        pass
 
+    @raises_not_implemented
     def _ipython_display_(self, include=None, exclude=None):
         # This works better than AttributeError for Ape.
-        raise NotImplementedError("This manager does not implement '_ipython_display_'.")
+        pass

--- a/tests/functional/test_base_manager.py
+++ b/tests/functional/test_base_manager.py
@@ -1,0 +1,25 @@
+import pytest
+
+from ape.exceptions import APINotImplementedError
+from ape.managers.base import BaseManager
+
+
+@pytest.fixture(scope="module")
+def manager():
+    class MyManager(BaseManager):
+        pass
+
+    return MyManager()
+
+
+@pytest.mark.parametrize("fn_name", ("_repr_mimebundle_", "_ipython_display_"))
+def test_ipython_integration_defaults(manager, fn_name):
+    """
+    Test default behavior for IPython integration methods.
+    The base-manager short-circuits to NotImplementedError to avoid
+    dealing with any custom `__getattr__` logic entirely. This prevents
+    side-effects such as unnecessary compiling in the ProjectManager.
+    """
+    with pytest.raises(APINotImplementedError):
+        fn = getattr(manager, fn_name)
+        fn()


### PR DESCRIPTION
### What I did

* Use `@raises_not_implemented()` instead of raise stmt to share code and use the universal method
* Adds tests

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
