### PR TITLE
fix: pin pydantic_settings as it broke ape

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setup(
         "pandas>=2.2.2,<3",
         "pluggy>=1.3,<2",
         "pydantic>=2.6.4,<3",
-        "pydantic-settings>=2.0.3,<3",
+        "pydantic-settings>=2.4.0,<2.5",  # Bug in pydantic_settings
         "pytest>=8.0,<9.0",
         "python-dateutil>=2.8.2,<3",
         "PyYAML>=5.0,<7",


### PR DESCRIPTION
### What I did

pydantic_setting was released 3 hours ago, and it broken python 3.9 and 3.10 on every plugin

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
