### PR TITLE
fix: make `.extract_manifest()` also compile if needed

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2460,9 +2460,7 @@ class LocalProject(Project):
 
         sources = dict(self.sources)
         contract_types = {
-            n: ct
-            for n, ct in self.load_contracts().items()
-            if ct.source_id in sources
+            n: ct for n, ct in self.load_contracts().items() if ct.source_id in sources
         }
 
         # Add any remaining data to the manifest here.

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2460,7 +2460,9 @@ class LocalProject(Project):
 
         sources = dict(self.sources)
         contract_types = {
-            n: ct for n, ct in self.load_contracts().items() if ct.source_id in sources
+            n: c.contract_type
+            for n, c in self.load_contracts().items()
+            if c.contract_type.source_id in sources
         }
 
         # Add any remaining data to the manifest here.

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2461,7 +2461,7 @@ class LocalProject(Project):
         sources = dict(self.sources)
         contract_types = {
             n: ct
-            for n, ct in (self.manifest.contract_types or {}).items()
+            for n, ct in self.load_contracts().items()
             if ct.source_id in sources
         }
 

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -18,7 +18,7 @@ from pydantic_core import Url
 
 from ape.api.projects import ApeProject, DependencyAPI, ProjectAPI
 from ape.contracts import ContractContainer, ContractInstance
-from ape.exceptions import APINotImplementedError, ChainError, ProjectError
+from ape.exceptions import APINotImplementedError, ChainError, CompilerError, ProjectError
 from ape.logging import logger
 from ape.managers.base import BaseManager
 from ape.managers.config import ApeConfig
@@ -1891,6 +1891,12 @@ class Project(ProjectManager):
         self.account_manager.test_accounts.reset()
 
     def extract_manifest(self) -> PackageManifest:
+        # Ensure it compiled (at least attempt).
+        try:
+            self.load_contracts()
+        except CompilerError as err:
+            logger.debug(err)
+
         return self.manifest
 
     def clean(self):

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -1891,11 +1891,13 @@ class Project(ProjectManager):
         self.account_manager.test_accounts.reset()
 
     def extract_manifest(self) -> PackageManifest:
-        # Ensure it compiled (at least attempt).
+        # Attempt to compile, if needed.
         try:
             self.load_contracts()
         except CompilerError as err:
-            logger.debug(err)
+            # Some manifest-based projects may not require compiling,
+            # such as OpenZeppelin or snekmate.
+            logger.warning(err)
 
         return self.manifest
 

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -299,6 +299,12 @@ def test_extract_manifest_compiles(tmp_project):
     assert actual.contract_types  # Fails if empty
 
 
+def test_extract_manifest_from_manifest_project(project_from_manifest):
+    project_from_manifest.manifest.contract_types = {}  # Not compiled.
+    manifest = project_from_manifest.extract_manifest()
+    assert "FooContractFromManifest" in manifest.contract_types
+
+
 def test_exclusions(tmp_project):
     exclusions = ["Other.json", "*Excl*"]
     exclude_config = {"compile": {"exclude": exclusions}}

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -293,6 +293,12 @@ def test_extract_manifest_excludes_cache(tmp_project):
     assert ".cache/subdir/CacheFile.json" not in (manifest.sources or {})
 
 
+def test_extract_manifest_compiles(tmp_project):
+    tmp_project.manifest.contract_types = {}  # Not compiled.
+    actual = tmp_project.extract_manifest()
+    assert actual.contract_types  # Fails if empty
+
+
 def test_exclusions(tmp_project):
     exclusions = ["Other.json", "*Excl*"]
     exclude_config = {"compile": {"exclude": exclusions}}

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -423,6 +423,35 @@ def test_load_contracts_output_abi(tmp_project):
         assert isinstance(data[0], dict)
 
 
+def test_load_contracts_use_cache(mocker, tmp_project):
+    """
+    Showing the 'use_cache=bool' kwarg works.
+    """
+    compile_spy = mocker.spy(tmp_project.contracts, "_compile")
+
+    tmp_project.manifest.contract_types = {}  # Force initial compile.
+    contracts = tmp_project.load_contracts(use_cache=True)
+    assert "Other" in contracts  # Other.json contract.
+    assert "Project" in contracts  # Project.json contract.
+    assert compile_spy.call_args_list[-1][-1]["use_cache"] is True
+
+    # Show they get added to the manifest.
+    assert "Other" in tmp_project.manifest.contract_types
+    assert "Project" in tmp_project.manifest.contract_types
+
+    # Showe we can use the cache again (no compiling!)
+    contracts = tmp_project.load_contracts(use_cache=True)
+    assert "Other" in contracts  # Other.json contract.
+    assert "Project" in contracts  # Project.json contract.
+    assert compile_spy.call_args_list[-1][-1]["use_cache"] is True
+
+    # Show force-recompiles.
+    contracts = tmp_project.load_contracts(use_cache=False)
+    assert "Other" in contracts  # Other.json contract.
+    assert "Project" in contracts  # Project.json contract.
+    assert compile_spy.call_args_list[-1][-1]["use_cache"] is False
+
+
 def test_manifest_path(tmp_project):
     assert tmp_project.manifest_path == tmp_project.path / ".build" / "__local__.json"
 


### PR DESCRIPTION
### What I did

pre 0.8. this happened, and I don't see why it should not happen, so making it happen again.
(here you go @Ninjagod1251 )

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
