### PR TITLE
feat: flatten the query dataframe for contracts

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -667,6 +667,8 @@ class ContractEvent(BaseInterfaceModel):
         columns_ls = validate_and_expand_columns(columns, ContractLog)
         data = map(partial(extract_fields, columns=columns_ls), contract_events)
         df = pd.DataFrame(columns=columns_ls, data=data)
+        # Note: The below check is to check for `event_arguments` in the request.
+        #       If `event_arguments` exists in the request, we flatten the field.
         if "event_arguments" in columns_ls:
             event_arguments = df["event_arguments"].apply(pd.Series)
             df = pd.concat([df.drop("event_arguments", axis=1), event_arguments], axis=1)


### PR DESCRIPTION
### What I did

Adding the ability to flatten `event_arguments` in queries for contracts.

fixes: #

### How I did it

Added a check for the `event_arguments` field

### How to verify it

use the `uniswap-sdk feat/add-v2` branch

### Checklist

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
