### PR TITLE
perf: avoid enriching entire trace when only requesting `return_value`

### DIFF
--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -485,6 +485,9 @@ class CurrencyValueComparable(int):
         return NotImplemented
 
 
+CurrencyValueComparable.__name__ = int.__name__
+
+
 CurrencyValue: TypeAlias = CurrencyValueComparable
 """
 An alias to :class:`~ape.types.CurrencyValueComparable` for

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -1120,6 +1120,7 @@ class Ethereum(EcosystemAPI):
             # Without a contract type, we can enrich no further.
             return call
 
+        kwargs["contract_type"] = contract_type
         if events := call.get("events"):
             call["events"] = self._enrich_trace_events(events, address=address, **kwargs)
 
@@ -1177,6 +1178,7 @@ class Ethereum(EcosystemAPI):
             # Without a contract type, we can enrich no further.
             return address
 
+        kwargs["contract_type"] = contract_type
         if kwargs.get("use_symbol_for_tokens") and "symbol" in contract_type.view_methods:
             # Use token symbol as name
             contract = self.chain_manager.contracts.instance_at(
@@ -1343,6 +1345,8 @@ class Ethereum(EcosystemAPI):
             # Without a contract type, we can enrich no further.
             return event
 
+        kwargs["contract_type"] = contract_type
+
         # The selector is always the first topic.
         selector = event["topics"][0]
         if not isinstance(selector, str):
@@ -1394,9 +1398,6 @@ class Ethereum(EcosystemAPI):
                 contract_type = self.chain_manager.contracts.get(address)
             except Exception as err:
                 logger.debug(f"Error getting contract type during event enrichment: {err}")
-            else:
-                # Set even if None to avoid re-checking.
-                kwargs["contract_type"] = contract_type
 
         return contract_type
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -721,15 +721,10 @@ class Ethereum(EcosystemAPI):
         ):
             # Array of structs or tuples: don't convert to list
             # Array of anything else: convert to single list
-            return (
-                (
-                    [
-                        output_values[0],
-                    ],
-                )
-                if issubclass(type(output_values[0]), Struct)
-                else ([o for o in output_values[0]],)  # type: ignore[union-attr]
-            )
+            if issubclass(type(output_values[0]), Struct):
+                return [output_values[0]]  # type: ignore
+            elif hasattr(output_values[0], "__iter__"):
+                return ([o for o in output_values[0]],)  # type: ignore[union-attr]
 
         elif returns_array(abi):
             # Tuple with single item as the array.

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -1143,14 +1143,14 @@ class Ethereum(EcosystemAPI):
                 # Check if method name duplicated. If that is the case, use selector.
                 times = len([x for x in contract_type.methods if x.name == method_abi.name])
                 name = (method_abi.name if times == 1 else method_abi.selector) or call["method_id"]
-                call = self._enrich_calldata(call, method_abi, contract_type, **kwargs)
+                call = self._enrich_calldata(call, method_abi, **kwargs)
         else:
             name = call.get("method_id") or "0x"
 
         call["method_id"] = name
 
         if method_abi:
-            call = self._enrich_calldata(call, method_abi, contract_type, **kwargs)
+            call = self._enrich_calldata(call, method_abi, **kwargs)
 
             if kwargs.get("return_value"):
                 # Return value was separately enriched.
@@ -1207,7 +1207,6 @@ class Ethereum(EcosystemAPI):
         self,
         call: dict,
         method_abi: Union[MethodABI, ConstructorABI],
-        contract_type: ContractType,
         **kwargs,
     ) -> dict:
         calldata = call["calldata"]
@@ -1219,6 +1218,7 @@ class Ethereum(EcosystemAPI):
             # Already enriched.
             return call
 
+        contract_type = kwargs["contract_type"]
         if call.get("call_type") and "CREATE" in call.get("call_type", ""):
             # Strip off bytecode
             bytecode = (

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -133,6 +133,8 @@ class Web3Provider(ProviderAPI, ABC):
 
     _supports_debug_trace_call: Optional[bool] = None
 
+    _transaction_trace_cache: dict[str, TransactionTrace] = {}
+
     def __new__(cls, *args, **kwargs):
         assert_web3_provider_uri_env_var_not_set()
 
@@ -440,10 +442,15 @@ class Web3Provider(ProviderAPI, ABC):
             raise  # Raise original error
 
     def get_transaction_trace(self, transaction_hash: str, **kwargs) -> TraceAPI:
+        if transaction_hash in self._transaction_trace_cache:
+            return self._transaction_trace_cache[transaction_hash]
+
         if "call_trace_approach" not in kwargs:
             kwargs["call_trace_approach"] = self.call_trace_approach
 
-        return TransactionTrace(transaction_hash=transaction_hash, **kwargs)
+        trace = TransactionTrace(transaction_hash=transaction_hash, **kwargs)
+        self._transaction_trace_cache[transaction_hash] = trace
+        return trace
 
     def send_call(
         self,

--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -227,11 +227,12 @@ class Trace(TraceAPI):
 
         elif abi := self.root_method_abi:
             return_data = self._return_data_from_trace_frames
-            try:
-                return self._ecosystem.decode_returndata(abi, return_data)
-            except Exception as err:
-                logger.debug(f"Failed decoding return data from trace frames. Error: {err}")
-                # Use enrichment method. It is slow but it'll at least work.
+            if return_data is not None:
+                try:
+                    return self._ecosystem.decode_returndata(abi, return_data)
+                except Exception as err:
+                    logger.debug(f"Failed decoding return data from trace frames. Error: {err}")
+                    # Use enrichment method. It is slow but it'll at least work.
 
         return self._return_value_from_enriched_calltree
 
@@ -289,13 +290,13 @@ class Trace(TraceAPI):
         return None
 
     @cached_property
-    def _return_data_from_trace_frames(self) -> HexBytes:
+    def _return_data_from_trace_frames(self) -> Optional[HexBytes]:
         if frame := self._last_frame:
             memory = frame["memory"]
             start_pos = int(frame["stack"][2], 16) // 32
             return HexBytes("".join(memory[start_pos:]))
 
-        return HexBytes("")
+        return None
 
     """ API Methods """
 

--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -219,17 +219,13 @@ class Trace(TraceAPI):
 
     @cached_property
     def return_value(self) -> Any:
-        if self._enriched_calltree or (
-            self.provider.network.is_local and not self.provider.network.is_fork
-        ):
-            # For non-local network (including forks), only check enrichment
-            # output if was already enriched! Don't enrich ONLY for return value,
-            # as that is very bad performance for realistic contract interactions.
+        if self._enriched_calltree:
+            # Only check enrichment output if was already enriched!
+            # Don't enrich ONLY for return value, as that is very bad performance
+            # for realistic contract interactions.
             return self._return_value_from_enriched_calltree
 
         elif abi := self.root_method_abi:
-            # When using a fork or live network and we are not enriched yet, we always
-            # opt for the trace-logs parsing approach as it typically faster for realistic contracts.
             return_data = self._return_data_from_trace_frames
             try:
                 return self._ecosystem.decode_returndata(abi, return_data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ def validate_cwd(start_dir):
 
 @pytest.fixture
 def project():
-    path = "functional/data/contracts/local"
+    path = "tests/functional/data/contracts/ethereum/local"
     with ape.project.temp_config(contracts_folder=path):
         yield ape.project
 
@@ -691,3 +691,8 @@ def shared_contracts_folder():
 @pytest.fixture
 def project_with_contracts(with_dependencies_project_path):
     return Project(with_dependencies_project_path)
+
+
+@pytest.fixture
+def geth_contract(geth_account, vyper_contract_container, geth_provider):
+    return geth_account.deploy(vyper_contract_container, 0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,9 @@ def validate_cwd(start_dir):
 def project():
     path = "tests/functional/data/contracts/ethereum/local"
     with ape.project.temp_config(contracts_folder=path):
+        ape.project.manifest_path.unlink(missing_ok=True)
         yield ape.project
+        ape.project.manifest_path.unlink(missing_ok=True)
 
 
 @pytest.fixture(scope="session")

--- a/tests/functional/geth/conftest.py
+++ b/tests/functional/geth/conftest.py
@@ -14,11 +14,6 @@ def parity_trace_response():
 
 
 @pytest.fixture
-def geth_contract(geth_account, vyper_contract_container, geth_provider):
-    return geth_account.deploy(vyper_contract_container, 0)
-
-
-@pytest.fixture
 def contract_with_call_depth_geth(
     owner, geth_provider, get_contract_type, leaf_contract_geth, middle_contract_geth
 ):

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -338,6 +338,7 @@ def test_return_value_list(geth_account, geth_contract, geth_provider):
 def test_return_value_nested_address_array(
     geth_account, geth_contract, geth_provider, zero_address
 ):
+    geth_contract.getNestedAddressArray()
     receipt = geth_contract.getNestedAddressArray.transact(sender=geth_account)
     expected = [
         [geth_account.address, geth_account.address, geth_account.address],

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -338,7 +338,6 @@ def test_return_value_list(geth_account, geth_contract, geth_provider):
 def test_return_value_nested_address_array(
     geth_account, geth_contract, geth_provider, zero_address
 ):
-    geth_contract.getNestedAddressArray()
     receipt = geth_contract.getNestedAddressArray.transact(sender=geth_account)
     expected = [
         [geth_account.address, geth_account.address, geth_account.address],

--- a/tests/functional/geth/test_trace.py
+++ b/tests/functional/geth/test_trace.py
@@ -33,16 +33,16 @@ ContractA\.methodWithoutArguments\(\) -> 0x[A-Fa-f0-9]{2}..[A-Fa-f0-9]{4} \[\d+ 
 │   └── ContractC\.methodC1\(
 │         windows95="simpler",
 │         jamaica=345457847457457458457457457,
-│         cardinal=ContractA
+│         cardinal=Contract[A|C]
 │       \) \[\d+ gas\]
 ├── SYMBOL\.callMe\(blue=tx\.origin\) -> tx\.origin \[\d+ gas\]
 ├── SYMBOL\.methodB2\(trombone=tx\.origin\) \[\d+ gas\]
-│   ├── ContractC\.paperwork\(ContractA\) -> \(
+│   ├── ContractC\.paperwork\(Contract[A|C]\) -> \(
 │   │     os="simpler",
 │   │     country=345457847457457458457457457,
-│   │     wings=ContractA
+│   │     wings=Contract[A|C]
 │   │   \) \[\d+ gas\]
-│   ├── ContractC\.methodC1\(windows95="simpler", jamaica=0, cardinal=ContractC\) \[\d+ gas\]
+│   ├── ContractC\.methodC1\(windows95="simpler", jamaica=0, cardinal=Contract[A|C]\) \[\d+ gas\]
 │   ├── ContractC\.methodC2\(\) \[\d+ gas\]
 │   └── ContractC\.methodC2\(\) \[\d+ gas\]
 ├── ContractC\.addressToValue\(tx.origin\) -> 0 \[\d+ gas\]
@@ -53,14 +53,14 @@ ContractA\.methodWithoutArguments\(\) -> 0x[A-Fa-f0-9]{2}..[A-Fa-f0-9]{4} \[\d+ 
 │   │     111344445534535353,
 │   │     993453434534534534534977788884443333
 │   │   \] \[\d+ gas\]
-│   └── ContractC\.methodC1\(windows95="simpler", jamaica=0, cardinal=ContractA\) \[\d+ gas\]
+│   └── ContractC\.methodC1\(windows95="simpler", jamaica=0, cardinal=Contract[A|C]\) \[\d+ gas\]
 └── SYMBOL\.methodB1\(lolol="snitches_get_stiches", dynamo=111\) \[\d+ gas\]
     ├── ContractC\.getSomeList\(\) -> \[
     │     3425311345134513461345134534531452345,
     │     111344445534535353,
     │     993453434534534534534977788884443333
     │   \] \[\d+ gas\]
-    └── ContractC\.methodC1\(windows95="simpler", jamaica=111, cardinal=ContractA\) \[\d+ gas\]
+    └── ContractC\.methodC1\(windows95="simpler", jamaica=111, cardinal=Contract[A|C]\) \[\d+ gas\]
 """
 
 

