### PR TITLE
fix: bug where compilers output selection wasn't updating when sources changes compiler

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -258,10 +258,16 @@ class ProjectAPI(BaseInterfaceModel):
 
                 # Clear output selection for new types, since they are present in the new compiler.
                 if existing_compiler.settings and "outputSelection" in existing_compiler.settings:
+                    new_src_ids = {
+                        (self.manifest.contract_types or {})[x].source_id
+                        for x in new_types
+                        if x in (self.manifest.contract_types or {})
+                        and (self.manifest.contract_types or {})[x].source_id is not None
+                    }
                     existing_compiler.settings["outputSelection"] = {
                         k: v
                         for k, v in existing_compiler.settings["outputSelection"].items()
-                        if k not in new_types
+                        if k not in new_src_ids
                     }
 
                 # Remove compilers without contract types.

--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -211,7 +211,9 @@ class ProjectAPI(BaseInterfaceModel):
             )
 
         for given_compiler in given_compilers:
-            other_given_compilers = [c for c in given_compilers if c != given_compiler]
+            if not (other_given_compilers := [c for c in given_compilers if c != given_compiler]):
+                continue
+
             contract_types_from_others = [
                 n for c in other_given_compilers for n in (c.contractTypes or [])
             ]
@@ -224,15 +226,12 @@ class ProjectAPI(BaseInterfaceModel):
                 raise ProjectError(f"Contract type(s) '{collide_str}' collision across compilers.")
 
         new_types = [n for c in given_compilers for n in (c.contractTypes or [])]
-
-        # Merge given compilers with existing compilers.
         existing_compilers = self.manifest.compilers or []
-
-        # Existing compilers remaining after processing new compilers.
         remaining_existing_compilers: List[Compiler] = []
 
         for existing_compiler in existing_compilers:
-            find_iter = iter(x for x in compiler_data if x == existing_compiler)
+            # NOTE: For compilers to be equal, their name, version, and settings must be equal.
+            find_iter = (x for x in compiler_data if x == existing_compiler)
 
             if matching_given_compiler := next(find_iter, None):
                 # Compiler already exists in the system, possibly with different contract types.
@@ -243,6 +242,7 @@ class ProjectAPI(BaseInterfaceModel):
                         *(matching_given_compiler.contractTypes or []),
                     }
                 )
+
                 # NOTE: Purposely we don't add the existing compiler back,
                 #   as it is the same as the given compiler, (meaning same
                 #   name, version, and settings), and we have

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -651,13 +651,13 @@ def test_add_compiler_data(project_with_dependency_config):
         name="comp",
         version="1.0.0",
         contractTypes=["foo"],
-        settings={"outputSelection": {"foo": "*"}},
+        settings={"outputSelection": {"path/to/Foo.sol": "*"}},
     )
     compiler_2 = Compiler(
         name="test",
         version="2.0.0",
         contractTypes=["bar", "stay"],
-        settings={"outputSelection": {"bar": "*", "stay": "*"}},
+        settings={"outputSelection": {"path/to/Bar.vy": "*", "stay.vy": "*"}},
     )
 
     # NOTE: Has same contract as compiler 2 and thus replaces the contract.
@@ -665,7 +665,7 @@ def test_add_compiler_data(project_with_dependency_config):
         name="test",
         version="3.0.0",
         contractTypes=["bar"],
-        settings={"outputSelection": {"bar": "*"}},
+        settings={"outputSelection": {"path/to/Bar.vy": "*"}},
     )
 
     proj = project.local_project
@@ -692,7 +692,7 @@ def test_add_compiler_data(project_with_dependency_config):
     assert "bar" not in comp.settings["outputSelection"]
     new_comp = [c for c in proj.manifest.compilers if c.name == "test" and c.version == "3.0.0"][0]
     assert "bar" in new_comp.contractTypes
-    assert "bar" in new_comp.settings["outputSelection"]
+    assert "path/to/Bar.vy" in new_comp.settings["outputSelection"]
 
     # Show that compilers without contract types go away.
     (compiler_3.contractTypes or []).append("stay")

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -675,6 +675,16 @@ def test_add_compiler_data(project_with_dependency_config):
     first_exp = [*start_compilers, compiler]
     final_exp = [*first_exp, compiler_2]
 
+    # Ensure types are in manifest for type-source-id lookup.
+    bar = ContractType(contractName="bar", sourceId="path/to/Bar.vy")
+    foo = ContractType(contractName="foo", sourceId="path/to/Foo.sol")
+    proj._cached_manifest = PackageManifest(
+        contractTypes={"bar": bar, "foo": foo},
+        sources={"path/to/Bar.vy": Source(), "path/to/Foo.vy": Source()},
+    )
+    proj._contracts = proj._cached_manifest.contract_types
+    assert proj.cached_manifest.contract_types, "Setup failed - need manifest contract types"
+
     # Add twice to show it's only added once.
     proj.add_compiler_data(argument)
     proj.add_compiler_data(argument)
@@ -689,7 +699,7 @@ def test_add_compiler_data(project_with_dependency_config):
     proj.add_compiler_data(third_arg)
     comp = [c for c in proj.manifest.compilers if c.name == "test" and c.version == "2.0.0"][0]
     assert "bar" not in comp.contractTypes
-    assert "bar" not in comp.settings["outputSelection"]
+    assert "path/to/Bar.vy" not in comp.settings["outputSelection"]
     new_comp = [c for c in proj.manifest.compilers if c.name == "test" and c.version == "3.0.0"][0]
     assert "bar" in new_comp.contractTypes
     assert "path/to/Bar.vy" in new_comp.settings["outputSelection"]


### PR DESCRIPTION
### What I did

re-fix this https://github.com/ApeWorX/ape/pull/2086
we need this, but it needs to use source ID lookup, not contract name.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
