### PR TITLE
feat: show events in pretty call-trace or from receipt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(
         "ethpm-types>=0.6.9,<0.7",
         "eth_pydantic_types>=0.1.0,<0.2",
         "evmchains>=0.0.10,<0.1",
-        "evm-trace>=0.1.5,<0.2",
+        "evm-trace>=0.2.0,<0.3",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -534,6 +534,12 @@ class ReceiptAPI(ExtraAttributesMixin, BaseInterfaceModel):
         like in local projects.
         """
 
+    @raises_not_implemented
+    def show_events(self):
+        """
+        Show the events from the receipt.
+        """
+
     def track_gas(self):
         """
         Track this receipt's gas in the on-going session gas-report.

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1440,9 +1440,11 @@ class ReportManager(BaseManager):
         style = "red" if failing else None
         console.print(str(traceback), style=style)
 
-    def show_events(self, events: dict, file: Optional[IO[str]] = None):
+    def show_events(self, events: list, file: Optional[IO[str]] = None):
         console = self._get_console(file)
-        console.print(events)
+        console.print("Events emitted:")
+        for event in events:
+            console.print(event)
 
     def _get_console(self, file: Optional[IO[str]] = None) -> RichConsole:
         if not file:

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1429,19 +1429,27 @@ class ReportManager(BaseManager):
 
         self.echo(*tables, file=file)
 
-    def echo(self, *rich_items, file: Optional[IO[str]] = None):
-        console = self._get_console(file=file)
+    def echo(
+        self, *rich_items, file: Optional[IO[str]] = None, console: Optional[RichConsole] = None
+    ):
+        console = console or self._get_console(file)
         console.print(*rich_items)
 
     def show_source_traceback(
-        self, traceback: SourceTraceback, file: Optional[IO[str]] = None, failing: bool = True
+        self,
+        traceback: SourceTraceback,
+        file: Optional[IO[str]] = None,
+        console: Optional[RichConsole] = None,
+        failing: bool = True,
     ):
-        console = self._get_console(file)
+        console = console or self._get_console(file)
         style = "red" if failing else None
         console.print(str(traceback), style=style)
 
-    def show_events(self, events: list, file: Optional[IO[str]] = None):
-        console = self._get_console(file)
+    def show_events(
+        self, events: list, file: Optional[IO[str]] = None, console: Optional[RichConsole] = None
+    ):
+        console = console or self._get_console(file)
         console.print("Events emitted:")
         for event in events:
             console.print(event)

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1440,6 +1440,10 @@ class ReportManager(BaseManager):
         style = "red" if failing else None
         console.print(str(traceback), style=style)
 
+    def show_events(self, events: dict, file: Optional[IO[str]] = None):
+        console = self._get_console(file)
+        console.print(events)
+
     def _get_console(self, file: Optional[IO[str]] = None) -> RichConsole:
         if not file:
             return get_console()

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -1227,11 +1227,12 @@ class Ethereum(EcosystemAPI):
         except DecodingError:
             call["calldata"] = ["<?>" for _ in method_abi.inputs]
         else:
-            call["calldata"] = {
-                k: self._enrich_value(v, **kwargs) for k, v in call["calldata"].items()
-            }
+            call["calldata"] = self._enrich_calldata_dict(call["calldata"], **kwargs)
 
         return call
+
+    def _enrich_calldata_dict(self, calldata: dict, **kwargs) -> dict:
+        return {k: self._enrich_value(v, **kwargs) for k, v in calldata.items()}
 
     def _enrich_returndata(self, call: dict, method_abi: MethodABI, **kwargs) -> dict:
         if "CREATE" in call.get("call_type", ""):
@@ -1375,7 +1376,8 @@ class Ethereum(EcosystemAPI):
 
         # Enrich the event-node data using the Ape ContractLog object.
         log: ContractLog = contract_logs[0]
-        return {"name": log.event_name, "calldata": log.event_arguments}
+        calldata = self._enrich_calldata_dict(log.event_arguments)
+        return {"name": log.event_name, "calldata": calldata}
 
     def _enrich_revert_message(self, call: dict) -> dict:
         returndata = call.get("returndata", "")

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -1024,7 +1024,6 @@ class Ethereum(EcosystemAPI):
             )
 
     def enrich_trace(self, trace: TraceAPI, **kwargs) -> TraceAPI:
