### PR TITLE
fix: allow local node to connect without HTTP

### DIFF
--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1382,7 +1382,9 @@ class EthereumNodeProvider(Web3Provider, ABC):
     def _set_web3(self):
         # Clear cached version when connecting to another URI.
         self._client_version = None
-        self._web3 = _create_web3(http_uri=self.http_uri, ipc_path=self.ipc_path, ws_uri=self.ws_uri)
+        self._web3 = _create_web3(
+            http_uri=self.http_uri, ipc_path=self.ipc_path, ws_uri=self.ws_uri
+        )
 
     def _complete_connect(self):
         client_version = self.client_version.lower()
@@ -1477,13 +1479,15 @@ class EthereumNodeProvider(Web3Provider, ABC):
         self._complete_connect()
 
 
-def _create_web3(http_uri: Optional[str] = None, ipc_path: Optional[Path] = None, ws_uri: Optional[str] = None):
+def _create_web3(
+    http_uri: Optional[str] = None, ipc_path: Optional[Path] = None, ws_uri: Optional[str] = None
+):
     # NOTE: This list is ordered by try-attempt.
     # Try ENV, then IPC, and then HTTP last.
     providers: list = [load_provider_from_environment]
     if ipc := ipc_path:
         providers.append(lambda: IPCProvider(ipc_path=ipc))
-    if http := http_uri :
+    if http := http_uri:
         providers.append(
             lambda: HTTPProvider(endpoint_uri=http, request_kwargs={"timeout": 30 * 60})
         )

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -217,6 +217,14 @@ def test_connect_to_chain_that_started_poa(mock_web3, web3_factory, ethereum):
 
 
 @geth_process_test
+def test_connect_using_only_ipc_for_uri(project, networks, geth_provider):
+    ipc_path = geth_provider.ipc_path
+    with project.temp_config(node={"ethereum": {"local": {"uri": f"{ipc_path}"}}}):
+        with networks.ethereum.local.use_provider("node") as node:
+            assert node.uri == f"{ipc_path}"
+
+
+@geth_process_test
 @pytest.mark.parametrize("block_id", (0, "0", "0x0", HexStr("0x0")))
 def test_get_block(geth_provider, block_id):
     block = cast(Block, geth_provider.get_block(block_id))


### PR DESCRIPTION
### What I did

a miss, unable to use IPC or WS alone without HTTP

### How I did it

make http uri optional in a helper method
### How to verify it

```yaml
node:
  ethereum:
    local:
      uri: $HOME/.ape/node/geth.ipc
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
