### PR TITLE
fix: issue missing source traceback on error when given only transaction

### DIFF
--- a/src/ape/types/trace.py
+++ b/src/ape/types/trace.py
@@ -336,7 +336,6 @@ class SourceTraceback(RootModel[list[ControlFlow]]):
         The revert type, such as a builtin-error code or a user dev-message,
         if there is one.
         """
-
         return self.statements[-1].type if self.statements[-1].type != "source" else None
 
     def append(self, __object) -> None:

--- a/tests/functional/test_exceptions.py
+++ b/tests/functional/test_exceptions.py
@@ -150,6 +150,16 @@ class TestTransactionError:
 
         assert_ape_traceback(err3)
 
+    def test_source_traceback_from_txn(self, owner):
+        """
+        Was not given a source-traceback but showing we can deduce one from
+        the given transaction.
+        """
+        tx = owner.transfer(owner, 0)
+        err = TransactionError(txn=tx)
+        _ = err.source_traceback
+        assert err._attempted_source_traceback
+
 
 class TestNetworkNotFoundError:
     def test_close_match(self):


### PR DESCRIPTION
### What I did

unreleased regression affecting dev message detection.
basically it was not trying to make a source traceback if only given a txn

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
