### PR TITLE
refactor: share hex-related validators

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -33,7 +33,7 @@ from ape.exceptions import (
     VirtualMachineError,
 )
 from ape.logging import LogLevel, logger
-from ape.types import AddressType, BlockID, ContractCode, ContractLog, LogFilter, SnapshotID
+from ape.types import AddressType, BlockID, ContractCode, ContractLog, HexInt, LogFilter, SnapshotID
 from ape.utils import BaseInterfaceModel, JoinableQueue, abstractmethod, cached_property, spawn
 from ape.utils.misc import (
     EMPTY_BYTES32,
@@ -54,33 +54,33 @@ class BlockAPI(BaseInterfaceModel):
     # NOTE: All fields in this class (and it's subclasses) should not be `Optional`
     #       except the edge cases noted below
 
+    num_transactions: HexInt = 0
     """
     The number of transactions in the block.
     """
-    num_transactions: int = 0
 
+    hash: Optional[Any] = None  # NOTE: pending block does not have a hash
     """
     The block hash identifier.
     """
-    hash: Optional[Any] = None  # NOTE: pending block does not have a hash
 
+    number: Optional[HexInt] = None  # NOTE: pending block does not have a number
     """
     The block number identifier.
     """
-    number: Optional[int] = None  # NOTE: pending block does not have a number
 
-    """
-    The preceeding block's hash.
-    """
     parent_hash: Any = Field(
         default=EMPTY_BYTES32, alias="parentHash"
     )  # NOTE: genesis block has no parent hash
+    """
+    The preceeding block's hash.
+    """
 
+    timestamp: HexInt
     """
     The timestamp the block was produced.
     NOTE: The pending block uses the current timestamp.
     """
-    timestamp: int
 
     _size: Optional[int] = None
 

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -68,11 +68,10 @@ providers when using this feature, so there should not be confusion over this ty
 cases.
 """
 
-
 HexInt = Annotated[
     int,
     BeforeValidator(
-        lambda v, info: v if v is None else ManagerAccessMixin.conversion_manager.convert(v, int)
+        lambda v, info: None if v is None else ManagerAccessMixin.conversion_manager.convert(v, int)
     ),
 ]
 """

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -70,7 +70,10 @@ cases.
 
 
 HexInt = Annotated[
-    int, BeforeValidator(lambda v, info: ManagerAccessMixin.conversion_manager.convert(v, int))
+    int,
+    BeforeValidator(
+        lambda v, info: v if v is None else ManagerAccessMixin.conversion_manager.convert(v, int)
+    ),
 ]
 """
 Validate any hex-str or bytes into an integer.

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -367,7 +367,11 @@ def _create_raises_not_implemented_error(fn):
     )
 
 
-def to_int(value) -> int:
+def to_int(value: Any) -> int:
+    """
+    Convert the given value, such as hex-strs or hex-bytes, to an integer.
+    """
+
     if isinstance(value, int):
         return value
     elif isinstance(value, str):
@@ -594,5 +598,6 @@ __all__ = [
     "run_until_complete",
     "singledispatchmethod",
     "stream_response",
+    "to_int",
     "USER_AGENT",
 ]

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -42,6 +42,7 @@ from ape.types import (
     ContractLog,
     CurrencyValueComparable,
     GasLimit,
+    HexInt,
     RawAddress,
     TransactionSignature,
 )
@@ -328,11 +329,11 @@ class Block(BlockAPI):
     Class for representing a block on a chain.
     """
 
-    gas_limit: int = Field(alias="gasLimit")
-    gas_used: int = Field(alias="gasUsed")
-    base_fee: int = Field(default=0, alias="baseFeePerGas")
-    difficulty: int = 0
-    total_difficulty: int = Field(default=0, alias="totalDifficulty")
+    gas_limit: HexInt = Field(alias="gasLimit")
+    gas_used: HexInt = Field(alias="gasUsed")
+    base_fee: HexInt = Field(default=0, alias="baseFeePerGas")
+    difficulty: HexInt = 0
+    total_difficulty: HexInt = Field(default=0, alias="totalDifficulty")
     uncles: list[HexBytes] = []
 
     # Type re-declares.
@@ -576,7 +577,9 @@ class Ethereum(EcosystemAPI):
         ):
             receipt_cls = SharedBlobReceipt
             receipt_kwargs["blob_gas_price"] = data.get("blob_gas_price", data.get("blobGasPrice"))
-            receipt_kwargs["blob_gas_used"] = data.get("blob_gas_used", data.get("blobGasUsed"))
+            receipt_kwargs["blob_gas_used"] = (
+                data.get("blob_gas_used", data.get("blobGasUsed")) or 0
+            )
         else:
             receipt_cls = Receipt
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -341,21 +341,6 @@ class Block(BlockAPI):
         default=EMPTY_BYTES32, alias="parentHash"
     )  # NOTE: genesis block has no parent hash
 
