### PR TITLE
perf: account alias lookup

### DIFF
--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -153,6 +153,8 @@ class AccountManager(BaseManager):
         my_accounts = accounts.load("dev")
     """
 
+    _alias_to_account_cache: dict[str, AccountAPI] = {}
+
     @property
     def default_sender(self) -> Optional[AccountAPI]:
         return _DEFAULT_SENDERS[-1] if _DEFAULT_SENDERS else None
@@ -257,12 +259,15 @@ class AccountManager(BaseManager):
         Returns:
             :class:`~ape.api.accounts.AccountAPI`
         """
-
         if alias == "":
             raise ValueError("Cannot use empty string as alias!")
 
+        elif alias in self._alias_to_account_cache:
+            return self._alias_to_account_cache[alias]
+
         for account in self:
             if account.alias and account.alias == alias:
+                self._alias_to_account_cache[alias] = account
                 return account
 
         raise KeyError(f"No account with alias '{alias}'.")

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -881,3 +881,8 @@ def test_import_account_from_private_key_insecure_passphrase(delete_account_afte
     with delete_account_after(simple_alias):
         with pytest.warns(UserWarning, match="simple"):
             import_account_from_private_key(simple_alias, "simple", PRIVATE_KEY)
+
+
+def test_load(accounts, keyfile_account):
+    account = accounts.load(keyfile_account.alias)
+    assert account == keyfile_account


### PR DESCRIPTION
### What I did

In [7]: %time accounts.load("laughing-sepolia-safe")
CPU times: user 566 µs, sys: 497 µs, total: 1.06 ms
Wall time: 729 µs
Out[7]: <SafeAccount 0x872Df5f6CF2C2Eaa9e7511AB079D263AB8fdc79f>

In [8]: %time accounts.load("laughing-sepolia-safe")
CPU times: user 7 µs, sys: 1e+03 ns, total: 8 µs
Wall time: 9.78 µs
Out[8]: <SafeAccount 0x872Df5f6CF2C2Eaa9e7511AB079D263AB8fdc79f>

**Note:** Some accounts plugins a bit slower than others on first load.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
