### PR TITLE
perf: avoid duplicate account generation

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -584,15 +584,27 @@ class TestAccountContainerAPI(AccountContainerAPI):
         """
         return Path("/dev/null" if os.name == "posix" else "NUL")
 
-    # TODO: 0.9 change this to abstractmethod
     @raises_not_implemented
     def get_test_account(self, index: int) -> "TestAccountAPI":  # type: ignore[empty-body]
-        pass
+        """
+        Get the test account at the given index.
+
+        Args:
+            index (int): The index of the test account.
+
+        Returns:
+            :class:`~ape.api.accounts.TestAccountAPI`
+        """
 
     @abstractmethod
     def generate_account(self) -> "TestAccountAPI":
         """
         Generate a new test account.
+        """
+
+    def reset(self):
+        """
+        Reset the account container to an original state.
         """
 
 

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -1,5 +1,6 @@
 import os
 from collections.abc import Iterator
+from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -443,11 +444,11 @@ class AccountContainerAPI(BaseInterfaceModel):
             Iterator[:class:`~ape.api.accounts.AccountAPI`]
         """
 
-    @property
+    @cached_property
     def data_folder(self) -> Path:
         """
         The path to the account data files.
-        Defaults to ``$HOME/.ape/<plugin_name>`` unless overriden.
+        Defaults to ``$HOME/.ape/<plugin_name>`` unless overridden.
         """
         path = self.config_manager.DATA_FOLDER / self.name
         path.mkdir(parents=True, exist_ok=True)
@@ -573,18 +574,15 @@ class TestAccountContainerAPI(AccountContainerAPI):
     ``AccountContainerAPI`` directly. Then, they show up in the ``accounts`` test fixture.
     """
 
-    @property
+    @cached_property
     def data_folder(self) -> Path:
         """
         **NOTE**: Test account containers do not touch
-        persistant data. By default and unless overriden,
+        persistent data. By default and unless overridden,
         this property returns the path to ``/dev/null`` and
         it is not used for anything.
         """
-        if os.name == "posix":
-            return Path("/dev/null")
-
-        return Path("NUL")
+        return Path("/dev/null" if os.name == "posix" else "NUL")
 
     @abstractmethod
     def generate_account(self) -> "TestAccountAPI":

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -24,7 +24,7 @@ from ape.exceptions import (
 )
 from ape.logging import logger
 from ape.types import AddressType, MessageSignature, SignableMessage
-from ape.utils import BaseInterfaceModel, abstractmethod
+from ape.utils import BaseInterfaceModel, abstractmethod, raises_not_implemented
 
 if TYPE_CHECKING:
     from ape.contracts import ContractContainer, ContractInstance
@@ -583,6 +583,11 @@ class TestAccountContainerAPI(AccountContainerAPI):
         it is not used for anything.
         """
         return Path("/dev/null" if os.name == "posix" else "NUL")
+
+    # TODO: 0.9 change this to abstractmethod
+    @raises_not_implemented
+    def get_test_account(self, index: int) -> "TestAccountAPI":  # type: ignore[empty-body]
+        pass
 
     @abstractmethod
     def generate_account(self) -> "TestAccountAPI":

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -597,7 +597,7 @@ class TestAccountContainerAPI(AccountContainerAPI):
         """
 
     @abstractmethod
-    def generate_account(self) -> "TestAccountAPI":
+    def generate_account(self, index: Optional[int] = None) -> "TestAccountAPI":
         """
         Generate a new test account.
         """

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -662,7 +662,6 @@ class ProviderAPI(BaseInterfaceModel):
             amount (int): The balance to set in the address.
         """
 
