### PR TITLE
docs: document environment variable support in `ape-config.yaml` files

### DIFF
--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -19,6 +19,16 @@ However, here is a list of common-use cases requiring the `ape-config.yaml` file
 2. Setting up project dependencies: See the [dependencies](#dependencies) section.
 3. Declaring your project's plugins: See the [plugins](#plugins) section.
 
+**Environment Variables**: `ape-config.yaml` files support environment-variable expansion.
+Simply include environment variables (with the `$` prefix) in your config file and Ape will automatically expand them.
+
+```yaml
+plugin:
+  secret_rpc: $MY_SECRET_RPC
+```
+
+This helps keep your secrets out of Ape!
+
 ## Contracts Folder
 
 Specify a different path to your `contracts/` directory.

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -216,7 +216,7 @@ def load_config(path: Path, expand_envars=True, must_exist=False) -> dict:
                                 and is able to be load.
 
     Returns:
-        Dict (dict): Configured settings parsed from a config file.
+        dict: Configured settings parsed from a config file.
     """
     if path.is_file():
         contents = path.read_text()


### PR DESCRIPTION
### What I did

Document and test for environment variable expansion in ape-config yaml files
I saw the issue and was like "im pretty sure this was added already" but I noticed both there were not docs or tests for this feature..

fixes: #292 

so this PR completes the request by including the missing docs and tests

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
