### PR TITLE
test: show we can use namedtuples and web3 namedtuples

### DIFF
--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -726,8 +726,9 @@ def test_tuple_as_struct_input(contract_instance, owner):
 
 def test_named_tuple_as_struct_input(contract_instance, owner):
     # NOTE: Also showing extra keys like "extra_key" don't matter and are ignored.
-    MyStruct = namedtuple("MyStruct", {"a": AddressType, "b": HexBytes, "c": int, "extra_key": int})
-    data = MyStruct(owner, HexBytes(123), 999, 0)
+    values = {"a": AddressType, "b": HexBytes, "c": int, "extra_key": int}
+    MyStruct = namedtuple("MyStruct", values)  # type: ignore
+    data = MyStruct(owner, HexBytes(123), 999, 0)  # type: ignore
     assert contract_instance.setStruct(data) is None
 
 


### PR DESCRIPTION
### What I did

* Show we can use namedtuples as inputs
* Try out new web3 namedtuple functionality (I found an https://github.com/ethereum/web3.py/issues/3429)
* Adding notes here:
** Unable to have underscore prefixed values in structs which is bad / breaking for Ape... I get it is rare but it is rather unfortunate. I don't see a reason to change our Struct to use namedtuple for reasons like this, also because the name in the namedtuple is not very dynamic in web3.py, it is the same name and not the name of the struct like it is in Ape. Ape's struct seems a lot more powerful so I am tempted to stick with that, albeit overengineered in some respects. I just can't rationalize changing to namedtuple at this time.

fixes: #1893 

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
