### PR TITLE
feat: better CLI message when compiling a dependency produces no contracts

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -749,7 +749,32 @@ class Dependency(BaseManager, ExtraAttributesMixin):
             self.project.reconfigure(**override)
             self._cache.cache_api(self.api)
 
-        return self.project.load_contracts(use_cache=use_cache)
+        result = self.project.load_contracts(use_cache=use_cache)
+        if not result:
+            contracts_folder = self.project.contracts_folder
+            message = "Compiling dependency produced no contract types."
+            if isinstance(self.project, LocalProject):
+                all_files = [x.name for x in get_all_files_in_directory(contracts_folder)]
+                has_solidity_sources = any(get_full_extension(Path(x)) == ".sol" for x in all_files)
+                has_vyper_sources = any(
+                    get_full_extension(Path(x)) in (".vy", ".vyi") for x in all_files
+                )
+                compilers = self.compiler_manager.registered_compilers
+                warn_sol = has_solidity_sources and ".sol" not in compilers
+                warn_vyper = has_vyper_sources and ".vy" not in compilers
+                suffix = ""
+                if warn_sol:
+                    suffix = "Try installing 'ape-solidity'"
+                if warn_vyper and warn_sol:
+                    suffix += " or 'ape-vyper'"
+                elif warn_vyper:
+                    suffix = "Try installing 'ape-vyper'"
+                if suffix:
+                    message = f"{message} {suffix}."
+
+            logger.warning(message)
+
+        return result
 
     def unpack(self, path: Path) -> Iterator["Dependency"]:
         """

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2356,7 +2356,7 @@ class LocalProject(Project):
             starting = {
                 n: ContractContainer(ct)
                 for n, ct in (self.manifest.contract_types or {}).items()
-                if ct.source_id and (self.path / ct.source_id).is_file()
+                if use_cache and ct.source_id and (self.path / ct.source_id).is_file()
             }
             paths = self.sources.paths
 

--- a/src/ape_pm/_cli.py
+++ b/src/ape_pm/_cli.py
@@ -7,8 +7,7 @@ import click
 from ape.cli.options import ape_cli_context, config_override_option
 from ape.exceptions import ProjectError
 from ape.logging import logger
-from ape.managers.project import Dependency, LocalProject
-from ape.utils import get_all_files_in_directory, get_full_extension
+from ape.managers.project import Dependency
 from ape_pm import LocalDependency
 
 
@@ -325,27 +324,5 @@ def _compile_dependency(cli_ctx, dependency: Dependency, force: bool):
     else:
         if result:
             cli_ctx.logger.success(f"Package '{dependency.name}@{dependency.version}' compiled.")
-        else:
-            dep_project = dependency.project
-            contracts_folder = dep_project.contracts_folder
-            message = "Compiling dependency produced no contract types."
-            if isinstance(dep_project, LocalProject):
-                all_files = [x.name for x in get_all_files_in_directory(contracts_folder)]
-                has_solidity_sources = any(get_full_extension(Path(x)) == ".sol" for x in all_files)
-                has_vyper_sources = any(
-                    get_full_extension(Path(x)) in (".vy", ".vyi") for x in all_files
-                )
-                compilers = cli_ctx.compiler_manager.register_compilers
-                warn_sol = has_solidity_sources and ".sol" not in compilers
-                warn_vyper = has_vyper_sources and ".vy" not in compilers
-                suffix = ""
-                if warn_sol:
-                    suffix = "Try installing 'ape-solidity'"
-                if warn_vyper and warn_sol:
-                    suffix += " or 'ape-vyper'"
-                elif warn_vyper:
-                    suffix = "Try installing 'ape-vyper'"
-                if suffix:
-                    message = f"{message} {suffix}."
-
-            cli_ctx.logger.warning(message)
+        # else: user should have received warning from `dependency.compile()` if there
+        # was no result.

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -10,6 +10,7 @@ import ape
 from ape.managers.project import Dependency, LocalProject, PackagesCache, Project, ProjectManager
 from ape.utils import create_tempdir
 from ape_pm.dependency import GithubDependency, LocalDependency, NpmDependency
+from tests.conftest import skip_if_plugin_installed
 
 
 @pytest.fixture
@@ -542,6 +543,35 @@ class TestDependency:
         name = dependency.api.package_id.replace("/", "_")
         expected = data_folder / "packages" / "manifests" / name / "1_0_0.json"
         assert actual == expected
+
+    def test_compile(self, project):
+        with create_tempdir() as path:
+            api = LocalDependency(local=path, name="ooga", version="1.0.0")
+            dependency = Dependency(api, project)
+            contract_path = dependency.project.contracts_folder / "CCC.json"
+            contract_path.write_text(
+                '[{"name":"foo","type":"fallback", "stateMutability":"nonpayable"}]'
+            )
+            result = dependency.compile()
+            assert len(result) == 1
+            assert result["CCC"].name == "CCC"
+
+    @skip_if_plugin_installed("vyper", "solidity")
+    def test_compile_missing_compilers(self, project, ape_caplog):
+        with create_tempdir() as path:
+            api = LocalDependency(local=path, name="ooga", version="1.0.0")
+            dependency = Dependency(api, project)
+            sol_path = dependency.project.contracts_folder / "Sol.sol"
+            sol_path.write_text("// Sol")
+            vy_path = dependency.project.contracts_folder / "Vy.vy"
+            vy_path.write_text("# Vy")
+            expected = (
+                "Compiling dependency produced no contract types. "
+                "Try installing 'ape-solidity' or 'ape-vyper'."
+            )
+            result = dependency.compile()
+            assert len(result) == 0
+            assert expected in ape_caplog.head
 
 
 class TestProject:

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -559,7 +559,7 @@ class TestDependency:
     @skip_if_plugin_installed("vyper", "solidity")
     def test_compile_missing_compilers(self, project, ape_caplog):
         with create_tempdir() as path:
-            api = LocalDependency(local=path, name="ooga", version="1.0.0")
+            api = LocalDependency(local=path, name="ooga2", version="1.1.0")
             dependency = Dependency(api, project)
             sol_path = dependency.project.contracts_folder / "Sol.sol"
             sol_path.write_text("// Sol")

--- a/tests/integration/cli/projects/with-contracts/ape-config.yaml
+++ b/tests/integration/cli/projects/with-contracts/ape-config.yaml
@@ -11,6 +11,9 @@ dependencies:
     config_override:
       contracts_folder: .
 
+  - name: depwithunregisteredcontracts
+    local: ./dep_with_sol_and_vy
+
 test:
   # `false` because running pytest within pytest.
   disconnect_providers_after: false

--- a/tests/integration/cli/projects/with-contracts/dep_with_sol_and_vy/contracts/SolFile.sol
+++ b/tests/integration/cli/projects/with-contracts/dep_with_sol_and_vy/contracts/SolFile.sol
@@ -1,0 +1,1 @@
+// Solidity file test

--- a/tests/integration/cli/projects/with-contracts/dep_with_sol_and_vy/contracts/VyFile.vy
+++ b/tests/integration/cli/projects/with-contracts/dep_with_sol_and_vy/contracts/VyFile.vy
@@ -1,0 +1,1 @@
+# Vyper file test

--- a/tests/integration/cli/test_pm.py
+++ b/tests/integration/cli/test_pm.py
@@ -157,6 +157,11 @@ def test_compile_dependency(pm_runner, integ_project):
     assert result.exit_code == 0, result.output
     assert f"Package '{name}@local' compiled." in result.output
 
+    # Show it can happen more than once. (no --force this time).
+    result = pm_runner.invoke("compile", name)
+    assert result.exit_code == 0, result.output
+    assert f"Package '{name}@local' compiled." in result.output
+
 
 @skip_if_plugin_installed("vyper", "solidity")
 @skip_projects_except("with-contracts")


### PR DESCRIPTION
### What I did

was confused for a bit because i had uninstalled `ape-solidity` but `ape pm compile . --force` was not telling me it was successful but it nothing was really happening... 

### How I did it

detect if no result and warn.
additionally, if you notice the dependency has .vy or .sol contracts and you are missing those from 

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
