### PR TITLE
fix: issue where could not define custom networks in any non-local project

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -272,7 +272,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
                 )
 
             is_fork = net_name.endswith("-fork")
-            custom_net["ecosystem"] = self
+            custom_net["ecosystem"] = self.name
             network_type = create_network_type(
                 custom_net["chain_id"], custom_net["chain_id"], is_fork=is_fork
             )

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -239,8 +239,8 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
         # Include configured custom networks.
         custom_networks: list = [
             n
-            for n in self.config_manager.get_config("networks").custom
-            if (n.ecosystem or self.network_manager.default_ecosystem.name) == self.name
+            for n in self.network_manager.custom_networks
+            if (n["ecosystem"] or self.network_manager.default_ecosystem.name) == self.name
         ]
 
         # Ensure forks are added automatically for custom networks.

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -272,7 +272,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
                 )
 
             is_fork = net_name.endswith("-fork")
-            custom_net["ecosystem"] = self.name
+            custom_net["ecosystem"] = self
             network_type = create_network_type(
                 custom_net["chain_id"], custom_net["chain_id"], is_fork=is_fork
             )

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -265,12 +265,13 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
         custom_networks.extend(forked_custom_networks)
 
         for custom_net in custom_networks:
-            if custom_net["name"] in networks:
+            net_name = custom_net["name"]
+            if net_name in networks:
                 raise NetworkError(
-                    f"More than one network named '{custom_net['name']}' in ecosystem '{self.name}'."
+                    f"More than one network named '{net_name}' in ecosystem '{self.name}'."
                 )
 
