### PR TITLE
feat: add `ws_uri` config to `ape-node`

### DIFF
--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -365,7 +365,7 @@ To configure network URIs in `node`, you can use the `ape-config.yaml` file:
 
 ```yaml
 node:
-  # When managing or running a node, configure its IPC path directly (optional)
+  # When managing or running a node, configure an IPC path globally (optional)
   ipc_path: path/to/geth.ipc
 
   ethereum:
@@ -374,13 +374,16 @@ node:
       # **Most often, you only need HTTP!**
       uri: https://foo.node.example.com
       # uri: wss://bar.feed.example.com
-      # uri: path/to/geth.ipc
+      # uri: path/to/mainnet/geth.ipc
       
       # For strict HTTP connections, you can configure a http_uri directly.
       http_uri: https://foo.node.example.com
 
       # You can also configure a websockets URI (used by Silverback SDK).
       ws_uri: wss://bar.feed.example.com
+    
+      # Specify per-network IPC paths as well.
+      ipc_path: path/to/mainnet/geth.ipc
 ```
 
 ## Network Config
@@ -393,7 +396,7 @@ The following example shows how to do this.
 (note: even though this example uses `ethereum:mainnet`, you can use any of the L2 networks mentioned above, as they all have these config properties).
 
 ```yaml
-ethereum:
+ethereum: 
   mainnet:
     # Ethereum mainnet in Ape uses EIP-1559 by default,
     # but we can change that here. Note: most plugins

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -396,7 +396,7 @@ The following example shows how to do this.
 (note: even though this example uses `ethereum:mainnet`, you can use any of the L2 networks mentioned above, as they all have these config properties).
 
 ```yaml
-ethereum: 
+ethereum:
   mainnet:
     # Ethereum mainnet in Ape uses EIP-1559 by default,
     # but we can change that here. Note: most plugins

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -367,7 +367,9 @@ To configure network URIs in `node`, you can use the `ape-config.yaml` file:
 node:
   ethereum:
     mainnet:
-      uri: https://foo.node.bar
+      uri: https://foo.node.example.com
+      # You can also configure a websockets URI (used by Silverback SDK).
+      ws_uri: wss://bar.feed.example.com
 ```
 
 ## Network Config

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -365,11 +365,16 @@ To configure network URIs in `node`, you can use the `ape-config.yaml` file:
 
 ```yaml
 node:
+  # When managing or running a node, configure its IPC path directly (optional)
+  ipc_path: path/to/geth.ipc
+
   ethereum:
     mainnet:
       # For `uri`, you can use either HTTP, WS, or IPC values.
       # **Most often, you only need HTTP!**
       uri: https://foo.node.example.com
+      # uri: wss://bar.feed.example.com
+      # uri: path/to/geth.ipc
       
       # For strict HTTP connections, you can configure a http_uri directly.
       http_uri: https://foo.node.example.com

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -367,7 +367,13 @@ To configure network URIs in `node`, you can use the `ape-config.yaml` file:
 node:
   ethereum:
     mainnet:
+      # For `uri`, you can use either HTTP, WS, or IPC values.
+      # **Most often, you only need HTTP!**
       uri: https://foo.node.example.com
