### PR TITLE
feat: add info logger to display connection status and chain ID

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1054,7 +1054,21 @@ class SubprocessProvider(ProviderAPI):
             self.stop()
 
     def start(self, timeout: int = 20):
-        """Start the process and wait for its RPC to be ready."""
+        """
+        Start the process and wait for its RPC to be ready.
+
+        This method initializes the provider process and waits until it is
+        connected and ready. It logs messages based on the connection status
+        and the chain ID.
+
+        Args:
+            timeout (int): The time in seconds to wait for the RPC to be ready.
+                        Defaults to 20 seconds.
+
+        Raises:
+            RPCTimeoutError: If the RPC does not become ready within the timeout
+                            period.
+    """
 
         if self.is_connected:
             logger.info(f"Connecting to existing '{self.process_name}' process.")
@@ -1075,7 +1089,12 @@ class SubprocessProvider(ProviderAPI):
             with RPCTimeoutError(self, seconds=timeout) as _timeout:
                 while True:
                     if self.is_connected:
-                        break
+                        chain_id = self.chain_id  # Ensure this is how chain_id is accessed
+                    if chain_id == 1337:
+                        logger.info(f"Connecting to Test chain with chain_id={chain_id}")
+                    else:
+                        logger.info(f"Connected to {self.process_name} network with chain_id={chain_id}")
+                    break
 
                     time.sleep(0.1)
                     _timeout.check()

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -543,3 +543,21 @@ def test_ipc_per_network(project, key):
         # TODO: 0.9 investigate not using random if ipc set.
 
         assert node.ipc_path == Path(ipc)
+
+@mock.patch('ape_ethereum.provider.logger')
+def test_start_logging_local_test_chain(mock_logger, ethereum):
+    """Test logging when connecting to a local test chain."""
+
+    # Use the provider with custom settings
+    with ethereum.local.use_provider("test", provider_settings={"chain_id": 1337}) as provider:
+        # Ensure provider is disconnected initially
+        provider.disconnect()
+        assert not provider.is_connected
+        # Start the provider
+        provider.connect()
+
+        # Verify connection and chain_id
+        assert provider.is_connected
+        assert provider.chain_id == 1337
+        # Check logging output
+        mock_logger.info.assert_any_call("Connecting to Test chain with chain_id=1337")


### PR DESCRIPTION
### What I did

* added logging to the start method to differentiate between local test chains and other networks

### How I did it

Modify the start method in the provider to include additional logging. 

after confirming the provider is connected, the method checks the chain_id. If the chain_id is 1337, it logs a message indicating a connection to a local test chain.

### How to verify it

1. Run the Provider: Start the provider process using the modified start method.
2. Check Logs: Verify that the correct logging messages are displayed:
   * If the provider is connected to a local test chain with chain_id=1337, ensure the log message reflects this.
   * For other networks, check that the log message indicates the connected network and its chain ID.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
