### PR TITLE
fix: issues with manifest-dependencies, evm-version in foundry projects, and unpacking

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -779,7 +779,8 @@ class Dependency(BaseManager, ExtraAttributesMixin):
             )
             destination = folder / contracts_folder_id
             destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copytree(self.project.contracts_folder, destination)
+            if self.project.contracts_folder.is_dir():
+                shutil.copytree(self.project.contracts_folder, destination)
 
         # self is done!
         yield self

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -774,13 +774,19 @@ class Dependency(BaseManager, ExtraAttributesMixin):
 
         if not folder.is_dir():
             # Not yet unpacked.
-            contracts_folder_id = get_relative_path(
-                self.project.contracts_folder, self.project.path
-            )
-            destination = folder / contracts_folder_id
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            if self.project.contracts_folder.is_dir():
-                shutil.copytree(self.project.contracts_folder, destination)
+            if isinstance(self.project, LocalProject):
+                contracts_folder_id = get_relative_path(
+                    self.project.contracts_folder, self.project.path
+                )
+                destination = folder / contracts_folder_id
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                if self.project.contracts_folder.is_dir():
+                    shutil.copytree(self.project.contracts_folder, destination)
+
+            else:
+                # Will create contracts folder from source IDs.
+                folder.parent.mkdir(parents=True, exist_ok=True)
+                self.project.manifest.unpack_sources(folder)
 
         # self is done!
         yield self

--- a/src/ape_pm/projects.py
+++ b/src/ape_pm/projects.py
@@ -173,6 +173,9 @@ class FoundryProject(ProjectAPI):
             solidity_data["optimize"] = root_data["optimizer"]
         if runs := solidity_data.get("optimizer_runs"):
             solidity_data["optimization_runs"] = runs
+        if evm_version := root_data.get("evm_version"):
+            solidity_data["evm_version"] = evm_version
+
         if soldata := solidity_data:
             ape_cfg["solidity"] = soldata
 

--- a/src/ape_pm/projects.py
+++ b/src/ape_pm/projects.py
@@ -149,7 +149,7 @@ class FoundryProject(ProjectAPI):
         # Handle root project configuration.
         # NOTE: The default contracts folder name is `src` in foundry
         #  instead of `contracts`, hence the default.
-        ape_cfg["contracts_folder"] = root_data.get("src", "src")
+        ape_cfg["contracts_folder"] = root_data.get("src")
 
         # Used for seeing which remappings are comings from dependencies.
         lib_paths = root_data.get("libs", ("lib",))

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -262,9 +262,9 @@ def test_unpack(project_with_downloaded_dependencies):
 def test_unpack_dependencies_of_dependencies(project, with_dependencies_project_path):
     dep = project.dependencies.install(local=with_dependencies_project_path, name="wdep")
     with create_tempdir() as tempdir:
-        dep.unpack(tempdir)
-
-        # TODO: Check for dependency of dependency!
+        list(dep.unpack(tempdir))
+        subdirs = [x.name for x in tempdir.iterdir() if x.is_dir()]
+        assert "sub-dependency" in subdirs
 
 
 class TestPackagesCache:

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -267,6 +267,14 @@ def test_unpack_dependencies_of_dependencies(project, with_dependencies_project_
         assert "sub-dependency" in subdirs
 
 
+def test_unpack_no_contracts_folder(project, with_dependencies_project_path):
+    dep = project.dependencies.install(local=with_dependencies_project_path, name="wdep")
+    with create_tempdir() as tempdir:
+        list(dep.unpack(tempdir))
+        subdirs = [x.name for x in tempdir.iterdir() if x.is_dir()]
+        assert "empty-dependency" in subdirs
+
+
 class TestPackagesCache:
     @pytest.fixture
     def cache(self):

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -582,6 +582,7 @@ src = 'src'
 out = 'out'
 libs = ['lib']
 solc = "0.8.18"
+evm_version = 'cancun'
 
 remappings = [
     'forge-std/=lib/forge-std/src/',
@@ -630,6 +631,7 @@ remappings = [
                 "@openzeppelin/=openzeppelin-contracts/",
             ]
             assert actual_sol["version"] == "0.8.18"
+            assert actual_sol["evm_version"] == "cancun"
 
             # Ensure dependencies migrated from .gitmodules.
             assert "dependencies" in actual, "Dependencies failed to migrate"

--- a/tests/integration/cli/projects/with-dependencies/ape-config.yaml
+++ b/tests/integration/cli/projects/with-dependencies/ape-config.yaml
@@ -20,3 +20,6 @@ dependencies:
 
   - name: manifest-dependency
     local: ./manifest_dependency.json
+
+  - name: empty-dependency
+    local: ./empty_dependency

--- a/tests/integration/cli/projects/with-dependencies/empty_dependency/README.md
+++ b/tests/integration/cli/projects/with-dependencies/empty_dependency/README.md
@@ -1,0 +1,1 @@
+# For testing anything with a dependency with no contracts.


### PR DESCRIPTION
### What I did

trying to fix everything hehe

1. fix: support `evm_version` reading from foundry.toml
2. fix: issue with empty dependencies (such as ones with only test.sol) causing issues during the unpacking stage, which ape-solidity used... so we just check if contracts folder exists first before unpacking, easy peasy.
3. fix: issue with manifest-only based dependencies when it comes to unpacking, was getting attr errors.


I think I am still hitting another issue, will either put on this PR or another...