### PR TITLE
fix: issues with pattern matching for source file exclusions

### DIFF
--- a/src/ape/cli/arguments.py
+++ b/src/ape/cli/arguments.py
@@ -110,7 +110,7 @@ class _ContractPaths(ManagerAccessMixin):
     def do_exclude(self, path: Union[Path, str]) -> bool:
         name = path if isinstance(path, str) else str(path)
         if name not in self.exclude_list:
-            self.exclude_list[name] = path_match(name, self.exclude_patterns)
+            self.exclude_list[name] = path_match(name, *self.exclude_patterns)
 
         return self.exclude_list[name]
 

--- a/src/ape/cli/arguments.py
+++ b/src/ape/cli/arguments.py
@@ -1,4 +1,3 @@
-from fnmatch import fnmatch
 from functools import cached_property
 from pathlib import Path
 from typing import Iterable, List, Set, Union
@@ -9,7 +8,7 @@ from click import BadArgumentUsage
 from ape.cli.choices import _ACCOUNT_TYPE_FILTER, Alias
 from ape.logging import logger
 from ape.utils.basemodel import ManagerAccessMixin
-from ape.utils.os import get_all_files_in_directory, get_full_extension
+from ape.utils.os import get_all_files_in_directory, get_full_extension, path_match
 from ape.utils.validators import _validate_account_alias
 
 
@@ -111,7 +110,7 @@ class _ContractPaths(ManagerAccessMixin):
     def do_exclude(self, path: Union[Path, str]) -> bool:
         name = path if isinstance(path, str) else str(path)
         if name not in self.exclude_list:
-            self.exclude_list[name] = any(fnmatch(name, p) for p in self.exclude_patterns)
+            self.exclude_list[name] = path_match(name, self.exclude_patterns)
 
         return self.exclude_list[name]
 

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -1,5 +1,4 @@
 import os
-from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -10,7 +9,7 @@ from yaml import safe_dump, safe_load
 from ape.api import ProjectAPI
 from ape.logging import logger
 from ape.managers.config import CONFIG_FILE_NAME as APE_CONFIG_FILE_NAME
-from ape.utils import cached_property, get_all_files_in_directory, get_relative_path
+from ape.utils import cached_property, get_all_files_in_directory, get_relative_path, path_match
 
 
 class _ProjectSources:
@@ -183,7 +182,7 @@ class BaseProject(ProjectAPI):
                 else [
                     p
                     for p in self.source_paths
-                    if not any(fnmatch(p, e) for e in compile_config.exclude)
+                    if not path_match(p, compile_config.exclude)
                 ]
             )
         )

--- a/src/ape/managers/project/types.py
+++ b/src/ape/managers/project/types.py
@@ -179,11 +179,7 @@ class BaseProject(ProjectAPI):
             set(
                 [p for p in self.source_paths if p in file_paths]
                 if file_paths
-                else [
-                    p
-                    for p in self.source_paths
-                    if not path_match(p, compile_config.exclude)
-                ]
+                else [p for p in self.source_paths if not path_match(p, *compile_config.exclude)]
             )
         )
 

--- a/src/ape/utils/__init__.py
+++ b/src/ape/utils/__init__.py
@@ -53,6 +53,7 @@ from ape.utils.os import (
     get_all_files_in_directory,
     get_full_extension,
     get_relative_path,
+    path_match,
     run_in_tempdir,
     use_temp_sys_path,
 )
