### PR TITLE
feat: allow forking custom networks automatically

### DIFF
--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -67,7 +67,7 @@ Here are some examples of changes L2 plugins make that allow improved support fo
 
 Here is a list of all L2 network plugins supported by Ape:
 
-| Name              | GitHub                                                               |
+| Name              | GitHub                                                                    |
 | ----------------- | ------------------------------------------------------------------------- |
 | ape-arbitrum      | [ApeWorX/ape-arbitrum](https://github.com/ApeWorX/ape-arbitrum)           |
 | ape-avalanche     | [ApeWorX/ape-avalanche](https://github.com/ApeWorX/ape-avalanche)         |

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -67,13 +67,15 @@ Here are some examples of changes L2 plugins make that allow improved support fo
 
 Here is a list of all L2 network plugins supported by Ape:
 
-| Name              | GitHub Path                                                               |
+| Name              | GitHub                                                               |
 | ----------------- | ------------------------------------------------------------------------- |
-| ape-avalanche     | [ApeWorX/ape-avalanche](https://github.com/ApeWorX/ape-avalanche)         |
 | ape-arbitrum      | [ApeWorX/ape-arbitrum](https://github.com/ApeWorX/ape-arbitrum)           |
+| ape-avalanche     | [ApeWorX/ape-avalanche](https://github.com/ApeWorX/ape-avalanche)         |
 | ape-base          | [ApeWorX/ape-base](https://github.com/ApeWorX/ape-base)                   |
+| ape-blast         | [ApeWorX/ape-base](https://github.com/ApeWorX/ape-blast)                  |
+| ape-bsc           | [ApeWorX/ape-base](https://github.com/ApeWorX/ape-bsc)                    |
 | ape-fantom        | [ApeWorX/ape-fantom](https://github.com/ApeWorX/ape-fantom)               |
-| ape-optmism       | [ApeWorX/ape-optimism](https://github.com/ApeWorX/ape-optimism)           |
+| ape-optimism      | [ApeWorX/ape-optimism](https://github.com/ApeWorX/ape-optimism)           |
 | ape-polygon       | [ApeWorX/ape-polygon](https://github.com/ApeWorX/ape-polygon)             |
 | ape-polygon-zkevm | [ApeWorX/ape-polygon-zkevm](https://github.com/ApeWorX/ape-polygon-zkevm) |
 
@@ -177,6 +179,28 @@ node:
 ```
 
 Now, when using `ethereum:apenet:node`, it will connect to the RPC URL `https://apenet.example.com/rpc`.
+
+#### Forking Custom Networks
+
+You can fork your custom network using provider with forked-network support such as `ape-foundry` or `ape-hardhat`.
+To fork a custom network, first ensure the custom network is set-up by following the sections above.
+Once you can successfully connect to a custom network in Ape, you can fork it.
+
+To fork the network, launch an Ape command with the `--network` option with your custom network name suffixed with `-fork` and use one of the forking providers (such as `ape-foundry`):
+
+```
+ape <cmd> --network shibarium:puppynet-fork:foundry
+```
+
+Configure the forked network in the plugin the same way you configure other forked networks:
+
+```yaml
+foundry:
+  fork:
+    shibarium:
+      puppynet:
+        block_number: 500
+```
 
 #### Explorer URL
 

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -182,7 +182,7 @@ Now, when using `ethereum:apenet:node`, it will connect to the RPC URL `https://
 
 #### Forking Custom Networks
 
-You can fork your custom network using provider with forked-network support such as `ape-foundry` or `ape-hardhat`.
+You can fork custom networks using providers that support forking, such as `ape-foundry` or `ape-hardhat`.
 To fork a custom network, first ensure the custom network is set-up by following the sections above.
 Once you can successfully connect to a custom network in Ape, you can fork it.
 

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -234,6 +234,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
         Returns:
             dict[str, :class:`~ape.api.networks.NetworkAPI`]
         """
+
         networks = {**self._networks_from_plugins}
 
         # Include configured custom networks.
@@ -269,7 +270,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
                     f"More than one network named '{custom_net.name}' in ecosystem '{self.name}'."
                 )
 
-            is_fork = custom_net.name.endswith("-fork")
+            is_fork = custom_net.is_fork
             network_data = custom_net.model_dump(by_alias=True, exclude=("default_provider",))
             network_data["ecosystem"] = self
             network_type = create_network_type(
@@ -1080,7 +1081,7 @@ class NetworkAPI(BaseInterfaceModel):
             provider = self.providers[provider_name](provider_settings=provider_settings)
             return _set_provider(provider)
 
-        elif self.name.endswith("-fork") and provider_name in common_forking_providers:
+        elif self.is_fork and provider_name in common_forking_providers:
             provider = common_forking_providers[provider_name](
                 provider_settings=provider_settings,
                 network=self,

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -234,7 +234,6 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
         Returns:
             dict[str, :class:`~ape.api.networks.NetworkAPI`]
         """
-
         networks = {**self._networks_from_plugins}
 
         # Include configured custom networks.

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -1072,8 +1072,8 @@ class NetworkAPI(BaseInterfaceModel):
             provider_settings["ipc_path"] = provider_name
             provider_name = "node"
 
-        # Assuming any installed forking plugin can at least for Ethereum mainnet.
-        # NOTE: This is a bit limiting for non-EVM custom forked networks.
+        # If it can fork Ethereum (and we are asking for it) assume it can fork this one.
+        # TODO: Refactor this approach to work for custom-forked non-EVM networks.
         common_forking_providers = self.network_manager.ethereum.mainnet_fork.providers
 
         if provider_name in self.providers:

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -359,20 +359,18 @@ class NetworkChoice(click.Choice):
             try:
                 # Validate result.
                 choice = super().convert(value, param, ctx)
-            except BadParameter as err:
+            except BadParameter:
                 # Attempt to get the provider anyway.
                 # Sometimes, depending on the provider, it'll still work.
                 # (as-is the case for custom-forked networks).
                 try:
-                    return networks.get_provider_from_choice(network_choice=value)
-                except Exception:
-                    pass  # Pretend this never happened and raise BadParam.
-
-                # If an error was not raised for some reason, raise a simpler error.
-                # NOTE: Still avoid showing the massive network options list.
-                raise click.BadParameter(
-                    "Invalid network choice. Use `ape networks list` to see options."
-                ) from err
+                    choice = networks.get_provider_from_choice(network_choice=value)
+                except Exception as err:
+                    # If an error was not raised for some reason, raise a simpler error.
+                    # NOTE: Still avoid showing the massive network options list.
+                    raise click.BadParameter(
+                        "Invalid network choice. Use `ape networks list` to see options."
+                    ) from err
 
         if (
             choice not in (None, _NONE_NETWORK)

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -361,8 +361,8 @@ class NetworkChoice(click.Choice):
                 choice = super().convert(value, param, ctx)
             except BadParameter as err:
                 # Attempt to get the provider anyway.
-                # Some plugins will handle networks anyway,
-                # such as forked-custom networks.
+                # Sometimes, depending on the provider, it'll still work.
+                # (as-is the case for custom-forked networks).
                 try:
                     return networks.get_provider_from_choice(network_choice=value)
                 except Exception:

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -335,15 +335,15 @@ class NetworkChoice(click.Choice):
 
         self.base_type = base_type
         self.callback = callback
-        super().__init__(
-            get_networks(ecosystem=ecosystem, network=network, provider=provider), case_sensitive
-        )
+        networks = get_networks(ecosystem=ecosystem, network=network, provider=provider)
+        super().__init__(networks, case_sensitive)
 
     def get_metavar(self, param):
         return "[ecosystem-name][:[network-name][:[provider-name]]]"
 
     def convert(self, value: Any, param: Optional[Parameter], ctx: Optional[Context]) -> Any:
         choice: Optional[Union[str, ProviderAPI]]
+        networks = ManagerAccessMixin.network_manager
         if not value:
             choice = None
 
@@ -360,6 +360,14 @@ class NetworkChoice(click.Choice):
                 # Validate result.
                 choice = super().convert(value, param, ctx)
             except BadParameter as err:
+                # Attempt to get the provider anyway.
+                # Some plugins will handle networks anyway,
+                # such as forked-custom networks.
+                try:
+                    return networks.get_provider_from_choice(network_choice=value)
+                except Exception:
+                    pass  # Pretend this never happened and raise BadParam.
+
                 # If an error was not raised for some reason, raise a simpler error.
                 # NOTE: Still avoid showing the massive network options list.
                 raise click.BadParameter(
@@ -372,10 +380,7 @@ class NetworkChoice(click.Choice):
             and issubclass(self.base_type, ProviderAPI)
         ):
             # Return the provider.
-
-            choice = ManagerAccessMixin.network_manager.get_provider_from_choice(
-                network_choice=value
-            )
+            choice = networks.get_provider_from_choice(network_choice=value)
 
         return self.callback(ctx, param, choice) if self.callback else choice
 

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -296,7 +296,7 @@ def network_option(
             # No network kwargs are used. No need for partial wrapper.
             wrapped_f = f
 
-        # Use NetworkChoice option.    Raises:
+        # Use NetworkChoice option.
         kwargs["type"] = None
 
         # Set this to false to avoid click passing in a str value for network.

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -462,7 +462,6 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
                 self.get_ecosystem(ecosystem_name) if ecosystem_name else self.default_ecosystem
             )
             network = ecosystem.get_network(network_name or ecosystem.default_network_name)
-
             return network.get_provider(
                 provider_name=provider_name, provider_settings=provider_settings
             )

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -462,6 +462,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
                 self.get_ecosystem(ecosystem_name) if ecosystem_name else self.default_ecosystem
             )
             network = ecosystem.get_network(network_name or ecosystem.default_network_name)
+
             return network.get_provider(
                 provider_name=provider_name, provider_settings=provider_settings
             )

--- a/src/ape_networks/__init__.py
+++ b/src/ape_networks/__init__.py
@@ -30,7 +30,7 @@ class CustomNetwork(PluginConfig):
     @property
     def is_fork(self) -> bool:
         """
-        True when the name of the network ends in "-fork".
+        ``True`` when the name of the network ends in ``"-fork"``.
         """
         return self.name.endswith("-fork")
 

--- a/src/ape_networks/__init__.py
+++ b/src/ape_networks/__init__.py
@@ -27,6 +27,13 @@ class CustomNetwork(PluginConfig):
     request_header: dict = {}
     """The HTTP request header."""
 
+    @property
+    def is_fork(self) -> bool:
+        """
+        True when the name of the network ends in "-fork".
+        """
+        return self.name.endswith("-fork")
+
 
 class NetworksConfig(PluginConfig):
     custom: list[CustomNetwork] = []

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -301,7 +301,6 @@ def test_network_option_specified_none(runner):
 def test_network_option_specify_custom_network(
     runner, project, custom_networks_config_dict, network_name
 ):
-    network_part = ("--network", f"ethereum:{network_name}:node")
     with project.temp_config(**custom_networks_config_dict):
         # NOTE: Also testing network filter with a custom network
         #  But this is also required to work around LRU cache
@@ -312,10 +311,12 @@ def test_network_option_specify_custom_network(
         @click.command()
         @network_option(network=network_name)
         def cmd(network):
-            click.echo(f"Value is '{network.name}'")
+            click.echo(f"Value is '{getattr(network, 'name', network)}'")
 
-        result = runner.invoke(cmd, network_part)
+        result = runner.invoke(cmd, ("--network", f"ethereum:{network_name}:node"))
         assert f"Value is '{network_name}'" in result.output
+        result = runner.invoke(cmd, ("--network", f"ethereum:{network_name}-fork:node"))
+        assert f"Value is '{network_name}-fork'" in result.output
 
 
 def test_account_option(runner, keyfile_account):

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -894,6 +894,9 @@ def test_networks_includes_custom_networks(
             LOCAL_NETWORK_NAME,
             custom_network_name_0,
             custom_network_name_1,
+            # Show custom networks are auto-forked!
+            f"{custom_network_name_0}-fork",
+            f"{custom_network_name_1}-fork",
         ):
             assert net in actual
             assert isinstance(actual[net], NetworkAPI)

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -868,9 +868,19 @@ def test_set_default_network_not_exists(ethereum):
 
 def test_networks(ethereum):
     actual = ethereum.networks
-    for net in ("sepolia", "mainnet", LOCAL_NETWORK_NAME):
+
+    with_forks = ("sepolia", "mainnet")
+    without_forks = (LOCAL_NETWORK_NAME,)
+
+    def assert_net(net: str):
         assert net in actual
         assert isinstance(actual[net], NetworkAPI)
+
+    for net in with_forks:
+        assert_net(net)
+        assert_net(f"{net}-fork")
+    for net in without_forks:
+        assert_net(net)
 
 
 def test_networks_includes_custom_networks(

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -9,7 +9,7 @@ from ethpm_types import ContractType, ErrorABI
 from ethpm_types.abi import ABIType, EventABI, MethodABI
 from evm_trace import CallTreeNode, CallType
 
-from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI
+from ape.api.networks import LOCAL_NETWORK_NAME, ForkedNetworkAPI, NetworkAPI
 from ape.exceptions import CustomError, DecodingError, NetworkError, NetworkNotFoundError
 from ape.types import AddressType
 from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
@@ -872,9 +872,12 @@ def test_networks(ethereum):
     with_forks = ("sepolia", "mainnet")
     without_forks = (LOCAL_NETWORK_NAME,)
 
-    def assert_net(net: str):
+    def assert_net(
+        net: str,
+    ):
         assert net in actual
-        assert isinstance(actual[net], NetworkAPI)
+        base_class = ForkedNetworkAPI if net.endswith("-fork") else NetworkAPI
+        assert isinstance(actual[net], base_class)
 
     for net in with_forks:
         assert_net(net)

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -187,11 +187,11 @@ def test_use_provider_previously_used_and_not_connected(eth_tester_provider):
 def test_create_network_type():
     chain_id = 123321123321123321
     actual = create_network_type(chain_id, chain_id)
-    assert isinstance(actual, NetworkAPI)
+    assert issubclass(actual, NetworkAPI)
 
 
 def test_create_network_type_fork():
     chain_id = 123321123321123322
     actual = create_network_type(chain_id, chain_id, is_fork=True)
-    assert isinstance(actual, NetworkAPI)
-    assert isinstance(actual, ForkedNetworkAPI)
+    assert issubclass(actual, NetworkAPI)
+    assert issubclass(actual, ForkedNetworkAPI)

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 import pytest
 
-from ape.api import ProviderAPI
+from ape.api.networks import ForkedNetworkAPI, NetworkAPI, create_network_type
+from ape.api.providers import ProviderAPI
 from ape.exceptions import NetworkError, ProviderNotFoundError
 from ape_ethereum import EthereumConfig
 from ape_ethereum.transactions import TransactionType
@@ -181,3 +182,16 @@ def test_use_provider_previously_used_and_not_connected(eth_tester_provider):
     eth_tester_provider.disconnect()
     with network.use_provider("test") as provider:
         assert provider.is_connected
+
+
+def test_create_network_type():
+    chain_id = 123321123321123321
+    actual = create_network_type(chain_id, chain_id)
+    assert isinstance(actual, NetworkAPI)
+
+
+def test_create_network_type_fork():
+    chain_id = 123321123321123322
+    actual = create_network_type(chain_id, chain_id, is_fork=True)
+    assert isinstance(actual, NetworkAPI)
+    assert isinstance(actual, ForkedNetworkAPI)

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from ape.api import EcosystemAPI
+from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.exceptions import NetworkError, ProviderNotFoundError
 from ape.utils import DEFAULT_TEST_CHAIN_ID
 
@@ -388,3 +389,14 @@ def test_getitem(networks):
     ethereum = networks["ethereum"]
     assert ethereum.name == "ethereum"
     assert isinstance(ethereum, EcosystemAPI)
+
+
+def test_network_names(networks, custom_networks_config_dict, project):
+    data = copy.deepcopy(custom_networks_config_dict)
+    with project.temp_config(**data):
+        actual = networks.network_names
+        assert LOCAL_NETWORK_NAME in actual
+        assert "mainnet" in actual  # Normal
+        assert "mainnet-fork" in actual  # Forked
+        assert "apenet" in actual  # Custom
+        assert "apenet-fork" in actual  # Custom forked


### PR DESCRIPTION
### What I did

allows forking custom networks automatically

fixes: #1905

**NOTE**: Works best with this one https://github.com/ApeWorX/ape/pull/2144

### How I did it

if the provider is known for forking, just send it on through anyway.
had to do some finaggling throughout

### How to verify it

my cfg:

```yaml
networks:
  custom:
    - name: mainnet
      chain_id: 109
      ecosystem: shibarium
      base_ecosystem_plugin: polygon
      default_provider: node
```

**Note**: cfg is small because using evmchains via https://github.com/ApeWorX/ape/pull/2144

<img width="1182" alt="Screenshot 2024-06-14 at 15 58 36" src="https://github.com/ApeWorX/ape/assets/19540978/f4217d21-f2eb-464b-9bff-073d81fd763d">


### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
