### PR TITLE
feat: adding slim dockerfile

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,9 +25,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Checkout
-        uses: actions/checkout@v3
-
       - name: Get tags
         run: git fetch --tags origin
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,8 +59,6 @@ jobs:
           file: ./Dockerfile.slim
           tags: ${{ steps.meta.outputs.tags }}-slim
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ version }}
 
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Get current date and time
         id: build_date
-        run: echo 'BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")' >> $GITHUB_ENV
+        run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
 
       - name: Get commit sha
         id: commit_sha

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            type=ref,event=pr
             type=ref,event=branch,branch=main,latest=true
             type=ref,event=branch,branch=main
             type=ref,event=branch,branch!=main

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-tags: 'true'
+          fetch-depth: 0
 
       - name: PRINT GIT TAG
         run: git tag

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}-slim
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache,mode=max
 
       - name: Build and push
         uses: docker/build-push-action@v4
@@ -62,5 +64,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache,mode=max
+          build-args: |
+            SLIM_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags }}-slim

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: PRINT METADATA TAGS
-        run: echo "TAGS: ${{ steps.meta.outputs.tags }}"
+        run: echo ${{ steps.meta.outputs.tags }}
 
       - name: Log into GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,10 +32,16 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch,branch=main,latest=true
+            type=ref,event=branch,branch=main
+            type=ref,event=branch,branch!=main
+            type=semver,pattern={{version}},branch=main,latest=false
+            type=ref,event=tag
+
+      - name: Show tags
+        run: |
+          git tag
+          echo ${{ steps.meta.outputs.tags }}
 
       - name: Log into GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
+      - name: Set up Docker Buildkit
+        run: echo "DOCKER_BUILDKIT=1" >> $GITHUB_ENV
+
       - name: Cache Docker Layers
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,8 +61,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ version }}
-            BUILD_DATE=${{ github.event.repository.updated_at }}
-            VCS_REF=${{ github.sha }}
 
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get tags
+        run: git fetch --tags origin
+
       - name: Build and push slim
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,17 +37,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
-      - name: Set up Docker Buildkit
-        run: echo "DOCKER_BUILDKIT=1" >> $GITHUB_ENV
-
-      - name: Cache Docker Layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker-cache
-          key: ${{ runner.os }}-docker-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-docker-
-
       - name: Log into GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -61,11 +50,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.slim
-          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}-slim
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/docker-cache
-          cache-to: type=local,dest=/tmp/docker-cache
 
       - name: Build and push
         uses: docker/build-push-action@v4
@@ -75,7 +61,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/docker-cache
-          cache-to: type=local,dest=/tmp/docker-cache
           build-args: |
             SLIM_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags }}-slim

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,8 @@
 name: Container Images
 on:
+  push:
+    branches:
+      - main
   pull_request:
   release:
     types: [published]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
           build-args: |
             VERSION=${{ version }}
             BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ")
-            VCS_REF={{ github.sha }}
+            VCS_REF=${{ github.sha }}
 
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-tags: 'true'
 
       - name: Log into GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,14 @@ jobs:
           git tag
           echo ${{ steps.meta.outputs.tags }}
 
+      - name: Get current date and time
+        id: build_date
+        run: echo 'BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")' >> $GITHUB_ENV
+
+      - name: Get commit sha
+        id: commit_sha
+        run: echo "VCS_REF=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Log into GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -59,6 +67,10 @@ jobs:
           file: ./Dockerfile.slim
           tags: ${{ steps.meta.outputs.tags }}-slim
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ version }}
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            VCS_REF=${{ env.VCS_REF }}
 
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: Container Images
 on:
   pull_request:
   release:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,44 @@
+name: Release
+on:
+  pull_request:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log into GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push slim
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile.slim
+          push: true
+          tags: ${{ env.REGISTRY }}/apeworx/ape:latest-slim
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags ${{ env.Registry }}/apeworx/ape:latest
+
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
           build-args: |
             VERSION=${{ version }}
             BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-            VCS_REF=$(git rev-parse --short HEAD)