@@ -114,6 +115,7 @@ __all__ = [
     "only_raise_attribute_error",
     "parse_coverage_tables",
     "parse_gas_table",
+    "path_match",
     "raises_not_implemented",
     "returns_array",
     "run_in_tempdir",

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -8,7 +8,7 @@ from functools import cached_property, lru_cache, singledispatchmethod, wraps
 from importlib.metadata import PackageNotFoundError, distributions
 from importlib.metadata import version as version_metadata
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, Mapping, Optional, cast, Union
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, Mapping, Optional, cast
 
 import requests
 import yaml
@@ -33,10 +33,10 @@ DEFAULT_LIVE_NETWORK_BASE_FEE_MULTIPLIER = 1.4
 DEFAULT_TRANSACTION_TYPE = 0
 DEFAULT_MAX_RETRIES_TX = 20
 SOURCE_EXCLUDE_PATTERNS = (
-    "**/.cache/**",
+    ".cache",
     ".DS_Store",
     ".gitkeep",
-    "**/.build/**",
+    ".build",
     "*.md",
     "*.rst",
     "*.txt",

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -8,7 +8,7 @@ from functools import cached_property, lru_cache, singledispatchmethod, wraps
 from importlib.metadata import PackageNotFoundError, distributions
 from importlib.metadata import version as version_metadata
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, Mapping, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, Mapping, Optional, cast, Union
 
 import requests
 import yaml

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -36,7 +36,7 @@ SOURCE_EXCLUDE_PATTERNS = (
     "**/.cache/**",
     ".DS_Store",
     ".gitkeep",
-    "**/.build/**/*.json",
+    "**/.build/**",
     "*.md",
     "*.rst",
     "*.txt",

--- a/src/ape/utils/os.py
+++ b/src/ape/utils/os.py
@@ -225,7 +225,6 @@ def path_match(path: Union[str, Path], *exclusions: str) -> bool:
     >>> path_match(p, "**/.build/**")
     True
     """
-
     path_str = str(path)
     path_path = Path(path)
 
@@ -236,11 +235,16 @@ def path_match(path: Union[str, Path], *exclusions: str) -> bool:
         elif fnmatch(path_path.name, excl):
             return True
 
-        elif "*" not in excl:
+        else:
             # If the exclusion is he full name of any of the parents
             # (e.g. ".cache", it is a match).
             for parent in path_path.parents:
                 if parent.name == excl:
+                    return True
+
+                # Walk the path recursively.
+                relative_str = path_str.replace(str(parent), "").strip(os.path.sep)
+                if fnmatch(relative_str, excl):
                     return True
 
     return False

--- a/src/ape/utils/os.py
+++ b/src/ape/utils/os.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 from contextlib import contextmanager
+from fnmatch import fnmatch
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Callable, Iterator, List, Optional, Pattern, Union
@@ -203,9 +204,25 @@ def run_in_tempdir(
     Args:
         fn (Callable): A function that takes a path. It gets called
           with the resolved path to the temporary directory.
+        name (str): Optionally name the temporary directory.
 
     Returns:
         Any: The result of the function call.
     """
     with create_tempdir(name=name) as temp_dir:
         return fn(temp_dir)
+
+
+def path_match(path: Union[str, Path], *exclusions: str) -> bool:
+    """
+    A better glob-matching function. For example:
+
+    >>> from pathlib import Path
+    >>> p = Path("test/to/.build/me/2/file.json")
+    >>> p.match("**/.build/**")
+    False
+    >>> from ape.utils.os import path_match
+    >>> path_match(p, "**/.build/**")
+    True
+    """
+    return any(fnmatch(str(path), e) for e in exclusions)

--- a/src/ape/utils/os.py
+++ b/src/ape/utils/os.py
@@ -225,4 +225,22 @@ def path_match(path: Union[str, Path], *exclusions: str) -> bool:
     >>> path_match(p, "**/.build/**")
     True
     """
-    return any(fnmatch(str(path), e) for e in exclusions)
+
+    path_str = str(path)
+    path_path = Path(path)
+
+    for excl in exclusions:
+        if fnmatch(path_str, excl):
+            return True
+
+        elif fnmatch(path_path.name, excl):
+            return True
+
+        elif "*" not in excl:
+            # If the exclusion is he full name of any of the parents
+            # (e.g. ".cache", it is a match).
+            for parent in path_path.parents:
+                if parent.name == excl:
+                    return True
+
+    return False

--- a/src/ape_compile/__init__.py
+++ b/src/ape_compile/__init__.py
@@ -25,6 +25,9 @@ class Config(PluginConfig):
     exclude: Set[str] = set()
     """
     Source exclusion globs across all file types.
+
+    **NOTE**: ``ape.utils.misc.SOURCE_EXCLUDE_PATTERNS`` are automatically
+    included in this set.
     """
 
     cache_folder: Optional[Path] = None

--- a/tests/functional/utils/test_os.py
+++ b/tests/functional/utils/test_os.py
@@ -2,11 +2,13 @@ from pathlib import Path
 
 import pytest
 
+from ape.utils.misc import SOURCE_EXCLUDE_PATTERNS
 from ape.utils.os import (
     create_tempdir,
     get_all_files_in_directory,
     get_full_extension,
     get_relative_path,
+    path_match,
     run_in_tempdir,
 )
 
@@ -117,3 +119,62 @@ def test_run_in_tempdir(name):
     assert arguments[0].resolve() == arguments[0]
     if name is not None:
         assert arguments[0].name == name
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "path/to/.cache/file/1.json",
+        Path("path/to/.cache/file/1.json"),
+        ".cache",
+        Path(".cache"),
+        Path("contracts/.cache/TEST.json"),
+    ),
+)
+def test_path_match_cache_folder(path):
+    assert path_match(path, *SOURCE_EXCLUDE_PATTERNS)
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "path/to/.build/__local__.json",
+        Path("path/to/.build/__local__.json"),
+        ".build",
+        Path(".build"),
+        Path("contracts/.build/TEST.json"),
+    ),
+)
+def test_path_match_build_folder(path):
+    assert path_match(path, *SOURCE_EXCLUDE_PATTERNS)
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "path/to/MyFile.build.json/__local__.json",
+        Path("path/to/MyFile.build.json/__local__.json"),
+        ".builder",
+        Path(".cacher"),
+        Path("contracts/.builder/TEST.json"),
+    ),
+)
+def test_patch_match_does_not_match_but_close(path):
+    """
+    Ensures we don't get false positives.
+    """
+    assert not path_match(path, *SOURCE_EXCLUDE_PATTERNS)
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        ".gitkeep",
+        "path/to/.gitkeep",
+        "index.html",
+        "path/to/index.css",
+        "py.typed",
+    ),
+)
+def test_patch_match(path):
+    assert path_match(path, *SOURCE_EXCLUDE_PATTERNS)

--- a/tests/functional/utils/test_os.py
+++ b/tests/functional/utils/test_os.py
@@ -196,15 +196,16 @@ def test_path_match_test_contracts(path, exc):
 
 
 @pytest.mark.parametrize(
-    "path", (
+    "path",
+    (
         Path("path/to/contracts/exclude_dir/subdir/MyContract.json"),
         Path("exclude_dir/subdir/MyContract.json"),
         Path("exclude_dir/MyContract.json"),
-    )
+    ),
 )
 def test_path_match_recurse_dir(path):
     """
     Testing a specific way of excluding all the files in a directory.
     """
     excl = "exclude_dir/**"
-    assert path_match(path, path)
+    assert path_match(path, excl)

--- a/tests/functional/utils/test_os.py
+++ b/tests/functional/utils/test_os.py
@@ -193,3 +193,18 @@ def test_path_match_test_contracts(path, exc):
     assert not path_match(path, *SOURCE_EXCLUDE_PATTERNS)
     exclusions = [*SOURCE_EXCLUDE_PATTERNS, exc]
     assert path_match(path, *exclusions)
+
+
+@pytest.mark.parametrize(
+    "path", (
+        Path("path/to/contracts/exclude_dir/subdir/MyContract.json"),
+        Path("exclude_dir/subdir/MyContract.json"),
+        Path("exclude_dir/MyContract.json"),
+    )
+)
+def test_path_match_recurse_dir(path):
+    """
+    Testing a specific way of excluding all the files in a directory.
+    """
+    excl = "exclude_dir/**"
+    assert path_match(path, path)

--- a/tests/functional/utils/test_os.py
+++ b/tests/functional/utils/test_os.py
@@ -159,7 +159,7 @@ def test_path_match_build_folder(path):
         Path("contracts/.builder/TEST.json"),
     ),
 )
-def test_patch_match_does_not_match_but_close(path):
+def test_pat_match_does_not_match_but_close(path):
     """
     Ensures we don't get false positives.
     """
@@ -176,5 +176,20 @@ def test_patch_match_does_not_match_but_close(path):
         "py.typed",
     ),
 )
-def test_patch_match(path):
+def test_path_match(path):
     assert path_match(path, *SOURCE_EXCLUDE_PATTERNS)
+
+
+@pytest.mark.parametrize(
+    "path,exc",
+    [
+        ("path/to/MyContract.t.sol", "*t.sol"),
+        ("contracts/mocks/MyContract.sol", "mocks"),
+        ("mocks/MyContract.sol", "mocks"),
+        ("MockContract.sol", "Mock*"),
+    ],
+)
+def test_path_match_test_contracts(path, exc):
+    assert not path_match(path, *SOURCE_EXCLUDE_PATTERNS)
+    exclusions = [*SOURCE_EXCLUDE_PATTERNS, exc]
+    assert path_match(path, *exclusions)


### PR DESCRIPTION
### What I did

finally think i got this....

* issue where couldnt match by solid name

basically fixes an issue where if you change contracts folder and your build is now somewhere it else, it my start "compiling"... so this adjusts the exclusions so it's always excluded, how it was before

### How I did it

* make a helper method to handle and share and do this

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
