### PR TITLE
fix: `ValueError: Unknown level: 'LOGLEVEL.WARNING'`

### DIFF
--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -73,10 +73,8 @@ def _create_verbosity_kwargs(
 
     def set_level(ctx, param, value):
         if isinstance(value, str):
-            if "." in value:
-                # Handle "LogLevel" prefix that exists in some environments.
-                # TODO: Figure out why this happens (seen in github_action in a few projects).
-                value = value.split(".")[-1]
+            if value.lower().startswith("loglevel."):
+                value = value.split(".")[-1].strip()
 
             value = value.upper()
 

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -73,10 +73,9 @@ def _create_verbosity_kwargs(
 
     def set_level(ctx, param, value):
         if isinstance(value, str):
-            if value.lower().startswith("loglevel."):
-                value = value.split(".")[-1].strip()
-
             value = value.upper()
+            if value.startswith("LOGLEVEL."):
+                value = value.split(".")[-1].strip()
 
         cli_logger._load_from_sys_argv(default=value)
 

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -72,7 +72,15 @@ def _create_verbosity_kwargs(
     cli_logger = _logger or logger
 
     def set_level(ctx, param, value):
-        cli_logger._load_from_sys_argv(default=value.upper() if isinstance(value, str) else value)
+        if isinstance(value, str):
+            if "." in value:
+                # Handle "LogLevel" prefix that exists in some environments.
+                # TODO: Figure out why this happens (seen in github_action in a few projects).
+                value = value.split(".")[-1]
+
+            value = value.upper()
+
+        cli_logger._load_from_sys_argv(default=value)
 
     level_names = [lvl.name for lvl in LogLevel]
     names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -274,8 +274,11 @@ def _get_level(level: Optional[Union[str, int, LogLevel]] = None) -> str:
         return DEFAULT_LOG_LEVEL
     elif isinstance(level, LogLevel):
         return level.name
-    elif isinstance(level, int) or level.isnumeric():
+    elif isinstance(level, int) or (isinstance(level, str) and level.isnumeric()):
         return LogLevel(int(level)).name
+    elif isinstance(level, str) and level.lower().startswith("loglevel."):
+        # Handle 'LogLevel.' prefix.
+        return level.split(".")[-1].strip()
 
     return level
 

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -175,9 +175,11 @@ class ApeLogger:
         """
         if level == self._logger.level:
             return
-
         elif isinstance(level, LogLevel):
             level = level.value
+        elif isinstance(level, str) and level.lower().startswith("loglevel."):
+            # Seen in some environments.
+            level = level.split(".")[-1].strip()
 
         self._logger.setLevel(level)
         for _logger in self._extra_loggers.values():

--- a/src/ape_test/_cli.py
+++ b/src/ape_test/_cli.py
@@ -80,6 +80,8 @@ def _run_main_loop(delay: float, pytest_args: Sequence[str]) -> None:
     short_help="Launches pytest and runs the tests for a project",
     context_settings=dict(ignore_unknown_options=True),
 )
+# NOTE: 'default_log_level=LogLevel.WARNING' fails in some situations, and we don't know why.
+#  Thus, we use 'default_log_level=LogLevel.WARNING.value' to be safer.
 @ape_cli_context(default_log_level=LogLevel.WARNING.value)
 @click.option(
     "-w",

--- a/src/ape_test/_cli.py
+++ b/src/ape_test/_cli.py
@@ -80,8 +80,9 @@ def _run_main_loop(delay: float, pytest_args: Sequence[str]) -> None:
     short_help="Launches pytest and runs the tests for a project",
     context_settings=dict(ignore_unknown_options=True),
 )
-# NOTE: 'default_log_level=LogLevel.WARNING' fails in some situations, and we don't know why.
-#  Thus, we use 'default_log_level=LogLevel.WARNING.value' to be safer.
+# NOTE: 'default_log_level=LogLevel.WARNING' in some environments turns to
+#   `"LogLevel.WARNING"` and we don't know why. Thus, we use `.value`.
+# TODO: Figure out why that happens ^.
 @ape_cli_context(default_log_level=LogLevel.WARNING.value)
 @click.option(
     "-w",

--- a/src/ape_test/_cli.py
+++ b/src/ape_test/_cli.py
@@ -12,7 +12,7 @@ from watchdog import events
 from watchdog.observers import Observer
 
 from ape.cli import ape_cli_context
-from ape.logging import LogLevel
+from ape.logging import LogLevel, _get_level
 from ape.utils import ManagerAccessMixin, cached_property
 
 # Copied from https://github.com/olzhasar/pytest-watcher/blob/master/pytest_watcher/watcher.py
@@ -75,14 +75,37 @@ def _run_main_loop(delay: float, pytest_args: Sequence[str]) -> None:
     time.sleep(delay)
 
 
+def _validate_pytest_args(*pytest_args) -> list[str]:
+    threshold = len(pytest_args) - 1
+    args_iter = iter(pytest_args)
+    valid_args = []
+    for idx, argument in enumerate(args_iter):
+        if idx >= threshold:
+            # If the last arg is -v without a value, it is a valid
+            # pytest arg.
+            valid_args.append(argument)
+            break
+
+        elif argument == "-v":
+            # Ensure this is a pytest -v and not ape's -v.
+            next_arg = next(args_iter)
+            lvl_name = _get_level(next_arg)
+            if lvl_name in [x.name for x in LogLevel]:
+                # Ape log level found, cannot use.
+                continue
+
+        else:
+            valid_args.append(argument)
+
+    return valid_args
+
+
 @click.command(
     add_help_option=False,  # NOTE: This allows pass-through to pytest's help
     short_help="Launches pytest and runs the tests for a project",
     context_settings=dict(ignore_unknown_options=True),
 )
-# NOTE: 'default_log_level=LogLevel.WARNING' in some environments turns to
-#   `"LogLevel.WARNING"` and we don't know why. Thus, we use `.value`.
-# TODO: Figure out why that happens ^.
+# NOTE: Using '.value' because more performant.
 @ape_cli_context(default_log_level=LogLevel.WARNING.value)
 @click.option(
     "-w",
@@ -122,6 +145,7 @@ def cli(cli_ctx, watch, watch_folders, watch_delay, pytest_args):
                 cli_ctx.logger.warning(f"Folder '{folder}' doesn't exist or isn't a folder.")
 
         observer.start()
+        pytest_args = _validate_pytest_args(pytest_args)
 
         try:
             _run_ape_test(pytest_args)

--- a/src/ape_test/_cli.py
+++ b/src/ape_test/_cli.py
@@ -80,7 +80,7 @@ def _run_main_loop(delay: float, pytest_args: Sequence[str]) -> None:
     short_help="Launches pytest and runs the tests for a project",
     context_settings=dict(ignore_unknown_options=True),
 )
-@ape_cli_context(default_log_level=LogLevel.WARNING)
+@ape_cli_context(default_log_level=LogLevel.WARNING.value)
 @click.option(
     "-w",
     "--watch",

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -434,7 +434,7 @@ def test_verbosity_option(runner):
     def cmd():
         click.echo(f"__expected_{logger.level}")
 
-    result = runner.invoke(cmd, ["--verbosity", logger.level])
+    result = runner.invoke(cmd, ("--verbosity", logger.level))
     assert f"__expected_{logger.level}" in result.output
 
 

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -438,7 +438,9 @@ def test_verbosity_option(runner):
     assert f"__expected_{logger.level}" in result.output
 
 
-@pytest.mark.parametrize("level", (LogLevel.WARNING, LogLevel.WARNING.name, LogLevel.WARNING.value))
+@pytest.mark.parametrize(
+    "level", (LogLevel.WARNING, LogLevel.WARNING.name, LogLevel.WARNING.value, "LogLevel.WARNING")
+)
 def test_verbosity_option_change_default(runner, level):
     @click.command()
     @verbosity_option(default=level)

--- a/tests/functional/test_logging.py
+++ b/tests/functional/test_logging.py
@@ -101,7 +101,9 @@ def test_format(simple_runner):
     assert "SUCCESS" not in result.output
 
 
-@pytest.mark.parametrize("level", (LogLevel.INFO, LogLevel.INFO.value, LogLevel.INFO.name))
+@pytest.mark.parametrize(
+    "level", (LogLevel.INFO, LogLevel.INFO.value, LogLevel.INFO.name, "LogLevel.INFO")
+)
 def test_set_level(level):
     logger.set_level(level)
     assert logger.level == LogLevel.INFO.value


### PR DESCRIPTION
### What I did

Fix the bug in 3 spots because am mad:

* Handle stringified `LogLevel` values with LogLevel prefix everywhere
* Use `.value` in `ape test` because is more performant and makes more sense and you don't run into weird issues in some CI/CD environments.
* Validate pytest args by excluding Ape's usage of `-v` (in case it is ending up in there)

### How to verify it

https://github.com/ApeWorX/ApePay/pull/99

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