-    # TODO: In 0.9, add this to TestAccountAPI and make it abstractmethod.
     @raises_not_implemented
     def get_test_account(self, index: int) -> "TestAccountAPI":  # type: ignore[empty-body]
         """

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -12,7 +12,7 @@ from logging import FileHandler, Formatter, Logger, getLogger
 from pathlib import Path
 from signal import SIGINT, SIGTERM, signal
 from subprocess import DEVNULL, PIPE, Popen
-from typing import Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 from eth_pydantic_types import HexBytes
 from ethpm_types.abi import EventABI
@@ -41,6 +41,9 @@ from ape.utils.misc import (
     log_instead_of_fail,
     raises_not_implemented,
 )
+
+if TYPE_CHECKING:
+    from ape.api.accounts import TestAccountAPI
 
 
 class BlockAPI(BaseInterfaceModel):
@@ -659,6 +662,14 @@ class ProviderAPI(BaseInterfaceModel):
             amount (int): The balance to set in the address.
         """
 
+    @raises_not_implemented
+    def get_test_account(self, index: int) -> "TestAccountAPI":  # type: ignore[empty-body]
+        pass  # Test account API
+
+    @raises_not_implemented
+    def generate_test_account(self):  # type: ignore[empty-body]
+        pass  # Test account API
+
     @log_instead_of_fail(default="<ProviderAPI>")
     def __repr__(self) -> str:
         return f"<{self.name.capitalize()} chain_id={self.chain_id}>"
@@ -907,6 +918,27 @@ class TestProviderAPI(ProviderAPI):
         if method_id in contract_type.view_methods:
             method = contract_type.methods[method_id]
             self._test_runner.coverage_tracker.hit_function(contract_src, method)
+
+    @raises_not_implemented
+    def get_test_account(self, index: int) -> "TestAccountAPI":  # type: ignore[empty-body]
+        """
+        Retrieve one of the provider-generated test accounts.
+
+        Args:
+            index (int): The index of the test accoun in the HD-Path.
+
+        Returns:
+            :class:`~ape.api.accounts.TestAccountAPI`
+        """
+
+    @raises_not_implemented
+    def generate_test_account(self) -> "TestAccountAPI":  # type: ignore[empty-body]
+        """
+        Generate a new test account.
+
+        Returns:
+            :class:`~ape.api.accounts.TestAccountAPI`
+        """
 
 
 class UpstreamProvider(ProviderAPI):

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -662,13 +662,18 @@ class ProviderAPI(BaseInterfaceModel):
             amount (int): The balance to set in the address.
         """
 
+    # TODO: In 0.9, add this to TestAccountAPI and make it abstractmethod.
     @raises_not_implemented
     def get_test_account(self, index: int) -> "TestAccountAPI":  # type: ignore[empty-body]
-        pass  # Test account API
+        """
+        Retrieve one of the provider-generated test accounts.
 
