### PR TITLE
perf: most performant `.return_value` calculation

### DIFF
--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -186,7 +186,7 @@ class TransactionError(ApeException):
         contract_address: Optional["AddressType"] = None,
         source_traceback: _SOURCE_TRACEBACK_ARG = None,
         project: Optional["ProjectManager"] = None,
-        set_ape_traceback: bool = False,  # Overriden in ContractLogicError
+        set_ape_traceback: bool = False,  # Overridden in ContractLogicError
     ):
         message = message or (str(base_err) if base_err else self.DEFAULT_MESSAGE)
         self.message = message

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -1254,7 +1254,6 @@ class Ethereum(EcosystemAPI):
         default_return_value = "<?>"
         returndata = call.get("returndata", "")
         is_hexstr = isinstance(returndata, str) and is_0x_prefixed(returndata)
-        return_value_bytes = None
 
         # Check if return is only a revert string.
         call = self._enrich_revert_message(call)

--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -239,8 +239,8 @@ class Trace(TraceAPI):
                 # Barely enrich a calltree for performance reasons
                 # (likely not a need to enrich the whole thing).
                 calltree = self.get_raw_calltree()
-                enriched_return = self._ecosystem._enrich_returndata(calltree, abi)
-                return enriched_return["returndata"]
+                enriched_calltree = self._ecosystem._enrich_returndata(calltree, abi)
+                return self._get_return_value_from_calltree(enriched_calltree)
 
         return self._return_value_from_enriched_calltree
 
@@ -252,6 +252,9 @@ class Trace(TraceAPI):
         if "return_value" in self.__dict__:
             return self.__dict__["return_value"]
 
+        return self._get_return_value_from_calltree(calltree)
+
+    def _get_return_value_from_calltree(self, calltree: dict) -> Any:
         # If enriching too much, Ethereum places regular values in a key
         # named "unenriched_return_values".
         if "unenriched_return_values" in calltree:


### PR DESCRIPTION
### What I did

Finally - `.return_value` is speedy as it ever was.

stats:

```
 Before:
 10 passed in 197.45s (0:03:17)
 After:
 10 passed in 69.65s (0:01:09) 
```

### How I did it

if possible, use a barely enriched raw call tree, as opposed to a fully enriched (least performant) and a trace-calculated return (middle performance).
this is by far the best.

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
