### PR TITLE
fix: handle anonymous and strange event data in `parse_rich_tree()` method

### DIFF
--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -657,7 +657,7 @@ def parse_rich_tree(call: dict, verbose: bool = False) -> Tree:
         event_tree = _create_event_tree(event)
         tree.add(event_tree)
 
-    for sub_call in call["calls"]:
+    for sub_call in call.get("calls", []):
         sub_tree = parse_rich_tree(sub_call, verbose=verbose)
         tree.add(sub_tree)
 
@@ -757,7 +757,8 @@ def _call_to_str(call: dict, stylize: bool = False, verbose: bool = False) -> st
 def _event_to_str(event: dict, stylize: bool = False, suffix: str = "") -> str:
     # NOTE: Some of the styles are matching others parts of the trace,
     #  even though the 'name' is a bit misleading.
-    name = f"[{TraceStyles.METHODS}]{event['name']}[/]" if stylize else event["name"]
+    event_name = event.get("name", "ANONYMOUS_EVENT")
+    name = f"[{TraceStyles.METHODS}]{event_name}[/]" if stylize else event_name
     arguments_str = _get_inputs_str(event.get("calldata"), stylize=stylize)
     prefix = f"[{TraceStyles.CONTRACTS}]log[/]" if stylize else "log"
     return f"{prefix} {name}{arguments_str}{suffix}"

--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -772,7 +772,7 @@ def _event_to_str(event: dict, stylize: bool = False, suffix: str = "") -> str:
     #  even though the 'name' is a bit misleading.
     event_name = event.get("name", "ANONYMOUS_EVENT")
     name = f"[{TraceStyles.METHODS}]{event_name}[/]" if stylize else event_name
-    arguments_str = _get_inputs_str(event.get("calldata"), stylize=stylize)
+    arguments_str = _get_inputs_str(event.get("calldata", "0x"), stylize=stylize)
     prefix = f"[{TraceStyles.CONTRACTS}]log[/]" if stylize else "log"
     return f"{prefix} {name}{arguments_str}{suffix}"
 

--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -654,6 +654,11 @@ class CallTrace(Trace):
 def parse_rich_tree(call: dict, verbose: bool = False) -> Tree:
     tree = _create_tree(call, verbose=verbose)
     for event in call.get("events", []):
+        if "calldata" not in event and "name" not in event:
+            # Not sure; or not worth showing.
+            logger.debug(f"Unknown event data: '{event}'.")
+            continue
+
         event_tree = _create_event_tree(event)
         tree.add(event_tree)
 
@@ -671,6 +676,8 @@ def _events_to_trees(events: list[dict]) -> list[Tree]:
         calldata = evt.get("calldata")
 
         if not name or not calldata:
+            # Not sure; or not worth showing.
+            logger.debug(f"Unknown event data: '{evt}'.")
             continue
 
         tuple_key = (
@@ -682,9 +689,15 @@ def _events_to_trees(events: list[dict]) -> list[Tree]:
     result = []
     for evt_tup, events in event_counter.items():
         count = len(events)
+        evt = events[0]
+        if "name" not in evt and "calldata" not in evt:
+            # Not sure; or not worth showing.
+            logger.debug(f"Unknown event data: '{evt}'.")
+            continue
+
         # NOTE: Using similar style to gas-cost on purpose.
         suffix = f"[[{TraceStyles.GAS_COST}]x{count}[/]]" if count > 1 else ""
-        evt_tree = _create_event_tree(events[0], suffix=suffix)
+        evt_tree = _create_event_tree(evt, suffix=suffix)
         result.append(evt_tree)
 
     return result

--- a/tests/functional/test_trace.py
+++ b/tests/functional/test_trace.py
@@ -88,6 +88,13 @@ def test_parse_rich_tree(vyper_contract_instance):
     assert actual == expected
 
 
+def test_parse_rich_tree_handles_anon_events():
+    data = {"events": [{"calldata": "0x123"}]}
+    tree = parse_rich_tree(data)
+    actual = tree.children[0].label.label  # type: ignore
+    assert actual == "[#ff8c00]log[/] [bright_green]ANONYMOUS_EVENT[/](0x123)"
+
+
 def test_get_gas_report(gas_tracker, owner, vyper_contract_instance):
     tx = vyper_contract_instance.setNumber(924, sender=owner)
     trace = tx.trace

--- a/tests/functional/test_trace.py
+++ b/tests/functional/test_trace.py
@@ -95,6 +95,12 @@ def test_parse_rich_tree_handles_anon_events():
     assert actual == "[#ff8c00]log[/] [bright_green]ANONYMOUS_EVENT[/](0x123)"
 
 
+def test_parse_rich_tree_handle_bad_event_data():
+    data = {"events": [{"foo": "I don't know what this is."}]}
+    tree = parse_rich_tree(data)
+    assert len(tree.children) == 0
+
+
 def test_get_gas_report(gas_tracker, owner, vyper_contract_instance):
     tx = vyper_contract_instance.setNumber(924, sender=owner)
     trace = tx.trace


### PR DESCRIPTION
### What I did

anon events have no name.
Likewise, what evm-trace is just bad?
Either way, best not to crash all of everything in the universe.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
