### PR TITLE
chore: remove an inaccurate warning

### DIFF
--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -177,20 +177,7 @@ def get_package_version(obj: Any) -> str:
     # NOTE: In case the distribution and package name differ
     dists = _get_distributions(pkg_name)
     if dists:
-        num_packages = len(dists)
         pkg_name = dists[0].metadata["Name"]
-
-        if num_packages != 1:
-            # Warn that there are more than 1 package with this name,
-            # which can lead to odd behaviors.
-            found_paths = [str(d._path) for d in dists if hasattr(d, "_path")]
-            found_paths_str = ",\n\t".join(found_paths)
-            message = f"Found {num_packages} packages named '{pkg_name}'."
-            if found_paths:
-                message = f"{message}\nInstallation paths:\n\t{found_paths_str}"
-
-            logger.debug(message)
-
     try:
         return str(version_metadata(pkg_name))
 

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -189,7 +189,7 @@ def get_package_version(obj: Any) -> str:
             if found_paths:
                 message = f"{message}\nInstallation paths:\n\t{found_paths_str}"
 
-            logger.warning(message)
+            logger.debug(message)
 
     try:
         return str(version_metadata(pkg_name))


### PR DESCRIPTION
### What I did

this warning is annoying, i did some searching and it is quite normal for their to be multiple installs, depending on your install..

i think this warning used to matter more in earlier releases of ape anyway and the weird things we saw back then no longer happen because of switching to importlib.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