+            VCS_REF={{ github.sha }}
 
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,14 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
+      - name: Cache Docker Layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker-cache
+          key: ${{ runner.os }}-docker-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-docker-
+
       - name: Log into GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -53,8 +61,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}-slim
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache,mode=max
+          cache-from: type=local,src=/tmp/docker-cache
+          cache-to: type=local,dest=/tmp/docker-cache
 
       - name: Build and push
         uses: docker/build-push-action@v4
@@ -64,7 +72,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache,mode=max
+          cache-from: type=local,src=/tmp/docker-cache
+          cache-to: type=local,dest=/tmp/docker-cache
           build-args: |
             SLIM_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags }}-slim

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,4 +62,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            SLIM_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags }}-slim
+            SLIM_IMAGE=${{ steps.meta.outputs.tags }}-slim

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -13,6 +14,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      attestations: write
+      id-token: write
 
     steps:
       - name: Checkout
@@ -27,13 +30,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+
       - name: Build and push slim
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile.slim
           push: true
-          tags: ${{ env.REGISTRY }}/apeworx/ape:latest-slim
+          tags: ${{ steps.meta.outputs.tags }}-slim
+          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Build and push
         uses: docker/build-push-action@v4
@@ -41,6 +52,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ env.Registry }}/apeworx/ape:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,10 @@ jobs:
           git tag
           echo ${{ steps.meta.outputs.tags }}
 
+      - name: Extract version from tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
       - name: Log into GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -62,6 +66,7 @@ jobs:
           build-args: |
             BUILD_DATE=${{ github.event.repository.updated_at }}
             VCS_REF=${{ github.sha }}
+            VERSION=${{ env.VERSION }}
 
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags ${{ env.Registry }}/apeworx/ape:latest
+          tags: ${{ env.Registry }}/apeworx/ape:latest
 
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,6 +59,9 @@ jobs:
           file: ./Dockerfile.slim
           tags: ${{ steps.meta.outputs.tags }}-slim
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_DATE=${{ github.event.repository.updated_at }}
+            VCS_REF=${{ github.sha }}
 
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,14 +44,6 @@ jobs:
           git tag
           echo ${{ steps.meta.outputs.tags }}
 
-      - name: Get current date and time
-        id: build_date
-        run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
-
-      - name: Get commit sha
-        id: commit_sha
-        run: echo "VCS_REF=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-
       - name: Log into GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -69,8 +61,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ version }}
-            BUILD_DATE=${{ env.BUILD_DATE }}
-            VCS_REF=${{ env.VCS_REF }}
+            BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            VCS_REF=$(git rev-parse --short HEAD)
 
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,9 +27,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get tags
-        run: git fetch --tags origin
-
       - name: Build and push slim
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,9 +26,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: PRINT GIT TAG
-        run: git tag
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -39,9 +36,6 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-
-      - name: PRINT METADATA TAGS
-        run: echo ${{ steps.meta.outputs.tags }}
 
       - name: Log into GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ version }}
-            BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ")
+            BUILD_DATE=${{ github.event.repository.updated_at }}
             VCS_REF=${{ github.sha }}
 
       - name: Build and push

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,9 @@ jobs:
         with:
           fetch-tags: 'true'
 
+      - name: PRINT GIT TAG
+        run: git tag
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -36,6 +39,9 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+
+      - name: PRINT METADATA TAGS
+        run: echo "TAGS: ${{ steps.meta.outputs.tags }}"
 
       - name: Log into GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,26 +26,31 @@ jobs:
         with:
           fetch-tags: 'true'
 
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
       - name: Log into GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-
       - name: Build and push slim
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile.slim
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}-slim
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -54,7 +59,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ version }}
-            BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ")
             VCS_REF={{ github.sha }}
 
       - name: Build and push

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,43 +2,9 @@
 # See LICENSE in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
-ARG PYTHON_VERSION="3.11"
-ARG PLUGINS_FILE="./recommended-plugins.txt"
+FROM ape:latest-slim
 
