### PR TITLE
fix: ABI output was wrong when using `extra_output`

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2539,9 +2539,7 @@ class LocalProject(Project):
             abi_folder.mkdir(parents=True, exist_ok=True)
             for name, ct in (self.manifest.contract_types or {}).items():
                 file = abi_folder / f"{name}.json"
-                abi_json = json.dumps(
-                    [x.model_dump_json(by_alias=True, mode="json") for x in ct.abi]
-                )
+                abi_json = json.dumps([x.model_dump(by_alias=True, mode="json") for x in ct.abi])
                 file.write_text(abi_json, encoding="utf8")
 
 

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -408,6 +408,13 @@ def test_load_contracts_output_abi(tmp_project):
         for file in files:
             assert file.suffix == ".json"
 
+        # Ensure is usable.
+        data = json.loads(file.read_text(encoding="utf8"))
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        # There was bug where this was a str.
+        assert isinstance(data[0], dict)
+
 
 def test_manifest_path(tmp_project):
     assert tmp_project.manifest_path == tmp_project.path / ".build" / "__local__.json"


### PR DESCRIPTION
### What I did

`extra_output` handling ABI was a list of strings instead of a list of objects, in the JSON.

### How I did it

model_dump instead of model_dump_json
improve test

### How to verify it

ABI is usable now.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
