### PR TITLE
feat: support `request_header` driven from configs

### DIFF
--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -184,7 +184,7 @@ ape plugins install .
 For Ape's HTTP usage, such as requests made via `web3.py`, optionally specify extra request headers.
 
 ```yaml
-request_header:
+request_headers:
   # NOTE: Only using Content-Type as an example; can be any header key/value.
   Content-Type: application/json
 ```
@@ -209,6 +209,8 @@ node:
   request_headers:
     Content-Type: application/json
 ```
+
+To learn more about how request headers work in Ape, see [this section of the Networking guide](./networks.html#request-headers).
 
 ## Testing
 

--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -179,6 +179,16 @@ Install these plugins by running command:
 ape plugins install .
 ```
 
+## Request Headers
+
+For Ape's HTTP usage, such as requests made via `web3.py`, optionally specify extra request headers.
+
+```yaml
+request_header:
+  # NOTE: Only using Content-Type as an example; can be any header key/value.
+  Content-Type: application/json
+```
+
 ## Testing
 
 Configure your test accounts:

--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -189,6 +189,27 @@ request_header:
   Content-Type: application/json
 ```
 
+You can also specify request headers at the ecosystem, network, and provider levels:
+
+```yaml
+# NOTE: All the headers are the same only for demo purposes.
+# You can use headers you want for any of these config locations.
+ethereum:
+  # Apply to all requests made to ethereum networks.
+  request_headers:
+    Content-Type: application/json
+  
+  mainnet:
+    # Apply to all requests made to ethereum:mainnet (using any provider)
+    request_headers:
+      Content-Type: application/json
+  
+node:
+  # Apply to any request using the `node` provider.
+  request_headers:
+    Content-Type: application/json
+```
+
 ## Testing
 
 Configure your test accounts:

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -344,26 +344,26 @@ For the local network configuration, the default is `"max"`. Otherwise, it is `"
 
 There are several layers of request-header configuration.
 Use the top-level request header config to configure headers for every request.
-Also, EVM-based and custom-ecosystems offer their own `request_header:` config that gets used whenever using that ecosystem (regardless of network or provider).
-Then, each network, plugin or otherwise, has its own `request_header:` config that gets used when using this network (regardless of provider).
-Finally, providers (such as the default `node` provider) typically offer a `request_header:` config that gets used whenever using this provider (regardless of what network you are connecting to).
+Also, EVM-based and custom-ecosystems offer their own `request_headers:` config that gets used whenever using that ecosystem (regardless of network or provider).
+Then, each network, plugin or otherwise, has its own `request_headers:` config that gets used when using this network (regardless of provider).
+Finally, providers (such as the default `node` provider) typically offer a `request_headers:` config that gets used whenever using this provider (regardless of what network you are connecting to).
 
 Here is an example using each layer:
 
 ```yaml
-request_header:
+request_headers:
   Top-Level: "UseThisOnEveryRequest"
 
 ethereum:
-  request_header:
+  request_headers:
     Ecosystem-Level: "UseThisOnEveryEthereumRequest"
   
   mainnet:
-    request_header:
+    request_headers:
       Network-Level: "UseThisOnAllRequestsToEthereumMainnet"
 
 node:
-  request_header:
+  request_headers:
     Provider-Level: "UseThisOnAllRequestsUsingNodeProvider"
 ```
 

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -340,6 +340,30 @@ You may use one of:
 
 For the local network configuration, the default is `"max"`. Otherwise, it is `"auto"`.
 
+## Request Headers
+
+There are several layers of request-header configuration.
+Use the top-level request header config to configure headers for every request.
+Also, EVM-based and custom-ecosystems offer their own `request_header:` config that gets used whenever using that ecosystem for any network or provider.
+Then, each network, plugin or otherwise, also has its own `request_header:` config that gets used when using this network, regardless of provider.
+Finally, providers (such as the default `node` provider) typically offer `request_header:` config that gets used whenever using this provider regardless of what network you are connecting to.
+
+Here is an example using each layer:
+
+```yaml
+request_header:
+  Top-Level: "UseThisOnEveryRequest"
+
+ethereum:
+  request_header: "UseThisOnEveryEthereumRequest"
+  
+  mainnet:
+    request_header: "UseThisOnAllRequestsToEthereumMainnet"
+
+node:
+  request_header: "UseThisOnAllRequestsUsingNodeProvider"
+```
+
 ## Local Network
 
 The default network in Ape is the local network (keyword `"local"`).

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -343,10 +343,17 @@ For the local network configuration, the default is `"max"`. Otherwise, it is `"
 ## Request Headers
 
 There are several layers of request-header configuration.
-Use the top-level request header config to configure headers for every request.
-Also, EVM-based and custom-ecosystems offer their own `request_headers:` config that gets used whenever using that ecosystem (regardless of network or provider).
-Then, each network, plugin or otherwise, has its own `request_headers:` config that gets used when using this network (regardless of provider).
-Finally, providers (such as the default `node` provider) typically offer a `request_headers:` config that gets used whenever using this provider (regardless of what network you are connecting to).
+They get merged into each-other in this order, with the exception being `User-Agent`, which has an append-behavior.
+
+- Default Ape headers (includes `User-Agent`)
+- Top-level configuration for headers (using `request_headers:` key)
+- Per-ecosystem configuration
+- Per-network configuration
+- Per-provider configuration
+
+Use the top-level `request_headers:` config to specify headers for every request.
+Use ecosystem-level specification for only requests made when connected to that ecosystem.
+Network and provider configurations work similarly; they are only used when connecting to that network or provider.
 
 Here is an example using each layer:
 
@@ -366,6 +373,9 @@ node:
   request_headers:
     Provider-Level: "UseThisOnAllRequestsUsingNodeProvider"
 ```
