### PR TITLE
fix: skip trace contract-logic errors during proxy-detection and more error-handling in eth_call

### DIFF
--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -532,7 +532,13 @@ class Web3Provider(ProviderAPI, ABC):
         except Exception as err:
             trace = CallTrace(tx=arguments[0], arguments=arguments[1:], use_tokens_for_symbols=True)
             contract_address = arguments[0]["to"]
-            contract_type = self.chain_manager.contracts.get(contract_address)
+
+            try:
+                contract_type = self.chain_manager.contracts.get(contract_address)
+            except RecursionError:
+                # Occurs when already in the middle of fetching this contract.
+                contract_type = None
+
             method_id = arguments[0].get("data", "")[:10] or None
             tb = None
             if contract_type and method_id:

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -536,16 +536,17 @@ class Web3Provider(ProviderAPI, ABC):
         except Exception as err:
             trace = None
             tb = None
-            if contract_address := arguments[0]["to"]:
-                try:
-                    contract_type = self.chain_manager.contracts.get(contract_address)
-                except RecursionError:
-                    # Occurs when already in the middle of fetching this contract.
-                    contract_type = None
-            else:
-                contract_type = None
-
+            contract_address = arguments[0].get("to")
             if not skip_trace:
+                if address := contract_address:
+                    try:
+                        contract_type = self.chain_manager.contracts.get(address)
+                    except RecursionError:
+                        # Occurs when already in the middle of fetching this contract.
+                        contract_type = None
+                else:
+                    contract_type = None
+
                 trace = CallTrace(
                     tx=arguments[0], arguments=arguments[1:], use_tokens_for_symbols=True
                 )

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -462,7 +462,9 @@ class Web3Provider(ProviderAPI, ABC):
         skip_trace = kwargs.pop("skip_trace", False)
         arguments = self._prepare_call(txn, **kwargs)
         if skip_trace:
-            return self._eth_call(arguments, raise_on_revert=txn.raise_on_revert)
+            return self._eth_call(
+                arguments, raise_on_revert=txn.raise_on_revert, skip_trace=skip_trace
+            )
 
         show_gas = kwargs.pop("show_gas_report", False)
         show_trace = kwargs.pop("show_trace", False)
@@ -476,7 +478,7 @@ class Web3Provider(ProviderAPI, ABC):
 
         needs_trace = track_gas or track_coverage or show_gas or show_trace
         if not needs_trace:
-            return self._eth_call(arguments, raise_on_revert=raise_on_revert)
+            return self._eth_call(arguments, raise_on_revert=raise_on_revert, skip_trace=skip_trace)
 
         # The user is requesting information related to a call's trace,
         # such as gas usage data.
@@ -517,7 +519,9 @@ class Web3Provider(ProviderAPI, ABC):
 
         return HexBytes(trace.return_value)
 
-    def _eth_call(self, arguments: list, raise_on_revert: bool = True) -> HexBytes:
+    def _eth_call(
+        self, arguments: list, raise_on_revert: bool = True, skip_trace: bool = False
+    ) -> HexBytes:
         # Force the usage of hex-type to support a wider-range of nodes.
         txn_dict = copy(arguments[0])
         if isinstance(txn_dict.get("type"), int):
@@ -530,20 +534,26 @@ class Web3Provider(ProviderAPI, ABC):
         try:
             result = self.make_request("eth_call", arguments)
         except Exception as err:
-            trace = CallTrace(tx=arguments[0], arguments=arguments[1:], use_tokens_for_symbols=True)
-            contract_address = arguments[0]["to"]
-
-            try:
-                contract_type = self.chain_manager.contracts.get(contract_address)
-            except RecursionError:
-                # Occurs when already in the middle of fetching this contract.
+            trace = None
+            tb = None
+            if contract_address := arguments[0]["to"]:
+                try:
+                    contract_type = self.chain_manager.contracts.get(contract_address)
+                except RecursionError:
+                    # Occurs when already in the middle of fetching this contract.
+                    contract_type = None
+            else:
                 contract_type = None
 
-            method_id = arguments[0].get("data", "")[:10] or None
-            tb = None
-            if contract_type and method_id:
-                if contract_src := self.local_project._create_contract_source(contract_type):
-                    tb = SourceTraceback.create(contract_src, trace, method_id)
+            if not skip_trace:
+                trace = CallTrace(
+                    tx=arguments[0], arguments=arguments[1:], use_tokens_for_symbols=True
+                )
+                method_id = arguments[0].get("data", "")[:10] or None
+                tb = None
+                if contract_type and method_id:
+                    if contract_src := self.local_project._create_contract_source(contract_type):
+                        tb = SourceTraceback.create(contract_src, trace, method_id)
 
             vm_err = self.get_virtual_machine_error(
                 err, trace=trace, contract_address=contract_address, source_traceback=tb


### PR DESCRIPTION
### What I did

Background: The failing call in the test in the linked issue was actually from a proxy-check on the contract, and not one the actual project's contract logic.

fix: handle recursion error in getting a contract type when eth call fails
BUT that was actually not the main problem (but still was good to fix).

The main problem is that tracing-features, including the intense exception handling one expects from failed calls, should be skipped altogether for proxy checks, and the mostly were thankfully except in this one spot.

**perf**: The fixing of this bug should be a rather nice performance upgrade because this means before, all failed proxy checks were fetching contract-types and preparing traces (not calling trace RPCs but doing everything else but)

fixes: #2206 

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
