### PR TITLE
fix: Show network instead of provider in `ContractNotFoundError`

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -255,9 +255,7 @@ class ContractMethodHandler(ManagerAccessMixin):
 
         raise err
 
-
-class ContractCallHandler(ContractMethodHandler):
-    def __call__(self, *args, **kwargs) -> Any:
+    def _validate_is_contract(self):
         if not self.contract.is_contract:
             raise ContractNotFoundError(
                 self.contract.address,
@@ -265,6 +263,10 @@ class ContractCallHandler(ContractMethodHandler):
                 self.provider.network_choice,
             )
 
+
+class ContractCallHandler(ContractMethodHandler):
+    def __call__(self, *args, **kwargs) -> Any:
+        self._validate_is_contract()
         selected_abi = _select_method_abi(self.abis, args)
         arguments = self.conversion_manager.convert_method_args(selected_abi, args)
 
@@ -435,14 +437,6 @@ class ContractTransactionHandler(ContractMethodHandler):
             abi=selected_abi,
             address=self.contract.address,
         )
-
-    def _validate_is_contract(self):
-        if not self.contract.is_contract:
-            raise ContractNotFoundError(
-                self.contract.address,
-                self.provider.network.explorer is not None,
-                self.provider.network_choice,
-            )
 
 
 class ContractEvent(BaseInterfaceModel):

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -262,7 +262,7 @@ class ContractCallHandler(ContractMethodHandler):
             raise ContractNotFoundError(
                 self.contract.address,
                 self.provider.network.explorer is not None,
-                self.provider.name,
+                self.provider.network_choice,
             )
 
         selected_abi = _select_method_abi(self.abis, args)
@@ -429,19 +429,20 @@ class ContractTransactionHandler(ContractMethodHandler):
         return contract_transaction(*args, **kwargs)
 
     def _as_transaction(self, *args) -> ContractTransaction:
-        if not self.contract.is_contract:
-            raise ContractNotFoundError(
-                self.contract.address,
-                self.provider.network.explorer is not None,
-                self.provider.name,
-            )
-
+        self._validate_is_contract()
         selected_abi = _select_method_abi(self.abis, args)
-
         return ContractTransaction(
             abi=selected_abi,
             address=self.contract.address,
         )
+
+    def _validate_is_contract(self):
+        if not self.contract.is_contract:
+            raise ContractNotFoundError(
+                self.contract.address,
+                self.provider.network.explorer is not None,
+                self.provider.network_choice,
+            )
 
 
 class ContractEvent(BaseInterfaceModel):

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -534,13 +534,13 @@ class ContractNotFoundError(ChainError):
     Raised when a contract is not found at an address.
     """
 
-    def __init__(self, address: "AddressType", has_explorer: bool, provider_name: str):
+    def __init__(self, address: "AddressType", has_explorer: bool, network_name: str):
         msg = f"Failed to get contract type for address '{address}'."
         msg += (
             " Contract may need verification."
             if has_explorer
             else (
-                f" Current provider '{provider_name}' has no associated "
+                f" Current network '{network_name}' has no associated "
                 "explorer plugin. Try installing an explorer plugin using "
                 f"{click.style(text='ape plugins install etherscan', fg='green')}, "
                 "or using a network with explorer support."

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1459,7 +1459,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
         result = self.make_request("ots_getContractCreator", [address])
         if result is None:
             # NOTE: Skip the explorer part of the error message via `has_explorer=True`.
-            raise ContractNotFoundError(address, has_explorer=True, provider_name=self.name)
+            raise ContractNotFoundError(address, True, self.network_choice)
 
         return result
 

--- a/tests/functional/test_contract_call_handler.py
+++ b/tests/functional/test_contract_call_handler.py
@@ -1,5 +1,31 @@
+import pytest
+
+from ape.contracts.base import ContractCallHandler
+from ape.exceptions import ContractNotFoundError
+
+
 def test_struct_input(
     call_handler_with_struct_input, struct_input_for_call, output_from_struct_input_call
 ):
     actual = call_handler_with_struct_input.encode_input(*struct_input_for_call)
     assert actual == output_from_struct_input_call
+
+
+def test_call_contract_not_found(mocker, method_abi_with_struct_input):
+    contract = mocker.MagicMock()
+    contract.is_contract = False
+    method = method_abi_with_struct_input
+    handler = ContractCallHandler(contract=contract, abis=[method])
+    expected = ".*Current network 'ethereum:local:test'.*"
+    with pytest.raises(ContractNotFoundError, match=expected):
+        handler()
+
+
+def test_transact_contract_not_found(mocker, owner, method_abi_with_struct_input):
+    contract = mocker.MagicMock()
+    contract.is_contract = False
+    method = method_abi_with_struct_input
+    handler = ContractCallHandler(contract=contract, abis=[method])
+    expected = ".*Current network 'ethereum:local:test'.*"
+    with pytest.raises(ContractNotFoundError, match=expected):
+        handler.transact(sender=owner)

--- a/tests/functional/test_contracts_cache.py
+++ b/tests/functional/test_contracts_cache.py
@@ -163,7 +163,7 @@ def test_contracts_getitem_contract_not_found(chain, eth_tester_provider):
     new_address = "0x4a986a6dca6dbF99Bc3D17F8d71aFB0D60E740F9"
     expected = (
         rf"Failed to get contract type for address '{new_address}'. "
-        r"Current provider 'ethereum:local:test' has no associated explorer plugin. "
+        r"Current network 'ethereum:local:test' has no associated explorer plugin. "
         "Try installing an explorer plugin using .*ape plugins install etherscan.*, "
         r"or using a network with explorer support\."
     )

--- a/tests/functional/test_contracts_cache.py
+++ b/tests/functional/test_contracts_cache.py
@@ -80,7 +80,7 @@ def test_instance_at_contract_type_not_found(chain, eth_tester_provider):
     new_address = "0x4a986a6dca6dbF99Bc3D17F8d71aFB0D60E740F9"
     expected = (
         rf"Failed to get contract type for address '{new_address}'. "
-        r"Current provider 'ethereum:local:test' has no associated explorer plugin. "
+        r"Current network 'ethereum:local:test' has no associated explorer plugin. "
         "Try installing an explorer plugin using .*ape plugins install etherscan.*, "
         r"or using a network with explorer support\."
     )


### PR DESCRIPTION
### What I did

`ContractNotFoundError` was confusing in some cases by no using networkchoice and instead only showing provider name,
like

```
Current provider 'node' has no associated explorer plugin.
```

this pr improves the error message

### How I did it

now shows

```
2C497'. Current network 'ethereum:local:node' has no associated explorer plugin.
```

### How to verify it

see tests

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