+
+When using `User-Agent`, it will not override Ape's default `User-Agent` nor will each layer override each-other's.
+Instead, they are carefully appended to each other, allowing you to have a very customizable `User-Agent`.
 
 ## Local Network
 

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -344,9 +344,9 @@ For the local network configuration, the default is `"max"`. Otherwise, it is `"
 
 There are several layers of request-header configuration.
 Use the top-level request header config to configure headers for every request.
-Also, EVM-based and custom-ecosystems offer their own `request_header:` config that gets used whenever using that ecosystem for any network or provider.
-Then, each network, plugin or otherwise, also has its own `request_header:` config that gets used when using this network, regardless of provider.
-Finally, providers (such as the default `node` provider) typically offer `request_header:` config that gets used whenever using this provider regardless of what network you are connecting to.
+Also, EVM-based and custom-ecosystems offer their own `request_header:` config that gets used whenever using that ecosystem (regardless of network or provider).
+Then, each network, plugin or otherwise, has its own `request_header:` config that gets used when using this network (regardless of provider).
+Finally, providers (such as the default `node` provider) typically offer a `request_header:` config that gets used whenever using this provider (regardless of what network you are connecting to).
 
 Here is an example using each layer:
 
@@ -355,13 +355,16 @@ request_header:
   Top-Level: "UseThisOnEveryRequest"
 
 ethereum:
-  request_header: "UseThisOnEveryEthereumRequest"
+  request_header:
+    Ecosystem-Level: "UseThisOnEveryEthereumRequest"
   
   mainnet:
-    request_header: "UseThisOnAllRequestsToEthereumMainnet"
+    request_header:
+      Network-Level: "UseThisOnAllRequestsToEthereumMainnet"
 
 node:
-  request_header: "UseThisOnAllRequestsUsingNodeProvider"
+  request_header:
+    Provider-Level: "UseThisOnAllRequestsUsingNodeProvider"
 ```
 
 ## Local Network

--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -333,6 +333,11 @@ class ApeConfig(ExtraAttributesMixin, BaseSettings, ManagerAccessMixin):
     The name of the project.
     """
 
+    request_header: dict = {}
+    """
+    Extra request headers for all HTTP requests.
+    """
+
     version: str = ""
     """
     The version of the project.

--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -333,7 +333,7 @@ class ApeConfig(ExtraAttributesMixin, BaseSettings, ManagerAccessMixin):
     The name of the project.
     """
 
-    request_header: dict = {}
+    request_headers: dict = {}
     """
     Extra request headers for all HTTP requests.
     """

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -13,6 +13,7 @@ from eth_pydantic_types import HexBytes
 from eth_utils import keccak, to_int
 from ethpm_types import BaseModel, ContractType
 from ethpm_types.abi import ABIType, ConstructorABI, EventABI, MethodABI
+from pydantic import model_validator
 
 from ape.exceptions import (
     CustomError,
@@ -82,6 +83,14 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
 
     _default_network: Optional[str] = None
     """The default network of the ecosystem, such as ``local``."""
+
+    @model_validator(mode="after")
+    @classmethod
+    def _validate_ecosystem(cls, model):
+        headers = RPCHeaders(**model.request_header)
+        headers["User-Agent"] = f"ape-{model.name}"
+        model.request_header = dict(**headers)
+        return model
 
     @log_instead_of_fail(default="<EcosystemAPI>")
     def __repr__(self) -> str:

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -68,6 +68,8 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
     The name of the ecosystem. This should be set the same name as the plugin.
     """
 
+    # TODO: In 0.9, make @property that returns value from config,
+    #   and use REQUEST_HEADER as plugin-defined constants.
     request_header: dict
     """A shareable HTTP header for network requests."""
 
@@ -647,6 +649,13 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
             Optional[CustomError]: If it able to decode one, else ``None``.
         """
 
+    def _get_request_header(self) -> dict:
+        # Internal helper method called by NetworkManager
+        return {
+            **self.request_header,
+            **self.config.get("request_header", {}),
+        }
+
 
 class ProviderContextManager(ManagerAccessMixin):
     """
@@ -809,6 +818,8 @@ class NetworkAPI(BaseInterfaceModel):
     ecosystem: EcosystemAPI
     """The ecosystem of the network."""
 
+    # TODO: In 0.9, make @property that returns value from config,
+    #   and use REQUEST_HEADER as plugin-defined constants.
     request_header: dict
     """A shareable network HTTP header."""
 
