### PR TITLE
fix: issues with remapping and dependency detection in foundry projects

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2081,9 +2081,9 @@ class LocalProject(Project):
         # I am not sure this is even possible.
         raise ProjectError(f"'{self.path.name}' is not recognized as a project.")
 
-    def _get_ape_project_api(self) -> Optional[ProjectAPI]:
+    def _get_ape_project_api(self) -> Optional[ApeProject]:
         if instance := ApeProject.attempt_validate(path=self.path):
-            return instance
+            return cast(ApeProject, instance)
 
         return None
 

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -626,7 +626,6 @@ class Dependency(BaseManager, ExtraAttributesMixin):
         config_override = {**(self.api.config_override or {}), **(config_override or {})}
         project = None
         did_fetch = False
-
         if self._installation is not None and use_cache:
             if config_override:
                 self._installation.reconfigure(**config_override)
@@ -1363,15 +1362,15 @@ class DependencyManager(BaseManager):
         use_cache: bool = dependency.pop("use_cache", False)
         if dependency:
             return self.install_dependency(dependency, use_cache=use_cache)
-        else:
-            # Install all project's.
-            result: list[Dependency] = []
 
-            # Log the errors as they happen but don't crash the full install.
-            for dep in self._get_specified():
-                result.append(dep)
+        # Install all project's.
+        result: list[Dependency] = []
 
