### PR TITLE
feat: show config error linenos

### DIFF
--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -1,12 +1,10 @@
 import os
-import sys
 from collections.abc import Iterable, Iterator
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
 
-import rich
 import yaml
 from ethpm_types import PackageManifest, PackageMeta, Source
 from pydantic import ConfigDict, Field, ValidationError, model_validator
@@ -342,10 +340,7 @@ class ApeConfig(ExtraAttributesMixin, BaseSettings, ManagerAccessMixin):
             #   appear earlier in the list.
             final_msg = "\n".join(reversed(error_strs)).strip()
             final_msg = f"'{clean_path(path)}' is invalid!\n{final_msg}"
-            rich.print(final_msg)
-
-            # Exit now or else you can get very strange issues.
-            sys.exit(1)
+            raise ConfigError(final_msg)
 
     @classmethod
     def from_manifest(cls, manifest: PackageManifest, **overrides) -> "ApeConfig":

--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -1,13 +1,15 @@
 import os
+import sys
 from collections.abc import Iterable, Iterator
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
 
+import rich
 import yaml
-from ethpm_types import PackageManifest, PackageMeta
-from pydantic import ConfigDict, Field, model_validator
+from ethpm_types import PackageManifest, PackageMeta, Source
+from pydantic import ConfigDict, Field, ValidationError, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from ape.exceptions import ConfigError
@@ -274,7 +276,75 @@ class ApeConfig(ExtraAttributesMixin, BaseSettings, ManagerAccessMixin):
         #  relative from.
         data["project"] = path.parent
 
-        return cls.model_validate(data)
+        try:
+            return cls.model_validate(data)
+        except ValidationError as err:
+            if path.suffix == ".json":
+                # TODO: Support JSON configs here.
+                raise  # The validation error as-is
+
+            # Several errors may have been collected from he config.
+            all_errors = err.errors()
+            # Attempt to find line numbers in the config matching.
+            cfg_content = Source(content=path.read_text(encoding="utf8")).content
+            if not cfg_content:
+                # Likely won't happen?
+                raise  # The validation error as-is
+
+            err_map: dict = {}
+            for error in all_errors:
+                if not (location := error.get("loc")):
+                    continue
+
+                lineno = None
+                loc_idx = 0
+                depth = len(location)
+                for no, line in cfg_content.items():
+                    loc = location[loc_idx]
+                    if not line.lstrip().startswith(f"{loc}:"):
+                        continue
+
+                    # Look for the next location up the tree.
+                    loc_idx += 1
+                    if loc_idx < depth:
+                        continue
+
+                    # Found.
+                    lineno = no
+                    break
+
+                if lineno is not None and loc_idx >= depth:
+                    err_map[lineno] = error
+                # else: we looped through whole file and didn't find.
+
+            if not err_map:
+                # raise ValidationError as-is (no line numbers found for some reason).
+                raise
+
+            error_strs: list[str] = []
+            for line_no, cfg_err in err_map.items():
+                sub_message = cfg_err.get("msg", cfg_err)
+                line_before = line_no - 1 if line_no > 1 else None
+                line_after = line_no + 1 if line_no < len(cfg_content) else None
+                lines = []
+                if line_before is not None:
+                    lines.append(f"   {line_before}: {cfg_content[line_before]}")
+                lines.append(f"-->{line_no}: {cfg_content[line_no]}")
+                if line_after is not None:
+                    lines.append(f"   {line_after}: {cfg_content[line_after]}")
+
+                file_preview = "\n".join(lines)
+                sub_message = f"{sub_message}\n{file_preview}\n"
+                error_strs.append(sub_message)
+
+            # NOTE: Using reversed because later pydantic errors
+            #   appear earlier in the list.
+            final_msg = "\n".join(reversed(error_strs)).strip()
+            final_msg = f"'{path.name}' is invalid!\n{final_msg}"
+            rich.print(final_msg)
+
+            # Exit now or else you can get very strange issues.
+            sys.exit(1)
 
     @classmethod
     def from_manifest(cls, manifest: PackageManifest, **overrides) -> "ApeConfig":

--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -15,6 +15,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from ape.exceptions import ConfigError
 from ape.logging import logger
 from ape.types import AddressType
