### PR TITLE
feat: show nicer errors during bad network choices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,14 @@ include = '\.pyi?$'
 
 [tool.pytest.ini_options]
 norecursedirs = "projects"
-addopts = "-p no:ape_test"  # NOTE: Prevents the ape plugin from activating on our tests
+
+# NOTE: 'no:ape_test' Prevents the ape plugin from activating on our tests
+#    And 'pytest_ethereum' is not used and causes issues in some environments.
+addopts = """
+-p no:ape_test
+-p no:pytest_ethereum
+"""
+
 python_files = "test_*.py"
 testpaths = "tests"
 markers = """fuzzing: Run Hypothesis fuzz test suite

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -9,7 +9,12 @@ from click import BadParameter, Choice, Context, Parameter
 
 from ape.api.accounts import AccountAPI
 from ape.api.providers import ProviderAPI
-from ape.exceptions import AccountsError
+from ape.exceptions import (
+    AccountsError,
+    EcosystemNotFoundError,
+    NetworkNotFoundError,
+    ProviderNotFoundError,
+)
 from ape.types import _LazySequence
 from ape.utils.basemodel import ManagerAccessMixin
 
@@ -369,6 +374,12 @@ class NetworkChoice(click.Choice):
                 # (as-is the case for custom-forked networks).
                 try:
                     choice = networks.get_provider_from_choice(network_choice=value)
+
+                except (EcosystemNotFoundError, NetworkNotFoundError, ProviderNotFoundError) as err:
+                    # This error makes more sense, as it has attempted parsing.
+                    # Show this message as the BadParameter message.
+                    raise click.BadParameter(str(err)) from err
+
                 except Exception as err:
                     # If an error was not raised for some reason, raise a simpler error.
                     # NOTE: Still avoid showing the massive network options list.

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -463,7 +463,7 @@ class ProviderNotFoundError(NetworkError):
         if options:
             close_matches = difflib.get_close_matches(provider, options, cutoff=0.6)
             if close_matches:
-                message = f"{message} Did you mean '{', '.join(close_matches)}'?"
+                message = f"{message}. Did you mean '{', '.join(close_matches)}'?"
             else:
                 # No close matches. Show all provider options.
                 options_str = "\n".join(sorted(options))

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import click
 import pytest
+from click import BadParameter
 
 from ape.cli import (
     AccountAliasPromptChoice,
@@ -878,6 +879,27 @@ class TestNetworkChoice:
     def test_explicit_none(self, network_choice):
         actual = network_choice.convert("None", None, None)
         assert actual == _NONE_NETWORK
+
+    def test_bad_ecosystem(self, network_choice):
+        # NOTE: "ethereum" is spelled wrong.
+        expected = r"No ecosystem named 'etheruem'\. Did you mean 'ethereum'\?"
+        with pytest.raises(BadParameter, match=expected):
+            network_choice.convert("etheruem:local:test", None, None)
+
+    def test_bad_network(self, network_choice):
+        # NOTE: "local" is spelled wrong.
+        expected = r"No network in 'ethereum' named 'lokal'\. Did you mean 'local'\?"
+        with pytest.raises(BadParameter, match=expected):
+            network_choice.convert("ethereum:lokal:test", None, None)
+
+    def test_bad_provider(self, network_choice):
+        # NOTE: "test" is spelled wrong.
+        expected = (
+            r"No provider named 'teest' in network 'local' in "
+            r"ecosystem 'ethereum'\. Did you mean 'test'\?"
+        )
+        with pytest.raises(BadParameter, match=expected):
+            network_choice.convert("ethereum:local:teest", None, None)
 
 
 def test_config_override_option(runner):


### PR DESCRIPTION
### What I did

when the ecosystem, network, or provider were slightly off, it did not show me the nice message but instead told me to figure it out (rude!)

we were already getting the nice message earlier so this was an easy fix.

### How I did it

leverage existing error message

### How to verify it

```sh
ape console --network etheruem:local:test
ape console --network ethereum:loocal:test
ape console --network ethereum:local:teest
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
