### PR TITLE
fix: allow random RPCs to work for custom networks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,12 +131,12 @@ setup(
         "eip712>=0.2.7,<0.3",
         "ethpm-types>=0.6.9,<0.7",
         "eth_pydantic_types>=0.1.0,<0.2",
-        "evmchains>=0.0.9,<0.1",
+        "evmchains>=0.0.10,<0.1",
         "evm-trace>=0.1.5,<0.2",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],
-        "pytest11": ["ape_test=ape.pytest.plugin"],
+        "pytest11": ["ape_test  =ape.pytest.plugin"],
         "ape_cli_subcommands": [
             "ape_accounts=ape_accounts._cli:cli",
             "ape_cache=ape_cache._cli:cli",

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup(
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],
-        "pytest11": ["ape_test  =ape.pytest.plugin"],
+        "pytest11": ["ape_test=ape.pytest.plugin"],
         "ape_cli_subcommands": [
             "ape_accounts=ape_accounts._cli:cli",
             "ape_cache=ape_cache._cli:cli",

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -6,6 +6,7 @@ from abc import ABC
 from collections.abc import Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from copy import copy
+from evmchains import get_random_rpc
 from functools import cached_property, wraps
 from pathlib import Path
 from typing import Any, Optional, Union, cast
@@ -1152,14 +1153,15 @@ class EthereumNodeProvider(Web3Provider, ABC):
     def uri(self) -> str:
         if "url" in self.provider_settings:
             raise ConfigError("Unknown provider setting 'url'. Did you mean 'uri'?")
-
         elif "uri" in self.provider_settings:
             # Use adhoc, scripted value
             return self.provider_settings["uri"]
 
         config = self.config.model_dump().get(self.network.ecosystem.name, None)
         if config is None:
-            if self.network.is_dev:
+            if rpc := self._get_random_rpc():
+                return rpc
+            elif self.network.is_dev:
                 return DEFAULT_SETTINGS["uri"]
 
             # We have no way of knowing what URL the user wants.
@@ -1170,6 +1172,9 @@ class EthereumNodeProvider(Web3Provider, ABC):
 
         if "url" in network_config:
             raise ConfigError("Unknown provider setting 'url'. Did you mean 'uri'?")
+        elif "uri" not in network_config:
+            if rpc := self._get_random_rpc():
+                return rpc
 
         settings_uri = network_config.get("uri", DEFAULT_SETTINGS["uri"])
         if _is_url(settings_uri):
@@ -1177,6 +1182,19 @@ class EthereumNodeProvider(Web3Provider, ABC):
 
         # Likely was an IPC Path and will connect that way.
         return ""
+
+    def _get_random_rpc(self) -> Optional[str]:
+        if self.network.is_dev:
+            return None
+
+        ecosystem = self.network.ecosystem.name
+        network = self.network.name
+
+        # Use public RPC if available
+        try:
+            return get_random_rpc(ecosystem, network)
+        except KeyError:
+            return None
 
     @property
     def connection_str(self) -> str:

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -6,7 +6,6 @@ from abc import ABC
 from collections.abc import Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from copy import copy
-from evmchains import get_random_rpc
 from functools import cached_property, wraps
 from pathlib import Path
 from typing import Any, Optional, Union, cast
@@ -17,6 +16,7 @@ from eth_pydantic_types import HexBytes
 from eth_typing import BlockNumber, HexStr
 from eth_utils import add_0x_prefix, is_hex, to_hex
 from ethpm_types import EventABI
+from evmchains import get_random_rpc
 from pydantic.dataclasses import dataclass
 from requests import HTTPError
 from web3 import HTTPProvider, IPCProvider, Web3

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -18,6 +18,7 @@ from web3.middleware import geth_poa_middleware
 from yarl import URL
 
 from ape.api import PluginConfig, SubprocessProvider, TestProviderAPI
+from ape.exceptions import ProviderError
 from ape.logging import LogLevel, logger
 from ape.types import SnapshotID
 from ape.utils import (
@@ -354,29 +355,4 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
 
 # NOTE: The default behavior of EthereumNodeBehavior assumes geth.
 class Node(EthereumNodeProvider):
-    @property
-    def uri(self) -> str:
-        if "uri" in self.provider_settings:
-            # If specifying in Python, use no matter what.
-            return self.provider_settings["uri"]
-
-        uri = super().uri
-        ecosystem = self.network.ecosystem.name
-        network = self.network.name
-
-        # If we didn't find one in config, look for a public RPC.
-        if not uri or uri == DEFAULT_SETTINGS["uri"]:
-            # Do not override explicit configuration
-            if ecosystem in self.config:
-                # Shape of this is odd. Pydantic model containing dicts
-                if network_config := self.config[ecosystem].get(network):
-                    if "uri" in network_config:
-                        return network_config["uri"]
-
-            # Use public RPC if available
-            try:
-                uri = get_random_rpc(ecosystem, network)
-            except KeyError:
-                pass
-
-        return uri
+    pass

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -18,7 +18,6 @@ from web3.middleware import geth_poa_middleware
 from yarl import URL
 
 from ape.api import PluginConfig, SubprocessProvider, TestProviderAPI
-from ape.exceptions import ProviderError
 from ape.logging import LogLevel, logger
 from ape.types import SnapshotID
 from ape.utils import (


### PR DESCRIPTION
### What I did

I noticed I could not get evmchains to work for my custom network pointed at Shibarium even after adding shibarium to evmchains.

I realized it was because the random RPC stuff was skipped over for custom networks for a couple reason...

### How I did it

basically if it is dev, we can use default, otherwise we can at least check for random RPC to try
Before it would just not find anything, realize it was not dev, and error out

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
