### PR TITLE
fix: issue where `project` was not honored in `console` function

### DIFF
--- a/tests/functional/test_console.py
+++ b/tests/functional/test_console.py
@@ -1,5 +1,9 @@
+import sys
+
 import pytest
 
+from ape import Project
+from ape.utils import create_tempdir
 from ape_console._cli import console
 
 
@@ -31,3 +35,19 @@ def test_console_extras_uses_ape_namespace(mocker, mock_console, mock_ape_consol
 
     # Show the custom accounts do get used in console.
     assert mock_console.call_args[0][0]["accounts"] == accounts_custom
+
+
+def test_console_custom_project(mock_console, mock_ape_console_extras):
+    with create_tempdir() as path:
+        project = Project(path)
+        console(project=project)
+        actuals = (
+            mock_console.call_args[0][0]["project"],  # Launch namespace
+            mock_ape_console_extras.call_args[1]["project"],  # extras-load namespace
+        )
+
+    for actual in actuals:
+        assert actual == project
+
+    # Ensure sys.path was updated correctly.
+    assert sys.path[0] == str(project.path)


### PR DESCRIPTION
### What I did

`ape_console.console` method accepts a `project` param however it was not fully honored.
(multi-project features are not super available yet in 0.7 but this is part of getting some of the project-refactor work in early to make things go smoother and diffs smaller, thank you)

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
