### PR TITLE
fix: bug preventing hyphenated plugin configs from working

### DIFF
--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -221,7 +221,7 @@ class ApeConfig(ExtraAttributesMixin, BaseSettings, ManagerAccessMixin):
             if fixed_deps:
                 fixed_model["dependencies"] = fixed_deps
 
-        # field: contracs_folder: Handle if given Path object.
+        # field: contracts_folder: Handle if given Path object.
         if "contracts_folder" in fixed_model and isinstance(fixed_model["contracts_folder"], Path):
             fixed_model["contracts_folder"] = str(fixed_model["contracts_folder"])
 
@@ -330,9 +330,9 @@ class ApeConfig(ExtraAttributesMixin, BaseSettings, ManagerAccessMixin):
             # Already decoded.
             return cfg
 
-        for plugin_name, config_class in self.plugin_manager.config_class:
+        for plugin_name, config_class in self._get_config_plugin_classes():
             cls: type[PluginConfig] = config_class  # type: ignore
-            if plugin_name != name:
+            if plugin_name.replace("-", "_") != name:
                 continue
 
             if cls != ConfigDict:
@@ -346,6 +346,10 @@ class ApeConfig(ExtraAttributesMixin, BaseSettings, ManagerAccessMixin):
             return config
 
         return None
+
+    def _get_config_plugin_classes(self):
+        # NOTE: Abstracted for easily mocking in tests.
+        return self.plugin_manager.config_class
 
     def get_custom_ecosystem_config(self, name: str) -> Optional[PluginConfig]:
         name = name.replace("-", "_")

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -1,4 +1,3 @@
-import copy
 from collections.abc import Collection, Iterator
 from functools import cached_property
 from typing import Optional, Union
@@ -171,9 +170,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         """
         All the registered ecosystems in ``ape``, such as ``ethereum``.
         """
-
-        # Use copy to avoid modifying the cached dict.
-        plugin_ecosystems = copy.deepcopy(self._plugin_ecosystems)
+        plugin_ecosystems = self._plugin_ecosystems
 
         # Load config.
         custom_networks: list = self.config_manager.get_config("networks").get("custom", [])

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -1,3 +1,4 @@
+import copy
 from collections.abc import Collection, Iterator
 from functools import cached_property
 from typing import Optional, Union
@@ -170,7 +171,9 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         """
         All the registered ecosystems in ``ape``, such as ``ethereum``.
         """
-        plugin_ecosystems = self._plugin_ecosystems
+
+        # Use copy to avoid modifying the cached dict.
+        plugin_ecosystems = copy.deepcopy(self._plugin_ecosystems)
 
         # Load config.
         custom_networks: list = self.config_manager.get_config("networks").get("custom", [])

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -974,7 +974,21 @@ def test_default_network_name_when_not_set_and_no_local_uses_only(
 
     with project.temp_config(networks={"custom": [net]}):
         ecosystem = project.network_manager.get_ecosystem(ecosystem_name)
-        assert ecosystem.default_network_name == only_network
+        actual = ecosystem.default_network_name
+
+        if actual == LOCAL_NETWORK_NAME:
+            # For some reason, this test is flake-y. Offer more info
+            # to try and debug when this happens (intermittent CI failure).
+            all_nets = ", ".join([x.name for x in ecosystem.networks])
+            pytest.fail(
+                f"assert '{LOCAL_NETWORK_NAME}' == '{only_network}'. More info below:\n"
+                f"ecosystem_name={ecosystem.name}\n"
+                f"networks={all_nets}\n"
+                f"type={type(ecosystem)}"
+            )
+        else:
+            # This should pass.
+            assert ecosystem.default_network_name == only_network
 
 
 def test_decode_custom_error(chain, ethereum):


### PR DESCRIPTION
### What I did

noticed when trying to upgrade ape-polygon-zkevm. dang! not sure what happened suddenly
### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
