### PR TITLE
fix: issue where trusted plugins showed up as 3rd party

### DIFF
--- a/tests/functional/utils/test_github.py
+++ b/tests/functional/utils/test_github.py
@@ -91,3 +91,10 @@ class TestGithubClient:
         expected_uri = "https://api.github.com/repos/test/path/releases/tags"
         assert calls[0][0] == ("GET", f"{expected_uri}/{version}")
         assert calls[1][0] == ("GET", f"{expected_uri}/{opposite}")
+
+    def test_get_org_repos(self, github_client, mock_session):
+        _ = list(github_client.get_org_repos())
+        call = mock_session.method_calls[-1]
+        params = call.kwargs["params"]
+        # Show we are fetching more than the default 30 per page.
+        assert params == {"per_page": 100, "page": 1}


### PR DESCRIPTION
### What I did

Regression from the GitHub refactor - turns out GH only gives you 30 repos at a time, so now we are paging and getting them all.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

install a bunch of plugins and type:

```
ape plugins list
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
