### PR TITLE
fix: issue where plugin config loading error was not shown

### DIFF
--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -7,7 +7,6 @@ from typing import Any, Optional
 
 from ethpm_types import PackageManifest
 
-from ape.api import PluginConfig
 from ape.api.config import ApeConfig
 from ape.managers.base import BaseManager
 from ape.utils import create_tempdir, in_tempdir, log_instead_of_fail
@@ -67,7 +66,6 @@ class ConfigManager(ExtraAttributesMixin, BaseManager):
         See :class:`~ape.api.config.ApeConfig` for field definitions
         and model-related controls.
         """
-
         return get_attribute_with_extras(self, name)
 
     def __getitem__(self, name: str) -> Any:
@@ -105,22 +103,6 @@ class ConfigManager(ExtraAttributesMixin, BaseManager):
             :class:`~ape.managers.config.ApeConfig`: Config data.
         """
         return ApeConfig.from_manifest(manifest, **overrides)
-
-    def get_config(self, plugin_name: str) -> PluginConfig:
-        """
-        Get the config for a plugin.
-
-        Args:
-            plugin_name (str): The name of the plugin.
-
-        Returns:
-            :class:`~ape.api.config.PluginConfig`
-        """
-        try:
-            return self.__getattr__(plugin_name)
-        except AttributeError:
-            # Empty config.
-            return PluginConfig()
 
     @contextmanager
     def isolate_data_folder(self) -> Iterator[Path]:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -87,6 +87,11 @@ BLUEPRINT_HEADER = HexBytes("0xfe71")
 
 
 class NetworkConfig(PluginConfig):
+    """
+    The Ethereum network config base class for each
+    network, e.g. ``"mainnet"``, ```"local"``, etc.
+    """
+
     required_confirmations: int = 0
     """
     The amount of blocks to wait before

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -388,8 +388,16 @@ def test_get_config_unknown_plugin(config):
 
 def test_get_config_invalid_plugin_config(project):
     with project.temp_config(node={"ethereum": [1, 2]}):
+        # Show project's ApeConfig model works.
         with pytest.raises(ValidationError):
             project.config.get_config("node")
+
+        # Show the manager-wrapper also works
+        # (simple wrapper for local project's config,
+        # but at one time pointlessly overrode the `get_config()`
+        # which caused issues).
+        with pytest.raises(ValidationError):
+            project.config_manager.get_config("node")
 
 
 def test_write_to_disk_json(config):

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 import pytest
+from pydantic import ValidationError
 from pydantic_settings import SettingsConfigDict
 
 from ape.api.config import ApeConfig, ConfigEnum, PluginConfig
@@ -375,6 +376,20 @@ def test_get_config_hyphen_in_plugin_name(config):
 
     finally:
         config.local_project.config._get_config_plugin_classes = original_method
+
+
+def test_get_config_unknown_plugin(config):
+    """
+    Simulating reading plugin configs w/o those plugins installed.
+    """
+    actual = config.get_config("thisshouldnotbeinstalled")
+    assert isinstance(actual, PluginConfig)
+
+
+def test_get_config_invalid_plugin_config(project):
+    with project.temp_config(node={"ethereum": [1, 2]}):
+        with pytest.raises(ValidationError):
+            project.config.get_config("node")
 
 
 def test_write_to_disk_json(config):


### PR DESCRIPTION
### What I did

I had my config set up with some environment variables that did not exist, and i noticed that instead of Ape crashing where it was supposed to, my error s were dropped and the configs were turned to regular `PluginConfig` and i got attribute errors within the plugin instead, kinda weird... 

### How I did it

Removed duplicate `get_config` method that hid the errors for no reason.
instead, let `ConfigManager` run `ApeConfig.get_config` and the error shows up correctly.

### How to verify it

```yaml
foundry:
  fork:
    shibarium:
      mainnet:
        block_number: {asdf}

```

try to use foundry

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
