### PR TITLE
fix: bug where ENS domains were not handled in account history queries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,12 @@ repos:
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.1.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.10.1
     hooks:
     -   id: mypy
         additional_dependencies: [

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extras_require = {
     ],
     "lint": [
         "black>=24.4.2,<25",  # Auto-formatter and linter
-        "mypy>=1.10.0,<2",  # Static type analyzer
+        "mypy>=1.10.1,<2",  # Static type analyzer
         "types-PyYAML",  # Needed due to mypy typeshed
         "types-requests",  # Needed due to mypy typeshed
         "types-setuptools",  # Needed due to mypy typeshed
@@ -29,7 +29,7 @@ extras_require = {
         "types-toml",  # Needed due to mypy typeshed
         "types-SQLAlchemy>=1.4.49",  # Needed due to mypy typeshed
         "types-python-dateutil",  # Needed due to mypy typeshed
-        "flake8>=7.0.0,<8",  # Style linter
+        "flake8>=7.1.0,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
         "flake8-print>=4.0.1,<5",  # Detect print statements left in code
         "isort>=5.13.2,<6",  # Import sorting linter

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -118,7 +118,7 @@ def test_history_getitem_receipt(chain, vyper_contract_instance, owner):
 def test_history_getitem_account(chain, vyper_contract_instance, owner):
     actual = chain.history[owner.address]
     assert isinstance(actual, AccountHistory)
-    assert actual.adress == owner.address
+    assert actual.address == owner.address
 
 
 def test_history_getitem_account_ens(mocker, chain, vyper_contract_instance, owner):

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -3,6 +3,8 @@ from datetime import datetime, timedelta
 import pytest
 
 from ape.exceptions import APINotImplementedError, ChainError
+from ape.managers.chain import AccountHistory
+from ape.types import AddressType
 
 
 def test_snapshot_and_restore(chain, owner, receiver, vyper_contract_instance):
@@ -85,7 +87,7 @@ def test_isolate(chain, vyper_contract_instance, owner):
     assert vyper_contract_instance.myNumber() == number_at_start
 
 
-def test_get_receipt_uses_cache(mocker, eth_tester_provider, chain, vyper_contract_instance, owner):
+def test_history_uses_cache(mocker, eth_tester_provider, chain, vyper_contract_instance, owner):
     expected = vyper_contract_instance.setNumber(3, sender=owner)
     eth = eth_tester_provider.web3.eth
     rpc_spy = mocker.spy(eth, "get_transaction")
@@ -105,12 +107,28 @@ def test_get_receipt_uses_cache(mocker, eth_tester_provider, chain, vyper_contra
     assert rpc_spy.call_count == 1  # Not changed
 
 
-def test_get_receipt_from_history(chain, vyper_contract_instance, owner):
+def test_history_getitem_receipt(chain, vyper_contract_instance, owner):
     expected = vyper_contract_instance.setNumber(3, sender=owner)
     actual = chain.history[expected.txn_hash]
     assert actual.txn_hash == expected.txn_hash
     assert actual.sender == expected.sender
     assert actual.receiver == expected.receiver
+
+
+def test_history_getitem_account(chain, vyper_contract_instance, owner):
+    actual = chain.history[owner.address]
+    assert isinstance(actual, AccountHistory)
+    assert actual.adress == owner.address
+
+
+def test_history_getitem_account_ens(mocker, chain, vyper_contract_instance, owner):
+    conversion_spy = mocker.spy(chain.history.conversion_manager, "convert")
+    value = "this will not work, but would if given ens and using ape-ens"
+    expected_err = rf"'{value}' is not a known address or transaction hash\."
+    with pytest.raises(ChainError, match=expected_err):
+        _ = chain.history[value]
+
+    conversion_spy.assert_called_once_with(value, AddressType)
 
 
 def test_set_pending_timestamp(chain):


### PR DESCRIPTION
### What I did

The documentation for querying accounts used an example with an ENS name as the arhttps://docs.apeworx.io/ape/stable/userguides/data.html#getting-account-transaction-datagument: 

however, when I went to try it, it was not seen as valid and no conversion took place.
Thus it is a bug fix since it was a documented feature that isnt working.

### How I did it

convert

### How to verify it

```python
chain.history["vitalik.eth"]
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
