### PR TITLE
feat: make the dependency manager accessible on `ManagerAccessMixin`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,14 @@ include = '\.pyi?$'
 
 [tool.pytest.ini_options]
 norecursedirs = "projects"
-addopts = "-p no:ape_test"  # NOTE: Prevents the ape plugin from activating on our tests
+
+# NOTE: 'no:ape_test' Prevents the ape plugin from activating on our tests
+#    And 'pytest_ethereum' is not used and causes issues in some environments.
+addopts = """
+-p no:ape_test
+-p no:pytest_ethereum
+"""
+
 python_files = "test_*.py"
 testpaths = "tests"
 markers = """fuzzing: Run Hypothesis fuzz test suite

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from ape.managers.converters import ConversionManager
     from ape.managers.networks import NetworkManager
     from ape.managers.plugins import PluginManager
-    from ape.managers.project import ProjectManager
+    from ape.managers.project import DependencyManager, ProjectManager
     from ape.managers.query import QueryManager
     from ape.pytest.runners import PytestApeRunner
 
@@ -121,11 +121,11 @@ class ManagerAccessMixin:
         "ConversionManager", injected_before_use()
     )
 
+    local_project: ClassVar["ProjectManager"] = cast("ProjectManager", injected_before_use())
+
     network_manager: ClassVar["NetworkManager"] = cast("NetworkManager", injected_before_use())
 
     plugin_manager: ClassVar["PluginManager"] = cast("PluginManager", injected_before_use())
-
-    local_project: ClassVar["ProjectManager"] = cast("ProjectManager", injected_before_use())
 
     Project: ClassVar[type["ProjectManager"]] = cast(type["ProjectManager"], injected_before_use())
 
@@ -149,6 +149,12 @@ class ManagerAccessMixin:
             return provider
 
         raise ProviderNotConnectedError()
+
+    @classproperty
+    def dependency_manager(cls) -> "DependencyManager":
+        # We make this available for more intuitive access to
+        # global dependencies, which any project has access to.
+        return cls.local_project.dependencies
 
 
 class BaseInterface(ManagerAccessMixin, ABC):

--- a/src/ape_pm/_cli.py
+++ b/src/ape_pm/_cli.py
@@ -26,11 +26,11 @@ def _list(cli_ctx, list_all):
     List installed packages
     """
 
-    pm = cli_ctx.local_project
+    dm = cli_ctx.dependency_manager
     packages = []
-    dependencies = [*list(pm.dependencies.specified)]
+    dependencies = [*list(dm.specified)]
     if list_all:
-        dependencies = list({*dependencies, *pm.dependencies.installed})
+        dependencies = list({*dependencies, *dm.installed})
 
     for dependency in dependencies:
         try:

--- a/tests/functional/utils/test_basemodel.py
+++ b/tests/functional/utils/test_basemodel.py
@@ -2,6 +2,7 @@ import pytest
 
 from ape.exceptions import ProviderNotConnectedError
 from ape.logging import logger
+from ape.managers.project import DependencyManager
 from ape.utils.basemodel import ManagerAccessMixin, only_raise_attribute_error
 
 
@@ -50,3 +51,8 @@ def test_only_raise_attribute_error_when_already_raises(mocker, ape_caplog):
 
     # Does not log because is already an attr err
     assert not spy.call_count
+
+
+def test_dependency_manager():
+    actual = ManagerAccessMixin.dependency_manager
+    assert isinstance(actual, DependencyManager)


### PR DESCRIPTION
### What I did

I noticed when trying to manager global dependencies in python, it can be awkward referencing the local project to do this.
this makes it less awkward.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
