### PR TITLE
fix: .cache wasn't ignored correctly in `project.__getattr__`

### DIFF
--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -1,4 +1,5 @@
 import os
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -177,12 +178,12 @@ class BaseProject(ProjectAPI):
         self.project_manager.load_dependencies()
         source_paths: List[Path] = list(
             set(
-                [p for p in self.source_paths if p in file_paths]
+                [str(p) for p in self.source_paths if p in file_paths]
                 if file_paths
                 else [
                     p
                     for p in self.source_paths
-                    if not any(p.match(e) for e in compile_config.exclude)
+                    if not any(fnmatch(p, e) for e in compile_config.exclude)
                 ]
             )
         )

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -178,7 +178,7 @@ class BaseProject(ProjectAPI):
         self.project_manager.load_dependencies()
         source_paths: List[Path] = list(
             set(
-                [str(p) for p in self.source_paths if p in file_paths]
+                [p for p in self.source_paths if p in file_paths]
                 if file_paths
                 else [
                     p

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -213,6 +213,18 @@ def test_create_manifest_empty_files(compilers, mock_compiler, config, ape_caplo
             assert f"Compiling '{name}.__mock__'." not in ape_caplog.head
 
 
+def test_create_manifest_excludes_cache(ape_project):
+    cachefile = ape_project.contracts_folder / ".cache" / "CacheFile.json"
+    cachefile2 = ape_project.contracts_folder / ".cache" / "subdir" / "Cache2.json"
+    cachefile2.parent.mkdir(parents=True)
+    cachefile.write_text("Doesn't matter")
+    cachefile2.write_text("Doesn't matter")
+    manifest = ape_project.create_manifest()
+    assert isinstance(manifest, PackageManifest)
+    assert ".cache/CacheFile.json" not in (manifest.sources or {})
+    assert ".cache/subdir/CacheFile.json" not in (manifest.sources or {})
+
+
 def test_meta(temp_config, project):
     meta_config = {
         "meta": {


### PR DESCRIPTION
### What I did

I guess this matching technique was off! Ugh, I am sick of glob patterns and sorry I broken everything by trying to rely on them... Hopefully this does it...


### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
