### PR TITLE
fix: bypass balance check impersonated accounts

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -393,7 +393,10 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
 
         txn = self.provider.prepare_transaction(txn)
 
-        if txn.total_transfer_value > self.balance:
+        if (
+            txn.sender not in self.account_manager.test_accounts._impersonated_accounts
+            and txn.total_transfer_value > self.balance
+        ):
             raise AccountsError(
                 f"Transfer value meets or exceeds account balance "
                 f"for account '{self.address}' on chain '{self.provider.chain_id}' "

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -356,6 +356,19 @@ def test_send_transaction_without_enough_funds(sender, receiver, eth_tester_prov
         sender.transfer(receiver, "10000000000000 ETH")
 
 
+def test_send_transaction_without_enough_funds_impersonated_account(
+    receiver, accounts, eth_tester_provider, convert
+):
+    address = "0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97"  # Not a test account!
+    impersonated_account = ImpersonatedAccount(raw_address=address)
+    accounts.test_accounts._impersonated_accounts[address] = impersonated_account
+
+    # Basically, it failed anywhere else besides the AccountsError you get from not
+    # enough balance.
+    with pytest.raises(SignatureError):
+        impersonated_account.transfer(receiver, "10000000000000 ETH")
+
+
 def test_send_transaction_sets_defaults(sender, receiver):
     receipt = sender.transfer(receiver, "1 GWEI", gas_limit=None, required_confirmations=None)
     assert receipt.gas_limit > 0


### PR DESCRIPTION
### What I did

Let's not check balance for impersonated accounts, as some providers (with the right settings) will allow it to work regardless. In any case, the VM error may be better anyway.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