-        breakpoint()
         kwargs["trace"] = trace
         if not isinstance(trace, Trace):
             return trace
@@ -1363,7 +1362,7 @@ class Ethereum(EcosystemAPI):
         assert isinstance(abi, EventABI)  # For mypy.
         log_data = {
             "topics": event["topics"],
-            "data": HexBytes(b"".join([HexBytes(d) for d in event["data"]])),
+            "data": event["data"],
             "address": address,
         }
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -1024,6 +1024,7 @@ class Ethereum(EcosystemAPI):
             )
 
     def enrich_trace(self, trace: TraceAPI, **kwargs) -> TraceAPI:
+        breakpoint()
         kwargs["trace"] = trace
         if not isinstance(trace, Trace):
             return trace
@@ -1349,7 +1350,9 @@ class Ethereum(EcosystemAPI):
                 return event
 
         # The selector is always the first topic.
-        selector = event["topics"][0].hex()
+        selector = event["topics"][0]
+        if not isinstance(selector, str):
+            selector = selector.hex()
 
         if selector not in contract_type.identifier_lookup:
             # Unable to enrich using this contract type.

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -241,6 +241,19 @@ class Web3Provider(ProviderAPI, ABC):
 
         return pending_base_fee
 
+    @property
+    def call_trace_approach(self) -> Optional[TraceApproach]:
+        """
+        The default tracing approach to use when building up a call-tree.
+        By default, Ape attempts to use the faster approach. Meaning, if
+        geth-call-tracer or parity are available, Ape will use one of those
+        instead of building a call-trace entirely from struct-logs.
+        """
+        if approach := self._call_trace_approach:
+            return approach
+
+        return self.settings.get("call_trace_approach")
+
     def _get_fee_history(self, block_number: int) -> FeeHistory:
         try:
             return self.web3.eth.fee_history(1, BlockNumber(block_number), reward_percentiles=[])
@@ -407,7 +420,7 @@ class Web3Provider(ProviderAPI, ABC):
 
     def get_transaction_trace(self, transaction_hash: str, **kwargs) -> TraceAPI:
         if "call_trace_approach" not in kwargs:
-            kwargs["call_trace_approach"] = self._call_trace_approach
+            kwargs["call_trace_approach"] = self.call_trace_approach
 
         return TransactionTrace(transaction_hash=transaction_hash, **kwargs)
 

--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -218,6 +218,10 @@ class Trace(TraceAPI):
 
     def show(self, verbose: bool = False, file: IO[str] = sys.stdout):
         call = self.enriched_calltree
+
+        # If the trace-approach was struct-logs, the events emitted
+        # are present in their calls.
+
         failed = call.get("failed", False)
         revert_message = None
         if failed:

--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -266,7 +266,7 @@ class Trace(TraceAPI):
                     event_counter[tuple_key].append(evt)
 
                 if event_counter:
-                    console.print("Events emitted:")
+                    console.print("\nEvents emitted:")
 
                 for evt_tup, events in event_counter.items():
                     count = len(events)
@@ -277,7 +277,11 @@ class Trace(TraceAPI):
                     evt_tree = _create_event_tree(events[0], suffix=suffix)
                     console.print(evt_tree)
 
-        # else: the events are already included in the right spots.
+                if event_counter:
+                    # Keep the events-block in its section for easier reading.
+                    console.print()
+
+        # else: the events are already included in the right spots in the call tree.
 
         console.print(root)
 

--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -278,7 +278,7 @@ class Trace(TraceAPI):
                 event_trees = _events_to_trees(enriched_events)
                 if event_trees:
                     console.print()
-                    self.chain_manager._reports.show_events(event_trees, file=file)
+                    self.chain_manager._reports.show_events(event_trees, console=console)
                     console.print()
 
         # else: the events are already included in the right spots in the call tree.

