### PR TITLE
feat: handle commas and underscores in currency string conversions

### DIFF
--- a/src/ape_ethereum/_converters.py
+++ b/src/ape_ethereum/_converters.py
@@ -1,3 +1,4 @@
+import re
 from decimal import Decimal
 
 from ape.api.convert import ConverterAPI
@@ -18,6 +19,7 @@ ETHER_UNITS = {
     "babbage": int(1e3),
     "wei": 1,
 }
+NUMBER_PATTERN = re.compile(r"^-?\d{1,3}(?:[,_]?\d{3})*(?:\.\d+)?(?:[eE][+-]?\d+)?$")
 
 
 class WeiConversions(ConverterAPI):
@@ -30,11 +32,12 @@ class WeiConversions(ConverterAPI):
         if " " not in value or len(value.split(" ")) > 2:
             return False
 
-        _, unit = value.split(" ")
-
-        return unit.lower() in ETHER_UNITS
+        val, unit = value.split(" ")
+        return unit.lower() in ETHER_UNITS and bool(NUMBER_PATTERN.match(val))
 
     def convert(self, value: str) -> int:
         value, unit = value.split(" ")
-        converted_value = int(Decimal(value) * ETHER_UNITS[unit.lower()])
+        converted_value = int(
+            Decimal(value.replace("_", "").replace(",", "")) * ETHER_UNITS[unit.lower()]
+        )
         return CurrencyValue(converted_value)

--- a/tests/functional/conversion/test_ether.py
+++ b/tests/functional/conversion/test_ether.py
@@ -6,6 +6,8 @@ from hypothesis import strategies as st
 from ape.exceptions import ConversionError
 from ape_ethereum._converters import ETHER_UNITS
 
+TEN_THOUSAND_ETHER_IN_WEI = 10_000_000_000_000_000_000_000
+
 
 @pytest.mark.fuzzing
 @given(
@@ -41,3 +43,15 @@ def test_no_registered_converter(convert):
         convert("something", ChecksumAddress)
 
     assert str(err.value) == "No conversion registered to handle 'something'."
+
+
+@pytest.mark.parametrize("sep", (",", "_"))
+def test_separaters(convert, sep):
+    """
+    Show that separates, such as commands and underscores, are OK
+    in currency-string values, e.g. "10,000 ETH" is valid.
+    """
+    currency_str = f"10{sep}000 ETHER"
+    actual = convert(currency_str, int)
+    expected = TEN_THOUSAND_ETHER_IN_WEI
+    assert actual == expected


### PR DESCRIPTION
### What I did

Now, if you convert like this:

```python
convert("10,000 ETH", int)
```

It will work.

I think `10_000 ETH` worked already, but I made sure of it.

Test accounts are pre-funded with 10,000 ETH which is a big number and the commas make the currency string a bit more readable.

Since these are string types, commas are a normal way of expressing separation in numbers, so i think it intuitive to do that

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