-    @raises_not_implemented
-    def generate_test_account(self):  # type: ignore[empty-body]
-        pass  # Test account API
+        Args:
+            index (int): The index of the test account in the HD-Path.
+
+        Returns:
+            :class:`~ape.api.accounts.TestAccountAPI`
+        """
 
     @log_instead_of_fail(default="<ProviderAPI>")
     def __repr__(self) -> str:
@@ -918,27 +923,6 @@ class TestProviderAPI(ProviderAPI):
         if method_id in contract_type.view_methods:
             method = contract_type.methods[method_id]
             self._test_runner.coverage_tracker.hit_function(contract_src, method)
-
-    @raises_not_implemented
-    def get_test_account(self, index: int) -> "TestAccountAPI":  # type: ignore[empty-body]
-        """
-        Retrieve one of the provider-generated test accounts.
-
-        Args:
-            index (int): The index of the test accoun in the HD-Path.
-
-        Returns:
-            :class:`~ape.api.accounts.TestAccountAPI`
-        """
-
-    @raises_not_implemented
-    def generate_test_account(self) -> "TestAccountAPI":  # type: ignore[empty-body]
-        """
-        Generate a new test account.
-
-        Returns:
-            :class:`~ape.api.accounts.TestAccountAPI`
-        """
 
 
 class UpstreamProvider(ProviderAPI):

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -132,6 +132,9 @@ class TestAccountManager(list, ManagerAccessMixin):
     def __contains__(self, address: AddressType) -> bool:  # type: ignore
         return any(address in container for container in self.containers.values())
 
+    def generate_test_account(self, container_name: str = "test") -> TestAccountAPI:
+        return self.containers[container_name].generate_account()
+
     def use_sender(self, account_id: Union[TestAccountAPI, AddressType, int]) -> ContextManager:
         account = account_id if isinstance(account_id, TestAccountAPI) else self[account_id]
         return _use_sender(account)

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -63,7 +63,7 @@ class TestAccountManager(list, ManagerAccessMixin):
                 yield account.alias
 
     def __len__(self) -> int:
-        return self.config_manager.get_config("test").number_of_accounts
+        return sum(len(c) for c in self.containers.values())
 
     def __iter__(self) -> Iterator[AccountAPI]:
         yield from self.accounts
@@ -81,7 +81,7 @@ class TestAccountManager(list, ManagerAccessMixin):
         if account_id < 0:
             account_id = len(self) + account_id
 
-        account = self.containers["test"].get_test_account(account_id)
+        account = self.containers["test"].get_test_account(account_id)  # type: ignore
         self._accounts_by_index[original_account_id] = account
         return account
 
@@ -147,8 +147,10 @@ class TestAccountManager(list, ManagerAccessMixin):
             index, address, private_key
         )
 
-    def _reset(self):
+    def reset(self):
         self._accounts_by_index = {}
+        for container in self.containers.values():
+            container.reset()
 
 
 class AccountManager(BaseManager):

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -43,14 +43,14 @@ class TestAccountManager(list, ManagerAccessMixin):
 
     @cached_property
     def containers(self) -> dict[str, TestAccountContainerAPI]:
-        containers = {}
-        account_types = [
-            t for t in self.plugin_manager.account_types if issubclass(t[1][1], TestAccountAPI)
-        ]
-        for plugin_name, (container_type, account_type) in account_types:
-            containers[plugin_name] = container_type(name=plugin_name, account_type=account_type)
-
-        return containers
+        account_types = filter(
+            lambda t: issubclass(t[1][1], TestAccountAPI),
+            self.plugin_manager.account_types
+        )
+        return {
+            plugin_name: container_type(name=plugin_name, account_type=account_type)
+            for plugin_name, (container_type, account_type) in account_types
+        }
 
     @property
     def accounts(self) -> Iterator[AccountAPI]:

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -81,7 +81,7 @@ class TestAccountManager(list, ManagerAccessMixin):
         if account_id < 0:
             account_id = len(self) + account_id
 
-        account = self.containers["test"].get_test_account(account_id)  # type: ignore
+        account = self.containers["test"].get_test_account(account_id)
         self._accounts_by_index[original_account_id] = account
         return account
 

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -132,9 +132,6 @@ class TestAccountManager(list, ManagerAccessMixin):
     def __contains__(self, address: AddressType) -> bool:  # type: ignore
         return any(address in container for container in self.containers.values())
 
-    def generate_test_account(self, container_name: str = "test") -> TestAccountAPI:
-        return self.containers[container_name].generate_account()
-
     def use_sender(self, account_id: Union[TestAccountAPI, AddressType, int]) -> ContextManager:
         account = account_id if isinstance(account_id, TestAccountAPI) else self[account_id]
         return _use_sender(account)

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -1887,7 +1887,7 @@ class Project(ProjectManager):
         self._config_override = overrides
         _ = self.config
 
-        self.account_manager.test_accounts._reset()
+        self.account_manager.test_accounts.reset()
 
     def extract_manifest(self) -> PackageManifest:
         return self.manifest

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -1887,6 +1887,8 @@ class Project(ProjectManager):
         self._config_override = overrides
         _ = self.config
 
+        self.account_manager.initialize_test_accounts()
+
     def extract_manifest(self) -> PackageManifest:
         return self.manifest
 

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -1887,7 +1887,7 @@ class Project(ProjectManager):
         self._config_override = overrides
         _ = self.config
 
-        self.account_manager.initialize_test_accounts()
+        self.account_manager.test_accounts._reset()
 
     def extract_manifest(self) -> PackageManifest:
         return self.manifest

--- a/src/ape/utils/testing.py
+++ b/src/ape/utils/testing.py
@@ -48,17 +48,19 @@ def generate_dev_accounts(
         list[:class:`~ape.utils.GeneratedDevAccount`]: List of development accounts.
     """
     seed = Mnemonic.to_seed(mnemonic)
