### PR TITLE
fix: issue where Vyper source-lines were not displayed in call-stacktraces

### DIFF
--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -962,7 +962,7 @@ def test_sending_funds_to_non_payable_constructor_by_contractContainerDeploy(
 ):
     with pytest.raises(
         MethodNonPayableError,
-        match="Sending funds to a non-payable constructor.",
+        match=r"Sending funds to a non-payable constructor\.",
     ):
         solidity_contract_container.deploy(1, sender=owner, value="1 ether")
 
@@ -972,7 +972,7 @@ def test_sending_funds_to_non_payable_constructor_by_accountDeploy(
 ):
     with pytest.raises(
         MethodNonPayableError,
-        match="Sending funds to a non-payable constructor.",
+        match=r"Sending funds to a non-payable constructor\.",
     ):
         owner.deploy(solidity_contract_container, 1, value="1 ether")
 

--- a/tests/functional/test_exceptions.py
+++ b/tests/functional/test_exceptions.py
@@ -1,8 +1,28 @@
 import re
 
+import pytest
+
 from ape.api import ReceiptAPI
 from ape.exceptions import Abort, NetworkNotFoundError, TransactionError
 from ape_ethereum.transactions import DynamicFeeTransaction, Receipt
+
+
+@pytest.fixture(scope="module")
+def failing_call():
+    # A call (tx without sender)
+    data = {
+        "chainId": 1337,
+        "to": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+        "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "gas": 30029122,
+        "value": 0,
+        "data": "0xce50aa7d00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c80000000000000000000000000000000000000000000000000000000000000001",  # noqa: E501
+        "type": 2,
+        "maxFeePerGas": 875000000,
+        "maxPriorityFeePerGas": 0,
+        "accessList": [],
+    }
+    return DynamicFeeTransaction.model_validate(data)
 
 
 class TestAbort:
@@ -54,26 +74,49 @@ class TestTransactionError:
         err = TransactionError(txn=tx)
         assert err.address == contract.address
 
-    def test_call(self):
+    def test_call_with_txn_and_not_source_tb(self, failing_call):
         """
         Simulating a failing-call, making sure it doesn't
         blow up if it doesn't get a source-tb.
         """
-        data = {
-            "chainId": 1337,
-            "to": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
-            "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-            "gas": 30029122,
-            "value": 0,
-            "data": "0xce50aa7d00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c80000000000000000000000000000000000000000000000000000000000000001",  # noqa: E501
-            "type": 2,
-            "maxFeePerGas": 875000000,
-            "maxPriorityFeePerGas": 0,
-            "accessList": [],
-        }
-        failing_call = DynamicFeeTransaction.model_validate(data)
         err = TransactionError(txn=failing_call)
         assert err.source_traceback is None
+
+    def test_call_with_source_tb_and_not_txn(self, mocker, project_with_contract):
+        """
+        Simulating a failing call, making sure the source-tb lines
+        show up when a txn is NOT given.
+        """
+        # Using mocks for simplicity. Otherwise have to use a bunch of models from ethpm-types;
+        # most of the stuff being mocked seems simple but is calculated from AST-Nodes and such.
+        src_path = "path/to/VyperFile.vy"
+        mock_tb = mocker.MagicMock()
+        mock_exec = mocker.MagicMock()
+        mock_exec.depth = 1
+        mock_exec.source_path = src_path
+        mock_exec.begin_lineno = 5
+        mock_exec.end_lineno = 5
+        mock_closure = mocker.MagicMock()
+        mock_closure.name = "setNumber"
+        mock_exec.closure = mock_closure
+        mock_tb.__getitem__.return_value = mock_exec
+        mock_tb.__len__.return_value = 1
+
+        err = TransactionError(source_traceback=mock_tb, project=project_with_contract)
+
+        # Have to raise for sys.exc_info() to be available.
+        try:
+            raise err
+        except Exception:
+            pass
+
+        assert err.__traceback__ is not None
+
+        # The Vyper-frame gets injected at tb_next.
+        assert err.__traceback__.tb_next is not None
+
+        actual = str(err.__traceback__.tb_next.tb_frame)
+        assert src_path in actual
 
 
 class TestNetworkNotFoundError:


### PR DESCRIPTION
### What I did

We show the lines of Vyper files in the Python stack traces well for Transactions.
However, I noticed it was not working for call.

This PR fixes that.

### How I did it

Mostly just remove the unnecessary reliance on the txn= kwarg when setting the traceback

### How to verify it

make a call that fails, im doing:

```
contract.setNumber.call(5) 
```

in a script, then you should see the trace showing the vyper lines:

```
  File "$HOME/ApeProjects/ape-playground/contracts/VyperContract.vy", line 98, in 
setNumber
    assert msg.sender == self.owner, "!authorized"
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [ ] Documentation has been updated
