### PR TITLE
fix: regression decoding boolean values

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -781,7 +781,7 @@ class Ethereum(EcosystemAPI):
         elif isinstance(value, bytes):
             return HexBytes(value)
 
-        elif isinstance(value, int):
+        elif isinstance(value, int) and not isinstance(value, bool):
             # Wrap integers in a special type that allows us to compare
             # them with currency-value strings.
             return CurrencyValueComparable(value)

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -757,6 +757,19 @@ def test_decode_returndata_returns_str_comparable_ints(ethereum):
     assert isinstance(actual[0], CurrencyValueComparable)
 
 
+def test_decode_returndata_bool(ethereum):
+    abi = MethodABI(
+        type="function",
+        name="view_method",
+        stateMutability="view",
+        inputs=[],
+        outputs=[ABIType(name="", type="bool", components=None, internal_type=None)],
+    )
+    raw_data = HexBytes("0x000000000000000000000000000000000000000000000000000000000000001")
+    actual = ethereum.decode_returndata(abi, raw_data)[0]
+    assert isinstance(actual, bool)
+
+
 @pytest.mark.parametrize("tx_type", TransactionType)
 def test_create_transaction_uses_network_gas_limit(tx_type, ethereum, eth_tester_provider, owner):
     tx = ethereum.create_transaction(type=tx_type.value, sender=owner.address)


### PR DESCRIPTION
### What I did

the currency-value broke decoding bools from returndata because bools are technically `isinstance(x, int)`

### How I did it

adjust check to verify isnt a bool before going to currency-val- comparable

### How to verify it

```vyper
@view
@external
def view_method() -> bool:
    return True
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