--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -608,7 +608,7 @@ def _call_to_str(call: dict, stylize: bool = False, verbose: bool = False) -> st
 def _event_to_str(event: dict, stylize: bool = False) -> str:
     name = event["name"]
     arguments_str = _get_inputs_str(event.get("calldata"), stylize=stylize)
-    return f"{name}{arguments_str}"
+    return f"emit {name}{arguments_str}"
 
 
 def _create_tree(call: dict, verbose: bool = False) -> Tree:

--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -64,7 +64,7 @@ class TraceApproach(Enum):
         if isinstance(key, TraceApproach):
             return key
         elif isinstance(key, int) or (isinstance(key, str) and key.isnumeric()):
-            return int(key)
+            return cls(int(key))
 
         # Check if given a name.
         key = key.replace("-", "_").upper()

--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -57,6 +57,16 @@ class TraceApproach(Enum):
 
     @classmethod
     def from_key(cls, key: str) -> "TraceApproach":
+        return cls(cls._validate(key))
+
+    @classmethod
+    def _validate(cls, key: Any) -> int:
+        if isinstance(key, TraceApproach):
+            return key
+        elif isinstance(key, int) or (isinstance(key, str) and key.isnumeric()):
+            return int(key)
+
+        # Check if given a name.
         key = key.replace("-", "_").upper()
 
         # Allow shorter, nicer values for the geth-struct-log approach.
@@ -67,8 +77,7 @@ class TraceApproach(Enum):
             if member.name == key:
                 return member
 
-        # Try it as a value.
-        return cls(key)
+        raise ValueError(f"No enum named '{key}'.")
 
 
 class Trace(TraceAPI):

--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -55,6 +55,21 @@ class TraceApproach(Enum):
     NOT RECOMMENDED.
     """
 
+    @classmethod
+    def from_key(cls, key: str) -> "TraceApproach":
+        key = key.replace("-", "_").upper()
+
+        # Allow shorter, nicer values for the geth-struct-log approach.
+        if key in ("GETH", "GETH_STRUCT_LOG", "GETH_STRUCT_LOGS"):
+            key = "GETH_STRUCT_LOG_PARSE"
+
+        for member in cls:
+            if member.name == key:
+                return member
+
+        # Try it as a value.
+        return cls(key)
+
 
 class Trace(TraceAPI):
     """

--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -530,11 +530,20 @@ class CallTrace(Trace):
 
 def parse_rich_tree(call: dict, verbose: bool = False) -> Tree:
     tree = _create_tree(call, verbose=verbose)
+    for event in call.get("events", []):
+        event_tree = _create_event_tree(event)
+        tree.add(event_tree)
+
     for sub_call in call["calls"]:
         sub_tree = parse_rich_tree(sub_call, verbose=verbose)
         tree.add(sub_tree)
 
     return tree
+
+
+def _create_event_tree(event: dict) -> Tree:
+    signature = _event_to_str(event, stylize=True)
+    return Tree(signature)
 
 
 def _call_to_str(call: dict, stylize: bool = False, verbose: bool = False) -> str:
@@ -594,6 +603,12 @@ def _call_to_str(call: dict, stylize: bool = False, verbose: bool = False) -> st
         signature = f"{signature}\n{extra}"
 
     return signature
+
+
+def _event_to_str(event: dict, stylize: bool = False) -> str:
+    name = event["name"]
+    arguments_str = _get_inputs_str(event.get("calldata"), stylize=stylize)
+    return f"{name}{arguments_str}"
 
 
 def _create_tree(call: dict, verbose: bool = False) -> Tree:

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -21,7 +21,7 @@ from ape.exceptions import OutOfGasError, SignatureError, TransactionError
 from ape.logging import logger
 from ape.types import AddressType, ContractLog, ContractLogContainer, SourceTraceback
 from ape.utils import ZERO_ADDRESS
-from ape_ethereum.trace import Trace
+from ape_ethereum.trace import Trace, _events_to_trees
 
 
 class TransactionStatusEnum(IntEnum):
@@ -273,14 +273,15 @@ class Receipt(ReceiptAPI):
             self.source_traceback, file=file, failing=self.failed
         )
 
