### PR TITLE
fix: bug where compilers output selection wasn't updating when contract types changes compiler

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -256,6 +256,14 @@ class ProjectAPI(BaseInterfaceModel):
                     c for c in (existing_compiler.contractTypes or []) if c not in new_types
                 ]
 
+                # Clear output selection for new types, since they are present in the new compiler.
+                if existing_compiler.settings and "outputSelection" in existing_compiler.settings:
+                    existing_compiler.settings["outputSelection"] = {
+                        k: v
+                        for k, v in existing_compiler.settings["outputSelection"].items()
+                        if k not in new_types
+                    }
+
                 # Remove compilers without contract types.
                 if existing_compiler.contractTypes:
                     remaining_existing_compilers.append(existing_compiler)


### PR DESCRIPTION
### What I did

**this bug is affecting etherscan verification**

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