@@ -1284,6 +1295,13 @@ class NetworkAPI(BaseInterfaceModel):
         """
         if self.name not in ("custom", LOCAL_NETWORK_NAME) and self.chain_id != chain_id:
             raise NetworkMismatchError(chain_id, self)
+
+    def _get_request_header(self) -> dict:
+        # Internal helper method called by NetworkManager
+        return {
+            **self.request_header,
+            **self.config.get("request_header", {}),
+        }
 
 
 class ForkedNetworkAPI(NetworkAPI):

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -71,7 +71,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
 
     # TODO: In 0.9, make @property that returns value from config,
     #   and use REQUEST_HEADER as plugin-defined constants.
-    request_header: dict
+    request_header: dict = {}
     """A shareable HTTP header for network requests."""
 
     fee_token_symbol: str
@@ -292,9 +292,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
     @cached_property
     def _networks_from_plugins(self) -> dict[str, "NetworkAPI"]:
         return {
-            network_name: network_class(
-                name=network_name, ecosystem=self, request_header=self.request_header
-            )
+            network_name: network_class(name=network_name, ecosystem=self)
             for _, (ecosystem_name, network_name, network_class) in self.plugin_manager.networks
             if ecosystem_name == self.name
         }
@@ -824,7 +822,7 @@ class NetworkAPI(BaseInterfaceModel):
 
     # TODO: In 0.9, make @property that returns value from config,
     #   and use REQUEST_HEADER as plugin-defined constants.
-    request_header: dict
+    request_header: dict = {}
     """A shareable network HTTP header."""
 
     # See ``.default_provider`` which is the proper field.
@@ -1058,7 +1056,6 @@ class NetworkAPI(BaseInterfaceModel):
                     provider_class,
                     name=provider_name,
                     network=self,
-                    request_header=self.request_header,
                 )
 
         return providers

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -652,10 +652,13 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
 
     def _get_request_headers(self) -> RPCHeaders:
         # Internal helper method called by NetworkManager
-        return RPCHeaders(
-            **self.request_header,
-            **self.config.get("request_headers", {}),
-        )
+        headers = RPCHeaders(**self.request_header)
+        # Have to do it this way to avoid "multiple-keys" error.
+        configured_headers: dict = self.config.get("request_headers", {})
+        for key, value in configured_headers.items():
+            headers[key] = value
+
+        return headers
 
 
 class ProviderContextManager(ManagerAccessMixin):
@@ -1299,10 +1302,13 @@ class NetworkAPI(BaseInterfaceModel):
 
     def _get_request_headers(self) -> RPCHeaders:
         # Internal helper method called by NetworkManager
-        return RPCHeaders(
-            **self.request_header,
-            **self.config.get("request_headers", {}),
-        )
+        headers = RPCHeaders(**self.request_header)
+        # Have to do it this way to avoid multiple-keys error.
+        configured_headers: dict = self.config.get("request_headers", {})
+        for key, value in configured_headers.items():
+            headers[key] = value
+
+        return headers
 
 
 class ForkedNetworkAPI(NetworkAPI):

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -31,6 +31,7 @@ from ape.utils import (
     ExtraAttributesMixin,
     ExtraModelAttributes,
     ManagerAccessMixin,
+    RPCHeaders,
     abstractmethod,
     cached_property,
     log_instead_of_fail,
@@ -649,12 +650,12 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
             Optional[CustomError]: If it able to decode one, else ``None``.
         """
 
-    def _get_request_header(self) -> dict:
+    def _get_request_headers(self) -> RPCHeaders:
         # Internal helper method called by NetworkManager
-        return {
+        return RPCHeaders(
             **self.request_header,
-            **self.config.get("request_header", {}),
-        }
+            **self.config.get("request_headers", {}),
+        )
 
 
 class ProviderContextManager(ManagerAccessMixin):
@@ -1296,12 +1297,12 @@ class NetworkAPI(BaseInterfaceModel):
         if self.name not in ("custom", LOCAL_NETWORK_NAME) and self.chain_id != chain_id:
             raise NetworkMismatchError(chain_id, self)
 
-    def _get_request_header(self) -> dict:
+    def _get_request_headers(self) -> RPCHeaders:
         # Internal helper method called by NetworkManager
-        return {
+        return RPCHeaders(
             **self.request_header,
-            **self.config.get("request_header", {}),
-        }
+            **self.config.get("request_headers", {}),
+        )
 
 
 class ForkedNetworkAPI(NetworkAPI):

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -177,6 +177,8 @@ class ProviderAPI(BaseInterfaceModel):
     provider_settings: dict = {}
     """The settings for the provider, as overrides to the configuration."""
 
+    # TODO: In 0.9, make @property that returns value from config,
+    #   and use REQUEST_HEADER as plugin-defined constants.
     request_header: dict
     """A header to set on HTTP/RPC requests."""
 
@@ -844,6 +846,13 @@ class ProviderAPI(BaseInterfaceModel):
                went wrong in the call.
         """
         return VirtualMachineError(base_err=exception, **kwargs)
+
+    def _get_request_header(self) -> dict:
+        # Internal helper method called by NetworkManager
+        return {
+            **self.request_header,
+            **self.config.get("request_header", {}),
+        }
 
 
 class TestProviderAPI(ProviderAPI):

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -850,10 +850,13 @@ class ProviderAPI(BaseInterfaceModel):
 
     def _get_request_headers(self) -> RPCHeaders:
         # Internal helper method called by NetworkManager
-        return RPCHeaders(
-            **self.request_header,
-            **self.config.get("request_headers", {}),
-        )
+        headers = RPCHeaders(**self.request_header)
+        # Have to do it this way to avoid "multiple-keys" error.
+        configured_headers: dict = self.config.get("request_headers", {})
+        for key, value in configured_headers.items():
+            headers[key] = value
+
+        return headers
 
 
 class TestProviderAPI(ProviderAPI):

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -41,6 +41,7 @@ from ape.utils.misc import (
     log_instead_of_fail,
     raises_not_implemented,
 )
+from ape.utils.rpc import RPCHeaders
 
 if TYPE_CHECKING:
     from ape.api.accounts import TestAccountAPI
@@ -847,12 +848,12 @@ class ProviderAPI(BaseInterfaceModel):
         """
         return VirtualMachineError(base_err=exception, **kwargs)
 
-    def _get_request_header(self) -> dict:
+    def _get_request_headers(self) -> RPCHeaders:
         # Internal helper method called by NetworkManager