-    accounts = []
+    hd_path_format = (
+        hd_path if "{}" in hd_path or "{0}" in hd_path else f"{hd_path.rstrip('/')}/{{}}"
+    )
+    return [
+        _generate_dev_account(hd_path_format, i, seed)
+        for i in range(start_index, start_index + number_of_accounts)
+    ]
 
-    if "{}" in hd_path or "{0}" in hd_path:
-        hd_path_format = hd_path
-    else:
-        hd_path_format = f"{hd_path.rstrip('/')}/{{}}"
 
-    for i in range(start_index, start_index + number_of_accounts):
-        hd_path_obj = HDPath(hd_path_format.format(i))
-        private_key = HexBytes(hd_path_obj.derive(seed)).hex()
-        address = Account.from_key(private_key).address
-        accounts.append(GeneratedDevAccount(address, private_key))
-
-    return accounts
+def _generate_dev_account(hd_path, index: int, seed: bytes) -> GeneratedDevAccount:
+    return GeneratedDevAccount(
+        address=Account.from_key(
+            private_key := HexBytes(HDPath(hd_path.format(index)).derive(seed)).hex()
+        ).address,
+        private_key=private_key,
+    )

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -18,7 +18,7 @@ from requests.exceptions import ConnectionError
 from web3.middleware import geth_poa_middleware
 from yarl import URL
 
-from ape.api import PluginConfig, SubprocessProvider, TestProviderAPI
+from ape.api import PluginConfig, SubprocessProvider, TestAccountAPI, TestProviderAPI
 from ape.logging import LogLevel, logger
 from ape.types import SnapshotID
 from ape.utils.misc import ZERO_ADDRESS, log_instead_of_fail, raises_not_implemented
@@ -130,10 +130,10 @@ class GethDevProcess(BaseGethProcess):
 
         geth_kwargs["dev_mode"] = True
         hd_path = hd_path or DEFAULT_TEST_HD_PATH
