### PR TITLE
fix: incorrect image release tags in build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=pr,tag=test
+            type=ref,event=pr,pattern=test
             type=ref,event=branch,branch=main,tag=latest
             type=ref,event=tag,tag=stable
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,10 +34,10 @@ jobs:
           tags: |
             type=ref,event=pr
             type=ref,event=branch,branch=main,latest=true
-            type=ref,event=branch,branch=main
+            type=ref,event=branch,branch=main,tag=latest
             type=ref,event=branch,branch!=main
-            type=semver,pattern={{version}},branch=main,latest=false
-            type=ref,event=tag
+            type=semver,pattern={{version}},branch=main,latest=false,tag=stable
+            type=ref,event=tag,tag={{ tag }}
 
       - name: Show tags
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,6 +61,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.slim
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}-slim
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,10 +32,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            type=raw,value=latest
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/') }}
-            type=ref,event=tag
-            type=ref,event=pr
 
       - name: Show tags
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=pr
+            type=ref,event=pr,tag=test
             type=ref,event=branch,branch=main,tag=latest
             type=ref,event=tag,tag=stable
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,11 +33,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=pr
-            type=ref,event=branch,branch=main,latest=true
             type=ref,event=branch,branch=main,tag=latest
-            type=ref,event=branch,branch!=main
-            type=semver,pattern={{version}},branch=main,latest=false,tag=stable
-            type=ref,event=tag,tag={{ tag }}
+            type=ref,event=tag,tag=stable
 
       - name: Show tags
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,8 +32,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=stable,enable={{tag}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=ref,event=tag
             type=ref,event=pr
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=tag
             type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=ref,event=pr
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,9 +32,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=pr,value=test
-            type=ref,event=branch,branch=main,tag=latest
-            type=ref,event=tag,tag=stable
+            type=raw,value=testing
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=stable,enable={{tag}}
 
       - name: Show tags
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,9 +32,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=testing
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=stable,enable={{tag}}
+            type=ref,event=tag
+            type=ref,event=pr
 
       - name: Show tags
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=pr,pattern=test
+            type=ref,event=pr,value=test
             type=ref,event=branch,branch=main,tag=latest
             type=ref,event=tag,tag=stable
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,9 +32,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=ref,event=pr
 
       - name: Show tags
         run: |


### PR DESCRIPTION
### What I did

The tag that is created when merged to `main` is `main`. We want this to be `latest` and then on version release, we want this to be `stable`

fixes: APE-1769

### How I did it

Added the tag to the build yaml

### How to verify it

After merge, check the release

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
~~- [ ] New test cases have been added~~
~~- [ ] Documentation has been updated~~
