### PR TITLE
chore: delete double-ly implemented `__getitem__`

### DIFF
--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -385,3 +385,9 @@ def test_fork_past_genesis(networks, mock_sepolia, mock_fork_provider, eth_teste
     with pytest.raises(NetworkError, match="Unable to fork past genesis block."):
         with networks.fork(block_number=block_id):
             pass
+
+
+def test_getitem(networks):
+    ethereum = networks["ethereum"]
+    assert ethereum.name == "ethereum"
+    assert isinstance(ethereum, EcosystemAPI)


### PR DESCRIPTION
### What I did

* deletes a method that was unneeded - already present via ape-extra getitem=True

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
