### PR TITLE
fix: issues showing lines for plugin config validation errors

### DIFF
--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -88,7 +88,9 @@ class PluginConfig(BaseSettings):
             return cls.model_validate(data)
         except ValidationError as err:
             plugin_name = plugin_name or cls.__name__.replace("Config", "").lower()
-            if problems := cls._find_plugin_config_problems(err, plugin_name):
+            if problems := cls._find_plugin_config_problems(
+                err, plugin_name, project_path=project_path
+            ):
                 raise ConfigError(problems) from err
             else:
                 raise ConfigError(str(err)) from err

--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -276,6 +276,12 @@ class ApeConfig(ExtraAttributesMixin, BaseSettings, ManagerAccessMixin):
     The top-level config.
     """
 
+    def __init__(self, *args, **kwargs):
+        project_path = kwargs.get("project")
+        super(BaseSettings, self).__init__(*args, **kwargs)
+        # NOTE: Cannot reference `self` at all until after super init.
+        self._project_path = project_path
+
     contracts_folder: Optional[str] = None
     """
     The path to the folder containing the contract source files.

--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -116,6 +116,8 @@ class PluginConfig(BaseSettings):
         if problems := cls._find_plugin_config_problems_from_file(err, ape.local_project.path):
             return problems
 
+        return None
+
     @classmethod
     def _find_plugin_config_problems_from_file(
         cls, err: ValidationError, base_path: Path

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -275,9 +275,7 @@ def test_from_overrides_shows_errors_in_project_config():
         with pytest.raises(ConfigError) as err:
             _ = MyConfig.from_overrides({"foo": [1, 2, 3]}, project_path=tmp_path)
 
-        # TODO
-        assert err
-        # assert "asfaf" in str(err)
+        assert "-->1: foo: [1,2,3]" in str(err.value)
 
 
 @pytest.mark.parametrize("override_0,override_1", [(True, {"foo": 0}), ({"foo": 0}, True)])

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -243,7 +243,15 @@ def test_config_access():
     )
 
 
-def test_plugin_config_updates_when_default_is_empty_dict():
+def test_from_overrides():
+    class MyConfig(PluginConfig):
+        foo: int = 0
+
+    actual = MyConfig.from_overrides({"foo": 1})
+    assert actual.foo == 1
+
+
+def test_from_overrides_updates_when_default_is_empty_dict():
     class SubConfig(PluginConfig):
         foo: int = 0
         bar: int = 1
@@ -254,6 +262,22 @@ def test_plugin_config_updates_when_default_is_empty_dict():
     overrides = {"sub": {"baz": {"test": {"foo": 5}}}}
     actual = MyConfig.from_overrides(overrides)
     assert actual.sub == {"baz": {"test": SubConfig(foo=5, bar=1)}}
+
+
+def test_from_overrides_shows_errors_in_project_config():
+    class MyConfig(PluginConfig):
+        foo: int = 0
+
+    with create_tempdir() as tmp_path:
+        file = tmp_path / "ape-config.yaml"
+        file.write_text("foo: [1,2,3]")
+
+        with pytest.raises(ConfigError) as err:
+            _ = MyConfig.from_overrides({"foo": [1, 2, 3]}, project_path=tmp_path)
+
+        # TODO
+        assert err
+        # assert "asfaf" in str(err)
 
 
 @pytest.mark.parametrize("override_0,override_1", [(True, {"foo": 0}), ({"foo": 0}, True)])


### PR DESCRIPTION
### What I did

OK- this is the issue I have been trying to fix all week...
When problems arise in plugin configs, we can show the lines in the config files.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