-        return {
+        return RPCHeaders(
             **self.request_header,
-            **self.config.get("request_header", {}),
-        }
+            **self.config.get("request_headers", {}),
+        )
 
 
 class TestProviderAPI(ProviderAPI):

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -180,7 +180,7 @@ class ProviderAPI(BaseInterfaceModel):
 
     # TODO: In 0.9, make @property that returns value from config,
     #   and use REQUEST_HEADER as plugin-defined constants.
-    request_header: dict
+    request_header: dict = {}
     """A header to set on HTTP/RPC requests."""
 
     block_page_size: int = 100

--- a/src/ape/managers/__init__.py
+++ b/src/ape/managers/__init__.py
@@ -14,7 +14,7 @@ from .query import QueryManager
 
 ManagerAccessMixin.plugin_manager = PluginManager()
 ManagerAccessMixin.config_manager = ConfigManager(
-    request_header={"User-Agent": USER_AGENT},
+    request_header={"User-Agent": USER_AGENT, "Content-Type": "application/json"},
 )
 ManagerAccessMixin.compiler_manager = CompilerManager()
 ManagerAccessMixin.network_manager = NetworkManager()

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -17,6 +17,7 @@ from ape.utils.basemodel import (
     get_item_with_extras,
     only_raise_attribute_error,
 )
+from ape.utils.rpc import RPCHeaders
 
 CONFIG_FILE_NAME = "ape-config.yaml"
 
@@ -124,6 +125,9 @@ class ConfigManager(ExtraAttributesMixin, BaseManager):
 
             finally:
                 self.DATA_FOLDER = original_data_folder
+
+    def _get_request_headers(self) -> RPCHeaders:
+        return RPCHeaders(**self.REQUEST_HEADER, **self.request_headers)
 
 
 def merge_configs(*cfgs: dict) -> dict:

--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -127,7 +127,12 @@ class ConfigManager(ExtraAttributesMixin, BaseManager):
                 self.DATA_FOLDER = original_data_folder
 
     def _get_request_headers(self) -> RPCHeaders:
-        return RPCHeaders(**self.REQUEST_HEADER, **self.request_headers)
+        # Avoid multiple keys error by not initializing with both dicts.
+        headers = RPCHeaders(**self.REQUEST_HEADER)
+        for key, value in self.request_headers.items():
+            headers[key] = value
+
+        return headers
 
 
 def merge_configs(*cfgs: dict) -> dict:

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -6,6 +6,7 @@ from ape.api import EcosystemAPI, ProviderAPI, ProviderContextManager
 from ape.api.networks import NetworkAPI
 from ape.exceptions import EcosystemNotFoundError, NetworkError, NetworkNotFoundError
 from ape.managers.base import BaseManager
