### PR TITLE
fix: create data dir in clean method

### DIFF
--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -140,7 +140,7 @@ class GethDevProcess(BaseGethProcess):
         bal_dict = {"balance": str(initial_balance)}
         alloc = {a: bal_dict for a in addresses}
         genesis = create_genesis_data(alloc, chain_id)
-        self._data_dir.mkdir(parents=True, exist_ok=True)
+
         initialize_chain(genesis, self.data_dir)
         super().__init__(geth_kwargs)
 

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -140,7 +140,6 @@ class GethDevProcess(BaseGethProcess):
         bal_dict = {"balance": str(initial_balance)}
         alloc = {a: bal_dict for a in addresses}
         genesis = create_genesis_data(alloc, chain_id)
-
         initialize_chain(genesis, self.data_dir)
         super().__init__(geth_kwargs)
 

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -111,7 +111,6 @@ class GethDevProcess(BaseGethProcess):
         self._data_dir = data_dir
         self._hostname = hostname
         self._port = port
-        self._data_dir.mkdir(exist_ok=True, parents=True)
         self.is_running = False
         self._auto_disconnect = auto_disconnect
 

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -208,6 +208,9 @@ class GethDevProcess(BaseGethProcess):
         if self._data_dir.is_dir():
             shutil.rmtree(self._data_dir)
 
+        # dir must exist when initializing chain.
+        self._data_dir.mkdir(parents=True, exist_ok=True)
+
     def wait(self, *args, **kwargs):
         if self.proc is None:
             return

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -779,7 +779,10 @@ class TestSourceManager:
             ):
                 actual = pm.sources.lookup(closest)
                 expected = nested_source_b
-                assert actual == expected, f"Failed to lookup {closest}"
+
+                # Using stem in case it returns `Contract.__mock__`, which is
+                # added / removed as part of other tests (running x-dist).
+                assert actual.stem == expected.stem, f"Failed to lookup {closest}"
 
         finally:
             clean()


### PR DESCRIPTION
### What I did

data dir was getting removed / created at weird times
also a test failed on merge to main for last PR

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
