### PR TITLE
fix: missing comma

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,7 @@ myst_all_links_external = True
 # Set some default to avoid unnecessary repetitious directives.
 autodoc_default_options = {
     "exclude-members": (
-        "__repr__, __weakref__, __metaclass__, __init__, __format__,  __new__, __str__, __dir__"
+        "__repr__, __weakref__, __metaclass__, __init__, __format__,  __new__, __str__, __dir__,"
         "model_config, model_fields, model_post_init, model_computed_fields,"
         "__ape_extra_attributes__,"
     )


### PR DESCRIPTION
### What I did
Missing comma in `exclude-members` lead to `model_config` still being compiled in the documentation
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
