### PR TITLE
fix: plugin warning message didn't show unimplemented methods

### DIFF
--- a/src/ape/managers/plugins.py
+++ b/src/ape/managers/plugins.py
@@ -33,7 +33,7 @@ def valid_impl(api_class: Any) -> bool:
 
 
 def _get_unimplemented_methods_warning(api, plugin_name: str) -> str:
-    unimplemented_methods = []
+    unimplemented_methods: List[str] = []
 
     # Find the best API name to warn about.
     if isinstance(api, (list, tuple)):
@@ -153,7 +153,7 @@ class PluginManager:
             # Already warned
             return
 
-        message = _get_unimplemented_methods_warning(results)
+        message = _get_unimplemented_methods_warning(results, plugin_name)
         logger.warning(message)
 
         # Record so we don't warn repeatedly

--- a/src/ape/managers/plugins.py
+++ b/src/ape/managers/plugins.py
@@ -1,5 +1,5 @@
 import importlib
-from typing import Any, Generator, Iterator, List, Optional, Set, Tuple
+from typing import Any, Generator, Iterable, Iterator, List, Optional, Set, Tuple
 
 from ape.__modules__ import __modules__
 from ape.exceptions import ApeAttributeError
@@ -30,6 +30,46 @@ def valid_impl(api_class: Any) -> bool:
         return True  # not an abstract class
 
     return len(api_class.__abstractmethods__) == 0
+
+
+def _get_unimplemented_methods_warning(api, plugin_name: str) -> str:
+    unimplemented_methods = []
+
+    # Find the best API name to warn about.
+    if isinstance(api, (list, tuple)):
+        if classes := [p for p in api if hasattr(p, "__name__")]:
+            # Likely only ever a single class in a registration, but just in case.
+            api_name = " - ".join([p.__name__ for p in classes if hasattr(p, "__name__")])
+            for api_cls in classes:
+                unimplemented_methods.extend(_get_unimplemented_methods(api_cls))
+
+        else:
+            # This would only happen if the registration consisted of all primitives.
+            api_name = " - ".join(api)
+
+    elif hasattr(api, "__name__"):
+        api_name = api.__name__
+        unimplemented_methods.extend(_get_unimplemented_methods(api))
+
+    else:
+        api_name = api
+
+    message = f"'{api_name}' from '{plugin_name}' is not fully implemented."
+    if unimplemented_methods:
+        # NOTE: Sorted for consistency.
+        methods_str = ", ".join(sorted(unimplemented_methods))
+        message = f"{message} Remaining abstract methods: '{methods_str}'."
+
+    return message
+
+
+def _get_unimplemented_methods(api) -> Iterable[str]:
+    if (abstract_methods := getattr(api, "__abstractmethods__", None)) and hasattr(
+        abstract_methods, "__iter__"
+    ):
+        return api.__abstractmethods__
+
+    return []
 
 
 class PluginManager:
@@ -113,39 +153,7 @@ class PluginManager:
             # Already warned
             return
 
-        unimplemented_methods = []
-
-        # Find the best API name to warn about.
-        if isinstance(results, (list, tuple)):
-            classes = [p for p in results if hasattr(p, "__name__")]
-            if classes:
-                # Likely only ever a single class in a registration, but just in case.
-                api_name = " - ".join([p.__name__ for p in classes if hasattr(p, "__name__")])
-                for api_cls in classes:
-                    if (
-                        abstract_methods := getattr(api_cls, "__abstractmethods__", None)
-                    ) and isinstance(abstract_methods, dict):
-                        unimplemented_methods.extend(api_cls.__abstractmethods__)
-
-            else:
-                # This would only happen if the registration consisted of all primitives.
-                api_name = " - ".join(results)
-
-        elif hasattr(results, "__name__"):
-            api_name = results.__name__
-            if (abstract_methods := getattr(results, "__abstractmethods__", None)) and isinstance(
-                abstract_methods, dict
-            ):
-                unimplemented_methods.extend(results.__abstractmethods__)
-
-        else:
-            api_name = results
-
-        message = f"'{api_name}' from '{plugin_name}' is not fully implemented."
-        if unimplemented_methods:
-            methods_str = ", ".join(unimplemented_methods)
-            message = f"{message} Remaining abstract methods: '{methods_str}'."
-
+        message = _get_unimplemented_methods_warning(results)
         logger.warning(message)
 
         # Record so we don't warn repeatedly

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -3,7 +3,9 @@ from unittest import mock
 
 import pytest
 
+from ape.api import TransactionAPI
 from ape.logging import LogLevel
+from ape.managers.plugins import _get_unimplemented_methods_warning
 from ape.plugins._utils import (
     ApePluginsRepr,
     ModifyPluginResultHandler,
@@ -375,4 +377,15 @@ def test_filter_plugins_from_dists_py310_and_greater(mocker):
     plugins = [make_dist("solidity"), make_dist("vyper"), make_dist("optimism")]
     actual = set(_filter_plugins_from_dists(plugins))
     expected = {"ape-solidity", "ape-vyper", "ape-optimism"}
+    assert actual == expected
+
+
+@pytest.mark.parametrize("abstract_methods", [("method1", "method2"), {"method1": 0, "method2": 0}])
+def test_get_unimplemented_methods_warning_list_containing_plugin(abstract_methods):
+    plugin_registration = ("foo", "bar", TransactionAPI)
+    actual = _get_unimplemented_methods_warning(plugin_registration, "p1")
+    expected = (
+        "'TransactionAPI' from 'p1' is not fully implemented. "
+        "Remaining abstract methods: 'serialize_transaction, txn_hash'."
+    )
     assert actual == expected


### PR DESCRIPTION
### What I did

on python 3.12 I noticed the unimplemented methods were not showing in the warning message
this PR fixes it

### How I did it

adjust the check

### How to verify it

botch an api impl method and look at the warning

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