-    @field_validator(
-        "base_fee",
-        "difficulty",
-        "gas_limit",
-        "gas_used",
-        "number",
-        "size",
-        "timestamp",
-        "total_difficulty",
-        mode="before",
-    )
-    @classmethod
-    def validate_ints(cls, value):
-        return to_int(value) if value else 0
-
     @computed_field()  # type: ignore[misc]
     @property
     def size(self) -> int:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -599,7 +599,9 @@ class Ethereum(EcosystemAPI):
         if "transaction_ids" in data:
             data["transactions"] = data.pop("transaction_ids")
         if "total_difficulty" in data:
-            data["totalDifficulty"] = data.pop("total_difficulty")
+            data["totalDifficulty"] = data.pop("total_difficulty") or 0
+        elif "totalDifficulty" in data:
+            data["totalDifficulty"] = data.pop("totalDifficulty") or 0
         if "base_fee" in data:
             data["baseFeePerGas"] = data.pop("base_fee")
         elif "baseFee" in data:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -274,6 +274,7 @@ def geth_provider(networks):
     if (
         not networks.active_provider
         or networks.provider.name != "node"
+        or networks.network.name != "local"
         or not networks.provider.is_connected
         or getattr(networks.provider, "uri", "") != GETH_URI
     ):

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -547,7 +547,7 @@ def test_decode_receipt_from_etherscan(eth_tester_provider, ethereum):
     )
     assert type(receipt) is Receipt  # NOTE: Purposely not using isinstance()
     assert receipt.type == 0
-    assert receipt.max_fee == 0
+    assert receipt.max_fee > 0
     assert receipt.gas_price == 1499999989
 
 

--- a/tests/functional/test_gas_tracker.py
+++ b/tests/functional/test_gas_tracker.py
@@ -1,4 +1,4 @@
-def test_append_gas(gas_tracker, owner, vyper_contract_instance):
+def test_append_gas(gas_tracker, owner, vyper_contract_instance, eth_tester_provider):
     tx = vyper_contract_instance.setNumber(924, sender=owner)
     trace = tx.trace
     gas_tracker.append_gas(trace, vyper_contract_instance.address)

--- a/tests/functional/test_trace.py
+++ b/tests/functional/test_trace.py
@@ -13,7 +13,7 @@ from tests.functional.data.python import (
     TRACE_WITH_SUB_CALLS,
 )
 
-# Used foundry to retrieve this partity-style trace data.
+# Used foundry to retrieve this parity-style trace data.
 FAILING_TRACE = {
     "call_type": "CALL",
     "address": "0x5fbdb2315678afecb367f032d93f642f64180aa3",

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 import pytest
 from eth_utils import to_hex
 from ethpm_types.abi import EventABI
 from hexbytes import HexBytes
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ape.types import AddressType, ContractLog, HexInt, LogFilter
 from ape.utils import ZERO_ADDRESS
@@ -131,7 +133,9 @@ def test_address_type(owner):
 class TestHexInt:
     class MyModel(BaseModel):
         ual: HexInt = 0
+        ual_optional: Optional[HexInt] = Field(default=None, validate_default=True)
 
     act = MyModel.model_validate({"ual": "0x123"})
     expected = 291  # Base-10 form of 0x123.
     assert act.ual == expected
+    assert act.ual_optional is None

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -4,7 +4,7 @@ from ethpm_types.abi import EventABI
 from hexbytes import HexBytes
 from pydantic import BaseModel
 
-from ape.types import AddressType, ContractLog, LogFilter
+from ape.types import AddressType, ContractLog, HexInt, LogFilter
 from ape.utils import ZERO_ADDRESS
 
 TXN_HASH = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa222222222222222222222222"
@@ -126,3 +126,12 @@ def test_address_type(owner):
     # Show int works.
     instance_bytes = MyModel(addr=int(owner.address, 16))
     assert instance_bytes.addr == owner.address
+
+
+class TestHexInt:
+    class MyModel(BaseModel):
+        ual: HexInt = 0
+
+    act = MyModel.model_validate({"ual": "0x123"})
+    expected = 291  # Base-10 form of 0x123.
+    assert act.ual == expected


### PR DESCRIPTION
### What I did

noticed bugs and also lack of decent use of annotated-validators for hex-to-int situations, so made `HexInt` for that - likely will end up in `eth-pydantic-types` after @bitwise-constructs work is complete there.
also had to delete some unnecessary validators for hex-str and hexbytes as it happens automatically when using those types.

note, did this originally because there was a regression i think with a recent merge validating BlobReceipts, somehow it occasionally go a hex-str for an int there and I was going to add the validator but I am getting tired of repeating this validator everywhere, hence HexInt's birthday

### How to verify it

things still work (only better in the case of Blob receipts)!

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
