### PR TITLE
fix: issues with `CurrencyComparableValue` appearing `ContractLog.event_arguments` & on Pydantic models

### DIFF
--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -19,7 +19,7 @@ from ethpm_types import (
 )
 from ethpm_types.abi import EventABI
 from ethpm_types.source import Closure
-from pydantic import BaseModel, BeforeValidator, field_validator, model_validator
+from pydantic import BaseModel, BeforeValidator, field_serializer, field_validator, model_validator
 from pydantic_core.core_schema import (
     CoreSchema,
     ValidationInfo,
@@ -257,6 +257,15 @@ class BaseContractLog(BaseInterfaceModel):
                 return False
 
         return True
+
+    @field_serializer("event_arguments")
+    def _serialize_event_arguments(self, event_arguments, info):
+        """
+        Because of an issue with BigInt in Pydantic,
+        (https://github.com/pydantic/pydantic/issues/10152)
+        we have to ensure these are regular ints.
+        """
+        return {k: int(v) if isinstance(v, int) else v for k, v in event_arguments.items()}
 
 
 class ContractLog(ExtraAttributesMixin, BaseContractLog):

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -20,6 +20,12 @@ from ethpm_types import (
 from ethpm_types.abi import EventABI
 from ethpm_types.source import Closure
 from pydantic import BaseModel, BeforeValidator, field_validator, model_validator
+from pydantic_core.core_schema import (
+    CoreSchema,
+    int_schema,
+    plain_serializer_function_ser_schema,
+    with_info_before_validator_function,
+)
 from typing_extensions import TypeAlias
 from web3.types import FilterParams
 
@@ -483,6 +489,12 @@ class CurrencyValueComparable(int):
 
         # Try from the other end, if hasn't already.
         return NotImplemented
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, value, handler=None) -> CoreSchema:
+        schema = with_info_before_validator_function(lambda x, y: int(x), int_schema())
+        schema["serialization"] = plain_serializer_function_ser_schema(function=lambda x: int(x))
+        return schema
 
 
 CurrencyValueComparable.__name__ = int.__name__

--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -507,7 +507,7 @@ class CurrencyValueComparable(int):
         # NOTE: For some reason, for this to work, it has to happen
         #   in an "after" validator, or else it always only `int` type on the model.
         if value is None:
-            # Will fail if  not optional.
+            # Will fail if not optional.
             # Type ignore because this is an hacky and unlikely situation.
             return None  # type: ignore
 

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -95,6 +95,7 @@ def test_uri_when_configured(geth_provider, project, ethereum):
     assert actual_mainnet_uri == expected
 
 
+@geth_process_test
 def test_uri_non_dev_and_not_configured(mocker, ethereum):
     """
     If the URI was not configured and we are not using a dev
@@ -547,6 +548,7 @@ def test_make_request_not_exists(geth_provider):
         geth_provider.make_request("ape_thisDoesNotExist")
 
 
+@geth_process_test
 def test_geth_bin_not_found():
     bin_name = "__NOT_A_REAL_EXECUTABLE_HOPEFULLY__"
     with pytest.raises(NodeSoftwareNotInstalledError):
@@ -677,6 +679,7 @@ def test_trace_approach_config(project):
         assert provider.call_trace_approach is TraceApproach.GETH_STRUCT_LOG_PARSE
 
 
+@geth_process_test
 def test_start(mocker, convert, project, geth_provider):
     amount = convert("100_000 ETH", int)
     spy = mocker.spy(GethDevProcess, "from_uri")

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -156,15 +156,18 @@ class TestCurrencyValueComparable:
         dumped = model.model_dump()
         assert dumped["val"] == value
 
-    def test_use_in_model_annotation(self):
+    @pytest.mark.parametrize("mode", ("json", "python"))
+    def test_use_in_model_annotation(self, mode):
         value = 100000000000000000000000000000000000000000000
 
         class MyModel(BaseModel):
             val: CurrencyValueComparable
+            val_optional: Optional[CurrencyValueComparable]
 
-        model = MyModel.model_validate({"val": value})
+        model = MyModel.model_validate({"val": value, "val_optional": value})
         assert model.val == value
 
         # Ensure serializes.
-        dumped = model.model_dump()
+        dumped = model.model_dump(mode=mode)
         assert dumped["val"] == value
+        assert dumped["val_optional"] == value

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -6,7 +6,7 @@ from ethpm_types.abi import EventABI
 from hexbytes import HexBytes
 from pydantic import BaseModel, Field
 
-from ape.types import AddressType, ContractLog, HexInt, LogFilter
+from ape.types import AddressType, ContractLog, CurrencyValueComparable, HexInt, LogFilter
 from ape.utils import ZERO_ADDRESS
 
 TXN_HASH = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa222222222222222222222222"
@@ -131,11 +131,27 @@ def test_address_type(owner):
 
 
 class TestHexInt:
-    class MyModel(BaseModel):
-        ual: HexInt = 0
-        ual_optional: Optional[HexInt] = Field(default=None, validate_default=True)
+    def test_model(self):
+        class MyModel(BaseModel):
+            ual: HexInt = 0
+            ual_optional: Optional[HexInt] = Field(default=None, validate_default=True)
 
-    act = MyModel.model_validate({"ual": "0x123"})
-    expected = 291  # Base-10 form of 0x123.
-    assert act.ual == expected
-    assert act.ual_optional is None
+        act = MyModel.model_validate({"ual": "0x123"})
+        expected = 291  # Base-10 form of 0x123.
+        assert act.ual == expected
+        assert act.ual_optional is None
+
+
+class TestCurrencyValueComparable:
+    def test_use_on_int_in_pydantic_model(self):
+        value = 100000000000000000000000000000000000000000000
+
+        class MyModel(BaseModel):
+            val: int
+
+        model = MyModel.model_validate({"val": CurrencyValueComparable(value)})
+        assert model.val == value
+
+        # Ensure serializes.
+        dumped = model.model_dump()
+        assert dumped["val"] == value

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -143,13 +143,26 @@ class TestHexInt:
 
 
 class TestCurrencyValueComparable:
-    def test_use_on_int_in_pydantic_model(self):
+    def test_use_for_int_in_pydantic_model(self):
         value = 100000000000000000000000000000000000000000000
 
         class MyModel(BaseModel):
             val: int
 
         model = MyModel.model_validate({"val": CurrencyValueComparable(value)})
+        assert model.val == value
+
+        # Ensure serializes.
+        dumped = model.model_dump()
+        assert dumped["val"] == value
+
+    def test_use_in_model_annotation(self):
+        value = 100000000000000000000000000000000000000000000
+
+        class MyModel(BaseModel):
+            val: CurrencyValueComparable
+
+        model = MyModel.model_validate({"val": value})
         assert model.val == value
 
         # Ensure serializes.

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -146,10 +146,10 @@ class TestCurrencyValueComparable:
     def test_use_for_int_in_pydantic_model(self):
         value = 100000000000000000000000000000000000000000000
 
-        class MyModel(BaseModel):
+        class MyBasicModel(BaseModel):
             val: int
 
-        model = MyModel.model_validate({"val": CurrencyValueComparable(value)})
+        model = MyBasicModel.model_validate({"val": CurrencyValueComparable(value)})
         assert model.val == value
 
         # Ensure serializes.
@@ -160,12 +160,16 @@ class TestCurrencyValueComparable:
     def test_use_in_model_annotation(self, mode):
         value = 100000000000000000000000000000000000000000000
 
-        class MyModel(BaseModel):
+        class MyAnnotatedModel(BaseModel):
             val: CurrencyValueComparable
             val_optional: Optional[CurrencyValueComparable]
 
-        model = MyModel.model_validate({"val": value, "val_optional": value})
+        model = MyAnnotatedModel.model_validate({"val": value, "val_optional": value})
+        assert isinstance(model.val, CurrencyValueComparable)
         assert model.val == value
+
+        # Show can use currency-comparable
+        assert model.val == "100000000000000000000000000 ETH"
 
         # Ensure serializes.
         dumped = model.model_dump(mode=mode)

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Any
 
 import pytest
 from eth_utils import to_hex
@@ -163,13 +163,23 @@ class TestCurrencyValueComparable:
         class MyAnnotatedModel(BaseModel):
             val: CurrencyValueComparable
             val_optional: Optional[CurrencyValueComparable]
+            val_in_dict: dict[str, Any]
 
-        model = MyAnnotatedModel.model_validate({"val": value, "val_optional": value})
+        model = MyAnnotatedModel.model_validate(
+            {
+                "val": value,
+                "val_optional": value,
+                "val_in_dict": {"value": CurrencyValueComparable(value)},
+            }
+        )
         assert isinstance(model.val, CurrencyValueComparable)
         assert model.val == value
 
         # Show can use currency-comparable
-        assert model.val == "100000000000000000000000000 ETH"
+        expected_currency_value = "100000000000000000000000000 ETH"
+        assert model.val == expected_currency_value
+        assert model.val_optional == expected_currency_value
+        assert model.val_in_dict["value"] == expected_currency_value
 
         # Ensure serializes.
         dumped = model.model_dump(mode=mode)
@@ -180,11 +190,16 @@ class TestCurrencyValueComparable:
         class MyAnnotatedModel(BaseModel):
             val: CurrencyValueComparable
             val_optional: Optional[CurrencyValueComparable]
+            val_in_dict: dict[str, Any]
 
         value = "100000000000000000000000000 ETH"
         expected = 100000000000000000000000000000000000000000000
-        data = {"val": value, "val_optional": value}
+        data = {
+            "val": value,
+            "val_optional": value,
+            "val_in_dict": {"value": CurrencyValueComparable(expected)},
+        }
         model = MyAnnotatedModel.model_validate(data)
-        for actual in (model.val, model.val_optional):
+        for actual in (model.val, model.val_optional, model.val_in_dict["value"]):
             for ex in (value, expected):
                 assert actual == ex

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -175,3 +175,16 @@ class TestCurrencyValueComparable:
         dumped = model.model_dump(mode=mode)
         assert dumped["val"] == value
         assert dumped["val_optional"] == value
+
+    def test_validate_from_currency_value(self):
+        class MyAnnotatedModel(BaseModel):
+            val: CurrencyValueComparable
+            val_optional: Optional[CurrencyValueComparable]
+
+        value = "100000000000000000000000000 ETH"
+        expected = 100000000000000000000000000000000000000000000
+        data = {"val": value, "val_optional": value}
+        model = MyAnnotatedModel.model_validate(data)
+        for actual in (model.val, model.val_optional):
+            for ex in (value, expected):
+                assert actual == ex

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any
+from typing import Any, Optional
 
 import pytest
 from eth_utils import to_hex
@@ -163,15 +163,8 @@ class TestCurrencyValueComparable:
         class MyAnnotatedModel(BaseModel):
             val: CurrencyValueComparable
             val_optional: Optional[CurrencyValueComparable]
-            val_in_dict: dict[str, Any]
 
-        model = MyAnnotatedModel.model_validate(
-            {
-                "val": value,
-                "val_optional": value,
-                "val_in_dict": {"value": CurrencyValueComparable(value)},
-            }
-        )
+        model = MyAnnotatedModel.model_validate({"val": value, "val_optional": value})
         assert isinstance(model.val, CurrencyValueComparable)
         assert model.val == value
 
@@ -179,7 +172,6 @@ class TestCurrencyValueComparable:
         expected_currency_value = "100000000000000000000000000 ETH"
         assert model.val == expected_currency_value
         assert model.val_optional == expected_currency_value
-        assert model.val_in_dict["value"] == expected_currency_value
 
         # Ensure serializes.
         dumped = model.model_dump(mode=mode)


### PR DESCRIPTION
### What I did

The following bug fixes are in this PR:

1. Can now use `CurrencyComparableValue` as a type annotation (And still using comparison-feature!)
2. Can validate CurrencyComparableValue into int declared type
3. ContractLog serialized event_arguments out of this type because of https://github.com/pydantic/pydantic/issues/10152

### How I did it

Implement a custom serializer in the type that treats it like a normal int

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
