### PR TITLE
fix: issue where could not compile file and subdir in the same command

### DIFF
--- a/src/ape/cli/arguments.py
+++ b/src/ape/cli/arguments.py
@@ -129,18 +129,22 @@ class _ContractPaths(ManagerAccessMixin):
                 self.project.path / path.name
             ) == contracts_folder or path.name == contracts_folder.name:
                 # Was given the path to the contracts folder.
-                return {p for p in self.project.sources.paths}
+                path_set = path_set.union({p for p in self.project.sources.paths})
 
             elif (self.project.path / path).is_dir():
                 # Was given sub-dir in the project folder.
-                return self.lookup(
-                    (p for p in (self.project.path / path).iterdir()), path_set=path_set
+                path_set = path_set.union(
+                    self.lookup(
+                        (p for p in (self.project.path / path).iterdir()), path_set=path_set
+                    )
                 )
 
             elif (contracts_folder / path.name).is_dir():
                 # Was given sub-dir in the contracts folder.
-                return self.lookup(
-                    (p for p in (contracts_folder / path.name).iterdir()), path_set=path_set
+                path_set = path_set.union(
+                    self.lookup(
+                        (p for p in (contracts_folder / path.name).iterdir()), path_set=path_set
+                    )
                 )
 
             elif resolved_path := self.project.sources.lookup(path):

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -557,6 +557,24 @@ def test_contract_file_paths_argument_contract_does_not_exist(
     assert expected in result.output
 
 
+def test_contract_file_paths_argument_given_directory_and_file(
+    project_with_contract, runner, contracts_paths_cmd
+):
+    """
+    Tests against a bug where if given a directory AND a file together,
+    only the directory resolved and the file was lost.
+    """
+    pm = project_with_contract
+    src_stem = next(x for x in pm.sources if Path(x).suffix == ".json").split(".")[0]
+    arguments = ("subdir", src_stem, "--project", f"{pm.path}")
+    result = runner.invoke(contracts_paths_cmd, arguments)
+    paths = sorted(pm.sources.paths)
+
+    all_paths = ", ".join(x.name for x in paths if x.parent.name == "subdir")
+    assert f"{all_paths}" in result.output
+    assert f"{src_stem.split('/')[-1]}" in result.output
+
+
 def test_existing_alias_option(runner):
     @click.command()
     @existing_alias_argument()


### PR DESCRIPTION
### What I did

An annoying issue I found while testing where one could not compile a subdirectory with a source file in one go, e.g.

```
ape compile subdir MyContract.vy
```

### How I did it

set unions instead of early return in the loop

### How to verify it

from project with subdir and contracts

```sh
ape compile subdir MyContract.vy
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
