### PR TITLE
fix: issue where returndata integers could not be used in dictionary

### DIFF
--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -500,6 +500,9 @@ class CurrencyValueComparable(int):
         # Try from the other end, if hasn't already.
         return NotImplemented
 
+    def __hash__(self) -> int:
+        return hash(int(self))
+
     @classmethod
     def __get_pydantic_core_schema__(cls, value, handler=None) -> CoreSchema:
         return no_info_plain_validator_function(

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -195,3 +195,9 @@ class TestCurrencyValueComparable:
         for actual in (model.val, model.val_optional, model.val_in_dict["value"]):
             for ex in (value, expected):
                 assert actual == ex
+
+    def test_hashable(self):
+        mapping: dict[int, str] = {0: "0", 1: "1"}
+        key = CurrencyValueComparable(0)
+        assert key in mapping
+        assert mapping[key] == "0"


### PR DESCRIPTION
### What I did

hashing was lost on our custom int type

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