-            return result
+        # Log the errors as they happen but don't crash the full install.
+        for dep in self._get_specified(use_cache=use_cache):
+            result.append(dep)
+
+        return result
 
     def install_dependency(
         self,

--- a/src/ape_pm/_cli.py
+++ b/src/ape_pm/_cli.py
@@ -8,6 +8,7 @@ from ape.cli.options import ape_cli_context, config_override_option
 from ape.exceptions import ProjectError
 from ape.logging import logger
 from ape.managers.project import Dependency
+from ape_pm import LocalDependency
 
 
 @click.group()
@@ -38,8 +39,16 @@ def _list(cli_ctx, list_all):
             # Project may not even be installed right.
             is_compiled = False
 
+        # For local dependencies, use the short name.
+        # This is mostly because it looks nicer than very long paths.
+        name = (
+            dependency.name
+            if isinstance(dependency.api, LocalDependency)
+            else dependency.package_id
+        )
+
         item = {
-            "name": dependency.package_id,
+            "name": name,
             "version": dependency.version,
             "compiled": is_compiled,
         }

--- a/src/ape_pm/_cli.py
+++ b/src/ape_pm/_cli.py
@@ -29,7 +29,7 @@ def _list(cli_ctx, list_all):
     packages = []
     dependencies = [*list(pm.dependencies.specified)]
     if list_all:
-        dependencies = list(set([*dependencies, *pm.dependencies.installed]))
+        dependencies = list({*dependencies, *pm.dependencies.installed})
 
     for dependency in dependencies:
         try:
@@ -39,7 +39,7 @@ def _list(cli_ctx, list_all):
             is_compiled = False
 
         item = {
-            "name": dependency.name,
+            "name": dependency.package_id,
             "version": dependency.version,
             "compiled": is_compiled,
         }

--- a/src/ape_pm/projects.py
+++ b/src/ape_pm/projects.py
@@ -167,7 +167,7 @@ class FoundryProject(ProjectAPI):
             remappings_from_file = self.remapping_file.read_text().splitlines()
             remappings_cfg.extend(remappings_from_file)
         if remappings := remappings_cfg:
-            solidity_data["import_remappings"] = remappings
+            solidity_data["import_remapping"] = remappings
 
         if "optimizer" in root_data:
             solidity_data["optimize"] = root_data["optimizer"]
@@ -196,7 +196,7 @@ class FoundryProject(ProjectAPI):
 
                 # Check for short-name in remappings.
                 fixed_remappings: list[str] = []
-                for remapping in ape_cfg.get("solidity", {}).get("import_remappings", []):
+                for remapping in ape_cfg.get("solidity", {}).get("import_remapping", []):
                     parts = remapping.split("=")
                     value = parts[1]
                     found = False
@@ -215,7 +215,7 @@ class FoundryProject(ProjectAPI):
                         fixed_remappings.append(remapping)
 
                 if fixed_remappings:
-                    ape_cfg["solidity"]["import_remappings"] = fixed_remappings
+                    ape_cfg["solidity"]["import_remapping"] = fixed_remappings
 
                 if "name" not in gh_dependency and path_name:
                     found = False
@@ -238,7 +238,6 @@ class FoundryProject(ProjectAPI):
                     gh_dependency["ref"] = module["branch"]
 
                 if "version" not in gh_dependency and "ref" not in gh_dependency:
-
                     gh_parts = github.split("/")
                     if len(gh_parts) != 2:
                         # Likely not possible, but just try `main`.

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -156,7 +156,14 @@ def test_get_dependency_by_name(project_with_downloaded_dependencies):
     assert actual.package_id == "OpenZeppelin/openzeppelin-contracts"
 
 
-def test_get_versions(project_with_downloaded_dependencies):
+def test_get_versions_using_package_id(project_with_downloaded_dependencies):
+    dm = project_with_downloaded_dependencies.dependencies
+    package_id = "OpenZeppelin/openzeppelin-contracts"
+    actual = list(dm.get_versions(package_id))
+    assert len(actual) == 2
+
+
+def test_get_versions_using_name(project_with_downloaded_dependencies):
     dm = project_with_downloaded_dependencies.dependencies
     name = "openzeppelin"
     actual = list(dm.get_versions(name))

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -213,7 +213,7 @@ def test_add_dependency_with_dependencies(project, with_dependencies_project_pat
     assert actual.version == "local"
 
 
-def test_install(project):
+def test_install(project, mocker):
     with project.isolate_in_tempdir() as tmp_project:
         contracts_path = tmp_project.path / "src"
         contracts_path.mkdir(exist_ok=True, parents=True)
@@ -234,6 +234,11 @@ def test_install(project):
         project = dependency.install()
         assert isinstance(project, ProjectManager)
         assert dependency.project_path.is_dir()  # Was re-created from manifest sources.
+
+        # Force install and prove it actually does the re-install.
+        spy = mocker.spy(tmp_project.dependencies, "_get_specified")
+        tmp_project.dependencies.install(use_cache=False)
+        spy.assert_called_once_with(use_cache=False)
 
 
 def test_install_dependencies_of_dependencies(project, with_dependencies_project_path):

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -626,7 +626,7 @@ remappings = [
             assert actual["contracts_folder"] == "src"
             assert "solidity" in actual, "Solidity failed to migrate"
             actual_sol = actual["solidity"]
-            assert actual_sol["import_remappings"] == [
+            assert actual_sol["import_remapping"] == [
                 "forge-std/=forge-std/src/",
                 "@openzeppelin/=openzeppelin-contracts/",
             ]

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -622,13 +622,15 @@ remappings = [
             assert isinstance(api, FoundryProject)
 
             # Ensure solidity config migrated.
-            actual = temp_project.config  # Is result of ``api.extract_config()``.
+            actual = temp_project.config.model_dump(
+                by_alias=True
+            )  # Is result of ``api.extract_config()``.
             assert actual["contracts_folder"] == "src"
             assert "solidity" in actual, "Solidity failed to migrate"
             actual_sol = actual["solidity"]
             assert actual_sol["import_remapping"] == [
-                "forge-std/=forge-std/src/",
-                "@openzeppelin/=openzeppelin-contracts/",
+                "@openzeppelin=src/.cache/openzeppelin/v4.9.5/",
+                "forge-std=src/.cache/forge-std/v1.5.2/src",
             ]
             assert actual_sol["version"] == "0.8.18"
             assert actual_sol["evm_version"] == "cancun"

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -9,6 +9,7 @@ from pydantic_core import Url
 
 import ape
 from ape import Project
+from ape.api.projects import ApeProject
 from ape.contracts import ContractContainer
 from ape.exceptions import ProjectError
 from ape.logging import LogLevel
@@ -49,6 +50,23 @@ def contract_block_hash(eth_tester_provider, vyper_contract_instance):
 @pytest.fixture
 def project_from_manifest(manifest):
     return Project.from_manifest(manifest)
+
+
+@pytest.fixture(scope="module")
+def foundry_toml():
+    return """
+[profile.default]
+src = 'src'
+out = 'out'
+libs = ['lib']
+solc = "0.8.18"
+evm_version = 'cancun'
+
+remappings = [
+    'forge-std/=lib/forge-std/src/',
+    '@openzeppelin/=lib/openzeppelin-contracts/',
+]
+""".lstrip()
 
 
 def make_contract(name: str = "test") -> ContractType:
@@ -484,6 +502,23 @@ def test_add_compiler_data(project_with_dependency_config):
         project.add_compiler_data([compiler_4, compiler_5])
 
 
+def test_project_api_foundry_and_ape_config_found(foundry_toml):
+    """
+    If a project is both a Foundry project and an Ape project,
+    ensure Ape treats it as an Ape project.
+    """
+    with ape.Project.create_temporary_project() as temp_project:
+        foundry_cfg_file = temp_project.path / "foundry.toml"
+        foundry_cfg_file.write_text(foundry_toml)
+
+        ape_cfg_file = temp_project.path / "ape-config.yaml"
+        ape_cfg_file.write_text("name: testfootestfootestfoo")
+
+        actual = temp_project.project_api
+        assert isinstance(actual, ApeProject)
+        assert not isinstance(actual, FoundryProject)
+
+
 class TestProject:
     """
     All tests related to ``ape.Project``.
@@ -575,22 +610,6 @@ class TestFoundryProject:
         return mocker.MagicMock()
 
     @pytest.fixture(scope="class")
-    def toml(self):
-        return """
-[profile.default]
-src = 'src'
-out = 'out'
-libs = ['lib']
-solc = "0.8.18"
-evm_version = 'cancun'
-
-remappings = [
-    'forge-std/=lib/forge-std/src/',
-    '@openzeppelin/=lib/openzeppelin-contracts/',
-]
-""".lstrip()
-
-    @pytest.fixture(scope="class")
     def gitmodules(self):
         return """
 [submodule "lib/forge-std"]
@@ -609,10 +628,10 @@ remappings = [
             "    ", "\t"
         )
 
-    def test_extract_config(self, toml, gitmodules, mock_github):
+    def test_extract_config(self, foundry_toml, gitmodules, mock_github):
         with ape.Project.create_temporary_project() as temp_project:
             cfg_file = temp_project.path / "foundry.toml"
-            cfg_file.write_text(toml)
+            cfg_file.write_text(foundry_toml)
             gitmodules_file = temp_project.path / ".gitmodules"
             gitmodules_file.write_text(gitmodules)
 


### PR DESCRIPTION
### What I did

all the massaging needed to get foundry projects really working.

Goes with https://github.com/ApeWorX/ape-solidity/pull/147

### How I did it

ugh.

### How to verify it

this beast is now compiling without any ape-config.yaml required: https://github.com/yearn/tokenized-strategy
all from reading the foundry's project stuff.
the trickiest part was handling weird stuff with gitsubmodules and older foundry libs with so many different wways of doing remappings and names and i cant even explain it. Ape as a side-effect is way smarter now.

The attached ape-solidity PR will attempt to correct bad import remappings so things just work now, this also helps compile older Ape projects.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