-    def show_events(self):
+    def show_events(self, file: IO[str] = sys.stdout):
         if provider := self.network_manager.active_provider:
             ecosystem = provider.network.ecosystem
         else:
             ecosystem = self.network_manager.ethereum
 
-        events = ecosystem._enrich_trace_events(self.logs)
-        self.chain_manager._reports.show_events(events)
+        enriched_events = ecosystem._enrich_trace_events(self.logs)
+        event_trees = _events_to_trees(enriched_events)
+        self.chain_manager._reports.show_events(event_trees, file=file)
 
     def decode_logs(
         self,

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -273,6 +273,15 @@ class Receipt(ReceiptAPI):
             self.source_traceback, file=file, failing=self.failed
         )
 
+    def show_events(self):
+        if provider := self.network_manager.active_provider:
+            ecosystem = provider.network.ecosystem
+        else:
+            ecosystem = self.network_manager.ethereum
+
+        events = ecosystem._enrich_trace_events(self.logs)
+        self.chain_manager._reports.show_events(events)
+
     def decode_logs(
         self,
         abi: Optional[

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -204,10 +204,35 @@ class EthereumNetworkConfig(PluginConfig):
 
 
 class EthereumNodeConfig(PluginConfig):
+    """
+    Configure your ``node:`` in Ape, the default provider
+    plugin for live-network nodes. Also, ``ape node`` can
+    start-up a local development node for testing purposes.
+    """
+
     ethereum: EthereumNetworkConfig = EthereumNetworkConfig()
+    """
+    Configure the Ethereum network settings for the ``ape node`` provider,
+    such as which URIs to use for each network.
+    """
+
     executable: Optional[str] = None
-    ipc_path: Optional[Path] = None
+    """
+    For starting nodes, select the executable. Defaults to using
+    ``shutil.which("geth")``.
+    """
+
     data_dir: Optional[Path] = None
+    """
+    For node-management, choose where the geth data directory shall
+    be located. Defaults to using a location within Ape's DATA_FOLDER.
+    """
+
+    ipc_path: Optional[Path] = None
+    """
+    For IPC connections, select the IPC path. If managing a process,
+    web3.py can determine the IPC w/o needing to manually configure.
+    """
 
     model_config = SettingsConfigDict(extra="allow")
 

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -12,6 +12,7 @@ from geth.accounts import ensure_account_exists  # type: ignore
 from geth.chain import initialize_chain  # type: ignore
 from geth.process import BaseGethProcess  # type: ignore
 from geth.wrapper import construct_test_chain_kwargs  # type: ignore
+from pydantic import field_validator
 from pydantic_settings import SettingsConfigDict
 from requests.exceptions import ConnectionError
 from web3.middleware import geth_poa_middleware
@@ -37,6 +38,7 @@ from ape_ethereum.provider import (
     DEFAULT_SETTINGS,
     EthereumNodeProvider,
 )
+from ape_ethereum.trace import TraceApproach
 
 
 class GethDevProcess(BaseGethProcess):
@@ -234,7 +236,19 @@ class EthereumNodeConfig(PluginConfig):
     web3.py can determine the IPC w/o needing to manually configure.
     """
 
+    call_trace_approach: Optional[TraceApproach] = None
+    """
+    Select the trace approach to use. Defaults to deducing one
+    based on your node's client-version and available RPCs.
+    """
+
     model_config = SettingsConfigDict(extra="allow")
+
+    @field_validator("call_trace_approach", mode="before")
+    @classmethod
+    def validate_trace_approach(cls, value):
+        # This handles nicer config values.
+        return None if value is None else TraceApproach.from_key(value)
 
 
 class NodeSoftwareNotInstalledError(ConnectionError):

--- a/tests/functional/data/sources/VyperContract.vy
+++ b/tests/functional/data/sources/VyperContract.vy
@@ -31,6 +31,7 @@ event EventWithUintArray:
 struct MyStruct:
     a: address
     b: bytes32
+    c: uint256
 
 struct NestedStruct1:
     t: MyStruct
@@ -104,22 +105,22 @@ def getStruct() -> MyStruct:
 @view
 @external
 def getNestedStruct1() -> NestedStruct1:
-    return NestedStruct1({t: MyStruct({a: msg.sender, b: block.prevhash}), foo: 1})
+    return NestedStruct1({t: MyStruct({a: msg.sender, b: block.prevhash, c: 244}), foo: 1})
 
 @view
 @external
 def getNestedStruct2() -> NestedStruct2:
-    return NestedStruct2({foo: 2, t: MyStruct({a: msg.sender, b: block.prevhash})})
+    return NestedStruct2({foo: 2, t: MyStruct({a: msg.sender, b: block.prevhash, c: 244})})
 
 @view
 @external
 def getNestedStructWithTuple1() -> (NestedStruct1, uint256):
-    return (NestedStruct1({t: MyStruct({a: msg.sender, b: block.prevhash}), foo: 1}), 1)
+    return (NestedStruct1({t: MyStruct({a: msg.sender, b: block.prevhash, c: 244}), foo: 1}), 1)
 
 @view
 @external
 def getNestedStructWithTuple2() -> (uint256, NestedStruct2):
-    return (2, NestedStruct2({foo: 2, t: MyStruct({a: msg.sender, b: block.prevhash})}))
+    return (2, NestedStruct2({foo: 2, t: MyStruct({a: msg.sender, b: block.prevhash, c: 244})}))
 
 @pure
 @external
@@ -161,8 +162,8 @@ def getStructWithArray() -> WithArray:
         {
             foo: 1,
             arr: [
-                MyStruct({a: msg.sender, b: block.prevhash}),
-                MyStruct({a: msg.sender, b: block.prevhash})
+                MyStruct({a: msg.sender, b: block.prevhash, c: 244}),
+                MyStruct({a: msg.sender, b: block.prevhash, c: 244})
             ],
             bar: 2
         }
@@ -192,16 +193,16 @@ def getAddressArray() -> DynArray[address, 2]:
 @external
 def getDynamicStructArray() -> DynArray[NestedStruct1, 2]:
     return [
-        NestedStruct1({t: MyStruct({a: msg.sender, b: block.prevhash}), foo: 1}),
-        NestedStruct1({t: MyStruct({a: msg.sender, b: block.prevhash}), foo: 2})
+        NestedStruct1({t: MyStruct({a: msg.sender, b: block.prevhash, c: 244}), foo: 1}),
+        NestedStruct1({t: MyStruct({a: msg.sender, b: block.prevhash, c: 244}), foo: 2})
     ]
 
 @view
 @external
 def getStaticStructArray() -> NestedStruct2[2]:
     return [
-        NestedStruct2({foo: 1, t: MyStruct({a: msg.sender, b: block.prevhash})}),
-        NestedStruct2({foo: 2, t: MyStruct({a: msg.sender, b: block.prevhash})})
+        NestedStruct2({foo: 1, t: MyStruct({a: msg.sender, b: block.prevhash, c: 244})}),
+        NestedStruct2({foo: 2, t: MyStruct({a: msg.sender, b: block.prevhash, c: 244})})
     ]
 
 @pure
@@ -288,7 +289,8 @@ def logStruct():
     _bytes: bytes32 = 0x1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef
     _struct: MyStruct = MyStruct({
         a: msg.sender,
-        b: _bytes
+        b: _bytes,
+        c: 244
     })
     log EventWithStruct(_struct)
 

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -23,6 +23,7 @@ from ape.exceptions import (
 from ape.utils import to_int
 from ape_ethereum.ecosystem import Block
 from ape_ethereum.provider import DEFAULT_SETTINGS, EthereumNodeProvider
+from ape_ethereum.trace import TraceApproach
 from ape_ethereum.transactions import (
     AccessList,
     AccessListTransaction,
@@ -592,3 +593,12 @@ def test_get_virtual_machine_error(geth_provider):
     error = Web3ContractLogicError(f"execution reverted: {expected}", "0x08c379a")
     actual = geth_provider.get_virtual_machine_error(error)
     assert actual.message == expected
+
+
+@geth_process_test
+def test_trace_approach_config(project):
+    node_cfg = project.config.node.model_dump(by_alias=True)
+    node_cfg["call_trace_approach"] = "geth"
+    with project.temp_config(node=node_cfg):
+        provider = project.network_manager.ethereum.local.get_provider("node")
+        assert provider.call_trace_approach is TraceApproach.GETH_STRUCT_LOG_PARSE

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -1110,6 +1110,7 @@ def test_enrich_trace_handles_events(ethereum, vyper_contract_instance, owner):
 
     trace = MyTrace(transaction_hash=tx.txn_hash)
     actual = ethereum.enrich_trace(trace)
+    assert "events" in actual._enriched_calltree, "is evm-trace updated?"
     events = actual._enriched_calltree["events"]
     expected = [
         {

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -1077,3 +1077,19 @@ def test_enrich_trace_handles_call_type_enum(ethereum, vyper_contract_instance, 
     call = trace.get_calltree().model_dump(by_alias=True)
     actual = ethereum._enrich_calltree(call)
     assert actual["call_type"] == CallType.CALL.value
+
+
+def test_enrich_trace_handles_events(ethereum):
+    class MyTrace(TransactionTrace):
+        def get_calltree(self) -> CallTreeNode:
+            return CallTreeNode.model_validate(CALL_TREE_NODE)
+
+        # @property
+        # def transaction(self) -> dict:
+        #     return TRANSACTION_DICT
+
+    trace = MyTrace(
+        transaction_hash="0x430674d92a4825cb07abc352f0e06cdd12b5e641d1f6005676c0be8ca9f9dba4"
+    )
+    actual = ethereum.enrich_trace(trace)
+    breakpoint()

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -58,10 +58,11 @@ def test_show_events(trace_print_capture, invoke_receipt):
     invoke_receipt.show_events()
     actual = trace_print_capture.call_args[0][0]
     assert isinstance(actual, Tree)
+    label = str(actual.label)
     # Formatted and enriched signature string.
-    assert "[bright_green]NumberChange" in actual.label
-    assert 'dynData=[bright_magenta]"Dynamic"' in actual.label
-    assert "newNum=[bright_magenta]1" in actual.label
+    assert "[bright_green]NumberChange" in label
+    assert 'dynData=[bright_magenta]"Dynamic"' in label
+    assert "newNum=[bright_magenta]1" in label
 
 
 def test_decode_logs_specify_abi(invoke_receipt, vyper_contract_instance):

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -54,6 +54,16 @@ def test_show_gas_report(trace_print_capture, invoke_receipt):
     assert actual.title == "VyperContract Gas"
 
 
+def test_show_events(trace_print_capture, invoke_receipt):
+    invoke_receipt.show_events()
+    actual = trace_print_capture.call_args[0][0]
+    assert isinstance(actual, Tree)
+    # Formatted and enriched signature string.
+    assert "[bright_green]NumberChange" in actual.label
+    assert 'dynData=[bright_magenta]"Dynamic"' in actual.label
+    assert "newNum=[bright_magenta]1" in actual.label
+
+
 def test_decode_logs_specify_abi(invoke_receipt, vyper_contract_instance):
     abi = vyper_contract_instance.NumberChange.abi
     logs = invoke_receipt.decode_logs(abi=abi)

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -39,9 +39,30 @@ def test_receipt_properties(chain, invoke_receipt):
 
 def test_show_trace(trace_print_capture, invoke_receipt):
     invoke_receipt.show_trace()
-    actual = trace_print_capture.call_args[0][0]
-    assert isinstance(actual, Tree)
-    label = f"{actual.label}"
+    call_args = trace_print_capture.call_args_list
+
+    # Trace title assertion.
+    actual_title = call_args[0][0][0]
+    assert actual_title == f"Call trace for [bold blue]'{invoke_receipt.txn_hash}'[/]"
+
+    # The origin comes below the title.
+    actual_origin = call_args[1][0][0]
+    assert actual_origin == f"tx.origin=[#ff8c00]{invoke_receipt.sender}[/]"
+
+    # Next are events.
+    events_title = call_args[3][0][0]
+    event_tree = call_args[4][0][0]
+    event_label = str(event_tree.label)
+    assert events_title == "Events emitted:"
+    assert isinstance(event_tree, Tree)
+    assert "[bright_green]NumberChange" in event_label
+    assert 'dynData=[bright_magenta]"Dynamic"' in event_label
+    assert "newNum=[bright_magenta]1" in event_label
+
+    # Assert stuff about actual call-tree now.
+    actual_calltree = call_args[6][0][0]
+    assert isinstance(actual_calltree, Tree)
+    label = f"{actual_calltree.label}"
     assert "VyperContract" in label
     assert "setNumber" in label
     assert f"[{invoke_receipt.gas_used} gas]" in label

--- a/tests/functional/test_trace.py
+++ b/tests/functional/test_trace.py
@@ -231,3 +231,14 @@ def test_enriched_calltree_adds_missing_gas(simple_trace_cls):
     trace = trace_cls.model_validate(TRACE_API_DATA)
     actual = trace.enriched_calltree
     assert actual["gas_cost"] == compute_gas
+
+
+class TestTraceApproach:
+    @pytest.mark.parametrize("key", ("geth", "geth-struct-log", "GETH_STRUCT_LOGS"))
+    def test_from_key_geth_struct_log(self, key):
+        actual = TraceApproach.from_key(key)
+        assert actual == TraceApproach.GETH_STRUCT_LOG_PARSE
+
+    def test_from_key_parity(self):
+        actual = TraceApproach.from_key("parity")
+        assert actual == TraceApproach.PARITY

--- a/tests/functional/test_trace.py
+++ b/tests/functional/test_trace.py
@@ -242,14 +242,6 @@ class TestTraceApproach:
         actual = TraceApproach.from_key(key)
         assert actual == TraceApproach.GETH_STRUCT_LOG_PARSE
 
-        # Show also works during init.
-        actual = TraceApproach(key)
-        assert actual == TraceApproach.GETH_STRUCT_LOG_PARSE
-
     def test_from_key_parity(self):
         actual = TraceApproach.from_key("parity")
-        assert actual == TraceApproach.PARITY
-
-        # Show also works during init.
-        actual = TraceApproach("parity")
         assert actual == TraceApproach.PARITY

--- a/tests/functional/test_trace.py
+++ b/tests/functional/test_trace.py
@@ -234,11 +234,22 @@ def test_enriched_calltree_adds_missing_gas(simple_trace_cls):
 
 
 class TestTraceApproach:
-    @pytest.mark.parametrize("key", ("geth", "geth-struct-log", "GETH_STRUCT_LOGS"))
+    @pytest.mark.parametrize(
+        "key",
+        ("geth", "geth-struct-log", "GETH_STRUCT_LOGS", TraceApproach.GETH_STRUCT_LOG_PARSE.value),
+    )
     def test_from_key_geth_struct_log(self, key):
         actual = TraceApproach.from_key(key)
         assert actual == TraceApproach.GETH_STRUCT_LOG_PARSE
 
+        # Show also works during init.
+        actual = TraceApproach(key)
+        assert actual == TraceApproach.GETH_STRUCT_LOG_PARSE
+
     def test_from_key_parity(self):
         actual = TraceApproach.from_key("parity")
+        assert actual == TraceApproach.PARITY
+
+        # Show also works during init.
+        actual = TraceApproach("parity")
         assert actual == TraceApproach.PARITY


### PR DESCRIPTION
### What I did

* Show and enrich event data in Call-traces
* Attach missing events to call tree during a `show()`.
* Add `show_events()` method to `ReceiptAPI`

fixes: #834
fixes: #1776 

requires: https://github.com/ApeWorX/evm-trace/pull/66

<img width="1128" alt="Screenshot 2024-06-26 at 18 35 27" src="https://github.com/ApeWorX/ape/assets/19540978/7f127160-13d7-4f24-a1d0-73a7682fa376">

note: for non structLog approach, logs are injected at top of the trace because that is the best we can do seemingly

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