--- a/tests/functional/geth/test_trace.py
+++ b/tests/functional/geth/test_trace.py
@@ -320,3 +320,18 @@ def test_return_value(geth_contract, geth_account):
     # (unlike receipt.return_value)
     actual = trace.return_value[0]
     assert actual == expected
+
+
+@geth_process_test
+def test_return_value_forked_network(geth_contract, geth_account, geth_provider):
+    network_name = geth_provider.network.name
+    geth_provider.network.name = "sepolia-fork"
+
+    try:
+        tx = geth_contract.getFilledArray.transact(sender=geth_account)
+    finally:
+        geth_provider.network.name = network_name
+
+    # NOTE: This is very important from a performance perspective!
+    # (VERY IMPORTANT). We should need to enrich anything.
+    assert tx.trace._enriched_calltree is None

--- a/tests/functional/geth/test_trace.py
+++ b/tests/functional/geth/test_trace.py
@@ -321,17 +321,6 @@ def test_return_value(geth_contract, geth_account):
     actual = trace.return_value[0]
     assert actual == expected
 
-
-@geth_process_test
-def test_return_value_forked_network(geth_contract, geth_account, geth_provider):
-    network_name = geth_provider.network.name
-    geth_provider.network.name = "sepolia-fork"
-
-    try:
-        tx = geth_contract.getFilledArray.transact(sender=geth_account)
-    finally:
-        geth_provider.network.name = network_name
-
     # NOTE: This is very important from a performance perspective!
     # (VERY IMPORTANT). We should need to enrich anything.