+      
+      # For strict HTTP connections, you can configure a http_uri directly.
+      http_uri: https://foo.node.example.com
+
       # You can also configure a websockets URI (used by Silverback SDK).
       ws_uri: wss://bar.feed.example.com
 ```

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1460,11 +1460,13 @@ def _create_web3(uri: str, ipc_path: Optional[Path] = None, ws_uri: Optional[str
     # Try ENV, then IPC, and then HTTP last.
     providers: list = [load_provider_from_environment]
     if ipc := ipc_path:
-        providers.append(IPCProvider(ipc_path=ipc))
+        providers.append(lambda: IPCProvider(ipc_path=ipc))
     if http := uri:
-        providers.append(HTTPProvider(endpoint_uri=http, request_kwargs={"timeout": 30 * 60}))
+        providers.append(
+            lambda: HTTPProvider(endpoint_uri=http, request_kwargs={"timeout": 30 * 60})
+        )
     if ws := ws_uri:
-        providers.append(WebsocketProvider(endpoint_uri=ws))
+        providers.append(lambda: WebsocketProvider(endpoint_uri=ws))
 
     provider = AutoProvider(potential_providers=providers)
     return Web3(provider)

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -518,3 +519,11 @@ def test_node_http_uri_with_ws_uri(project, http_key):
         assert node.uri == http
         assert node.http_uri == http
         assert node.ws_uri == ws
+
+
+def test_ipc_for_uri(project):
+    ipc = "path/to/example.ipc"
+    with project.temp_config(node={"ethereum": {"sepolia": {"uri": ipc}}}):
+        node = project.network_manager.ethereum.sepolia.get_provider("node")
+        assert node.uri == ipc
+        assert node.ipc_path == Path(ipc)

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -502,10 +502,19 @@ def test_account_balance_state(project, eth_tester_provider, owner):
 def test_node_ws_uri(project, uri, key):
     node = project.network_manager.ethereum.sepolia.get_provider("node")
     assert node.ws_uri is None
-
-    with project.temp_config(node={"ethereum": {"sepolia": {key: uri}}}):
+    config = {"ethereum": {"sepolia": {key: uri}}}
+    with project.temp_config(node=config):
         node = project.network_manager.ethereum.sepolia.get_provider("node")
         assert node.ws_uri == uri
 
-        # Even though you can configure URI to be websockets,
-        assert node.uri != uri
+
+@pytest.mark.parametrize("http_key", ("uri", "http_uri"))
+def test_node_http_uri_with_ws_uri(project, http_key):
+    http = "http://example.com"
+    ws = "ws://example.com"
+    # Showing `uri:` as an HTTP and `ws_uri`: as an additional ws.
+    with project.temp_config(node={"ethereum": {"sepolia": {http_key: http, "ws_uri": ws}}}):
+        node = project.network_manager.ethereum.sepolia.get_provider("node")
+        assert node.uri == http
+        assert node.http_uri == http
+        assert node.ws_uri == ws

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -495,11 +495,17 @@ def test_account_balance_state(project, eth_tester_provider, owner):
         assert bal == amount
 
 
-def test_node_ws_uri(project):
+@pytest.mark.parametrize(
+    "uri,key",
+    [("ws://example.com", "ws_uri"), ("wss://example.com", "ws_uri"), ("wss://example.com", "uri")],
+)
+def test_node_ws_uri(project, uri, key):
     node = project.network_manager.ethereum.sepolia.get_provider("node")
     assert node.ws_uri is None
 
-    ws_uri = "ws://example.com"
-    with project.temp_config(node={"ethereum": {"sepolia": {"ws_uri": ws_uri}}}):
+    with project.temp_config(node={"ethereum": {"sepolia": {key: uri}}}):
         node = project.network_manager.ethereum.sepolia.get_provider("node")
-        assert node.ws_uri == ws_uri
+        assert node.ws_uri == uri
+
+        # Even though you can configure URI to be websockets,
+        assert node.uri != uri

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -493,3 +493,13 @@ def test_account_balance_state(project, eth_tester_provider, owner):
         provider.connect()
         bal = provider.get_balance(owner.address)
         assert bal == amount
+
+
+def test_node_ws_uri(project):
+    node = project.network_manager.ethereum.sepolia.get_provider("node")
+    assert node.ws_uri is None
+
+    ws_uri = "ws://example.com"
+    with project.temp_config(node={"ethereum": {"sepolia": {"ws_uri": ws_uri}}}):
+        node = project.network_manager.ethereum.sepolia.get_provider("node")
+        assert node.ws_uri == ws_uri

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -508,6 +508,12 @@ def test_node_ws_uri(project, uri, key):
         node = project.network_manager.ethereum.sepolia.get_provider("node")
         assert node.ws_uri == uri
 
+        if key != "ws_uri":
+            assert node.uri == uri
+        # else: uri gets to set to random HTTP from default settings,
+        # but we may want to change that behavior.
+        # TODO: 0.9 investigate not using random if ws set.
+
 
 @pytest.mark.parametrize("http_key", ("uri", "http_uri"))
 def test_node_http_uri_with_ws_uri(project, http_key):
@@ -521,9 +527,15 @@ def test_node_http_uri_with_ws_uri(project, http_key):
         assert node.ws_uri == ws
 
 
-def test_ipc_for_uri(project):
+@pytest.mark.parametrize("key", ("uri", "ipc_path"))
+def test_ipc_per_network(project, key):
     ipc = "path/to/example.ipc"
-    with project.temp_config(node={"ethereum": {"sepolia": {"uri": ipc}}}):
+    with project.temp_config(node={"ethereum": {"sepolia": {key: ipc}}}):
         node = project.network_manager.ethereum.sepolia.get_provider("node")
-        assert node.uri == ipc
+        if key != "ipc_path":
+            assert node.uri == ipc
+        # else: uri gets to set to random HTTP from default settings,
+        # but we may want to change that behavior.
+        # TODO: 0.9 investigate not using random if ipc set.
+
         assert node.ipc_path == Path(ipc)


### PR DESCRIPTION
### What I did

allows users to configure a `ws_uri` in their node config (per network, same as uri).

### How I did it

implement a custom `ws_uri` in 
### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
