### PR TITLE
perf: improve performance of `project.get_contract()`

### DIFF
--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -540,6 +540,17 @@ def test_get_contract(project_with_contracts):
     assert isinstance(actual, ContractContainer)
     assert actual.contract_type.name == "Other"
 
+    # Ensure manifest is only loaded once by none-ing out the path.
+    # Otherwise, this can be a MAJOR performance hit.
+    manifest_path = project_with_contracts.manifest_path
+    project_with_contracts.manifest_path = None
+    try:
+        actual = project_with_contracts.get_contract("Other")
+        assert isinstance(actual, ContractContainer)
+        assert actual.contract_type.name == "Other"
+    finally:
+        project_with_contracts.manifest_path = manifest_path
+
 
 def test_get_contract_not_exists(project):
     actual = project.get_contract("this is not a contract")

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -43,6 +43,11 @@ def test_compile(ape_cli, runner, integ_project, clean_cache):
     cmd = ("compile", "--project", f"{integ_project.path}")
     result = runner.invoke(ape_cli, cmd, catch_exceptions=False)
     assert result.exit_code == 0, result.output
+
+    # We have to load the manifest again because normally we are not referencing
+    # the manifest in the same process as `ape compile`.
+    integ_project.load_manifest()
+
     assert integ_project.manifest.contract_types
 
     # First time it compiles, it compiles the files with registered compilers successfully.


### PR DESCRIPTION
### What I did

The performance of getting contracts from projects is bad because it pointlessly always reloaded the manifest. Mistake! Fixed!

For testing, using a MASSIVE PROJECT.

With change:

```
In [1]: %time project.get_contract("MyContract")
CPU times: user 116 ms, sys: 12 ms, total: 128 ms
Wall time: 132 ms
```

Without change:

```
In [1]: %time project.get_contract("MyContract")
CPU times: user 1min 19s, sys: 2.88 s, total: 1min 22s
Wall time: 1min 22s
```


Improvement≈99.84%

So, the performance improvement is approximately 99.84%.

### How I did it

delete code.
test.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