+from ape.utils import RPCHeaders
 from ape.utils.basemodel import (
     ExtraAttributesMixin,
     ExtraModelAttributes,
@@ -85,22 +86,21 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         """
         return self.network.ecosystem
 
-    def get_request_header(
+    def get_request_headers(
         self, ecosystem_name: str, network_name: str, provider_name: str
-    ) -> dict:
+    ) -> RPCHeaders:
         """
         All request headers to be used when connecting to this network.
         """
         ecosystem = self.get_ecosystem(ecosystem_name)
         network = ecosystem.get_network(network_name)
         provider = network.get_provider(provider_name)
-        return {
-            **self.config_manager.REQUEST_HEADER,
-            **self.config_manager.request_header,
-            **ecosystem._get_request_header(),
-            **network._get_request_header(),
-            **provider._get_request_header(),
-        }
+        headers = self.config_manager._get_request_headers()
+        for obj in (ecosystem, network, provider):
+            for key, value in obj._get_request_headers().items():
+                headers[key] = value
+
+        return headers
 
     def fork(
         self,

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -85,6 +85,23 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         """
         return self.network.ecosystem
 
+    def get_request_header(
+        self, ecosystem_name: str, network_name: str, provider_name: str
+    ) -> dict:
+        """
+        All request headers to be used when connecting to this network.
+        """
+        ecosystem = self.get_ecosystem(ecosystem_name)
+        network = ecosystem.get_network(network_name)
+        provider = network.get_provider(provider_name)
+        return {
+            **self.config_manager.REQUEST_HEADER,
+            **self.config_manager.request_header,
+            **ecosystem._get_request_header(),
+            **network._get_request_header(),
+            **provider._get_request_header(),
+        }
+
     def fork(
         self,
         provider_name: Optional[str] = None,

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -242,12 +242,9 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
 
     @cached_property
     def _plugin_ecosystems(self) -> dict[str, EcosystemAPI]:
-        def to_kwargs(name: str) -> dict:
-            return {"name": name, "request_header": self.config_manager.REQUEST_HEADER}
-
         # Load plugins.
         plugins = self.plugin_manager.ecosystems
-        return {n: cls(**to_kwargs(n)) for n, cls in plugins}  # type: ignore[operator]
+        return {n: cls(name=n) for n, cls in plugins}  # type: ignore[operator]
 
     def create_custom_provider(
         self,
@@ -304,7 +301,6 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
             network=network,
             provider_settings=provider_settings,
             data_folder=self.ethereum.data_folder / name,
-            request_header=network.request_header,
         )
 
     def __iter__(self) -> Iterator[str]:

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -16,7 +16,7 @@ from ape.managers.project import ProjectManager
 from ape.pytest.config import ConfigWrapper
 from ape.types import SnapshotID
 from ape.utils.basemodel import ManagerAccessMixin
-from ape.utils.misc import allow_disconnected
+from ape.utils.rpc import allow_disconnected
 
 
 class PytestApeFixtures(ManagerAccessMixin):

--- a/src/ape/utils/__init__.py
+++ b/src/ape/utils/__init__.py
@@ -25,10 +25,8 @@ from ape.utils.misc import (
     DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT,
     EMPTY_BYTES32,
     SOURCE_EXCLUDE_PATTERNS,
-    USER_AGENT,
     ZERO_ADDRESS,
     add_padding_to_strings,
-    allow_disconnected,
     as_our_module,
     cached_property,
     extract_nested_value,
@@ -44,7 +42,6 @@ from ape.utils.misc import (
     raises_not_implemented,
     run_until_complete,
     singledispatchmethod,
-    stream_response,
     to_int,
 )
 from ape.utils.os import (
@@ -61,6 +58,7 @@ from ape.utils.os import (
     use_temp_sys_path,
 )
 from ape.utils.process import JoinableQueue, spawn
+from ape.utils.rpc import USER_AGENT, RPCHeaders, allow_disconnected, stream_response
 from ape.utils.testing import (
     DEFAULT_NUMBER_OF_TEST_ACCOUNTS,
     DEFAULT_TEST_ACCOUNT_BALANCE,
@@ -125,6 +123,7 @@ __all__ = [
     "path_match",
     "raises_not_implemented",
     "returns_array",
+    "RPCHeaders",
     "run_in_tempdir",
     "run_until_complete",
     "singledispatchmethod",

--- a/src/ape/utils/_github.py
+++ b/src/ape/utils/_github.py
@@ -14,7 +14,8 @@ from urllib3.util.retry import Retry
 
 from ape.exceptions import CompilerError, ProjectError, UnknownVersionError
 from ape.logging import logger
-from ape.utils.misc import USER_AGENT, cached_property, stream_response
+from ape.utils.misc import cached_property
+from ape.utils.rpc import USER_AGENT, stream_response
 
 
 class GitProcessWrapper:

--- a/src/ape/utils/rpc.py
+++ b/src/ape/utils/rpc.py
@@ -78,8 +78,14 @@ class RPCHeaders(CaseInsensitiveDict):
 
         # Handle appending the user-agent (without replacing).
         existing_user_agent = self.__getitem__("user-agent")
-        if value in existing_user_agent:
-            # Already added.
-            return
+        parts = [a.strip() for a in value.split(" ")]
+        new_parts = []
+        for part in parts:
+            if part in existing_user_agent:
+                # Already added.
+                continue
+            else:
+                new_parts.append(part)
 
-        super().__setitem__(key, f"{existing_user_agent} {value}")
+        if new_user_agent := " ".join(new_parts):
+            super().__setitem__(key, f"{existing_user_agent} {new_user_agent}")

--- a/src/ape/utils/rpc.py
+++ b/src/ape/utils/rpc.py
@@ -1,0 +1,85 @@
+from collections.abc import Callable
+
+import requests
+from requests.models import CaseInsensitiveDict
+from tqdm import tqdm  # type: ignore
+
+from ape.exceptions import ProviderNotConnectedError
+from ape.logging import logger
+from ape.utils.misc import __version__, _python_version
+
+USER_AGENT = f"Ape/{__version__} (Python/{_python_version})"
+
+
+def allow_disconnected(fn: Callable):
+    """
+    A decorator that instead of raising :class:`~ape.exceptions.ProviderNotConnectedError`
+    warns and returns ``None``.
+
+    Usage example::
+
+        from typing import Optional
+        from ape.types import SnapshotID
+        from ape.utils import return_none_when_disconnected
+
+        @allow_disconnected
+        def try_snapshot(self) -> Optional[SnapshotID]:
+            return self.chain.snapshot()
+
+    """
+
+    def inner(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except ProviderNotConnectedError:
+            logger.warning("Provider is not connected.")
+            return None
+
+    return inner
+
+
+def stream_response(download_url: str, progress_bar_description: str = "Downloading") -> bytes:
+    """
+    Download HTTP content by streaming and returning the bytes.
+    Progress bar will be displayed in the CLI.
+
+    Args:
+        download_url (str): String to get files to download.
+        progress_bar_description (str): Downloading word.
+
+    Returns:
+        bytes: Content in bytes to show the progress.
+    """
+    response = requests.get(download_url, stream=True)
+    response.raise_for_status()
+
+    total_size = int(response.headers.get("content-length", 0))
+    progress_bar = tqdm(total=total_size, unit="iB", unit_scale=True, leave=False)
+    progress_bar.set_description(progress_bar_description)
+    content = b""
+    for data in response.iter_content(1024, decode_unicode=True):
+        progress_bar.update(len(data))
+        content += data
+
+    progress_bar.close()
+    return content
+
+
+class RPCHeaders(CaseInsensitiveDict):
+    """
+    A dict-like data-structure for HTTP-headers.
+    It is case-insensitive and appends user-agent strings
+    rather than overrides.
+    """
+
+    def __setitem__(self, key, value):
+        if key.lower() != "user-agent" or not self.__contains__("user-agent"):
+            return super().__setitem__(key, value)
+
+        # Handle appending the user-agent (without replacing).
+        existing_user_agent = self.__getitem__("user-agent")
+        if value in existing_user_agent:
+            # Already added.
+            return
+
+        super().__setitem__(key, f"{existing_user_agent} {value}")

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -384,9 +384,6 @@ class Ethereum(EcosystemAPI):
 
     fee_token_symbol: str = "ETH"
 
-    # NOTE: This gets appended to Ape's root User-Agent string.
-    request_header: dict = {"User-Agent": "ape-ethereum"}
-
     @property
     def config(self) -> EthereumConfig:
         return cast(EthereumConfig, super().config)

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -224,7 +224,7 @@ class BaseEthereumConfig(PluginConfig):
     _custom_networks: dict[str, NetworkConfig] = {}
 
     # NOTE: This gets appended to Ape's root User-Agent string.
-    request_headers: dict = {"User-Agent": "ape-ethereum"}
+    request_headers: dict = {}
 
     model_config = SettingsConfigDict(extra="allow")
 
@@ -383,6 +383,9 @@ class Ethereum(EcosystemAPI):
     #   if the chain doesn't support EIP-1559.
 
     fee_token_symbol: str = "ETH"
+
+    # NOTE: This gets appended to Ape's root User-Agent string.
+    request_header: dict = {"User-Agent": "ape-ethereum"}
 
     @property
     def config(self) -> EthereumConfig:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -147,7 +147,7 @@ class NetworkConfig(PluginConfig):
     base_fee_multiplier: float = 1.0
     """A multiplier to apply to a transaction base fee."""
 
-    request_header: dict = {}
+    request_headers: dict = {}
     """Optionally config extra request headers whenever using this network."""
 
     @field_validator("gas_limit", mode="before")
@@ -222,7 +222,7 @@ class BaseEthereumConfig(PluginConfig):
     default_network: str = LOCAL_NETWORK_NAME
     _forked_configs: dict[str, ForkedNetworkConfig] = {}
     _custom_networks: dict[str, NetworkConfig] = {}
-    request_header: dict = {}
+    request_headers: dict = {}
 
     model_config = SettingsConfigDict(extra="allow")
 
@@ -251,7 +251,7 @@ class BaseEthereumConfig(PluginConfig):
                 key != LOCAL_NETWORK_NAME
                 and key not in cls.NETWORKS
                 and isinstance(obj, dict)
-                and key not in ("request_header",)
+                and key not in ("request_headers",)
             ):
                 # Custom network.
                 default_network_model = create_network_config(

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -222,7 +222,9 @@ class BaseEthereumConfig(PluginConfig):
     default_network: str = LOCAL_NETWORK_NAME
     _forked_configs: dict[str, ForkedNetworkConfig] = {}
     _custom_networks: dict[str, NetworkConfig] = {}
-    request_headers: dict = {}
+
+    # NOTE: This gets appended to Ape's root User-Agent string.
+    request_headers: dict = {"User-Agent": "ape-ethereum"}
 
     model_config = SettingsConfigDict(extra="allow")
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -147,6 +147,9 @@ class NetworkConfig(PluginConfig):
     base_fee_multiplier: float = 1.0
     """A multiplier to apply to a transaction base fee."""
 
+    request_header: dict = {}
+    """Optionally config extra request headers whenever using this network."""
+
     @field_validator("gas_limit", mode="before")
     @classmethod
     def validate_gas_limit(cls, value):
@@ -219,6 +222,7 @@ class BaseEthereumConfig(PluginConfig):
     default_network: str = LOCAL_NETWORK_NAME
     _forked_configs: dict[str, ForkedNetworkConfig] = {}
     _custom_networks: dict[str, NetworkConfig] = {}
+    request_header: dict = {}
 
     model_config = SettingsConfigDict(extra="allow")
 
@@ -243,7 +247,12 @@ class BaseEthereumConfig(PluginConfig):
                 data = merge_configs(default_fork_model, obj)
                 cfg_forks[key] = ForkedNetworkConfig.model_validate(data)
 
-            elif key != LOCAL_NETWORK_NAME and key not in cls.NETWORKS and isinstance(obj, dict):
+            elif (
+                key != LOCAL_NETWORK_NAME
+                and key not in cls.NETWORKS
+                and isinstance(obj, dict)
+                and key not in ("request_header",)
+            ):
                 # Custom network.
                 default_network_model = create_network_config(
                     default_transaction_type=cls.DEFAULT_TRANSACTION_TYPE

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -22,6 +22,7 @@ from pydantic.dataclasses import dataclass
 from requests import HTTPError
 from web3 import HTTPProvider, IPCProvider, Web3
 from web3 import WebsocketProvider as WebSocketProvider
+from web3._utils.http import construct_user_agent
 from web3.exceptions import ContractLogicError as Web3ContractLogicError
 from web3.exceptions import (
     ExtraDataLengthError,
@@ -1296,6 +1297,11 @@ class EthereumNodeProvider(Web3Provider, ABC):
     concurrency: int = 16
 
     name: str = "node"
+
+    # NOTE: Appends user-agent to base User-Agent string.
+    request_header: dict = {
+        "User-Agent": construct_user_agent(str(HTTPProvider)),
+    }
 
     @property
     def uri(self) -> str:

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1444,8 +1444,14 @@ class EthereumNodeProvider(Web3Provider, ABC):
     def _set_web3(self):
         # Clear cached version when connecting to another URI.
         self._client_version = None
+        headers = self.network_manager.get_request_header(
+            self.network.ecosystem.name, self.network.name, self.name
+        )
         self._web3 = _create_web3(
-            http_uri=self.http_uri, ipc_path=self.ipc_path, ws_uri=self.ws_uri
+            http_uri=self.http_uri,
+            ipc_path=self.ipc_path,
+            ws_uri=self.ws_uri,
+            request_kwargs={"headers": headers},
         )
 
     def _complete_connect(self):
@@ -1544,7 +1550,10 @@ class EthereumNodeProvider(Web3Provider, ABC):
 
 
 def _create_web3(
-    http_uri: Optional[str] = None, ipc_path: Optional[Path] = None, ws_uri: Optional[str] = None
+    http_uri: Optional[str] = None,
+    ipc_path: Optional[Path] = None,
+    ws_uri: Optional[str] = None,
+    request_kwargs: Optional[dict] = None,
 ):
     # NOTE: This list is ordered by try-attempt.
     # Try ENV, then IPC, and then HTTP last.
@@ -1552,9 +1561,11 @@ def _create_web3(
     if ipc := ipc_path:
         providers.append(lambda: IPCProvider(ipc_path=ipc))
     if http := http_uri:
-        providers.append(
-            lambda: HTTPProvider(endpoint_uri=http, request_kwargs={"timeout": 30 * 60})
-        )
+        request_kwargs = request_kwargs or {}
+        if "timeout" not in request_kwargs:
+            request_kwargs["timeout"] = 30 * 60
+
+        providers.append(lambda: HTTPProvider(endpoint_uri=http, request_kwargs=request_kwargs))
     if ws := ws_uri:
         providers.append(lambda: WebSocketProvider(endpoint_uri=ws))
 

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1444,7 +1444,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
     def _set_web3(self):
         # Clear cached version when connecting to another URI.
         self._client_version = None
-        headers = self.network_manager.get_request_header(
+        headers = self.network_manager.get_request_headers(
             self.network.ecosystem.name, self.network.name, self.name
         )
         self._web3 = _create_web3(

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -361,7 +361,7 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
         # Include extra accounts to allocated funds to at genesis.
         extra_accounts = self.settings.ethereum.local.get("extra_funded_accounts", [])
         extra_accounts.extend(self.provider_settings.get("extra_funded_accounts", []))
-        extra_accounts = list({a.lower() for a in extra_accounts})
+        extra_accounts = list({a.lower() for a in extra_accounts if isinstance(a, str)})
         test_config["extra_funded_accounts"] = extra_accounts
         test_config["initial_balance"] = self.test_config.balance
 

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -262,6 +262,11 @@ class EthereumNodeConfig(PluginConfig):
     based on your node's client-version and available RPCs.
     """
 
+    request_headers: dict = {}
+    """
+    Optionally specify request headers to use whenever using this provider.
+    """
+
     model_config = SettingsConfigDict(extra="allow")
 
     @field_validator("call_trace_approach", mode="before")

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -366,7 +366,7 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
         # Include extra accounts to allocated funds to at genesis.
         extra_accounts = self.settings.ethereum.local.get("extra_funded_accounts", [])
         extra_accounts.extend(self.provider_settings.get("extra_funded_accounts", []))
-        extra_accounts = list({a.lower() for a in extra_accounts if isinstance(a, str)})
+        extra_accounts = list({a.lower() for a in extra_accounts})
         test_config["extra_funded_accounts"] = extra_accounts
         test_config["initial_balance"] = self.test_config.balance
 

--- a/tests/functional/geth/conftest.py
+++ b/tests/functional/geth/conftest.py
@@ -57,7 +57,6 @@ def mock_geth(geth_provider, mock_web3):
         network=geth_provider.network,
         provider_settings={},
         data_folder=Path("."),
-        request_header={},
     )
     original_web3 = provider._web3
     provider._web3 = mock_web3

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -247,14 +247,14 @@ def test_connect_using_only_ipc_for_uri(project, networks, geth_provider):
 def test_connect_request_headers(project, geth_provider, networks):
     http_provider = None
     config = {
-        "request_header": {"h0": 0},
+        "request_headers": {"h0": 0, "User-Agent": "myapp/2.0"},
         "ethereum": {
-            "request_header": {"h1": 1},
+            "request_headers": {"h1": 1, "User-Agent": "ETH/1.0"},
             "local": {
-                "request_header": {"h2": 2},
+                "request_headers": {"h2": 2, "user-agent": "MyPrivateNetwork/0.0.1"},
             },
         },
-        "node": {"request_header": {"h3": 3}},
+        "node": {"request_headers": {"h3": 3, "USER-AGENT": "custom-geth-client/v100"}},
     }
     with project.temp_config(**config):
         with networks.ethereum.local.use_provider("node") as geth:
@@ -284,6 +284,12 @@ def test_connect_request_headers(project, geth_provider, networks):
             # Also, assert Ape's default.
             assert actual["User-Agent"].startswith("Ape/")
             assert "Python" in actual["User-Agent"]
+            assert actual["Content-Type"] == "application/json"
+            # Show appended user-agents strings.
+            assert "myapp/2.0" in actual["User-Agent"]
+            assert "ETH/1.0" in actual["User-Agent"]
+            assert "MyPrivateNetwork/0.0.1" in actual["User-Agent"]
+            assert "custom-geth-client/v100" in actual["User-Agent"]
 
 
 @geth_process_test

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -111,7 +111,7 @@ def test_uri_non_dev_and_not_configured(mocker, ethereum):
     network.name = "gorillanet"
     network.ecosystem.name = "gorillas"
 
-    provider = Node.model_construct(network=network, request_header={})
+    provider = Node.model_construct(network=network)
 
     with pytest.raises(ProviderError):
         _ = provider.uri
@@ -285,6 +285,8 @@ def test_connect_request_headers(project, geth_provider, networks):
             # Also, assert Ape's default user-agent strings.
             assert actual["User-Agent"].startswith("Ape/")
             assert "Python" in actual["User-Agent"]
+            assert "ape-ethereum" in actual["User-Agent"]
+            assert "web3.py/" in actual["User-Agent"]
 
             # Show other default headers.
             assert actual["Content-Type"] == "application/json"

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -281,10 +281,14 @@ def test_connect_request_headers(project, geth_provider, networks):
             assert actual["h1"] == 1  # ecosystem
             assert actual["h2"] == 2  # network
             assert actual["h3"] == 3  # provider
-            # Also, assert Ape's default.
+
+            # Also, assert Ape's default user-agent strings.
             assert actual["User-Agent"].startswith("Ape/")
             assert "Python" in actual["User-Agent"]
+
+            # Show other default headers.
             assert actual["Content-Type"] == "application/json"
+
             # Show appended user-agents strings.
             assert "myapp/2.0" in actual["User-Agent"]
             assert "ETH/1.0" in actual["User-Agent"]

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -14,7 +14,7 @@ from ape.exceptions import CustomError, DecodingError, NetworkError, NetworkNotF
 from ape.types import AddressType, CurrencyValueComparable
 from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
 from ape_ethereum import TransactionTrace
-from ape_ethereum.ecosystem import BLUEPRINT_HEADER, BaseEthereumConfig, Block
+from ape_ethereum.ecosystem import BLUEPRINT_HEADER, BaseEthereumConfig, Block, Ethereum
 from ape_ethereum.transactions import (
     DynamicFeeTransaction,
     Receipt,
@@ -78,6 +78,22 @@ def configured_custom_ecosystem(
 
 def test_name(ethereum):
     assert ethereum.name == "ethereum"
+
+
+def test_request_header(ethereum):
+    actual = ethereum.request_header
+    expected = {"User-Agent": "ape-ethereum"}
+    assert actual == expected
+
+
+def test_request_header_subclass():
+    class L2(Ethereum):
+        name: str = "l2"
+
+    l2 = L2()
+    actual = l2.request_header
+    expected = {"User-Agent": "ape-l2"}
+    assert actual == expected
 
 
 def test_name_when_custom(configured_custom_ecosystem, networks):

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -478,7 +478,7 @@ def test_new_when_web3_provider_uri_set():
 
     try:
         with pytest.raises(ProviderError, match=expected):
-            _ = MyProvider(data_folder=None, name=None, network=None, request_header=None)
+            _ = MyProvider(data_folder=None, name=None, network=None)
 
     finally:
         if WEB3_PROVIDER_URI_ENV_VAR_NAME in os.environ:
@@ -494,7 +494,6 @@ def test_account_balance_state(project, eth_tester_provider, owner):
         provider = LocalProvider(
             name="test",
             network=eth_tester_provider.network,
-            request_header=eth_tester_provider.request_header,
         )
         provider.connect()
         bal = provider.get_balance(owner.address)

--- a/tests/functional/utils/test_rpc.py
+++ b/tests/functional/utils/test_rpc.py
@@ -1,0 +1,45 @@
+import pytest
+
+from ape.utils.rpc import RPCHeaders
+
+
+class TestRPCHeaders:
+    @pytest.fixture
+    def headers(self):
+        return RPCHeaders()
+
+    @pytest.mark.parametrize("key", ("Content-Type", "CONTENT-TYPE"))
+    def test_setitem_key_case_insensitive(self, key, headers):
+        headers[key] = "application/javascript"
+        headers[key.lower()] = "application/json"
+        assert headers[key] == "application/json"
+        assert headers[key.lower()] == "application/json"
+
+    def test_setitem_user_agent_does_not_add_twice(self, headers):
+        expected = "test-user-agent/1.0"
+        headers["User-Agent"] = expected
+        # Add again. It should not add twice.
+        headers["User-Agent"] = expected
+        assert headers["User-Agent"] == expected
+
+    def test_setitem_user_agent_appends(self, headers):
+        headers["User-Agent"] = "test0/1.0"
+        headers["User-Agent"] = "test1/2.0"
+        assert headers["User-Agent"] == "test0/1.0 test1/2.0"
+
+    def test_setitem_user_agent_parts_exist(self, headers):
+        """
+        Tests the case when user-agents share a sub-set
+        of each other, that it does not duplicate.
+        """
+        headers["User-Agent"] = "test0/1.0"
+        # The beginning of the user-agent is already present.
+        # It shouldn't add the full thing.
+        headers["User-Agent"] = "test0/1.0 test1/2.0"
+        assert headers["User-Agent"] == "test0/1.0 test1/2.0"
+        # unexpected = "test0/1.0 test0/1.0 test1/2.0"
+
+    @pytest.mark.parametrize("key", ("user-agent", "User-Agent", "USER-AGENT"))
+    def test_contains_user_agent(self, key, headers):
+        headers["User-Agent"] = "test0/1.0"
+        assert key in headers


### PR DESCRIPTION
### What I did

* Allow you to configure request headers across the board, via ecosystems, via networks, and via providers.
* Actually use said request_header in web3.py (was missing!)

### How to verify it

```yaml
request_headers:
  Top-Level: "UseThisOnEveryRequest"

ethereum:
  request_headers:
    Ecosystem-Level: "UseThisOnEveryEthereumRequest"
  
  mainnet:
    request_headers:
      Network-Level: "UseThisOnAllRequestsToEthereumMainnet"

node:
  request_headers:
    Provider-Level: "UseThisOnAllRequestsUsingNodeProvider"
```

then connect:

```sh
ape console --network ethereum:local:node
```

Then verify headers:

```python
In [12]: http = provider.web3.provider._potential_providers[2]()

In [13]: http._request_kwargs
Out[13]: 
{'headers': {'User-Agent': 'Ape/0.8.14.dev0+g228ab19a1.d20240827 (Python/3.12.2 final)',
  'Top-Level': 'UseThisOnEveryRequest',
  'Ecosystem-Level': 'UseThisOnEveryEthereumRequest',
  'Provider-Level': 'UseThisOnAllRequestsUsingNodeProvider'},
 'timeout': 1800}
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
