### PR TITLE
fix: 'nonce too low' errors during testing

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -326,6 +326,14 @@ class ReceiptAPI(ExtraAttributesMixin, BaseInterfaceModel):
         return False
 
     @property
+    def confirmed(self) -> bool:
+        """
+        ``True`` when the number of confirmations is equal or greater
+        to the required amount of confirmations.
+        """
+        return self._confirmations_occurred == self.required_confirmations
+
+    @property
     @abstractmethod
     def total_fees_paid(self) -> int:
         """
@@ -417,40 +425,40 @@ class ReceiptAPI(ExtraAttributesMixin, BaseInterfaceModel):
         Returns:
             :class:`~ape.api.ReceiptAPI`: The receipt that is now confirmed.
         """
-        # perf: avoid *everything* if required_confirmations is 0, as this is likely a
-        #   dev environment or the user doesn't care.
-        if self.required_confirmations == 0:
-            # The transaction might not yet be confirmed but
-            # the user is aware of this. Or, this is a development environment.
+        # NOTE: Event when required_confs is 0, we want to wait for the nonce to increment,
+        #   else in tests, you may end up with invalid nonce, seen when using ape-node locally
+        #   but potentially can happen to other providers.
+        self._await_sender_nonce_increment()
+        if self.required_confirmations == 0 or self._check_error_status() or self.confirmed:
             return self
 
-        try:
-            self.raise_for_status()
-        except TransactionError:
-            # Skip waiting for confirmations when the transaction has failed.
-            return self
+        # Confirming now.
+        self._log_submission()
+        self._await_confirmations()
+        return self
+
+    def _await_sender_nonce_increment(self):
+        if not self.sender:
+            return
 
         iterations_timeout = 20
         iteration = 0
-        # Wait for nonce from provider to increment.
-        if self.sender:
+        sender_nonce = self.provider.get_nonce(self.sender)
+        while sender_nonce == self.nonce:
+            time.sleep(1)
             sender_nonce = self.provider.get_nonce(self.sender)
+            iteration += 1
+            if iteration != iterations_timeout:
+                continue
 
-            while sender_nonce == self.nonce:
-                time.sleep(1)
-                sender_nonce = self.provider.get_nonce(self.sender)
-                iteration += 1
-                if iteration == iterations_timeout:
-                    tx_err = TransactionError("Timeout waiting for sender's nonce to increase.")
-                    self.error = tx_err
-                    if self.transaction.raise_on_revert:
-                        raise tx_err
+            tx_err = TransactionError("Timeout waiting for sender's nonce to increase.")
+            self.error = tx_err
+            if self.transaction.raise_on_revert:
+                raise tx_err
+            else:
+                break
 
-        confirmations_occurred = self._confirmations_occurred
-        if self.required_confirmations and confirmations_occurred >= self.required_confirmations:
-            return self
-
-        # If we get here, that means the transaction has been recently submitted.
+    def _log_submission(self):
         if explorer_url := self._explorer and self._explorer.get_transaction_url(self.txn_hash):
             log_message = f"Submitted {explorer_url}"
         else:
@@ -458,26 +466,34 @@ class ReceiptAPI(ExtraAttributesMixin, BaseInterfaceModel):
 
         logger.info(log_message)
 
-        if self.required_confirmations:
-            with ConfirmationsProgressBar(self.required_confirmations) as progress_bar:
-                while confirmations_occurred < self.required_confirmations:
-                    confirmations_occurred = self._confirmations_occurred
-                    progress_bar.confs = confirmations_occurred
+    def _check_error_status(self) -> bool:
+        try:
+            self.raise_for_status()
+        except TransactionError:
+            # Skip waiting for confirmations when the transaction has failed.
+            return True
 
-                    if confirmations_occurred == self.required_confirmations:
-                        break
+        return False
 
-                    time_to_sleep = int(self._block_time / 2)
-                    time.sleep(time_to_sleep)
+    def _await_confirmations(self):
+        if self.required_confirmations <= 0:
+            return
 
-        return self
+        with ConfirmationsProgressBar(self.required_confirmations) as progress_bar:
+            while not self.confirmed:
+                confirmations_occurred = self._confirmations_occurred
+                if confirmations_occurred >= self.required_confirmations:
+                    break
+
+                progress_bar.confs = confirmations_occurred
+                time_to_sleep = int(self._block_time / 2)
+                time.sleep(time_to_sleep)
 
     @property
     def method_called(self) -> Optional[MethodABI]:
         """
         The method ABI of the method called to produce this receipt.
         """
-
         return None
 
     @property


### PR DESCRIPTION
### What I did

probably another result of bad perfs, but we still need to await for nonces to increase when req confs is 0.
I added a test to ensure this doesnt break again.
Also added `.confirmed` property to receipt which is going to be useful later.
problems were rather anomalous but putting back 1 RPC call aint the end of the world

### How I did it

* put back nonce-await at top of method
* del comment
* add test
* use helper methods to pot. allow providers to make their own receipts with differing behavior

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