-            is_fork = custom_net["name"].endswith("-fork")
+            is_fork = net_name.endswith("-fork")
             custom_net["ecosystem"] = self
             network_type = create_network_type(
                 custom_net["chain_id"], custom_net["chain_id"], is_fork=is_fork
@@ -278,7 +279,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
             network_api = network_type.model_validate(custom_net)
             network_api._default_provider = custom_net["default_provider"]
             network_api._is_custom = True
-            networks[custom_net["name"]] = network_api
+            networks[net_name] = network_api
 
         return networks
 

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -265,6 +265,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
         custom_networks.extend(forked_custom_networks)
 
         for custom_net in custom_networks:
+            model_data = copy.deepcopy(custom_net)
             net_name = custom_net["name"]
             if net_name in networks:
                 raise NetworkError(
@@ -272,14 +273,14 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
                 )
 
             is_fork = net_name.endswith("-fork")
-            custom_net["ecosystem"] = self
+            model_data["ecosystem"] = self
             network_type = create_network_type(
                 custom_net["chain_id"], custom_net["chain_id"], is_fork=is_fork
             )
-            if "request_header" not in custom_net:
-                custom_net["request_header"] = self.request_header
+            if "request_header" not in model_data:
+                model_data["request_header"] = self.request_header
 
-            network_api = network_type.model_validate(custom_net)
+            network_api = network_type.model_validate(model_data)
             network_api._default_provider = custom_net.get("default_provider", "node")
             network_api._is_custom = True
             networks[net_name] = network_api

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -334,10 +334,14 @@ class AccountHistory(BaseInterfaceModel):
         # TODO: Add ephemeral network sessional history to `ape-cache` instead,
         #       and remove this (replace with `yield from iter(self[:len(self)])`)
         for receipt in self.sessional:
-            if receipt.nonce < start_nonce:
+            if receipt.nonce is None:
+                # Not an on-chain receipt? idk - has only seen as anomaly in tests.
+                continue
+
+            elif receipt.nonce < start_nonce:
                 raise QueryEngineError("Sessional history corrupted")
 
-            if receipt.nonce > start_nonce:
+            elif receipt.nonce > start_nonce:
                 # NOTE: There's a gap in our sessional history, so fetch from query engine
                 yield from iter(self[start_nonce : receipt.nonce + 1])  # noqa: E203
 

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -171,6 +171,10 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
 
     @property
     def custom_networks(self) -> list[dict]:
+        """
+        Custom network data defined in various ape-config files
+        or added adhoc to the network manager.
+        """
         return [
             *[
                 n.model_dump(by_alias=True)

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2042,6 +2042,11 @@ class LocalProject(Project):
             if data:
                 self.update_manifest(**data)
 
+        # Ensure any custom networks will work, otherwise Ape's network manager
+        # only knows about the "local" project's.
+        if custom_nets := (config_override or {}).get("networks", {}).get("custom", []):
+            self.network_manager._custom_networks.extend(custom_nets)
+
     @log_instead_of_fail(default="<ProjectManager>")
     def __repr__(self):
         path = f" {clean_path(self.path)}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -380,7 +380,7 @@ def skip_if_plugin_installed(*plugin_names: str):
                 compiler = ape.compilers.get_compiler(name)
                 if compiler:
 
-                    def test_skip_from_compiler():
+                    def test_skip_from_compiler(*args, **kwargs):
                         pytest.mark.skip(msg_f.format(name))
 
                     # NOTE: By returning a function, we avoid a collection warning.

--- a/tests/functional/geth/conftest.py
+++ b/tests/functional/geth/conftest.py
@@ -91,6 +91,7 @@ def custom_network_connection(
 ):
     data = copy.deepcopy(custom_networks_config_dict)
     data["networks"]["custom"][0]["chain_id"] = geth_provider.chain_id
+
     config = {
         ethereum.name: {custom_network_name_0: {"default_transaction_type": 0}},
         geth_provider.name: {ethereum.name: {custom_network_name_0: {"uri": geth_provider.uri}}},

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -707,147 +707,147 @@ def test_connected_provider_command_use_custom_options(runner):
     result = run(with_arg, extra_args=[argument])
     assert "test" in result.output
     assert argument in result.output
-#
-#
-# @geth_process_test
-# def test_connected_provider_command_with_network_option(runner, geth_provider):
-#     _ = geth_provider  # Ensure already running, to avoid clashing later on.
-#
-#     @click.command(cls=ConnectedProviderCommand)
-#     @network_option()
-#     def cmd(provider):
-#         click.echo(provider.name)
-#
-#     # NOTE: Must use a network that is not the default.
-#     spec = ("--network", "ethereum:local:node")
-#     res = runner.invoke(cmd, spec, catch_exceptions=False)
-#     assert res.exit_code == 0, res.output
-#     assert "node" in res.output
-#
-#
-# @geth_process_test
-# def test_connected_provider_command_with_network_option_and_cls_types_false(runner, geth_provider):
-#     _ = geth_provider  # Ensure already running, to avoid clashing later on.
-#
-#     @click.command(cls=ConnectedProviderCommand, use_cls_types=False)
-#     @network_option()
-#     def cmd(network):
-#         assert isinstance(network, str)
-#         assert network == "ethereum:local:node"
-#
-#     # NOTE: Must use a network that is not the default.
-#     spec = ("--network", "ethereum:local:node")
-#     res = runner.invoke(cmd, spec, catch_exceptions=False)
-#     assert res.exit_code == 0, res.output
-#
-#
-# def test_connected_provider_command_none_network(runner):
-#     @click.command(cls=ConnectedProviderCommand)
-#     def cmd(network, provider):
-#         click.echo(network)
-#         click.echo(provider)
-#
-#     spec = ("--network", "None")
-#     res = runner.invoke(cmd, spec, catch_exceptions=False)
-#     assert res.exit_code == 0, res.output
-#
-#
-# def test_get_param_from_ctx(mocker):
-#     mock_ctx = mocker.MagicMock()
-#     mock_ctx.params = {"foo": "bar"}
-#     mock_ctx.parent = mocker.MagicMock()
-#     mock_ctx.parent.params = {"interactive": True}
-#     actual = get_param_from_ctx(mock_ctx, "interactive")
-#     assert actual is True
-#
-#
-# def test_parse_network_when_interactive_and_no_param(mocker):
-#     ctx = mocker.MagicMock()
-#     ctx.params = {"interactive": True}
-#     ctx.parent = None
-#     network_ctx = parse_network(ctx)
-#     assert network_ctx is not None
-#     assert network_ctx.provider.name == "test"
-#     assert network_ctx._disconnect_on_exit is False  # Because of interactive: True
-#
-#
-# def test_parse_network_when_interactive_and_str_param(mocker):
-#     ctx = mocker.MagicMock()
-#     ctx.params = {"interactive": True, "network": "ethereum:local:test"}
-#     network_ctx = parse_network(ctx)
-#     assert network_ctx is not None
-#     assert network_ctx.provider.name == "test"
-#     assert network_ctx._disconnect_on_exit is False  # Because of interactive: True
-#
-#
-# def test_parse_network_when_interactive_and_class_param(mocker, eth_tester_provider):
-#     ctx = mocker.MagicMock()
-#     ctx.params = {"interactive": True, "network": eth_tester_provider}
-#     network_ctx = parse_network(ctx)
-#     assert network_ctx is not None
-#     assert network_ctx.provider.name == "test"
-#     assert network_ctx._disconnect_on_exit is False  # Because of interactive: True
-#
-#
-# def test_parse_network_when_explicit_none(mocker):
-#     ctx = mocker.MagicMock()
-#     ctx.params = {"network": _NONE_NETWORK}
-#     network_ctx = parse_network(ctx)
-#     assert network_ctx is None
-#
-#
-# def test_network_choice():
-#     network_choice = NetworkChoice()
-#     actual = network_choice.convert("ethereum:local:test", None, None)
-#     assert actual.name == "test"
-#     assert actual.network.name == "local"
-#
-#
-# @pytest.mark.parametrize("prefix", ("", "ethereum:custom:"))
-# def test_network_choice_custom_adhoc_network(prefix):
-#     network_choice = NetworkChoice()
-#     uri = "https://example.com"
-#     actual = network_choice.convert(f"{prefix}{uri}", None, None)
-#     assert actual.uri == uri
-#     assert actual.network.name == "custom"
-#
-#
-# def test_network_choice_custom_config_network(custom_networks_config_dict, project):
-#     data = copy.deepcopy(custom_networks_config_dict)
-#
-#     # Was a bug where couldn't have this name.
-#     data["networks"]["custom"][0]["name"] = "custom"
-#
-#     _get_networks_sequence_from_cache.cache_clear()
-#
-#     network_choice = NetworkChoice()
-#     with project.temp_config(**data):
-#         actual = network_choice.convert("ethereum:custom", None, None)
-#
-#     assert actual.network.name == "custom"
-#
-#
-# def test_network_choice_when_custom_local_network():
-#     network_choice = NetworkChoice()
-#     uri = "https://example.com"
-#     actual = network_choice.convert(f"ethereum:local:{uri}", None, None)
-#     assert actual.uri == uri
-#     assert actual.network.name == "local"
-#
-#
-# def test_network_choice_explicit_none():
-#     network_choice = NetworkChoice()
-#     actual = network_choice.convert("None", None, None)
-#     assert actual == _NONE_NETWORK
-#
-#
-# def test_config_override_option(runner):
-#     @click.command()
-#     @config_override_option()
-#     def cli(config_override):
-#         assert isinstance(config_override, dict)
-#         assert config_override["foo"] == "bar"
-#
-#     result = runner.invoke(cli, ("--config-override", '{"foo": "bar"}'))
-#     assert result.exit_code == 0
-#     assert not result.exception
+
+
+@geth_process_test
+def test_connected_provider_command_with_network_option(runner, geth_provider):
+    _ = geth_provider  # Ensure already running, to avoid clashing later on.
+
+    @click.command(cls=ConnectedProviderCommand)
+    @network_option()
+    def cmd(provider):
+        click.echo(provider.name)
+
+    # NOTE: Must use a network that is not the default.
+    spec = ("--network", "ethereum:local:node")
+    res = runner.invoke(cmd, spec, catch_exceptions=False)
+    assert res.exit_code == 0, res.output
+    assert "node" in res.output
+
+
+@geth_process_test
+def test_connected_provider_command_with_network_option_and_cls_types_false(runner, geth_provider):
+    _ = geth_provider  # Ensure already running, to avoid clashing later on.
+
+    @click.command(cls=ConnectedProviderCommand, use_cls_types=False)
+    @network_option()
+    def cmd(network):
+        assert isinstance(network, str)
+        assert network == "ethereum:local:node"
+
+    # NOTE: Must use a network that is not the default.
+    spec = ("--network", "ethereum:local:node")
+    res = runner.invoke(cmd, spec, catch_exceptions=False)
+    assert res.exit_code == 0, res.output
+
+
+def test_connected_provider_command_none_network(runner):
+    @click.command(cls=ConnectedProviderCommand)
+    def cmd(network, provider):
+        click.echo(network)
+        click.echo(provider)
+
+    spec = ("--network", "None")
+    res = runner.invoke(cmd, spec, catch_exceptions=False)
+    assert res.exit_code == 0, res.output
+
+
+def test_get_param_from_ctx(mocker):
+    mock_ctx = mocker.MagicMock()
+    mock_ctx.params = {"foo": "bar"}
+    mock_ctx.parent = mocker.MagicMock()
+    mock_ctx.parent.params = {"interactive": True}
+    actual = get_param_from_ctx(mock_ctx, "interactive")
+    assert actual is True
+
+
+def test_parse_network_when_interactive_and_no_param(mocker):
+    ctx = mocker.MagicMock()
+    ctx.params = {"interactive": True}
+    ctx.parent = None
+    network_ctx = parse_network(ctx)
+    assert network_ctx is not None
+    assert network_ctx.provider.name == "test"
+    assert network_ctx._disconnect_on_exit is False  # Because of interactive: True
+
+
+def test_parse_network_when_interactive_and_str_param(mocker):
+    ctx = mocker.MagicMock()
+    ctx.params = {"interactive": True, "network": "ethereum:local:test"}
+    network_ctx = parse_network(ctx)
+    assert network_ctx is not None
+    assert network_ctx.provider.name == "test"
+    assert network_ctx._disconnect_on_exit is False  # Because of interactive: True
+
+
+def test_parse_network_when_interactive_and_class_param(mocker, eth_tester_provider):
+    ctx = mocker.MagicMock()
+    ctx.params = {"interactive": True, "network": eth_tester_provider}
+    network_ctx = parse_network(ctx)
+    assert network_ctx is not None
+    assert network_ctx.provider.name == "test"
+    assert network_ctx._disconnect_on_exit is False  # Because of interactive: True
+
+
+def test_parse_network_when_explicit_none(mocker):
+    ctx = mocker.MagicMock()
+    ctx.params = {"network": _NONE_NETWORK}
+    network_ctx = parse_network(ctx)
+    assert network_ctx is None
+
+
+def test_network_choice():
+    network_choice = NetworkChoice()
+    actual = network_choice.convert("ethereum:local:test", None, None)
+    assert actual.name == "test"
+    assert actual.network.name == "local"
+
+
+@pytest.mark.parametrize("prefix", ("", "ethereum:custom:"))
+def test_network_choice_custom_adhoc_network(prefix):
+    network_choice = NetworkChoice()
+    uri = "https://example.com"
+    actual = network_choice.convert(f"{prefix}{uri}", None, None)
+    assert actual.uri == uri
+    assert actual.network.name == "custom"
+
+
+def test_network_choice_custom_config_network(custom_networks_config_dict, project):
+    data = copy.deepcopy(custom_networks_config_dict)
+
+    # Was a bug where couldn't have this name.
+    data["networks"]["custom"][0]["name"] = "custom"
+
+    _get_networks_sequence_from_cache.cache_clear()
+
+    network_choice = NetworkChoice()
+    with project.temp_config(**data):
+        actual = network_choice.convert("ethereum:custom", None, None)
+
+    assert actual.network.name == "custom"
+
+
+def test_network_choice_when_custom_local_network():
+    network_choice = NetworkChoice()
+    uri = "https://example.com"
+    actual = network_choice.convert(f"ethereum:local:{uri}", None, None)
+    assert actual.uri == uri
+    assert actual.network.name == "local"
+
+
+def test_network_choice_explicit_none():
+    network_choice = NetworkChoice()
+    actual = network_choice.convert("None", None, None)
+    assert actual == _NONE_NETWORK
+
+
+def test_config_override_option(runner):
+    @click.command()
+    @config_override_option()
+    def cli(config_override):
+        assert isinstance(config_override, dict)
+        assert config_override["foo"] == "bar"
+
+    result = runner.invoke(cli, ("--config-override", '{"foo": "bar"}'))
+    assert result.exit_code == 0
+    assert not result.exception

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -707,147 +707,147 @@ def test_connected_provider_command_use_custom_options(runner):
     result = run(with_arg, extra_args=[argument])
     assert "test" in result.output
     assert argument in result.output
-
-
-@geth_process_test
-def test_connected_provider_command_with_network_option(runner, geth_provider):
-    _ = geth_provider  # Ensure already running, to avoid clashing later on.
-
-    @click.command(cls=ConnectedProviderCommand)
-    @network_option()
-    def cmd(provider):
-        click.echo(provider.name)
-
-    # NOTE: Must use a network that is not the default.
-    spec = ("--network", "ethereum:local:node")
-    res = runner.invoke(cmd, spec, catch_exceptions=False)
-    assert res.exit_code == 0, res.output
-    assert "node" in res.output
-
-
-@geth_process_test
-def test_connected_provider_command_with_network_option_and_cls_types_false(runner, geth_provider):
-    _ = geth_provider  # Ensure already running, to avoid clashing later on.
-
-    @click.command(cls=ConnectedProviderCommand, use_cls_types=False)
-    @network_option()
-    def cmd(network):
-        assert isinstance(network, str)
-        assert network == "ethereum:local:node"
-
-    # NOTE: Must use a network that is not the default.
-    spec = ("--network", "ethereum:local:node")
-    res = runner.invoke(cmd, spec, catch_exceptions=False)
-    assert res.exit_code == 0, res.output
-
-
-def test_connected_provider_command_none_network(runner):
-    @click.command(cls=ConnectedProviderCommand)
-    def cmd(network, provider):
-        click.echo(network)
-        click.echo(provider)
-
-    spec = ("--network", "None")
-    res = runner.invoke(cmd, spec, catch_exceptions=False)
-    assert res.exit_code == 0, res.output
-
-
-def test_get_param_from_ctx(mocker):
-    mock_ctx = mocker.MagicMock()
-    mock_ctx.params = {"foo": "bar"}
-    mock_ctx.parent = mocker.MagicMock()
-    mock_ctx.parent.params = {"interactive": True}
-    actual = get_param_from_ctx(mock_ctx, "interactive")
-    assert actual is True
-
-
-def test_parse_network_when_interactive_and_no_param(mocker):
-    ctx = mocker.MagicMock()
-    ctx.params = {"interactive": True}
-    ctx.parent = None
-    network_ctx = parse_network(ctx)
-    assert network_ctx is not None
-    assert network_ctx.provider.name == "test"
-    assert network_ctx._disconnect_on_exit is False  # Because of interactive: True
-
-
-def test_parse_network_when_interactive_and_str_param(mocker):
-    ctx = mocker.MagicMock()
-    ctx.params = {"interactive": True, "network": "ethereum:local:test"}
-    network_ctx = parse_network(ctx)
-    assert network_ctx is not None
-    assert network_ctx.provider.name == "test"
-    assert network_ctx._disconnect_on_exit is False  # Because of interactive: True
-
-
-def test_parse_network_when_interactive_and_class_param(mocker, eth_tester_provider):
-    ctx = mocker.MagicMock()
-    ctx.params = {"interactive": True, "network": eth_tester_provider}
-    network_ctx = parse_network(ctx)
-    assert network_ctx is not None
-    assert network_ctx.provider.name == "test"
-    assert network_ctx._disconnect_on_exit is False  # Because of interactive: True
-
-
-def test_parse_network_when_explicit_none(mocker):
-    ctx = mocker.MagicMock()
-    ctx.params = {"network": _NONE_NETWORK}
-    network_ctx = parse_network(ctx)
-    assert network_ctx is None
-
-
-def test_network_choice():
-    network_choice = NetworkChoice()
-    actual = network_choice.convert("ethereum:local:test", None, None)
-    assert actual.name == "test"
-    assert actual.network.name == "local"
-
-
-@pytest.mark.parametrize("prefix", ("", "ethereum:custom:"))
-def test_network_choice_custom_adhoc_network(prefix):
-    network_choice = NetworkChoice()
-    uri = "https://example.com"
-    actual = network_choice.convert(f"{prefix}{uri}", None, None)
-    assert actual.uri == uri
-    assert actual.network.name == "custom"
-
-
-def test_network_choice_custom_config_network(custom_networks_config_dict, project):
-    data = copy.deepcopy(custom_networks_config_dict)
-
-    # Was a bug where couldn't have this name.
-    data["networks"]["custom"][0]["name"] = "custom"
-
-    _get_networks_sequence_from_cache.cache_clear()
-
-    network_choice = NetworkChoice()
-    with project.temp_config(**data):
-        actual = network_choice.convert("ethereum:custom", None, None)
-
-    assert actual.network.name == "custom"
-
-
-def test_network_choice_when_custom_local_network():
-    network_choice = NetworkChoice()
-    uri = "https://example.com"
-    actual = network_choice.convert(f"ethereum:local:{uri}", None, None)
-    assert actual.uri == uri
-    assert actual.network.name == "local"
-
-
-def test_network_choice_explicit_none():
-    network_choice = NetworkChoice()
-    actual = network_choice.convert("None", None, None)
-    assert actual == _NONE_NETWORK
-
-
-def test_config_override_option(runner):
-    @click.command()
-    @config_override_option()
-    def cli(config_override):
-        assert isinstance(config_override, dict)
-        assert config_override["foo"] == "bar"
-
-    result = runner.invoke(cli, ("--config-override", '{"foo": "bar"}'))
-    assert result.exit_code == 0
-    assert not result.exception
+#
+#
+# @geth_process_test
+# def test_connected_provider_command_with_network_option(runner, geth_provider):
+#     _ = geth_provider  # Ensure already running, to avoid clashing later on.
+#
+#     @click.command(cls=ConnectedProviderCommand)
+#     @network_option()
+#     def cmd(provider):
+#         click.echo(provider.name)
+#
+#     # NOTE: Must use a network that is not the default.
+#     spec = ("--network", "ethereum:local:node")
+#     res = runner.invoke(cmd, spec, catch_exceptions=False)
+#     assert res.exit_code == 0, res.output
+#     assert "node" in res.output
+#
+#
+# @geth_process_test
+# def test_connected_provider_command_with_network_option_and_cls_types_false(runner, geth_provider):
+#     _ = geth_provider  # Ensure already running, to avoid clashing later on.
+#
+#     @click.command(cls=ConnectedProviderCommand, use_cls_types=False)
+#     @network_option()
+#     def cmd(network):
+#         assert isinstance(network, str)
+#         assert network == "ethereum:local:node"
+#
+#     # NOTE: Must use a network that is not the default.
+#     spec = ("--network", "ethereum:local:node")
+#     res = runner.invoke(cmd, spec, catch_exceptions=False)
+#     assert res.exit_code == 0, res.output
+#
+#
+# def test_connected_provider_command_none_network(runner):
+#     @click.command(cls=ConnectedProviderCommand)
+#     def cmd(network, provider):
+#         click.echo(network)
+#         click.echo(provider)
+#
+#     spec = ("--network", "None")
+#     res = runner.invoke(cmd, spec, catch_exceptions=False)
+#     assert res.exit_code == 0, res.output
+#
+#
+# def test_get_param_from_ctx(mocker):
+#     mock_ctx = mocker.MagicMock()
+#     mock_ctx.params = {"foo": "bar"}
+#     mock_ctx.parent = mocker.MagicMock()
+#     mock_ctx.parent.params = {"interactive": True}
+#     actual = get_param_from_ctx(mock_ctx, "interactive")
+#     assert actual is True
+#
+#
+# def test_parse_network_when_interactive_and_no_param(mocker):
+#     ctx = mocker.MagicMock()
+#     ctx.params = {"interactive": True}
+#     ctx.parent = None
+#     network_ctx = parse_network(ctx)
+#     assert network_ctx is not None
+#     assert network_ctx.provider.name == "test"
+#     assert network_ctx._disconnect_on_exit is False  # Because of interactive: True
+#
+#
+# def test_parse_network_when_interactive_and_str_param(mocker):
+#     ctx = mocker.MagicMock()
+#     ctx.params = {"interactive": True, "network": "ethereum:local:test"}
+#     network_ctx = parse_network(ctx)
+#     assert network_ctx is not None
+#     assert network_ctx.provider.name == "test"
+#     assert network_ctx._disconnect_on_exit is False  # Because of interactive: True
+#
+#
+# def test_parse_network_when_interactive_and_class_param(mocker, eth_tester_provider):
+#     ctx = mocker.MagicMock()
+#     ctx.params = {"interactive": True, "network": eth_tester_provider}
+#     network_ctx = parse_network(ctx)
+#     assert network_ctx is not None
+#     assert network_ctx.provider.name == "test"
+#     assert network_ctx._disconnect_on_exit is False  # Because of interactive: True
+#
+#
+# def test_parse_network_when_explicit_none(mocker):
+#     ctx = mocker.MagicMock()
+#     ctx.params = {"network": _NONE_NETWORK}
+#     network_ctx = parse_network(ctx)
+#     assert network_ctx is None
+#
+#
+# def test_network_choice():
+#     network_choice = NetworkChoice()
+#     actual = network_choice.convert("ethereum:local:test", None, None)
+#     assert actual.name == "test"
+#     assert actual.network.name == "local"
+#
+#
+# @pytest.mark.parametrize("prefix", ("", "ethereum:custom:"))
+# def test_network_choice_custom_adhoc_network(prefix):
+#     network_choice = NetworkChoice()
+#     uri = "https://example.com"
+#     actual = network_choice.convert(f"{prefix}{uri}", None, None)
+#     assert actual.uri == uri
+#     assert actual.network.name == "custom"
+#
+#
+# def test_network_choice_custom_config_network(custom_networks_config_dict, project):
+#     data = copy.deepcopy(custom_networks_config_dict)
+#
+#     # Was a bug where couldn't have this name.
+#     data["networks"]["custom"][0]["name"] = "custom"
+#
+#     _get_networks_sequence_from_cache.cache_clear()
+#
+#     network_choice = NetworkChoice()
+#     with project.temp_config(**data):
+#         actual = network_choice.convert("ethereum:custom", None, None)
+#
+#     assert actual.network.name == "custom"
+#
+#
+# def test_network_choice_when_custom_local_network():
+#     network_choice = NetworkChoice()
+#     uri = "https://example.com"
+#     actual = network_choice.convert(f"ethereum:local:{uri}", None, None)
+#     assert actual.uri == uri
+#     assert actual.network.name == "local"
+#
+#
+# def test_network_choice_explicit_none():
+#     network_choice = NetworkChoice()
+#     actual = network_choice.convert("None", None, None)
+#     assert actual == _NONE_NETWORK
+#
+#
+# def test_config_override_option(runner):
+#     @click.command()
+#     @config_override_option()
+#     def cli(config_override):
+#         assert isinstance(config_override, dict)
+#         assert config_override["foo"] == "bar"
+#
+#     result = runner.invoke(cli, ("--config-override", '{"foo": "bar"}'))
+#     assert result.exit_code == 0
+#     assert not result.exception

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 import pytest
+from pydantic import ValidationError
 from pydantic_settings import SettingsConfigDict
 
 from ape.api.config import ApeConfig, ConfigEnum, PluginConfig

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -218,10 +218,9 @@ def test_network_gas_limit_invalid_numeric_string(project):
     Test that using hex strings for a network's gas_limit config must be
     prefixed with '0x'
     """
-    eth_config = _sepolia_with_gas_limit("4D2")
-    with project.temp_config(**eth_config):
-        with pytest.raises(AttributeError, match="Gas limit hex str must include '0x' prefix."):
-            _ = project.config.ethereum
+    sep_cfg = _sepolia_with_gas_limit("4D2")["ethereum"]["sepolia"]
+    with pytest.raises(ValidationError, match="Gas limit hex str must include '0x' prefix."):
+        NetworkConfig.model_validate(sep_cfg)
 
 
 def test_dependencies(project_with_dependency_config):

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -617,8 +617,10 @@ class TestDependency:
             api = LocalDependency(local=path, name="ooga", version="1.0.0")
             dependency = Dependency(api, project)
             contract_path = dependency.project.contracts_folder / "CCC.json"
+            contract_path.parent.mkdir(exist_ok=True, parents=True)
             contract_path.write_text(
-                '[{"name":"foo","type":"fallback", "stateMutability":"nonpayable"}]'
+                '[{"name":"foo","type":"fallback", "stateMutability":"nonpayable"}]',
+                encoding="utf8",
             )
             result = dependency.compile()
             assert len(result) == 1
@@ -630,9 +632,10 @@ class TestDependency:
             api = LocalDependency(local=path, name="ooga2", version="1.1.0")
             dependency = Dependency(api, project)
             sol_path = dependency.project.contracts_folder / "Sol.sol"
-            sol_path.write_text("// Sol")
+            sol_path.parent.mkdir(exist_ok=True, parents=True)
+            sol_path.write_text("// Sol", encoding="utf8")
             vy_path = dependency.project.contracts_folder / "Vy.vy"
-            vy_path.write_text("# Vy")
+            vy_path.write_text("# Vy", encoding="utf8")
             expected = (
                 "Compiling dependency produced no contract types. "
                 "Try installing 'ape-solidity' or 'ape-vyper'."

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -643,10 +643,6 @@ def test_default_transaction_type_changed_at_class_level(ethereum):
     assert config.mainnet_fork.default_transaction_type.value == 0
 
 
-def test_default_transaction_type_configured_from_custom_network():
-    pass
-
-
 @pytest.mark.parametrize("network_name", (LOCAL_NETWORK_NAME, "mainnet-fork", "mainnet_fork"))
 def test_gas_limit_local_networks(ethereum, network_name):
     network = ethereum.get_network(network_name)

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+import ape
 from ape.api import EcosystemAPI
 from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.exceptions import NetworkError, ProviderNotFoundError
@@ -400,3 +401,23 @@ def test_network_names(networks, custom_networks_config_dict, project):
         assert "mainnet-fork" in actual  # Forked
         assert "apenet" in actual  # Custom
         assert "apenet-fork" in actual  # Custom forked
+
+
+def test_custom_networks_defined_in_non_local_project(custom_networks_config_dict):
+    """
+    Showing we can read and use custom networks that are not defined
+    in the local project.
+    """
+    # Ensure we are using a name that is not used anywhere else, for accurte testing.
+    net_name = "customnetdefinedinnonlocalproj"
+    eco_name = "customecosystemnotdefinedyet"
+    custom_networks = copy.deepcopy(custom_networks_config_dict)
+    custom_networks["networks"]["custom"][0]["name"] = net_name
+    custom_networks["networks"]["custom"][0]["ecosystem"] = eco_name
+
+    with ape.Project.create_temporary_project(config_override=custom_networks) as temp_project:
+        nm = temp_project.network_manager
+        ecosystem = nm.get_ecosystem(eco_name)
+        assert ecosystem.name == eco_name
+        network = ecosystem.get_network(net_name)
+        assert network.name == net_name


### PR DESCRIPTION
### What I did

I need this fix to fix something else I am working on...
basically there was an issue where any custom network defined in a non-local project was not recognized by Ape.
See my test I added to see what I mean. That failed before but now it does not.

### How I did it

* projects with config override with inject their custom nets to network manager.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
