### PR TITLE
fix: handle HTTPError-based not-implemented RPCs and parity-trace detection error handling easement

### DIFF
--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1419,7 +1419,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
         try:
             # Try the Parity traces first, in case node client supports it.
             tree = self._get_parity_call_tree(txn_hash)
-        except (ValueError, APINotImplementedError, ProviderError):
+        except Exception:
             self.can_use_parity_traces = False
             return self._get_geth_call_tree(txn_hash)
 


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: https://github.com/ApeWorX/ape/issues/2075

### How I did it

fixes in 2 spots:

1. detect APINotImplemented, which is the proper fix
2. when an unknown exception happens while  testing for parity, mark it as non-parity and go for geth. this should prevent future problems like this more.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
