### PR TITLE
feat: improve impersonating accounts features in core

### DIFF
--- a/docs/userguides/testing.md
+++ b/docs/userguides/testing.md
@@ -135,12 +135,20 @@ test:
   hd_path: "m/44'/60'/0'/0/{}"
 ```
 
-If you are using a fork-provider, such as [Hardhat](https://github.com/ApeWorX/ape-hardhat), you can use impersonated accounts by accessing random addresses off the fixture:
+If you are using a provider that supports impersonating accounts, such as [Foundry](https://github.com/ApeWorX/ape-foundry), use the address as the key in the test-accounts manager:
 
 ```python
 @pytest.fixture
 def vitalik(accounts):
     return accounts["0xab5801a7d398351b8be11c439e05c5b3259aec9b"]
+```
+
+You can also call `accounts.impersonate_account()` for improved readability and performance.
+
+```python
+@pytest.fixture
+def vitalik(accounts):
+    return accounts.impersonate_account("0xab5801a7d398351b8be11c439e05c5b3259aec9b")
 ```
 
 Using a fork-provider such as [Hardhat](https://github.com/ApeWorX/ape-hardhat), when using a contract instance as the sender in a transaction, it will be automatically impersonated:

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -621,10 +621,10 @@ class ImpersonatedAccount(AccountAPI):
     An account to use that does not require signing.
     """
 
+    raw_address: AddressType
     """
     The field-address of the account.
     """
-    raw_address: AddressType
 
     @property
     def address(self) -> AddressType:

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -723,6 +723,15 @@ class ProviderAPI(BaseInterfaceModel):
         """
 
     @raises_not_implemented
+    def relock_account(self, address: AddressType):
+        """
+        Stop impersonating an account.
+
+        Args:
+            address (:class:`~ape.types.address.AddressType`): The address to relock.
+        """
+
+    @raises_not_implemented
     def get_transaction_trace(  # type: ignore[empty-body]
         self, txn_hash: Union[HexBytes, str]
     ) -> TraceAPI:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -361,6 +361,7 @@ class ContractTransaction(ManagerAccessMixin):
         if "sender" in kwargs and isinstance(kwargs["sender"], AccountAPI):
             return kwargs["sender"].call(txn, **kwargs)
 
+        txn = self.provider.prepare_transaction(txn)
         return (
             self.provider.send_private_transaction(txn)
             if private

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -113,7 +113,7 @@ class TestAccountManager(list, ManagerAccessMixin):
             return self.impersonate_account(account_id)
         except AccountsError as err:
             err_message = message_fmt.format("address", account_id)
-            raise KeyError(f"{err}:\n{err_message}") from err
+            raise KeyError(f"{str(err).rstrip('.')}:\n{err_message}") from err
 
     def __contains__(self, address: AddressType) -> bool:  # type: ignore
         return any(address in container for container in self.containers.values())

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1580,7 +1580,6 @@ class ChainManager(BaseManager):
             from ape import chain
             chain.pending_timestamp += 3600
         """
-
         return self.provider.get_block("pending").timestamp
 
     @pending_timestamp.setter

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -917,23 +917,40 @@ class Web3Provider(ProviderAPI, ABC):
 
     def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
         vm_err = None
+        txn_hash = None
         try:
-            if txn.signature or not txn.sender:
-                txn_hash = self.web3.eth.send_raw_transaction(txn.serialize_transaction()).hex()
-            else:
-                if txn.sender not in self.web3.eth.accounts:
-                    self.chain_manager.provider.unlock_account(txn.sender)
+            if txn.sender is not None and txn.signature is None:
+                # Missing signature, user likely trying to use an unlocked account.
+                attempt_send = True
+                if (
+                    self.network.is_dev
+                    and txn.sender not in self.account_manager.test_accounts._impersonated_accounts
+                ):
+                    try:
+                        self.account_manager.test_accounts.impersonate_account(txn.sender)
+                    except NotImplementedError:
+                        # Unable to impersonate. Try sending as raw-tx.
+                        attempt_send = False
 
-                # NOTE: Using JSON mode since used as request data.
-                txn_data = cast(TxParams, txn.model_dump(by_alias=True, mode="json"))
-                txn_hash = self.web3.eth.send_transaction(txn_data).hex()
+                if attempt_send:
+                    # For some reason, some nodes have issues with integer-types.
+                    txn_data = {
+                        k: to_hex(v) if isinstance(v, int) else v
+                        for k, v in txn.model_dump(by_alias=True, mode="json").items()
+                    }
+                    tx_params = cast(TxParams, txn_data)
+                    txn_hash = to_hex(self.web3.eth.send_transaction(tx_params))
+                # else: attempt raw tx
+
+            if txn_hash is None:
+                txn_hash = to_hex(self.web3.eth.send_raw_transaction(txn.serialize_transaction()))
 
         except (ValueError, Web3ContractLogicError) as err:
             vm_err = self.get_virtual_machine_error(err, txn=txn)
             if txn.raise_on_revert:
                 raise vm_err from err
             else:
-                txn_hash = txn.txn_hash.hex()
+                txn_hash = to_hex(txn.txn_hash)
 
         required_confirmations = (
             txn.required_confirmations
@@ -958,6 +975,14 @@ class Web3Provider(ProviderAPI, ABC):
         self.chain_manager.history.append(receipt)
 
         if receipt.failed:
+            # For some reason, some nodes have issues with integer-types.
+            if isinstance(txn_dict.get("type"), int):
+                txn_dict["type"] = to_hex(txn_dict["type"])
+
+            # NOTE: For some reason, some providers have issues with
+            #   `nonce`, it's not needed anyway.
+            txn_dict.pop("nonce", None)
+
             # NOTE: Using JSON mode since used as request data.
             txn_params = cast(TxParams, txn_dict)
 

--- a/tests/performance/test_project.py
+++ b/tests/performance/test_project.py
@@ -7,4 +7,8 @@ def test_get_contract(benchmark, project_with_contracts):
     )
     stats = benchmark.stats
     median = stats.get("median")
-    assert median < 0.0002
+
+    # NOTE: At one point, this was average '0.0007'.
+    # When I run locally, I tend to get 0.0001.
+    # In CI, when very busy, it can get slower
+    assert median < 0.00030


### PR DESCRIPTION
### What I did

I noticed some weird things with impersonating accounts... A bunch of repeated work in places.
And different ways of handling that in `send_transaction()`.
I am working on improving all of that, but in the mean time, I need a more plugin-friendly way of impersonating accounts.

now we get to delete a bunch of code in ape-foundry and ape-hardhat.

### How I did it

hence this PR, which separates the key aspect of that into a new API and has the [] access one use that

<!-- Discuss the thought process behind the change -->

### How to verify it

things work the same and able to refactor something in ape-foundry (coming soon!)

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
