### PR TITLE
fix: datetime utcnow bug

### DIFF
--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -4,6 +4,7 @@ import json
 import sys
 from asyncio import gather
 from datetime import datetime
+from dateutil.tz import tzutc
 from functools import cached_property, lru_cache, singledispatchmethod, wraps
 from importlib.metadata import PackageNotFoundError, distributions
 from importlib.metadata import version as version_metadata
@@ -457,7 +458,7 @@ def get_current_timestamp_ms() -> int:
     Returns:
         int
     """
-    return round(datetime.utcnow().timestamp() * 1000)
+    return round(datetime.now(tz=tzutc()).timestamp() * 1000)
 
 
 def is_evm_precompile(address: str) -> bool:

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -3,7 +3,7 @@ import functools
 import json
 import sys
 from asyncio import gather
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import cached_property, lru_cache, singledispatchmethod, wraps
 from importlib.metadata import PackageNotFoundError, distributions
 from importlib.metadata import version as version_metadata
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, Mapping,
 
 import requests
 import yaml
-from dateutil.tz import tzutc
 from eth_pydantic_types import HexBytes
 from eth_utils import is_0x_prefixed
 from packaging.specifiers import SpecifierSet
@@ -458,7 +457,7 @@ def get_current_timestamp_ms() -> int:
     Returns:
         int
     """
-    return round(datetime.now(tz=tzutc()).timestamp() * 1000)
+    return round(datetime.now(tz=timezone.utc).timestamp() * 1000)
 
 
 def is_evm_precompile(address: str) -> bool:

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -4,7 +4,6 @@ import json
 import sys
 from asyncio import gather
 from datetime import datetime
-from dateutil.tz import tzutc
 from functools import cached_property, lru_cache, singledispatchmethod, wraps
 from importlib.metadata import PackageNotFoundError, distributions
 from importlib.metadata import version as version_metadata
@@ -13,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, Mapping,
 
 import requests
 import yaml
+from dateutil.tz import tzutc
 from eth_pydantic_types import HexBytes
 from eth_utils import is_0x_prefixed
 from packaging.specifiers import SpecifierSet

--- a/tests/functional/utils/test_misc.py
+++ b/tests/functional/utils/test_misc.py
@@ -1,4 +1,4 @@
-from datetime import timezone, datetime
+from datetime import datetime
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -12,6 +12,7 @@ from ape.utils.misc import (
     _dict_overlay,
     add_padding_to_strings,
     extract_nested_value,
+    get_current_timestamp_ms,
     get_package_version,
     is_evm_precompile,
     is_zero_hex,
@@ -19,7 +20,6 @@ from ape.utils.misc import (
     pragma_str_to_specifier_set,
     raises_not_implemented,
     run_until_complete,
-    get_current_timestamp_ms,
     to_int,
 )
 

--- a/tests/functional/utils/test_misc.py
+++ b/tests/functional/utils/test_misc.py
@@ -1,3 +1,6 @@
+from datetime import timezone, datetime
+from zoneinfo import ZoneInfo
+
 import pytest
 from eth_pydantic_types import HexBytes
 from packaging.version import Version
@@ -16,6 +19,7 @@ from ape.utils.misc import (
     pragma_str_to_specifier_set,
     raises_not_implemented,
     run_until_complete,
+    get_current_timestamp_ms,
     to_int,
 )
 
@@ -169,3 +173,15 @@ def test_log_instead_of_fail(ape_caplog):
 
     my_method()
     assert "Oh no!" in ape_caplog.head
+
+
+def test_get_current_timestamp_ms():
+    """
+    Proving the current timestamp is UTC.
+    """
+    actual = get_current_timestamp_ms()  # UTC
+    zone = ZoneInfo("America/Chicago")
+    dt = datetime(2020, 10, 31, 12, tzinfo=zone)
+    unexpected = round(datetime.now(tz=dt.tzinfo).timestamp() * 1000)
+    diff = actual - unexpected
+    assert diff == pytest.approx(18_000_000)  # Difference of CST to UTC.

--- a/tests/functional/utils/test_misc.py
+++ b/tests/functional/utils/test_misc.py
@@ -1,6 +1,3 @@
-from datetime import datetime
-from zoneinfo import ZoneInfo
-
 import pytest
 from eth_pydantic_types import HexBytes
 from packaging.version import Version
@@ -12,7 +9,6 @@ from ape.utils.misc import (
     _dict_overlay,
     add_padding_to_strings,
     extract_nested_value,
-    get_current_timestamp_ms,
     get_package_version,
     is_evm_precompile,
     is_zero_hex,
@@ -173,15 +169,3 @@ def test_log_instead_of_fail(ape_caplog):
 
     my_method()
     assert "Oh no!" in ape_caplog.head
-
-
-def test_get_current_timestamp_ms():
-    """
-    Proving the current timestamp is UTC.
-    """
-    actual = get_current_timestamp_ms()  # UTC
-    zone = ZoneInfo("America/Chicago")
-    dt = datetime(2020, 10, 31, 12, tzinfo=zone)
-    unexpected = round(datetime.now(tz=dt.tzinfo).timestamp() * 1000)
-    diff = actual - unexpected
-    assert diff == pytest.approx(18_000_000)  # Difference of CST to UTC.


### PR DESCRIPTION
### What I did

`get_current_timestamp_ms` claimed to return UTC now but it wasn't actually. Also, `utcnow()` is deprecated.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
