### PR TITLE
fix: issue where home dir was not hidden in stacktraces

### DIFF
--- a/src/ape/__init__.py
+++ b/src/ape/__init__.py
@@ -1,36 +1,11 @@
 import signal
 import threading
-import traceback
-import os
 
 if threading.current_thread() is threading.main_thread():
     # If we are in the main thread, we can safely set the signal handler
     signal.signal(signal.SIGINT, lambda s, f: _sys.exit(130))
 
 import sys as _sys
-
-
-_HOME_DIR = os.path.expanduser("~")
-
-
-def custom_exception_hook(exctype, value, tb):
-    # Format the traceback
-    formatted_traceback = traceback.format_exception(exctype, value, tb)
-
-    # Filter out the home directory from the traceback
-    filtered_traceback = []
-    for line in formatted_traceback:
-        if _HOME_DIR in line:
-            filtered_traceback.append(line.replace(_HOME_DIR, "$HOME"))
-        else:
-            filtered_traceback.append(line)
-
-    # Print the filtered traceback
-    for line in filtered_traceback:
-        _sys.stderr.write(line)
-
-# Set the custom exception hook
-_sys.excepthook = custom_exception_hook
 
 from ape.managers.project import ProjectManager as Project
 from ape.pytest.contextmanagers import RevertsContextManager

--- a/src/ape/__init__.py
+++ b/src/ape/__init__.py
@@ -1,11 +1,36 @@
 import signal
 import threading
+import traceback
+import os
 
 if threading.current_thread() is threading.main_thread():
     # If we are in the main thread, we can safely set the signal handler
     signal.signal(signal.SIGINT, lambda s, f: _sys.exit(130))
 
 import sys as _sys
+
+
+_HOME_DIR = os.path.expanduser("~")
+
+
+def custom_exception_hook(exctype, value, tb):
+    # Format the traceback
+    formatted_traceback = traceback.format_exception(exctype, value, tb)
+
+    # Filter out the home directory from the traceback
+    filtered_traceback = []
+    for line in formatted_traceback:
+        if _HOME_DIR in line:
+            filtered_traceback.append(line.replace(_HOME_DIR, "$HOME"))
+        else:
+            filtered_traceback.append(line)
+
+    # Print the filtered traceback
+    for line in filtered_traceback:
+        _sys.stderr.write(line)
+
+# Set the custom exception hook
+_sys.excepthook = custom_exception_hook
 
 from ape.managers.project import ProjectManager as Project
 from ape.pytest.contextmanagers import RevertsContextManager

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -698,7 +698,7 @@ class PluginVersionError(PluginInstallError):
         super().__init__(message)
 
 
-def handle_ape_exception(err: ApeException, base_paths: Iterable[Path]) -> bool:
+def handle_ape_exception(err: ApeException, base_paths: Iterable[Union[Path, str]]) -> bool:
     """
     Handle a transaction error by showing relevant stack frames,
     including custom contract frames added to the exception.
@@ -708,24 +708,31 @@ def handle_ape_exception(err: ApeException, base_paths: Iterable[Path]) -> bool:
     Args:
         err (:class:`~ape.exceptions.TransactionError`): The transaction error
           being handled.
-        base_paths (Optional[Iterable[Path]]): Optionally include additional
+        base_paths (Optional[Iterable[Union[Path, str]]]): Optionally include additional
           source-path prefixes to use when finding relevant frames.
 
     Returns:
         bool: ``True`` if outputted something.
     """
-
-    tb = traceback.extract_tb(sys.exc_info()[2])
-    if not (relevant_tb := [f for f in tb if any(str(p) in f.filename for p in base_paths)]):
+    home_str = str(Path.home())
+    if not (relevant_frames := _get_relevant_frames(base_paths)):
         return False
 
-    click.echo()
-    formatted_tb = traceback.format_list(relevant_tb)
-    rich_print("".join(formatted_tb))
+    formatted_tb = [x.replace(home_str, "$HOME") for x in relevant_frames]
+    rich_print(f"\n{''.join(formatted_tb)}")
 
-    # Prevent double logging traceback.
+    # Prevent double logging of a traceback by using `show_traceback=False`.
     logger.error(Abort.from_ape_exception(err, show_traceback=False))
     return True
+
+
+def _get_relevant_frames(base_paths: Iterable[Union[Path, str]]):
+    # Abstracted for testing easement.
+    tb = traceback.extract_tb(sys.exc_info()[2])
+    if relevant_tb := [f for f in tb if any(str(p) in f.filename for p in base_paths)]:
+        return [x for x in traceback.format_list(relevant_tb)]
+
+    return []
 
 
 class Abort(click.ClickException):


### PR DESCRIPTION
### What I did

The home dir was not being hidden properly in stacktraces 
This makes it so!

### How I did it

When formatting the traceback, do the swap swap swap swap, do the swap.

### How to verify it

```python
    contract = owner.deploy(project.VyperContract, 0)
    contract.setNumber.call(5) 
```

should see 

```
  File "$HOME/ApeProjects/ape-playground/scripts/failu.py", line 18, in main
    contract.setNumber.call(5)

ERROR: (ContractLogicError) !authorized
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