-FROM python:${PYTHON_VERSION} as builder
+RUN pip install --upgrade pip
+RUN pip install /wheels/*.whl
 
-WORKDIR /wheels
-
-COPY ./recommended-plugins.txt ./recommended-plugins.txt
-COPY . .
-
-RUN pip install --upgrade pip \
-    && pip install wheel \
-    && pip wheel .[recommended-plugins] --wheel-dir=/wheels
-
-FROM python:${PYTHON_VERSION}-slim
-
-# See http://label-schema.org for metadata schema
-# TODO: Add `build-date` and `version`
-LABEL maintainer="ApeWorX" \
-      org.label-schema.schema-version="2.0" \
-      org.label-schema.name="ape" \
-      org.label-schema.description="Ape Ethereum Framework." \
-      org.label-schema.url="https://docs.apeworx.io/ape/stable/" \
-      org.label-schema.usage="https://docs.apeworx.io/ape/stable/userguides/quickstart.html#via-docker" \
-      org.label-schema.vcs-url="https://github.com/ApeWorX/ape" \
-      org.label-schema.docker.cmd="docker run --volume $HOME/.ape:/home/harambe/.ape --volume $HOME/.vvm:/home/harambe/.vvm --volume $HOME/.solcx:/home/harambe/.solcx --volume $PWD:/home/harambe/project --workdir /home/harambe/project apeworx/ape compile"
-
-RUN useradd --create-home --shell /bin/bash harambe
-
-COPY --from=builder /wheels /wheels
-COPY ./recommended-plugins.txt ./recommended-plugins.txt
-
-RUN pip install --upgrade pip \
-    pip install --no-cache-dir --find-links=/wheels -r ./recommended-plugins.txt \
-    && ape --version
-
-WORKDIR /home/harambe/project
-RUN chown --recursive harambe:harambe /home/harambe
-USER harambe
-ENTRYPOINT ["ape"]
+RUN ape --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY ./recommended-plugins.txt ./recommended-plugins.txt
 
 RUN pip wheel .[recommended-plugins] --wheel-dir=/wheels
 
-FROM ${SLIM_IMAGE}
+FROM ${SLIM_IMAGE} AS ape_slim
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,11 @@
 
 FROM ape:latest-slim
 
+USER root
+
 RUN pip install --upgrade pip
 RUN pip install /wheels/*.whl
+
+USER harambe
 
 RUN ape --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,22 @@
 # See LICENSE in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
+ARG PYTHON_VERSION="3.11"
+FROM python:${PYTHON_VERSION} as builder
+
+WORKDIR /wheels
+
+RUN pip install --upgrade pip \
+    && pip install wheel
+
+COPY . .
+
+RUN mkdir /wheels
+
+COPY ./recommended-plugins.txt ./recommended-plugins.txt
+
+RUN pip wheel .[recommended-plugins] --wheel-dir=/wheels
+
 FROM ape:latest-slim
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ RUN pip install --upgrade pip \
 
 COPY . .
 
-RUN mkdir /wheels
-
 COPY ./recommended-plugins.txt ./recommended-plugins.txt
 
 RUN pip wheel .[recommended-plugins] --wheel-dir=/wheels
@@ -21,6 +19,8 @@ RUN pip wheel .[recommended-plugins] --wheel-dir=/wheels
 FROM ape:latest-slim
 
 USER root
+
+COPY --from=builder /wheels/*.whl /wheels/
 
 RUN pip install --upgrade pip
 RUN pip install /wheels/*.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@
 # See LICENSE in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
+ARG SLIM_IMAGE
 ARG PYTHON_VERSION="3.11"
-FROM python:${PYTHON_VERSION} as builder
+FROM python:${PYTHON_VERSION} AS builder
 
 WORKDIR /wheels
 
@@ -16,7 +17,7 @@ COPY ./recommended-plugins.txt ./recommended-plugins.txt
 
 RUN pip wheel .[recommended-plugins] --wheel-dir=/wheels
 
-FROM ape:latest-slim
+FROM ${SLIM_IMAGE}
 
 USER root
 

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -15,12 +15,6 @@ COPY . .
 
 RUN pip wheel .
 
-RUN mkdir /wheels/recommended_plugins
-
-COPY ./recommended-plugins.txt ./recommended-plugins.txt
-
-RUN pip wheel .[recommended-plugins] --wheel-dir=/wheels/recommended_plugins
-
 FROM python:${PYTHON_VERSION}-slim
 
 # See http://label-schema.org for metadata schema
@@ -40,7 +34,6 @@ COPY --from=builder /wheels/*.whl /wheels/
 RUN pip install --upgrade pip
 RUN pip install /wheels/*.whl
 
-COPY --from=builder /wheels/recommended_plugins/*.whl /wheels/
 RUN ape --version
 
 WORKDIR /home/harambe/project

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -27,7 +27,7 @@ FROM python:${PYTHON_VERSION}-slim
 # TODO: Add `build-date` and `version`
 LABEL maintainer="ApeWorX" \
       org.label-schema.schema-version="2.0" \
-      org.label-schema.name="ape-slim" \
+      org.label-schema.name="ape" \
       org.label-schema.description="Ape Ethereum Framework." \
       org.label-schema.url="https://docs.apeworx.io/ape/stable/" \
       org.label-schema.usage="https://docs.apeworx.io/ape/stable/userguides/quickstart.html#via-docker" \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -15,6 +15,12 @@ COPY . .
 
 RUN pip wheel .
 
+RUN mkdir /wheels/recommended_plugins
+
+COPY ./recommended-plugins.txt ./recommended-plugins.txt
+
+RUN pip wheel .[recommended-plugins] --wheel-dir=/wheels/recommended_plugins
+
 FROM python:${PYTHON_VERSION}-slim
 
 # See http://label-schema.org for metadata schema
@@ -34,6 +40,7 @@ COPY --from=builder /wheels/*.whl /wheels/
 RUN pip install --upgrade pip
 RUN pip install /wheels/*.whl
 
+COPY --from=builder /wheels/recommended_plugins/*.whl /wheels/
 RUN ape --version
 
 WORKDIR /home/harambe/project

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,0 +1,42 @@
+#---------------------------------------------------------------------------------------------
+# See LICENSE in the project root for license information.
+#---------------------------------------------------------------------------------------------
+
+ARG PYTHON_VERSION="3.11"
+
+FROM python:${PYTHON_VERSION} as builder
+
+WORKDIR /wheels
+
+RUN pip install --upgrade pip \
+    && pip install wheel
+
+COPY . .
+
+RUN pip wheel .
+
+FROM python:${PYTHON_VERSION}-slim
+
+# See http://label-schema.org for metadata schema
+# TODO: Add `build-date` and `version`
+LABEL maintainer="ApeWorX" \
+      org.label-schema.schema-version="2.0" \
+      org.label-schema.name="ape-slim" \
+      org.label-schema.description="Ape Ethereum Framework." \
+      org.label-schema.url="https://docs.apeworx.io/ape/stable/" \
+      org.label-schema.usage="https://docs.apeworx.io/ape/stable/userguides/quickstart.html#via-docker" \
+      org.label-schema.vcs-url="https://github.com/ApeWorX/ape" \
+      org.label-schema.docker.cmd="docker run --volume $HOME/.ape:/home/harambe/.ape --volume $HOME/.vvm:/home/harambe/.vvm --volume $HOME/.solcx:/home/harambe/.solcx --volume $PWD:/home/harambe/project --workdir /home/harambe/project apeworx/ape compile"
+
+RUN useradd --create-home --shell /bin/bash harambe
+COPY --from=builder /wheels/*.whl /wheels/
+
+RUN pip install --upgrade pip
+RUN pip install /wheels/*.whl
+
+RUN ape --version
+
+WORKDIR /home/harambe/project
+RUN chown --recursive harambe:harambe /home/harambe
+USER harambe
+ENTRYPOINT ["ape"]

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -22,11 +22,11 @@ FROM python:${PYTHON_VERSION}-slim
 LABEL maintainer="ApeWorX" \
       org.label-schema.schema-version="2.0" \
       org.label-schema.name="ape" \
-      org.label-schema.description="Ape Ethereum Framework." \
-      org.label-schema.url="https://docs.apeworx.io/ape/stable/" \
-      org.label-schema.usage="https://docs.apeworx.io/ape/stable/userguides/quickstart.html#via-docker" \
+      org.label-schema.description="Ape Framework." \
+      org.label-schema.url="https://apeworx.io/framework" \
+      org.label-schema.usage="https://docs.apeworx.io/ape/stable/userguides/quickstart.html\#via-docker" \
       org.label-schema.vcs-url="https://github.com/ApeWorX/ape" \
-      org.label-schema.docker.cmd="docker run --volume $HOME/.ape:/home/harambe/.ape --volume $HOME/.vvm:/home/harambe/.vvm --volume $HOME/.solcx:/home/harambe/.solcx --volume $PWD:/home/harambe/project --workdir /home/harambe/project apeworx/ape compile"
+      org.label-schema.docker.cmd="docker run --volume $PWD:/home/harambe/project --workdir /home/harambe/project apeworx/ape run my_script.py"
 
 RUN useradd --create-home --shell /bin/bash harambe
 COPY --from=builder /wheels/*.whl /wheels/

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -19,14 +19,19 @@ FROM python:${PYTHON_VERSION}-slim
 
 # See http://label-schema.org for metadata schema
 # TODO: Add `build-date` and `version`
-LABEL maintainer="ApeWorX" \
-      org.label-schema.schema-version="2.0" \
-      org.label-schema.name="ape" \
-      org.label-schema.description="Ape Framework." \
-      org.label-schema.url="https://apeworx.io/framework" \
-      org.label-schema.usage="https://docs.apeworx.io/ape/stable/userguides/quickstart.html\#via-docker" \
-      org.label-schema.vcs-url="https://github.com/ApeWorX/ape" \
-      org.label-schema.docker.cmd="docker run --volume $PWD:/home/harambe/project --workdir /home/harambe/project apeworx/ape run my_script.py"
+LABEL org.opencontainers.image.title="ape" \
+    org.opencontainers.image.description="Ape Framework" \
+    org.opencontainers.image.url="https://apeworx.io/framework" \
+    org.opencontainers.image.documentation="https://docs.apeworx.io/ape/stable/userguides/quickstart.html\#installation" \
+    org.opencontainers.image.source="https://github.com/ApeWorX/ape" \
+    org.opencontainers.image.vendor="ApeWorX" \
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${VERSION:-latest}" \
+    org.opencontainers.image.created="${BUILD_DATE}" \
+    org.opencontainers.image.revision="${VCS_REF}" \
+    org.opencontainers.image.authors="ApeWorX" \
+    org.opencontainers.image.base.name="python:${PYTHON_VERSION}-slim"
+
 
 RUN useradd --create-home --shell /bin/bash harambe
 COPY --from=builder /wheels/*.whl /wheels/

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -4,7 +4,7 @@
 
 ARG PYTHON_VERSION="3.11"
 
-FROM python:${PYTHON_VERSION} as builder
+FROM python:${PYTHON_VERSION} AS builder
 
 WORKDIR /wheels
 

--- a/README.md
+++ b/README.md
@@ -69,11 +69,13 @@ $ docker pull ghcr.io/apeworx/ape:latest  # installs with recommended-plugins
 ```
 
 or pull the slim if you have specific needs that you'd like to build from:
+
 ```bash
 $ docker pull ghcr.io/apeworx/ape:latest-slim  # installs ape with required packages
 ```
 
 or build the image locally from source:
+
 ```bash
 $ docker build -t ape:latest-slim -f Dockerfile.slim .
 $ docker build -t ape:latest .

--- a/README.md
+++ b/README.md
@@ -90,9 +90,8 @@ docker run \
   apeworx/ape compile
 ```
 
-:::note
+> **Note:**
 > The above command requires the full install with the recommended-plugins.
-:::
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,31 @@ There are three ways to install ape: `pipx`, `pip`, or `Docker`.
 
 Ape can also run in a docker container.
 
-Please visit our [Dockerhub](https://hub.docker.com/repository/docker/apeworx/ape) for more details on using Ape with Docker.
+You can pull our images from [ghcr](https://ghcr.io/apeworx/ape). We currently have a `slim` docker image as well as an image that is built with the recommended-plugins.
+
+You can pull the image:
+
+```bash
+docker pull ghcr.io/apeworx/ape:latest-slim  # installs ape with required packages
+```
+
+or pull with the recommended-plugins:
+```bash
+docker pull ghcr.io/apeworx/ape:latest  # installs with recommended-plugins
+```
+
+or build the image locally from source:
+```bash
+docker build -t ape:latest-slim -f Dockerfile.slim .
+```
+
+If you want the recommended plugins as well:
+
+```python
+docker build -t ape:latest .
+```
+
+An example of running a command from the container would be:
 
 ```bash
 docker run \
@@ -69,6 +93,8 @@ docker run \
   --volume $PWD:/home/harambe/project \
   apeworx/ape compile
 ```
+
+The above command requires the full install with the recommended-plugins.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ There are three ways to install ape: `pipx`, `pip`, or `Docker`.
 
 Ape can also run in a docker container.
 
-You can pull our images from [ghcr](https://ghcr.io/apeworx/ape). We currently have a `slim` docker image as well as an image that is built with the recommended-plugins.
+You can pull our images from [ghcr](https://ghcr.io/apeworx/ape).
+We currently have a `slim` docker image that is built without any installed plugins, as well as an image that is built with all plugins included from our `recommended-plugins` extra.
 
 You can pull the image:
 

--- a/README.md
+++ b/README.md
@@ -65,23 +65,18 @@ We currently have a `slim` docker image that is built without any installed plug
 You can pull the image:
 
 ```bash
-docker pull ghcr.io/apeworx/ape:latest-slim  # installs ape with required packages
+$ docker pull ghcr.io/apeworx/ape:latest  # installs with recommended-plugins
 ```
 
-or pull with the recommended-plugins:
+or pull the slim if you have specific needs that you'd like to build from:
 ```bash
-docker pull ghcr.io/apeworx/ape:latest  # installs with recommended-plugins
+$ docker pull ghcr.io/apeworx/ape:latest-slim  # installs ape with required packages
 ```
 
 or build the image locally from source:
 ```bash
-docker build -t ape:latest-slim -f Dockerfile.slim .
-```
-
-If you want the recommended plugins as well:
-
-```python
-docker build -t ape:latest .
+$ docker build -t ape:latest-slim -f Dockerfile.slim .
+$ docker build -t ape:latest .
 ```
 
 An example of running a command from the container would be:
@@ -95,7 +90,9 @@ docker run \
   apeworx/ape compile
 ```
 
-The above command requires the full install with the recommended-plugins.
+:::note
+> The above command requires the full install with the recommended-plugins.
+:::
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ There are three ways to install ape: `pipx`, `pip`, or `Docker`.
 Ape can also run in a docker container.
 
 You can pull our images from [ghcr](https://ghcr.io/apeworx/ape).
-We currently have a `slim` docker image that is built without any installed plugins, as well as an image that is built with all plugins included from our `recommended-plugins` extra.
+This image is built using our `recommended-plugins` extra, so it is a great starting point for running ape in a containerized environment.
+
+We also have a `slim` docker image that is built without any installed plugins.
+This image is meant for production support and must be further configured if any plugins are in use.
 
 You can pull the image:
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ docker run \
 ```
 
 > **Note:**
-> The above command requires the full install with the recommended-plugins.
+> The above command requires the full install which includes `recommended-plugins` installation extra.
 
 ## Quickstart
 


### PR DESCRIPTION
### What I did

Created Dockerfile.slim for a slim version of ape without recommended-plugins

fixes: #2143 

### How I did it

Needed to create the whl files with python:3.11, then switch to python:3.11-slim after the whl files are created. This install ends up being 500MB in size vs 2.24GB in the current Dockerfile build.

I then install the recommended plugins in the Dockerfile for the latest version. The size of the image reduced from 2.24GB to 571MB.

### How to verify it

```bash
git checkout feat/create-bare-ape-image
docker build -t ape:latest-slim -f Dockerfile.slim .
docker image ls
...
...      ...               ...   SIZE
ape   latest-slim                500MB
ape   latest                     571MB
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
