### PR TITLE
test: make helper script for updating test contracts

### DIFF
--- a/tests/functional/data/README.md
+++ b/tests/functional/data/README.md
@@ -1,0 +1,14 @@
+# Test Data
+
+All contracts use `.JSON` contract types because core tests cannot assume `ape-vyper` or `ape-solidity` is installed.
+These artifacts are stored in `tests/functional/data/contracts/local`.
+Their counter-part actual source files are located in `tests/functional/data/sources` and have corresponding names (e.g. `SolidityContract.json` matches up with `SolidityContract.sol`).
+
+## Making Changes
+
+To make changes to the source files, first ensure you have `ape-solidity` and/or `ape-vyper` installed and then edit the files in `sources/`.
+After you are ready to test your changes, from this directory, run the following script:
+
+```shell
+ape run update <MyContract>
+```

--- a/tests/functional/data/README.md
+++ b/tests/functional/data/README.md
@@ -1,7 +1,7 @@
 # Test Data
 
 All contracts use `.JSON` contract types because core tests cannot assume `ape-vyper` or `ape-solidity` is installed.
-These artifacts are stored in `tests/functional/data/contracts/local`.
+These artifacts are stored in `tests/functional/data/contracts/ethereum/local`.
 Their counter-part actual source files are located in `tests/functional/data/sources` and have corresponding names (e.g. `SolidityContract.json` matches up with `SolidityContract.sol`).
 
 ## Making Changes
@@ -12,3 +12,5 @@ After you are ready to test your changes, from this directory, run the following
 ```shell
 ape run update <MyContract>
 ```
+
+Now, it's corresponding JSON file should have been updated.

--- a/tests/functional/data/scripts/update.py
+++ b/tests/functional/data/scripts/update.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import click
+from click import BadArgumentUsage, argument, command
+
+from ape.cli import ape_cli_context
+
+BASE_PATH = Path(__file__).parent.parent
+SOURCES_PATH = BASE_PATH / "sources"
+ARTIFACTS_PATH = BASE_PATH / "contracts" / "ethereum" / "local"
+
+
+def _contract_callback(ctx, param, val):
+    for ext in ("sol", "vy"):
+        path = SOURCES_PATH / f"{val}.{ext}"
+        if path.is_file():
+            return path
+
+    raise BadArgumentUsage(f"Contract not found: {val}")
+
+
+@command()
+@ape_cli_context()
+@argument("contract", callback=_contract_callback)
+def cli(cli_ctx, contract):
+    cm = cli_ctx.compiler_manager
+    compiler = "vyper" if contract.suffix == ".vy" else "solidity"
+    code = contract.read_text(encoding="utf-8")
+    destination = ARTIFACTS_PATH / f"{contract.stem}.json"
+    contract_type = cm.compile_source(compiler, code, contractName=contract.stem)
+    destination.unlink()
+    destination.write_text(contract_type.model_dump_json())
+    click.echo("Done!")

--- a/tests/functional/data/scripts/update.py
+++ b/tests/functional/data/scripts/update.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import click
-from click import BadArgumentUsage, argument, command
 
 from ape.cli import ape_cli_context
 
@@ -16,12 +15,12 @@ def _contract_callback(ctx, param, val):
         if path.is_file():
             return path
 
-    raise BadArgumentUsage(f"Contract not found: {val}")
+    raise click.BadArgumentUsage(f"Contract not found: {val}")
 
 
-@command()
+@click.command()
 @ape_cli_context()
-@argument("contract", callback=_contract_callback)
+@click.argument("contract", callback=_contract_callback)
 def cli(cli_ctx, contract):
     cm = cli_ctx.compiler_manager
     compiler = "vyper" if contract.suffix == ".vy" else "solidity"


### PR DESCRIPTION
### What I did

it is annoying updating test contracts for tests in ape, this pr adds a script and a readme to assist in the process

### How I did it

make a script for updating contract JSONs via their sources

### How to verify it

* make change to one of the contracts in sources dir
* run `ape run update MyFile`
* see the updates are available now
### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
