### PR TITLE
fix: issue where custom-networks defaulted to forked-providers when they were not forked networks.

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -1017,7 +1017,7 @@ class NetworkAPI(BaseInterfaceModel):
         from ape.plugins._utils import clean_plugin_name
 
         providers = {}
-        for _, plugin_tuple in self.plugin_manager.providers:
+        for _, plugin_tuple in self._get_plugin_providers():
             ecosystem_name, network_name, provider_class = plugin_tuple
             provider_name = clean_plugin_name(provider_class.__module__.split(".")[0])
             is_custom_with_config = self._is_custom and self.default_provider_name == provider_name
@@ -1047,6 +1047,10 @@ class NetworkAPI(BaseInterfaceModel):
                 )
 
         return providers
+
+    def _get_plugin_providers(self):
+        # NOTE: Abstracted for testing purposes.
+        return self.plugin_manager.providers
 
     def get_provider(
         self,

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -1022,10 +1022,10 @@ class NetworkAPI(BaseInterfaceModel):
             provider_name = clean_plugin_name(provider_class.__module__.split(".")[0])
             is_custom_with_config = self._is_custom and self.default_provider_name == provider_name
             # NOTE: Custom networks that are NOT from config must work with any provider.
-            #    Also, ensure we are only added forked providers for forked networks and
+            #    Also, ensure we are only adding forked providers for forked networks and
             #    non-forking providers for non-forked networks. For custom networks, it
             #    can be trickier (see last condition).
-            # TODO: In 0.9, add a better way for class-level ForkedProviders to defines
+            # TODO: In 0.9, add a better way for class-level ForkedProviders to define
             #   themselves as "Fork" providers.
             if (
                 self.is_adhoc

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -315,9 +315,13 @@ def test_network_option_specify_custom_network(
             click.echo(f"Value is '{getattr(network, 'name', network)}'")
 
         result = runner.invoke(cmd, ("--network", f"ethereum:{network_name}:node"))
+        assert result.exit_code == 0
         assert f"Value is '{network_name}'" in result.output
+
+        # Fails because node is not a fork provider.
         result = runner.invoke(cmd, ("--network", f"ethereum:{network_name}-fork:node"))
-        assert f"Value is '{network_name}-fork'" in result.output
+        assert result.exit_code != 0
+        assert f"No provider named 'node' in network '{network_name}-fork'" in result.output
 
 
 def test_account_option(runner, keyfile_account):

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -214,7 +214,7 @@ def test_providers_custom_network(project, custom_networks_config_dict, ethereum
 def test_providers_custom_non_fork_network_does_not_use_fork_provider(
     mocker, project, custom_networks_config_dict, ethereum
 ):
-    # NOTE: Have to a mock a Fork providers since none ship with Ape core.
+    # NOTE: Have to a mock a Fork provider since none ship with Ape core.
     with project.temp_config(**custom_networks_config_dict):
         network = ethereum.apenet
         network.__dict__.pop("providers", None)  # de-cache

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -235,3 +235,4 @@ def test_providers_custom_non_fork_network_does_not_use_fork_provider(
             assert name not in actual
         finally:
             network._get_plugin_providers = orig
+            network.__dict__.pop("providers", None)  # de-cache

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -195,3 +195,43 @@ def test_create_network_type_fork():
     actual = create_network_type(chain_id, chain_id, is_fork=True)
     assert issubclass(actual, NetworkAPI)
     assert issubclass(actual, ForkedNetworkAPI)
+
+
+def test_providers(ethereum):
+    network = ethereum.local
+    providers = network.providers
+    assert "test" in providers
+    assert "node" in providers
+
+
+def test_providers_custom_network(project, custom_networks_config_dict, ethereum):
+    with project.temp_config(**custom_networks_config_dict):
+        network = ethereum.apenet
+        actual = network.providers
+        assert "node" in actual
+
+
+def test_providers_custom_non_fork_network_does_not_use_fork_provider(
+    mocker, project, custom_networks_config_dict, ethereum
+):
+    # NOTE: Have to a mock a Fork providers since none ship with Ape core.
+    with project.temp_config(**custom_networks_config_dict):
+        network = ethereum.apenet
+        network.__dict__.pop("providers", None)  # de-cache
+
+        # Setup mock fork provider.
+        orig = network._get_plugin_providers
+        network._get_plugin_providers = mocker.MagicMock()
+        name = "foobar"
+
+        class MyForkProvider:
+            __module__ = "foobar.test"
+
+        network._get_plugin_providers.return_value = iter(
+            [(name, ("ethereum", "local", MyForkProvider))]
+        )
+        try:
+            actual = network.providers
+            assert name not in actual
+        finally:
+            network._get_plugin_providers = orig


### PR DESCRIPTION
### What I did

When using a provider that isn't node for a non-forked custom network would still use forked provider version.

### How I did it

* Notice both classes were registering
* Add condition to make sure the correct class was registering

### How to verify it

```yaml
foundry:
  blast:
    mainnet-tenderly:
      uri: "https://[REDACTED]"

networks:
  custom:
     - name: mainnet-tenderly
       chain_id: 69420
       ecosystem: blast
       base_ecosystem_plugin: optimism
       default_provider: foundry
```

connect:

```sh
ape console --network blast:mainnet-tenderly:foundry
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
