### PR TITLE
fix: better error handling for bad dependencies: config

### DIFF
--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -208,6 +208,11 @@ class ApeConfig(ExtraAttributesMixin, BaseSettings, ManagerAccessMixin):
             # dependencies).
             fixed_deps = []
             for dep in fixed_model.get("dependencies", []):
+                if not isinstance(dep, dict):
+                    raise ConfigError(
+                        f"Expecting mapping for dependency. Received: {type(dep).__name__}."
+                    )
+
                 fixed_dep = {**dep}
                 if "project" not in fixed_dep:
                     fixed_dep["project"] = project

--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -1,5 +1,5 @@
 import os
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
@@ -197,7 +197,7 @@ class ApeConfig(ExtraAttributesMixin, BaseSettings, ManagerAccessMixin):
     @classmethod
     def validate_model(cls, model):
         model = model or {}
-        fixed_model = {}
+        fixed_model: dict = {}
         for key, val in model.items():
             # Allows hyphens to work anywhere where underscores are.
             fixed_model[key.replace("-", "_")] = val
@@ -207,6 +207,13 @@ class ApeConfig(ExtraAttributesMixin, BaseSettings, ManagerAccessMixin):
             # problems when moving the project around (as happens in local
             # dependencies).
             fixed_deps = []
+            dependencies_list = fixed_model.get("dependencies", [])
+            if not isinstance(dependencies_list, Iterable):
+                raise ConfigError(
+                    "Expecting dependencies: to be iterable. "
+                    f"Received: {type(dependencies_list).__name__}"
+                )
+
             for dep in fixed_model.get("dependencies", []):
                 if not isinstance(dep, dict):
                     raise ConfigError(

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2013,6 +2013,8 @@ class LocalProject(Project):
                 if path.stem != item:
                     continue
 
+                if message and message[-1] not in (".", "?", "!"):
+                    message = f"{message}."
                 message = (
                     f"{message} However, there is a source file named '{path.name}', "
                     "did you mean to reference a contract name from this source file?"

--- a/src/ape/pytest/plugin.py
+++ b/src/ape/pytest/plugin.py
@@ -21,9 +21,9 @@ def pytest_addoption(parser):
             name_str = ", ".join(names)
             if "already added" in str(err):
                 raise ConfigError(
-                    f"Another pytest plugin besides `ape_test` uses an option with "
+                    "Another pytest plugin besides `ape_test` uses an option with "
                     f"one of '{name_str}'. Note that Ape does not support being "
-                    f"installed alongside Brownie; please use separate environments!"
+                    "installed alongside Brownie; please use separate environments!"
                 )
 
             raise ConfigError(f"Failed adding option {name_str}: {err}") from err

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -444,9 +444,14 @@ def get_attribute_with_extras(obj: Any, name: str) -> Any:
         extras_str = ", ".join(sorted(extras_checked))
         suffix = f"Also checked extra(s) '{extras_str}'"
         if suffix not in message:
+            if message and message[-1] not in (".", "?", "!"):
+                message = f"{message}."
             message = f"{message} {suffix}"
 
     _recursion_checker.reset(name)
+    if message and message[-1] not in (".", "?", "!"):
+        message = f"{message}."
+
     attr_err = ApeAttributeError(message)
     if base_err:
         raise attr_err from base_err

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -442,7 +442,9 @@ def get_attribute_with_extras(obj: Any, name: str) -> Any:
 
     if extras_checked:
         extras_str = ", ".join(sorted(extras_checked))
-        message = f"{message}. Also checked extra(s) '{extras_str}'."
+        suffix = f"Also checked extra(s) '{extras_str}'"
+        if suffix not in message:
+            message = f"{message} {suffix}"
 
     _recursion_checker.reset(name)
     attr_err = ApeAttributeError(message)

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -368,3 +368,21 @@ def test_write_to_disk_txt(config):
         path = base_path / "config.txt"
         with pytest.raises(ConfigError, match=f"Unsupported destination file type '{path}'."):
             config.write_to_disk(path)
+
+
+def test_dependencies_not_list_of_dicts(project):
+    # NOTE: `project:` is a not a user-facing config, only
+    #   for internal Ape.
+    data = {"dependencies": 123, "project": str(project.path)}
+    expected = "Expecting dependencies: to be iterable. Received: int"
+    with pytest.raises(ConfigError, match=expected):
+        _ = ApeConfig.model_validate(data)
+
+
+def test_dependencies_list_of_non_dicts(project):
+    # NOTE: `project:` is a not a user-facing config, only
+    #   for internal Ape.
+    data = {"dependencies": [123, 123], "project": str(project.path)}
+    expected = "Expecting mapping for dependency. Received: int."
+    with pytest.raises(ConfigError, match=expected):
+        _ = ApeConfig.model_validate(data)

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -206,7 +206,7 @@ def test_getattr_same_name_as_source_file(project_with_source_files_contract):
         r"Also checked extra\(s\) 'contracts'\. "
         r"However, there is a source file named 'ContractA\.sol', "
         r"did you mean to reference a contract name from this source file\? "
-        r"Else, could it be from one of the missing compilers for extensions: ."
+        r"Else, could it be from one of the missing compilers for extensions: .*"
     )
     with pytest.raises(AttributeError, match=expected):
         _ = project_with_source_files_contract.ContractA


### PR DESCRIPTION
### What I did

handle if the dependencies: config is the wrong type (e.g. not a list of dicts)

### How I did it

raise ConfigErrors in model_validate

### How to verify it

make  a config like:

```yaml
dependencies:
  name: openzeppelin
...

```

(notice forgot the - )

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
