### PR TITLE
feat: allow deploying contract types from account

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -9,6 +9,7 @@ from eip712.messages import SignableMessage as EIP712SignableMessage
 from eth_account import Account
 from eth_account.messages import encode_defunct
 from eth_pydantic_types import HexBytes
+from ethpm_types import ContractType
 
 from ape.api.address import BaseAddress
 from ape.api.transactions import ReceiptAPI, TransactionAPI
@@ -249,10 +250,15 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         """
         from ape.contracts import ContractContainer
 
+        if isinstance(contract, ContractType):
+            # Hack to allow deploying ContractTypes w/o being
+            # wrapped in a container first.
+            contract = ContractContainer(contract)
+
         # NOTE: It is important to type check here to prevent cases where user
         #    may accidentally pass in a ContractInstance, which has a very
         #    different implementation for __call__ than ContractContainer.
-        if not isinstance(contract, ContractContainer):
+        elif not isinstance(contract, ContractContainer):
             raise TypeError(
                 "contract argument must be a ContractContainer type, "
                 "such as 'project.MyContract' where 'MyContract' is the name of "

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -331,6 +331,12 @@ def test_deploy_no_deployment_bytecode(owner, bytecode):
         owner.deploy(contract)
 
 
+def test_deploy_contract_type(owner, vyper_contract_type, chain, clean_contracts_cache):
+    contract = owner.deploy(vyper_contract_type, 0)
+    assert contract.address
+    assert contract.txn_hash
+
+
 def test_send_transaction_with_bad_nonce(sender, receiver):
     # Bump the nonce so we can set one that is too low.
     sender.transfer(receiver, "1 gwei", type=0)

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -529,6 +529,17 @@ def test_project_api_foundry_and_ape_config_found(foundry_toml):
         assert not isinstance(actual, FoundryProject)
 
 
+def test_get_contract(project_with_contracts):
+    actual = project_with_contracts.get_contract("Other")
+    assert isinstance(actual, ContractContainer)
+    assert actual.contract_type.name == "Other"
+
+
+def test_get_contract_not_exists(project):
+    actual = project.get_contract("this is not a contract")
+    assert actual is None
+
+
 class TestProject:
     """
     All tests related to ``ape.Project``.


### PR DESCRIPTION
### What I did

allows you to do `account.deploy(contract_type)`

### How I did it

check isinstance, wrap if needed.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