-    assert tx.trace._enriched_calltree is None
+    assert trace._enriched_calltree is None

--- a/tests/functional/geth/test_trace.py
+++ b/tests/functional/geth/test_trace.py
@@ -322,5 +322,5 @@ def test_return_value(geth_contract, geth_account):
     assert actual == expected
 
     # NOTE: This is very important from a performance perspective!
-    # (VERY IMPORTANT). We should need to enrich anything.
+    # (VERY IMPORTANT). We shouldn't need to enrich anything.
     assert trace._enriched_calltree is None

--- a/tests/functional/geth/test_trace.py
+++ b/tests/functional/geth/test_trace.py
@@ -307,3 +307,16 @@ def test_call_trace_supports_debug_trace_call(geth_contract, geth_account):
     trace = CallTrace(tx=tx)
     _ = trace._traced_call
     assert trace.supports_debug_trace_call
+
+
+@geth_process_test
+def test_return_value(geth_contract, geth_account):
+    receipt = geth_contract.getFilledArray.transact(sender=geth_account)
+    trace = receipt.trace
+    expected = [1, 2, 3]  # Hardcoded in contract
+    assert receipt.return_value == expected
+
+    # In `trace.return_value`, it is still a tuple.
+    # (unlike receipt.return_value)
+    actual = trace.return_value[0]
+    assert actual == expected

