### PR TITLE
fix: mistakenly changed sources to in-memory manifest

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2359,16 +2359,11 @@ class LocalProject(Project):
             yield self
 
         else:
-            # Add sources to manifest memory, in case they are missing.
-            original_sources = self._manifest.sources
-            self._manifest.sources = dict(self.sources.items())
-            try:
-                with super().isolate_in_tempdir(**config_override) as project:
-                    yield project
-
-            finally:
-                # Restore original manifest sources in case compile failed.
-                self._manifest.sources = original_sources
+            sources = dict(self.sources.items())
+            with super().isolate_in_tempdir(**config_override) as project:
+                # Add sources to manifest memory, in case they are missing.
+                project.manifest.sources = sources
+                yield project
 
     def unpack(self, destination: Path, config_override: Optional[dict] = None) -> "LocalProject":
         config_override = {**self._config_override, **(config_override or {})}

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2137,7 +2137,7 @@ class LocalProject(Project):
 
                     message = (
                         f"{message} However, there is a source file named '{path.name}'. "
-                        "This file may no be compiling (see error above), or maybe you meant "
+                        "This file may not be compiling (see error above), or maybe you meant "
                         "to reference a contract name from this source file?"
                     )
                     did_append = True

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2136,8 +2136,8 @@ class LocalProject(Project):
                         message = f"{message}."
 
                     message = (
-                        f"{message} However, there is a source file named '{path.name}', "
-                        "this file may no be compiling (see error above), or maybe you meant "
+                        f"{message} However, there is a source file named '{path.name}'. "
+                        "This file may no be compiling (see error above), or maybe you meant "
                         "to reference a contract name from this source file?"
                     )
                     did_append = True

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -54,15 +54,7 @@ class InterfaceCompiler(CompilerAPI):
 
             code = src_path.read_text()
             source_id = source_ids[path]
-            try:
-                # NOTE: Always set the source ID to the source of the JSON file
-                #   to avoid manifest corruptions later on.
-                contract_type = self.compile_code(code, project=project, sourceId=source_id)
-            except CompilerError as err:
-                logger.warning(
-                    f"Unable to parse {ContractType.__name__} from '{source_id}'. Reason: {err}"
-                )
-                continue
+            contract_type = self.compile_code(code, project=project, sourceId=source_id)
 
             # NOTE: Try getting name/ ID from code-JSON first.
             #   That's why this is not part of `**kwargs` in `compile_code()`.

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -220,7 +220,7 @@ def test_getattr_same_name_as_source_file(project_with_source_files_contract):
         r"'LocalProject' object has no attribute 'ContractA'\. "
         r"Also checked extra\(s\) 'contracts'\. "
         r"However, there is a source file named 'ContractA\.sol'\. "
-        r"This file may no be compiling (see error above), "
+        r"This file may not be compiling \(see error above\), "
         r"or maybe you meant to reference a contract name from this source file\? "
         r"Else, could it be from one of the missing compilers for extensions: .*"
     )

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -148,6 +148,22 @@ def test_isolate_in_tempdir(project):
         assert not tmp_project.manifest_path.is_file()
 
 
+def test_isolate_in_tempdir_does_not_alter_sources(project):
+    # First, create a bad source.
+    new_src = project.contracts_folder / "newsource.json"
+    new_src.write_text("this is not json, oops")
+
+    try:
+        with project.isolate_in_tempdir() as tmp_project:
+            # The new (bad) source should be in the temp project.
+            assert "src/newsource.json" in (tmp_project.manifest.sources or {})
+    finally:
+        new_src.unlink()
+
+    # Ensure "newsource" did not persist in the in-memory manifest.
+    assert "src/newsource.json" not in (project.manifest.sources or {})
+
+
 def test_in_tempdir(project, tmp_project):
     assert not project.in_tempdir
     assert tmp_project.in_tempdir

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -150,18 +150,21 @@ def test_isolate_in_tempdir(project):
 
 def test_isolate_in_tempdir_does_not_alter_sources(project):
     # First, create a bad source.
-    new_src = project.contracts_folder / "newsource.json"
-    new_src.write_text("this is not json, oops")
+    with project.temp_config(contracts_folder="tests"):
+        new_src = project.contracts_folder / "newsource.json"
+        new_src.write_text("this is not json, oops")
+        project.sources.refresh()  # Only need to be called when run with other tests.
 
-    try:
-        with project.isolate_in_tempdir() as tmp_project:
-            # The new (bad) source should be in the temp project.
-            assert "src/newsource.json" in (tmp_project.manifest.sources or {})
-    finally:
-        new_src.unlink()
+        try:
+            with project.isolate_in_tempdir() as tmp_project:
+                # The new (bad) source should be in the temp project.
+                assert "tests/newsource.json" in (tmp_project.manifest.sources or {}), project.path
+        finally:
+            new_src.unlink()
+            project.sources.refresh()
 
-    # Ensure "newsource" did not persist in the in-memory manifest.
-    assert "src/newsource.json" not in (project.manifest.sources or {})
+        # Ensure "newsource" did not persist in the in-memory manifest.
+        assert "tests/newsource.json" not in (project.manifest.sources or {})
 
 
 def test_in_tempdir(project, tmp_project):
@@ -216,8 +219,9 @@ def test_getattr_same_name_as_source_file(project_with_source_files_contract):
     expected = (
         r"'LocalProject' object has no attribute 'ContractA'\. "
         r"Also checked extra\(s\) 'contracts'\. "
-        r"However, there is a source file named 'ContractA\.sol', "
-        r"did you mean to reference a contract name from this source file\? "
+        r"However, there is a source file named 'ContractA\.sol'\. "
+        r"This file may no be compiling (see error above), "
+        r"or maybe you meant to reference a contract name from this source file\? "
         r"Else, could it be from one of the missing compilers for extensions: .*"
     )
     with pytest.raises(AttributeError, match=expected):
@@ -603,7 +607,7 @@ def test_project_api_foundry_and_ape_config_found(foundry_toml):
 
 def test_get_contract(project_with_contracts):
     actual = project_with_contracts.get_contract("Other")
-    assert isinstance(actual, ContractContainer)
+    assert isinstance(actual, ContractContainer), f"{type(actual)}"
     assert actual.contract_type.name == "Other"
 
     # Ensure manifest is only loaded once by none-ing out the path.


### PR DESCRIPTION
### What I did

fixes: #2271

To reproduce problem:

1. Have a contract, working good, with a test.
2. Run ape test, all is good
3. Make a change to the contract that causes a compiler error
4. Run ape test again, test acts like it did before, and there is no compiler error.

**They key is that the change must be problematic and cause errors**

### How I did it

Frustratingly find spot where source Id is being overridden
Restore it.
Also, adjust error message

Test tbd

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
