### PR TITLE
fix: logger verbosity issues

### DIFF
--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -56,7 +56,7 @@ class ApeCliContextObject(ManagerAccessMixin, dict):
 
 
 def verbosity_option(
-    cli_logger: Optional[ApeLogger] = None, default: Union[str, LogLevel] = DEFAULT_LOG_LEVEL
+    cli_logger: Optional[ApeLogger] = None, default: Union[str, int, LogLevel] = DEFAULT_LOG_LEVEL
 ) -> Callable:
     """A decorator that adds a `--verbosity, -v` option to the decorated
     command.
@@ -67,7 +67,7 @@ def verbosity_option(
 
 
 def _create_verbosity_kwargs(
-    _logger: Optional[ApeLogger] = None, default: Union[str, LogLevel] = DEFAULT_LOG_LEVEL
+    _logger: Optional[ApeLogger] = None, default: Union[str, int, LogLevel] = DEFAULT_LOG_LEVEL
 ) -> dict:
     cli_logger = _logger or logger
 
@@ -87,7 +87,7 @@ def _create_verbosity_kwargs(
 
 
 def ape_cli_context(
-    default_log_level: Union[str, LogLevel] = DEFAULT_LOG_LEVEL,
+    default_log_level: Union[str, int, LogLevel] = DEFAULT_LOG_LEVEL,
     obj_type: type = ApeCliContextObject,
 ) -> Callable:
     """
@@ -96,7 +96,7 @@ def ape_cli_context(
     such as logging or accessing managers.
 
     Args:
-        default_log_level (Union[str, :class:`~ape.logging.LogLevel`]): The log-level
+        default_log_level (Union[str, int, :class:`~ape.logging.LogLevel`]): The log-level
           value to pass to :meth:`~ape.cli.options.verbosity_option`.
         obj_type (Type): The context object type. Defaults to
           :class:`~ape.cli.options.ApeCliContextObject`. Sub-class

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -166,14 +166,13 @@ class ApeLogger:
     def level(self) -> int:
         return self._logger.level
 
-    def set_level(self, level: Union[str, int]):
+    def set_level(self, level: Union[str, int, LogLevel]):
         """
         Change the global ape logger log-level.
 
         Args:
             level (str): The name of the level or the value of the log-level.
         """
-
         if level == self._logger.level:
             return
 

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -176,6 +176,9 @@ class ApeLogger:
         if level == self._logger.level:
             return
 
+        elif isinstance(level, LogLevel):
+            level = level.value
+
         self._logger.setLevel(level)
         for _logger in self._extra_loggers.values():
             _logger.setLevel(level)
@@ -266,9 +269,11 @@ def get_logger(
     return _logger
 
 
-def _get_level(level: Optional[Union[str, int]] = None) -> str:
+def _get_level(level: Optional[Union[str, int, LogLevel]] = None) -> str:
     if level is None:
         return DEFAULT_LOG_LEVEL
+    elif isinstance(level, LogLevel):
+        return level.name
     elif isinstance(level, int) or level.isnumeric():
         return LogLevel(int(level)).name
 

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -23,7 +23,7 @@ from ape.cli import (
 from ape.cli.choices import _NONE_NETWORK, _get_networks_sequence_from_cache
 from ape.cli.commands import get_param_from_ctx, parse_network
 from ape.exceptions import AccountsError
-from ape.logging import logger
+from ape.logging import logger, LogLevel
 from tests.conftest import geth_process_test, skip_if_plugin_installed
 
 OUTPUT_FORMAT = "__TEST__{0}:{1}:{2}_"
@@ -417,6 +417,17 @@ def test_verbosity_option(runner):
 
     result = runner.invoke(cmd, ["--verbosity", logger.level])
     assert f"__expected_{logger.level}" in result.output
+
+
+@pytest.mark.parametrize("level", (LogLevel.WARNING, LogLevel.WARNING.name, LogLevel.WARNING.value))
+def test_verbosity_option_change_default(runner, level):
+    @click.command()
+    @verbosity_option(default=level)
+    def cmd():
+        pass
+
+    verbosity_parameter = cmd.params[0]
+    assert verbosity_parameter.default == level
 
 
 def test_account_prompt_name():

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -23,7 +23,7 @@ from ape.cli import (
 from ape.cli.choices import _NONE_NETWORK, _get_networks_sequence_from_cache
 from ape.cli.commands import get_param_from_ctx, parse_network
 from ape.exceptions import AccountsError
-from ape.logging import logger, LogLevel
+from ape.logging import LogLevel, logger
 from tests.conftest import geth_process_test, skip_if_plugin_installed
 
 OUTPUT_FORMAT = "__TEST__{0}:{1}:{2}_"

--- a/tests/functional/test_logging.py
+++ b/tests/functional/test_logging.py
@@ -3,6 +3,7 @@ import pytest
 from click.testing import CliRunner
 
 from ape.cli import ape_cli_context
+from ape.logging import LogLevel, logger
 
 
 @pytest.fixture
@@ -98,3 +99,9 @@ def test_format(simple_runner):
 
     result = simple_runner.invoke(group_for_testing, ("cmd", "-v", "SUCCESS"))
     assert "SUCCESS" not in result.output
+
+
+@pytest.mark.parametrize("level", (LogLevel.INFO, LogLevel.INFO.value, LogLevel.INFO.name))
+def test_set_level(level):
+    logger.set_level(level)
+    assert logger.level == LogLevel.INFO.value


### PR DESCRIPTION
### What I did

A user is showing me a stack-trace ending with "Unknown level: LOGLEVEL.WARNING", likely caused by https://github.com/ApeWorX/ape/pull/2212
**However, no matter what I try, I am not able to reproduce, even in their repo with the same branches and versions.**

This PR is my attempt to "fix" without reproducing, even thought that isn't ideal, I just don't know what else to do.

### How I did it

Look at their stack trace and try to handle LogLevel types in more place.s

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
