### PR TITLE
fix: issue where using `version:` key for a GH ref-based releases caused invalid directory structure

### DIFF
--- a/docs/userguides/dependencies.md
+++ b/docs/userguides/dependencies.md
@@ -57,6 +57,8 @@ Often times, the `v` prefix is required when using tags.
 However, if cloning the tag fails, `ape` will retry with a `v` prefix.
 Bypass the original failing attempt by including a `v` in your dependency config.
 
+**By knowing if the release is from the version API or only available via tag, and whether the version is v-prefixed or not, you save Ape some time and complexity when installing dependencies.**
+
 ### Python
 
 You can use dependencies to PyPI by using the `python:` keyed dependency type.

--- a/src/ape_pm/dependency.py
+++ b/src/ape_pm/dependency.py
@@ -206,6 +206,11 @@ class GithubDependency(DependencyAPI):
                     "Use `ref:` instead of `version:` for release tags. "
                     "Checking for matching tags..."
                 )
+
+                # NOTE: When using ref-from-a-version, ensure
+                #   it didn't create the destination along the way;
+                #   else, the ref is cloned in the wrong spot.
+                shutil.rmtree(destination, ignore_errors=True)
                 try:
                     self._fetch_ref(version, destination)
                 except Exception:

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -467,7 +467,7 @@ class TestGitHubDependency:
         with pytest.raises(ValidationError, match=expected):
             _ = GithubDependency(name="foo", github="asdf")
 
-    def test_fetch(self, mock_client):
+    def test_fetch_given_version(self, mock_client):
         dependency = GithubDependency(
             github="ApeWorX/ApeNotAThing", version="3.0.0", name="apetestdep"
         )
@@ -546,7 +546,11 @@ class TestGitHubDependency:
         mock_client.download_package.side_effect = ValueError("nope")
 
         # Simulate only the non-v prefix ref working (for a fuller flow)
-        def needs_non_v_prefix_ref(n0, n1, path, branch):
+        def needs_non_v_prefix_ref(n0, n1, dst_path, branch):
+            # NOTE: This assertion is very important!
+            #  We must only give it non-existing directories.
+            assert not dst_path.is_dir()
+
             if branch.startswith("v"):
                 raise ValueError("nope")
 

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -533,7 +533,7 @@ class TestGitHubDependency:
         # The second call does not have the v!
         assert calls[1][0] == ("ApeWorX", "ApeNotAThing", "3.0.0", path)
 
-    def test_fetch_given_version_but_expects_reference(self, mock_client):
+    def test_fetch_given_version_when_expects_reference(self, mock_client):
         """
         Show that if a user configures `version:`, but version fails, it
         tries `ref:` instead as a backup.


### PR DESCRIPTION
### What I did

When using the dependency config:

```yaml
dependencies:
  - name: uniswap-core
    github: Uniswap/v3-core
    version: v1.0.0
  - name: uniswap-periphery
    github: Uniswap/v3-periphery
    version: v1.3.0
```

it first tries the GH release API. When that fails, it falls back to searching for the ref.
It finds the ref, but the checking of the API has already caused the destination to exist.
Our GH client will make a subdir in that case of the repo name, and that causes the whole import structure to fail

BTW, this problem wouldn't occur if using a more optimal and correct reference like this:

```
dependencies:
  - name: uniswap-core
    github: Uniswap/v3-core
    ref: v1.0.0
  - name: uniswap-periphery
    github: Uniswap/v3-periphery
    ref: v1.3.0
```

### How I did it

If in the fallback scenario, first ensure the dependency folder does not exist.

### How to verify it

1. Use the `version:` key bad-approach, run command:
```sh
ape pm install --force
```


3. Inspect the package project folder: 
```
ls ~/.ape/packages/projects/Uniswap_v3-core/v1_0_0
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
