### PR TITLE
fix: Change None check to Falsey check for ContractLogicError message to be the TB revert type

### DIFF
--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -305,7 +305,6 @@ class ContractLogicError(VirtualMachineError):
     ):
         self.txn = txn
         self.contract_address = contract_address
-
         super().__init__(
             base_err=base_err,
             contract_address=contract_address,
@@ -316,8 +315,7 @@ class ContractLogicError(VirtualMachineError):
             trace=trace,
             txn=txn,
         )
-
-        if revert_message is None and source_traceback is not None and (dev := self.dev_message):
+        if not revert_message and source_traceback is not None and (dev := self.dev_message):
             try:
                 # Attempt to use dev message as main exception message.
                 self.message = dev


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
