### PR TITLE
perf: lazy source traceback in transaction errors

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -1514,7 +1514,7 @@ class ContractContainer(ContractTypeWrapper, ExtraAttributesMixin):
         except ContractLogicError as err:
             if address := err.address:
                 self.chain_manager.contracts[address] = self.contract_type
-                err._set_tb()  # Re-try setting source traceback
+                err.reset_tb()  # Re-try setting source traceback
                 new_err = None
                 try:
                     # Try enrichment again now that the contract type is cached.

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -1514,7 +1514,7 @@ class ContractContainer(ContractTypeWrapper, ExtraAttributesMixin):
         except ContractLogicError as err:
             if address := err.address:
                 self.chain_manager.contracts[address] = self.contract_type
-                err.reset_tb()  # Re-try setting source traceback
+                err = err.with_ape_traceback()  # Re-try setting source traceback
                 new_err = None
                 try:
                     # Try enrichment again now that the contract type is cached.

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -233,14 +233,12 @@ class TransactionError(ApeException):
     @property
     def trace(self) -> Optional["TraceAPI"]:
         tr = self._trace
-        result: Optional["TraceAPI"]
         if callable(tr):
             result = tr()
             self._trace = result
-        else:
-            result = tr
+            return result
 
-        return result
+        return tr
 
     @trace.setter
     def trace(self, value):

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -361,8 +361,15 @@ class OutOfGasError(VirtualMachineError):
         code: Optional[int] = None,
         txn: Optional[FailedTxn] = None,
         base_err: Optional[Exception] = None,
+        set_ape_traceback: bool = False,
     ):
-        super().__init__("The transaction ran out of gas.", code=code, txn=txn, base_err=base_err)
+        super().__init__(
+            "The transaction ran out of gas.",
+            code=code,
+            txn=txn,
+            base_err=base_err,
+            set_ape_traceback=set_ape_traceback,
+        )
 
 
 class NetworkError(ApeException):

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -8,7 +8,7 @@ from functools import cached_property
 from inspect import getframeinfo, stack
 from pathlib import Path
 from types import CodeType, TracebackType
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
 
 import click
 from eth_typing import Hash32
@@ -163,6 +163,12 @@ class MethodNonPayableError(ContractDataError):
     """
 
 
+_TRACE_ARG = Optional[Union["TraceAPI", Callable[[], Optional["TraceAPI"]]]]
+_SOURCE_TRACEBACK_ARG = Optional[
+    Union["SourceTraceback", Callable[[], Optional["SourceTraceback"]]]
+]
+
+
 class TransactionError(ApeException):
     """
     Raised when issues occur related to transactions.
@@ -176,9 +182,9 @@ class TransactionError(ApeException):
         base_err: Optional[Exception] = None,
         code: Optional[int] = None,
         txn: Optional[FailedTxn] = None,
-        trace: Optional["TraceAPI"] = None,
+        trace: _TRACE_ARG = None,
         contract_address: Optional["AddressType"] = None,
-        source_traceback: Optional["SourceTraceback"] = None,
+        source_traceback: _SOURCE_TRACEBACK_ARG = None,
         project: Optional["ProjectManager"] = None,
     ):
         message = message or (str(base_err) if base_err else self.DEFAULT_MESSAGE)
@@ -186,15 +192,14 @@ class TransactionError(ApeException):
         self.base_err = base_err
         self.code = code
         self.txn = txn
-        self.trace = trace
+        self._trace = trace
         self.contract_address = contract_address
-        self.source_traceback: Optional["SourceTraceback"] = source_traceback
+        self._source_traceback = source_traceback
         self._project = project
         ex_message = f"({code}) {message}" if code else message
 
         # Finalizes expected revert message.
         super().__init__(ex_message)
-        self._set_tb()
 
     @property
     def address(self) -> Optional["AddressType"]:
@@ -223,15 +228,62 @@ class TransactionError(ApeException):
         except (RecursionError, ProviderNotConnectedError):
             return None
 
-    def _set_tb(self):
-        if not self.source_traceback and self.txn:
-            self.source_traceback = _get_ape_traceback_from_tx(self.txn)
+    @property
+    def trace(self) -> Optional["TraceAPI"]:
+        tr = self._trace
+        result: Optional["TraceAPI"]
+        if callable(tr):
+            result = tr()
+            self._trace = result
+        else:
+            result = tr
 
-        if src_tb := self.source_traceback:
+        return result
+
+    @trace.setter
+    def trace(self, value):
+        self._trace = value
+
+    @property
+    def source_traceback(self) -> Optional["SourceTraceback"]:
+        tb = self._source_traceback
+        result: Optional["SourceTraceback"]
+        if callable(tb):
+            result = tb()
+            self._source_traceback = result
+        else:
+            result = tb
+
+        return result
+
+    @source_traceback.setter
+    def source_traceback(self, value):
+        self._source_traceback = value
+
+    @cached_property
+    def _calculated_traceback(self) -> Optional[TracebackType]:
+        source_tb = self.source_traceback
+        if not source_tb and self.txn:
+            source_tb = _get_ape_traceback_from_tx(self.txn)
+
+        if src_tb := source_tb:
             # Create a custom Pythonic traceback using lines from the sources
             # found from analyzing the trace of the transaction.
             if py_tb := _get_custom_python_traceback(self, src_tb, project=self._project):
