### PR TITLE
fix: issue where `--account` did not fail when it was supposed to

### DIFF
--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -195,9 +195,13 @@ class AccountAliasPromptChoice(PromptChoice):
         else:
             alias = value
 
-        if isinstance(alias, str) and alias.startswith("TEST::"):
-            idx_str = value.replace("TEST::", "")
+        if isinstance(alias, str) and alias.upper().startswith("TEST::"):
+            idx_str = alias.upper().replace("TEST::", "")
             if not idx_str.isnumeric():
+                if alias in ManagerAccessMixin.account_manager.aliases:
+                    # Was actually a similar-alias.
+                    return ManagerAccessMixin.account_manager.load(alias)
+
                 self.fail(f"Cannot reference test account by '{value}'.", param=param)
 
             account_idx = int(idx_str)
@@ -209,7 +213,7 @@ class AccountAliasPromptChoice(PromptChoice):
         elif alias and alias in ManagerAccessMixin.account_manager.aliases:
             return ManagerAccessMixin.account_manager.load(alias)
 
-        return None
+        self.fail(f"Account with alias '{alias}' not found.", param=param)
 
     def print_choices(self):
         choices = dict(enumerate(self.choices, 0))

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -389,8 +389,7 @@ def test_account_option_alias_not_found(runner, keyfile_account):
 
     result = runner.invoke(cmd, ("--account", "THIS ALAS IS NOT FOUND"))
     expected = (
-        "Invalid value for '--account': "
-        "Account with alias 'THIS ALAS IS NOT FOUND' not found"
+        "Invalid value for '--account': " "Account with alias 'THIS ALAS IS NOT FOUND' not found"
     )
     assert expected in result.output
 

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -365,7 +365,8 @@ def test_account_prompts_when_more_than_one_keyfile_account(
     assert expected in result.output
 
 
-def test_account_option_can_use_test_account(runner, test_accounts):
+@pytest.mark.parametrize("test_key", ("test", "TEST"))
+def test_account_option_can_use_test_account(runner, test_accounts, test_key):
     index = 7
     test_account = test_accounts[index]
 
@@ -376,7 +377,21 @@ def test_account_option_can_use_test_account(runner, test_accounts):
         click.echo(_expected)
 
     expected = get_expected_account_str(test_account)
-    result = runner.invoke(cmd, ("--account", f"TEST::{index}"))
+    result = runner.invoke(cmd, ("--account", f"{test_key}::{index}"))
+    assert expected in result.output
+
+
+def test_account_option_alias_not_found(runner, keyfile_account):
+    @click.command()
+    @account_option()
+    def cmd(account):
+        pass
+
+    result = runner.invoke(cmd, ("--account", "THIS ALAS IS NOT FOUND"))
+    expected = (
+        "Invalid value for '--account': "
+        "Account with alias 'THIS ALAS IS NOT FOUND' not found"
+    )
     assert expected in result.output
 
 


### PR DESCRIPTION
### What I did

an annoying issue where if i mis-typed an alias, even when using the `--account` flag, it would prompt... id then enter the wrong alias again in the prompt but instead of failing, it  would treat it as `None` and try to use it in my script , None has no attribute deploy

### How I did it

fail if we resolve to an alias but that alias does not exist in your accounts

### How to verify it

have a script like:

```python
import click
from ape.cli import ConnectedProviderCommand, account_option, ape_cli_context


@click.command(cls=ConnectedProviderCommand)
@ape_cli_context()
@account_option()
def cli(cli_ctx, account):
    """
    Deploy the chess contract.
    """
    chess_contract = cli_ctx.local_project.chess
    account.deploy(chess_contract)
```

run it with a nonsense account like:

```sh
ape run deploy --account "SADFASDFG
```

should get some output like;

```
Try 'ape run deploy -h' for help.

Error: Invalid value for '--account': Account with alias 'SADFASDFG' not found.
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
