### PR TITLE
fix: issue where Ape tries starting geth-dev for custom networks w/o URIs

### DIFF
--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1159,7 +1159,11 @@ class EthereumNodeProvider(Web3Provider, ABC):
 
         config = self.config.model_dump().get(self.network.ecosystem.name, None)
         if config is None:
-            return DEFAULT_SETTINGS["uri"]
+            if self.network.is_dev:
+                return DEFAULT_SETTINGS["uri"]
+
+            # We have no way of knowing what URL the user wants.
+            raise ProviderError(f"Please configure a URL for '{self.network_choice}'.")
 
         # Use value from config file
         network_config = config.get(self.network.name) or DEFAULT_SETTINGS

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -16,6 +16,7 @@ from ape.exceptions import (
     BlockNotFoundError,
     ContractLogicError,
     NetworkMismatchError,
+    ProviderError,
     TransactionError,
     TransactionNotFoundError,
 )
@@ -29,7 +30,7 @@ from ape_ethereum.transactions import (
     TransactionStatusEnum,
     TransactionType,
 )
-from ape_node.provider import GethDevProcess, NodeSoftwareNotInstalledError
+from ape_node.provider import GethDevProcess, Node, NodeSoftwareNotInstalledError
 from tests.conftest import GETH_URI, geth_process_test
 
 
@@ -75,6 +76,21 @@ def test_uri_when_configured(geth_provider, project, ethereum):
 
     assert actual_local_uri == value
     assert actual_mainnet_uri == expected
+
+
+def test_uri_non_dev_and_not_configured(ethereum):
+    """
+    If the URI was not configured and we are not using a dev
+    network (local or -fork), then it should fail, rather than
+    use local-host.
+    """
+    network = ethereum.sepolia.model_copy(deep=True)
+    network.name = "gorillanet"
+    network.ecosystem.name = "gorillas"
+    provider = Node.model_construct(network=network, request_header={})
+
+    with pytest.raises(ProviderError):
+        _ = provider.uri
 
 
 @geth_process_test


### PR DESCRIPTION
### What I did

i forgot to specify a URI for my custom network and nothing was in evmchains yet and i noticed Ape went ahead and tried starting a geth dev for me with this , and that wouldnt really work.

this PR makes it so Ape only uses default localhost URI if nothing is configured AND we are in a dev-net (local or fork).

### How I did it

check `.is_dev` before using DEFAULT_SETTINGS

### How to verify it

make a config like:

```yaml
networks:
  custom:
    - name: mainnet
      chain_id: 109
      ecosystem: shibarium
      base_ecosystem_plugin: polygon
      default_provider: node
```

try launching geth

before it would try geth dev because it couldnt find any URI.
but now it fails because it knows you are not using a dev net and there is no Uri

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