-                self.__traceback__ = py_tb
+                return py_tb
+
+        return None
+
+    def reset_tb(self):
+        self.__dict__.pop("_calculated_traceback", None)
+
+    @property
+    def __traceback__(self) -> Optional[TracebackType]:
+        return self._calculated_traceback
+
+    @__traceback__.setter
+    def __traceback__(self, value):
+        self.__traceback__ = value
 
 
 class VirtualMachineError(TransactionError):
@@ -250,13 +302,12 @@ class ContractLogicError(VirtualMachineError):
         self,
         revert_message: Optional[str] = None,
         txn: Optional[FailedTxn] = None,
-        trace: Optional["TraceAPI"] = None,
+        trace: _TRACE_ARG = None,
         contract_address: Optional["AddressType"] = None,
-        source_traceback: Optional["SourceTraceback"] = None,
+        source_traceback: _SOURCE_TRACEBACK_ARG = None,
         base_err: Optional[Exception] = None,
     ):
         self.txn = txn
-        self.trace = trace
         self.contract_address = contract_address
 
         super().__init__(
@@ -786,10 +837,10 @@ class CustomError(ContractLogicError):
         abi: ErrorABI,
         inputs: dict[str, Any],
         txn: Optional[FailedTxn] = None,
-        trace: Optional["TraceAPI"] = None,
+        trace: _TRACE_ARG = None,
         contract_address: Optional["AddressType"] = None,
         base_err: Optional[Exception] = None,
-        source_traceback: Optional["SourceTraceback"] = None,
+        source_traceback: _SOURCE_TRACEBACK_ARG = None,
     ):
         self.abi = abi
         self.inputs = inputs

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -198,6 +198,8 @@ class TransactionError(ApeException):
         self._project = project
         ex_message = f"({code}) {message}" if code else message
 
+        self.__tb: Optional[TracebackType] = None
+
         # Finalizes expected revert message.
         super().__init__(ex_message)
 
@@ -279,11 +281,15 @@ class TransactionError(ApeException):
 
     @property
     def __traceback__(self) -> Optional[TracebackType]:
-        return self._calculated_traceback
+        if self.__tb is None:
+            # Calculating for the first time (though may be appended to later).
+            self.__tb = self._calculated_traceback
+
+        return self.__tb
 
     @__traceback__.setter
     def __traceback__(self, value):
-        self.__traceback__ = value
+        self.__tb = value
 
 
 class VirtualMachineError(TransactionError):

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -319,8 +319,8 @@ class CompilerManager(BaseManager, ExtraAttributesMixin):
                 HexBytes(message),
                 address,
                 base_err=err.base_err,
-                source_traceback=err.source_traceback,
-                trace=err.trace,
+                source_traceback=lambda: err.source_traceback,
+                trace=lambda: err.trace,
                 txn=err.txn,
             )
         except NotImplementedError:

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -320,7 +320,7 @@ class CompilerManager(BaseManager, ExtraAttributesMixin):
                 address,
                 base_err=err.base_err,
                 source_traceback=lambda: err.source_traceback,
-                trace=lambda: err.trace,
+                trace=err.trace,
                 txn=err.txn,
             )
         except NotImplementedError:

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -147,7 +147,7 @@ class InterfaceCompiler(CompilerAPI):
             abi,
             inputs,
             txn=err.txn,
-            trace=err.trace,
+            trace=lambda: err.trace,
             contract_address=address,
-            source_traceback=err.source_traceback,
+            source_traceback=lambda: err.source_traceback,
         )

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -152,7 +152,10 @@ class LocalProvider(TestProviderAPI, Web3Provider):
             else:
                 message = gas_estimation_error_message(ape_err)
                 raise TransactionError(
-                    message, base_err=ape_err, txn=txn, source_traceback=ape_err.source_traceback
+                    message,
+                    base_err=ape_err,
+                    txn=txn,
+                    source_traceback=lambda: ape_err.source_traceback,
                 ) from ape_err
 
     @property

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -203,7 +203,7 @@ def test_revert_allow(not_owner, contract_instance):
 
 
 def test_revert_handles_compiler_panic(owner, contract_instance):
-    # note: setBalance is a weird name - it actually adjust the balance.
+    # note: setBalance is a weird name - it actually adjusts the balance.
     # first, set it to be 1 less than an overflow.
     contract_instance.setBalance(owner, 2**256 - 1, sender=owner)
     # then, add 1 more, so it should no overflow and cause a compiler panic.

--- a/tests/functional/test_exceptions.py
+++ b/tests/functional/test_exceptions.py
@@ -108,22 +108,17 @@ class TestTransactionError:
         mock_exec.closure = mock_closure
         mock_tb.__getitem__.return_value = mock_exec
         mock_tb.__len__.return_value = 1
+        mock_tb.return_value = mock_tb
 
         err = TransactionError(source_traceback=mock_tb, project=project_with_contract)
 
         # Have to raise for sys.exc_info() to be available.
         try:
             raise err
-        except Exception:
-            pass
-
-        assert err.__traceback__ is not None
-
-        # The Vyper-frame gets injected at tb_next.
-        assert err.__traceback__.tb_next is not None
-
-        actual = str(err.__traceback__.tb_next.tb_frame)
-        assert src_path in actual
+        except Exception as same_err:
+            assert same_err.__traceback__ is not None
+            actual = str(same_err.__traceback__.tb_frame)
+            assert src_path in actual
 
 
 class TestNetworkNotFoundError:


### PR DESCRIPTION
### What I did

I had a dream last night that this was the last remaining performance problem.
Basically all call-based Vm errors seems to calculate their source tbs when they don't always have to.
I am hoping by lazy-ifying this, we re-gain some of performance loss from 0.6.22

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
