### PR TITLE
fix: issue where compiler panics were not detected using Eth-Tester provider

### DIFF
--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -300,7 +300,7 @@ class CompilerManager(BaseManager, ExtraAttributesMixin):
               as a custom error.
 
         Returns:
-
+            Optional[:class:`~ape.exceptions.CustomError`]
         """
         message = err.revert_message
         if not message.startswith("0x"):

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -202,6 +202,15 @@ def test_revert_allow(not_owner, contract_instance):
     contract_instance.setNumber.call(5, raise_on_revert=False)
 
 
+def test_revert_handles_compiler_panic(owner, contract_instance):
+    # note: setBalance is a weird name - it actually adjust the balance.
+    # first, set it to be 1 less than an overflow.
+    contract_instance.setBalance(owner, 2**256 - 1, sender=owner)
+    # then, add 1 more, so it should no overflow and cause a compiler panic.
+    with pytest.raises(ContractLogicError):
+        contract_instance.setBalance(owner, 1, sender=owner)
+
+
 def test_call_using_block_id(vyper_contract_instance, owner, chain, networks_connected_to_tester):
     contract = vyper_contract_instance
     contract.setNumber(1, sender=owner)


### PR DESCRIPTION
### What I did

we were not catching the right exception in the ape-test provider logic.

### How I did it

catch all exceptions
handle gracefully tracing issues.

### How to verify it

```python
def main():
    owner = accounts.test_accounts[0]
    contract = owner.deploy(project.VyperContract, 0)
    contract.setNumber.call(5) 
```

shows like

```
  File "$HOME/ApeProjects/ape-playground/scripts/failu.py", line 18, in main
    contract.setNumber.call(5)
  File "$HOME/ApeProjects/ape-playground/contracts/VyperContract.vy", line 98, in 
setNumber
    assert msg.sender == self.owner, "!authorized"
    ^^^^^^^^^^^^^^^^^^^^^^^
```


<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