--- a/tests/functional/test_coverage.py
+++ b/tests/functional/test_coverage.py
@@ -192,8 +192,8 @@ class TestCoverageTracker:
         return ConfigWrapper(pytest_config)
 
     @pytest.fixture
-    def tracker(self, pytest_config):
-        return CoverageTracker(pytest_config)
+    def tracker(self, pytest_config, project):
+        return CoverageTracker(pytest_config, project=project)
 
     def test_data(self, tracker):
         assert tracker.data is not None

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -233,11 +233,14 @@ def test_fixture_docs(setup_pytester, integ_project, pytester, eth_tester_provid
 
 
 @skip_projects_except("with-contracts")
-def test_gas_flag_when_not_supported(setup_pytester, integ_project, pytester, eth_tester_provider):
+def test_gas_flag_when_not_supported(
+    setup_pytester, project, integ_project, pytester, eth_tester_provider
+):
     _ = eth_tester_provider  # Ensure using EthTester for this test.
     setup_pytester(integ_project)
-    path = f"{integ_project.path}/tests/test_contract.py::test_contract_interaction_in_tests"
-    result = pytester.runpytest(path, "--gas")
+    path = f"{integ_project.path}/tests/test_contract.py"
+    path_w_test = f"{path}::test_contract_interaction_in_tests"
+    result = pytester.runpytest(path_w_test, "--gas")
     actual = "\n".join(result.outlines)
     expected = (
         "Provider 'test' does not support transaction tracing. "


### PR DESCRIPTION
### What I did

metrics from running a test in a real project with lots of stuff going on

before:
`107.63s`

after:
`28.28s`

### How I did it

Use raw trace frames carefully if have not already enriched.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
