### PR TITLE
Allow bypassing caching behavior for 2nd/3rd party QueryAPI plugins

### DIFF
--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -128,6 +128,15 @@ class QueryManager(ManagerAccessMixin):
 
     def _suggest_engines(self, engine_selection):
         return difflib.get_close_matches(engine_selection, list(self.engines), cutoff=0.6)
+    
+    def _get_skip_caching_plugins(self):
+        """
+        Get the list of query plugins to skip caching for from the configuration.
+        """
+        try:
+            return self.config_manager.query.skip_caching
+        except AttributeError:
+            return []  # Return an empty list if the configuration doesn't exist
 
     def query(
         self,


### PR DESCRIPTION
### What I did

This is related to this issue. [https://github.com/ApeWorX/ape/issues/1294](https://github.com/ApeWorX/ape/issues/1294)

1. Added a new method `_get_skip_caching_plugins()` that retrieves the list of plugins to skip caching from the configuration. If the configuration doesn't exist, it returns an empty list.
2. In the `query()` method, fetch the list of plugins to skip caching.
3. When iterating through the engines to update caches, check if the engine's name is in the skip list. If it's not in the list, proceed with the cache update as before. If it is in the list, skip the cache update and log a debug message.

### How I did it

Updated [class QueryManager](https://github.com/ApeWorX/ape/blob/ffd9ef2357a7354aca5f462844143aa262d35f3a/src/ape/managers/query.py#L99C13-L99C14)

### How to verify it

...

### Checklist
- [x] Add config item for `query.skip_caching`
- [x]  Add handling in `QueryManager` for bypassing calls to `engine.update_cache`
