### PR TITLE
fix: handle not-implemented method from tenderly in `ape-node`

### DIFF
--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1120,7 +1120,7 @@ class Web3Provider(ProviderAPI, ABC):
 
             if (
                 "does not exist/is not available" in str(message)
-                or re.match(r"Method .*?not found", message)
+                or re.match(r"[m|M]ethod .*?not found", message)
                 or message.startswith("Unknown RPC Endpoint")
                 or "RPC Endpoint has not been implemented" in message
             ):


### PR DESCRIPTION
### What I did

One of the errors mentioned in https://github.com/ApeWorX/ape/issues/2262
shows we are not handling the error message specific to Tenderly (and the user us not using the  Tenderly plugin but instead the generic node plugin)

### How I did it

adjust regex

### How to verify it

pytest using tenderly

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