-        accounts = generate_dev_accounts(
+        self._dev_accounts = generate_dev_accounts(
             mnemonic, number_of_accounts=number_of_accounts, hd_path=hd_path
         )
-        addresses = [a.address for a in accounts]
+        addresses = [a.address for a in self._dev_accounts]
         addresses.extend(extra_funded_accounts or [])
         bal_dict = {"balance": str(initial_balance)}
         alloc = {a: bal_dict for a in addresses}
@@ -417,6 +417,16 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
 
     def build_command(self) -> list[str]:
         return self._process.command if self._process else []
+
+    def get_test_account(self, index: int) -> "TestAccountAPI":
+        # NOTE: No need to cache here because it happens at the TestAccountManager already.
+        if proc := self._process:
+            account = proc._dev_accounts[index]
+            return self.account_manager.init_test_account(
+                index, account.address, account.private_key
+            )
+
+        raise IndexError(f"Cannot get account at index '{index}'. Reason: Process not started.")
 
 
 # NOTE: The default behavior of EthereumNodeBehavior assumes geth.

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -66,9 +66,11 @@ class TestAccountContainer(TestAccountContainerAPI):
         generated_account = generate_dev_accounts(
             self.mnemonic, 1, hd_path=self.hd_path, start_index=new_index
         )[0]
-        return self.init_test_account(
+        account = self.init_test_account(
             new_index, generated_account.address, generated_account.private_key
         )
+        self.num_generated += 1
+        return account
 
     @classmethod
     def init_test_account(cls, index: int, address: AddressType, private_key: str) -> "TestAccount":

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -1,6 +1,6 @@
 import warnings
 from collections.abc import Iterator
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from eip712.messages import EIP712Message
 from eth_account import Account as EthAccount
@@ -53,25 +53,15 @@ class TestAccountContainer(TestAccountContainerAPI):
     @property
     def accounts(self) -> Iterator["TestAccount"]:
         for index in range(self.number_of_accounts):
-            yield self.provider.get_test_account(index)
+            yield cast(TestAccount, self.get_test_account(index))
 
     def get_test_account(self, index: int) -> TestAccountAPI:
         try:
             return self.provider.get_test_account(index)
         except (NotImplementedError, ProviderNotConnectedError):
-            return self._generate_account_manually(index=index)
+            return self.generate_account(index=index)
 
-    def generate_account(self) -> "TestAccountAPI":
-        try:
-            acct = self.provider.generate_test_account()
-        except (NotImplementedError, ProviderNotConnectedError):
-            acct = self._generate_account_manually()
-
-        self.num_generated += 1
-        return acct
-
-    def _generate_account_manually(self, index: Optional[int] = None):
-        # Legacy method: will no longer be used once all providers implement.
+    def generate_account(self, index: Optional[int] = None) -> "TestAccountAPI":
         new_index = self.number_of_accounts + self.num_generated if index is None else index
         generated_account = generate_dev_accounts(
             self.mnemonic, 1, hd_path=self.hd_path, start_index=new_index

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -351,6 +351,9 @@ class LocalProvider(TestProviderAPI, Web3Provider):
             private_key.to_hex(),
         )
 
+    def add_account(self, private_key: str):
+        self.evm_backend.add_account(private_key)
+
     def get_virtual_machine_error(self, exception: Exception, **kwargs) -> VirtualMachineError:
         if isinstance(exception, ValidationError):
             match = self._CANNOT_AFFORD_GAS_PATTERN.match(str(exception))

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -351,10 +351,6 @@ class LocalProvider(TestProviderAPI, Web3Provider):
             private_key.to_hex(),
         )
 
-    # def generate_test_account(self) -> "TestAccountAPI":
-    #     # TODO
-    #     return self.evm_backend.add_account()
-
     def get_virtual_machine_error(self, exception: Exception, **kwargs) -> VirtualMachineError:
         if isinstance(exception, ValidationError):
             match = self._CANNOT_AFFORD_GAS_PATTERN.match(str(exception))

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -576,15 +576,15 @@ def test_account_comparison_to_non_account(core_account):
 
 def test_create_account(test_accounts):
     length_at_start = len(test_accounts)
-    created_acc = test_accounts.generate_test_account()
+    created_account = test_accounts.generate_test_account()
 
-    assert isinstance(created_acc, TestAccount)
-    assert created_acc.index == length_at_start
+    assert isinstance(created_account, TestAccount)
+    assert created_account.index == length_at_start
 
-    second_created_acc = test_accounts.generate_test_account()
+    second_created_account = test_accounts.generate_test_account()
 
-    assert created_acc.address != second_created_acc.address
-    assert second_created_acc.index == created_acc.index + 1
+    assert created_account.address != second_created_account.address
+    assert second_created_account.index == created_account.index + 1
 
 
 def test_dir(core_account):

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -610,30 +610,35 @@ def test_is_not_contract(owner, keyfile_account):
     assert not keyfile_account.is_contract
 
 
-def test_using_different_hd_path(test_accounts, project):
+def test_using_different_hd_path(test_accounts, project, eth_tester_provider):
     test_config = {
         "test": {
-            "hd_path": "m/44'/60'/0'/{}",
+            "hd_path": "m/44'/60'/0/0",
         }
     }
 
-    old_first_account = test_accounts[0]
+    old_address = test_accounts[0].address
+    original_settings = eth_tester_provider.settings.model_dump(by_alias=True)
     with project.temp_config(**test_config):
-        new_first_account = test_accounts[0]
-        assert old_first_account.address != new_first_account.address
+        eth_tester_provider.update_settings(test_config["test"])
+        new_address = test_accounts[0].address
+
+    eth_tester_provider.update_settings(original_settings)
+    assert old_address != new_address
 
 
-def test_using_random_mnemonic(test_accounts, project):
-    test_config = {
-        "test": {
-            "mnemonic": "test_mnemonic_for_ape",
-        }
-    }
+def test_using_random_mnemonic(test_accounts, project, eth_tester_provider):
+    mnemonic = "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
+    test_config = {"test": {"mnemonic": mnemonic}}
 
-    old_first_account = test_accounts[0]
+    old_address = test_accounts[0].address
+    original_settings = eth_tester_provider.settings.model_dump(by_alias=True)
     with project.temp_config(**test_config):
-        new_first_account = test_accounts[0]
-        assert old_first_account.address != new_first_account.address
+        eth_tester_provider.update_settings(test_config["test"])
+        new_address = test_accounts[0].address
+
+    eth_tester_provider.update_settings(original_settings)
+    assert old_address != new_address
 
 
 def test_iter_test_accounts(test_accounts):

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -645,8 +645,11 @@ def test_using_random_mnemonic(test_accounts, project, eth_tester_provider):
 
 
 def test_iter_test_accounts(test_accounts):
-    actual = list(iter(test_accounts))
-    assert len(actual) == len(test_accounts)
+    test_accounts.reset()
+    accounts = list(iter(test_accounts))
+    actual = len(accounts)
+    expected = len(test_accounts)
+    assert actual == expected
 
 
 def test_declare(contract_container, sender):

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -368,7 +368,10 @@ def test_accounts_splice_access(test_accounts):
     assert b == test_accounts[1]
     c = test_accounts[-1]
     assert c == test_accounts[len(test_accounts) - 1]
-    assert len(test_accounts[::2]) == len(test_accounts) / 2
+    expected = (
+        (len(test_accounts) // 2) if len(test_accounts) % 2 == 0 else (len(test_accounts) // 2 + 1)
+    )
+    assert len(test_accounts[::2]) == expected
 
 
 def test_accounts_address_access(owner, accounts):


### PR DESCRIPTION
### What I did

**It is unnecessary for Ape to generate the test accounts.**

This is because the provider already is doing this.
By allowing hooks for accessing the accounts from the provider, we can avoid duplicating the work.
Often times the provider is much faster, such as Anvil, because it is rust.
Account generation is a slow thing to do... so by not doing it, we make Ape as fast as a Texas Rat Snake.

### How I did it

Rely on provider for getting test accounts.

### How to verify it

Using Eth-Tester provider, before (main branch):

```
(ape08) ➜  ape-playground git:(main) ✗ ape console

In [1]: %time accounts.test_accounts[9]
CPU times: user 138 ms, sys: 5.47 ms, total: 144 ms
Wall time: 142 ms
Out[1]: <TestAccount 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720>

In [2]: %time accounts.test_accounts[9]
CPU times: user 181 µs, sys: 0 ns, total: 181 µs
Wall time: 187 µs
Out[2]: <TestAccount 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720>
```

after (with this PR):

```
In [1]: %time accounts.test_accounts[9]
CPU times: user 1.04 ms, sys: 294 µs, total: 1.33 ms
Wall time: 1.12 ms
Out[1]: <TestAccount 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720>

In [2]: %time accounts.test_accounts[9]
CPU times: user 27 µs, sys: 0 ns, total: 27 µs
Wall time: 30.8 µs
Out[2]: <TestAccount 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720>
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
