### PR TITLE
fix: issue where `v` prefix mattered in dependency mapping

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -909,31 +909,36 @@ class DependencyVersionMap(dict[str, "ProjectManager"]):
         keys = ",".join(list(self.keys()))
         return f"<{self._name} versions='{keys}'>"
 
-    def __contains__(self, version: str) -> bool:
+    def __contains__(self, version: Any) -> bool:
+        if not isinstance(version, str):
+            return False
+
         options = _version_to_options(version)
-        return any(dict.__contains__(self, v) for v in options)
+        return any(dict.__contains__(self, v) for v in options)  # type: ignore
 
     def __getitem__(self, version: str) -> "ProjectManager":
         options = _version_to_options(version)
         for vers in options:
-            if not dict.__contains__(self, vers):
+            if not dict.__contains__(self, vers):  # type: ignore
                 continue
 
             # Found.
-            return dict.__getitem__(self, vers)
+            return dict.__getitem__(self, vers)  # type: ignore
 
         raise KeyError(version)
 
-    def get(self, version: str):
+    def get(  # type: ignore
+        self, version: str, default: Optional["ProjectManager"] = None
+    ) -> Optional["ProjectManager"]:
         options = _version_to_options(version)
         for vers in options:
-            if not dict.__contains__(self, vers):
+            if not dict.__contains__(self, vers):  # type: ignore
                 continue
 
             # Found.
-            return dict.get(self, vers)
+            return dict.get(self, vers)  # type: ignore
 
-        return None
+        return default
 
     def extend(self, data: dict):
         for key, val in data.items():

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -163,6 +163,18 @@ def test_get_versions(project_with_downloaded_dependencies):
     assert len(actual) == 2
 
 
+def test_getitem_and_contains_and_get(project_with_downloaded_dependencies):
+    dm = project_with_downloaded_dependencies.dependencies
+    name = "openzeppelin"
+    versions = dm[name]
+    assert "3.1.0" in versions
+    assert "v3.1.0" in versions  # Also allows v-prefix.
+    assert (
+        versions["3.1.0"] == versions["v3.1.0"] == versions.get("3.1.0") == versions.get("v3.1.0")
+    )
+    assert isinstance(versions["3.1.0"], LocalProject)
+
+
 def test_add(project):
     with project.isolate_in_tempdir() as tmp_project:
         contracts_path = tmp_project.path / "src"

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -974,6 +974,7 @@ def test_default_network_name_when_not_set_and_no_local_uses_only(
 
     with project.temp_config(networks={"custom": [net]}):
         ecosystem = project.network_manager.get_ecosystem(ecosystem_name)
+        ecosystem._default_network = None
         actual = ecosystem.default_network_name
 
         if actual == LOCAL_NETWORK_NAME:


### PR DESCRIPTION
### What I did

if version was `v3.0.1` could not exclude `v` on `project.dependencies["yearn-vaults"]["v3.0.1"]` and likewise if version is `3.0.1`, v was required.

### How I did it

create a smarter intermediate mapping that smartly checked for both key when it makes sense

### How to verify it

```python
In [2]: versions["3.0.2"]
Out[2]: <ProjectManager $HOME/.ape/packages/projects/yearn_yearn-vaults/v3_0_2>

In [3]: versions["v3.0.2"]
Out[3]: <ProjectManager $HOME/.ape/packages/projects/yearn_yearn-vaults/v3_0_2>

In [4]: versions["vvv3.0.2"]
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