+from ape.utils import clean_path
 from ape.utils.basemodel import (
     ExtraAttributesMixin,
     ExtraModelAttributes,
@@ -283,7 +284,7 @@ class ApeConfig(ExtraAttributesMixin, BaseSettings, ManagerAccessMixin):
                 # TODO: Support JSON configs here.
                 raise  # The validation error as-is
 
-            # Several errors may have been collected from he config.
+            # Several errors may have been collected from the config.
             all_errors = err.errors()
             # Attempt to find line numbers in the config matching.
             cfg_content = Source(content=path.read_text(encoding="utf8")).content
@@ -315,7 +316,7 @@ class ApeConfig(ExtraAttributesMixin, BaseSettings, ManagerAccessMixin):
 
                 if lineno is not None and loc_idx >= depth:
                     err_map[lineno] = error
-                # else: we looped through whole file and didn't find.
+                # else: we looped through the whole file and didn't find anything.
 
             if not err_map:
                 # raise ValidationError as-is (no line numbers found for some reason).
@@ -340,7 +341,7 @@ class ApeConfig(ExtraAttributesMixin, BaseSettings, ManagerAccessMixin):
             # NOTE: Using reversed because later pydantic errors
             #   appear earlier in the list.
             final_msg = "\n".join(reversed(error_strs)).strip()
-            final_msg = f"'{path.name}' is invalid!\n{final_msg}"
+            final_msg = f"'{clean_path(path)}' is invalid!\n{final_msg}"
             rich.print(final_msg)
 
             # Exit now or else you can get very strange issues.

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2431,6 +2431,20 @@ class LocalProject(Project):
             self._manifest = PackageManifest()
 
         self.sources._path_cache = None
+        self._clear_cached_config()
+
+    def reload_config(self):
+        """
+        Reload the local ape-config.yaml file.
+        This is useful if the file was modified in the
+        active python session.
+        """
+        self._clear_cached_config()
+        _ = self.config
+
+    def _clear_cached_config(self):
+        if "config" in self.__dict__:
+            del self.__dict__["config"]
 
     def _create_contract_source(self, contract_type: ContractType) -> Optional[ContractSource]:
         if not (source_id := contract_type.source_id):

--- a/tests/integration/cli/test_misc.py
+++ b/tests/integration/cli/test_misc.py
@@ -1,7 +1,10 @@
+import os
 import re
 
 import pytest
 
+from ape import Project
+from tests.conftest import ApeSubprocessRunner
 from tests.integration.cli.utils import run_once
 
 
@@ -30,3 +33,26 @@ def test_help(ape_cli, runner):
         rf"test\s*Launches pytest{anything}"
     )
     assert re.match(expected.strip(), result.output)
+
+
+@run_once
+def test_invalid_config():
+    # Using subprocess runner so we re-hit the init of the cmd.
+    runner = ApeSubprocessRunner("ape")
+    here = os.curdir
+    with Project.create_temporary_project() as tmp:
+        cfgfile = tmp.path / "ape-config.yaml"
+        # Name is invalid!
+        cfgfile.write_text("name:\n  {asdf}")
+
+        os.chdir(tmp.path)
+        result = runner.invoke("--help")
+        os.chdir(here)
+
+        expected = """
+Input should be a valid string
+-->1: name:
+   2:   {asdf}
+""".strip()
+        assert result.exit_code != 0
+        assert expected in result.output


### PR DESCRIPTION
### What I did

When config failed to parse in Ape 0.7, you got a validation error.
in Ape 0.8, you get an AttributeError during a weird network-option callback (what?)
And the error still didn't show config line numbers.

So this PR does 2 things:

1. Exit early during config file parsing error... because it is too confusing otherwise!
2. Show the line numbers of the bad config

fixes: #1718

### How to verify it

with this config:

```yaml
name: {asd}


deployments:
 address: ooga
```

you should get this error now:

```
(ape08) ➜  ape-playground git:(main) ✗ ape console -v debug
'$HOME/ApeProjects/ape-playground/ape-config.yaml' is invalid!
Input should be a valid string
-->1: name: {asd}
   2: 

Input should be a valid dictionary
   4: deployments:
-->5:  address: ooga
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
