### PR TITLE
fix: issue when reassigned `project` to something else during exception in console

### DIFF
--- a/src/ape_console/plugin.py
+++ b/src/ape_console/plugin.py
@@ -10,8 +10,9 @@ import ape
 from ape._cli import cli
 from ape.exceptions import Abort, ApeException, handle_ape_exception
 from ape.logging import logger
+from ape.managers import ProjectManager
 from ape.types import AddressType
-from ape.utils import cached_property
+from ape.utils import ManagerAccessMixin, cached_property
 
 
 @magics_class
@@ -75,7 +76,15 @@ class ApeConsoleMagics(Magics):
 
 
 def custom_exception_handler(self, etype, value, tb, tb_offset=None):
-    if not handle_ape_exception(value, [self.user_ns["project"].path]):
+    project = self.user_ns["project"]
+    if isinstance(project, ProjectManager):
+        path = project.path
+    else:
+        # This happens if assigned the variable `project` in your session
+        # to something other than ``ape.project``.
+        path = ManagerAccessMixin.project_manager.path
+
+    if not handle_ape_exception(value, [path]):
         logger.error(Abort.from_ape_exception(value).format_message())
 
 


### PR DESCRIPTION
### What I did

Weird setup...

reassign project to something else in your console, e.g.

```python
project = 123
```

then cause an exception

it flupes out because of 123 has no `.path`

### How I did it

good ol' fashioned type checking
if projet 

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
