### PR TITLE
fix: invalid integer when using `-v` flag in `ape test`

### DIFF
--- a/src/ape/cli/__init__.py
+++ b/src/ape/cli/__init__.py
@@ -27,7 +27,7 @@ from ape.cli.options import (
     skip_confirmation_option,
     verbosity_option,
 )
-from ape.cli.paramtype import JSON, Path
+from ape.cli.paramtype import JSON, Noop, Path
 
 __all__ = [
     "account_option",
@@ -45,6 +45,7 @@ __all__ = [
     "network_option",
     "NetworkChoice",
     "NetworkOption",
+    "Noop",
     "non_existing_alias_argument",
     "output_format_choice",
     "output_format_option",

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -18,7 +18,7 @@ from ape.cli.choices import (
     output_format_choice,
 )
 from ape.cli.commands import ConnectedProviderCommand
-from ape.cli.paramtype import JSON
+from ape.cli.paramtype import JSON, Noop
 from ape.exceptions import Abort, ProjectError
 from ape.logging import DEFAULT_LOG_LEVEL, ApeLogger, LogLevel, logger
 from ape.utils.basemodel import ManagerAccessMixin
@@ -88,7 +88,7 @@ def _create_verbosity_kwargs(
         "expose_value": False,
         "help": f"One of {names_str}",
         "is_eager": True,
-        "type": lambda x: x,  # Ignores weird typing-issues
+        "type": Noop(),
     }
 
 

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -2,7 +2,7 @@ import inspect
 from collections.abc import Callable
 from functools import partial
 from pathlib import Path
-from typing import NoReturn, Optional, Union
+from typing import NoReturn, Optional, Union, Any
 
 import click
 from click import Option
@@ -88,6 +88,7 @@ def _create_verbosity_kwargs(
         "expose_value": False,
         "help": f"One of {names_str}",
         "is_eager": True,
+        "type": lambda x: x,  # Ignores weird typing-issues
     }
 
 

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -2,7 +2,7 @@ import inspect
 from collections.abc import Callable
 from functools import partial
 from pathlib import Path
-from typing import NoReturn, Optional, Union, Any
+from typing import NoReturn, Optional, Union
 
 import click
 from click import Option

--- a/src/ape/cli/paramtype.py
+++ b/src/ape/cli/paramtype.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path as PathLibPath
+from typing import Any
 
 import click
 
@@ -34,3 +35,14 @@ class JSON(click.ParamType):
                 self.fail(f"Invalid JSON string: {err}", param, ctx)
 
         return value  # Good already.
+
+
+class Noop(click.ParamType):
+    """
+    A param-type for ignoring param-types.
+    Good to use when the multi-type handling
+    happens already in a callback or in the command itself.
+    """
+
+    def convert(self, value: Any, param, ctx) -> Any:
+        return value

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -220,6 +220,18 @@ def test_test_isolation_disabled(setup_pytester, integ_project, pytester, eth_te
     assert "F _function_isolation" not in "\n".join(result.outlines)
 
 
+@skip_projects_except("test")
+def test_verbosity(runner, ape_cli):
+    """
+    Tests again an issue where `ape test -v debug` would fail because of
+    an invalid type check from click; only appeared in `ape test` command
+    for some reason.
+    """
+    # NOTE: Only using `--fixtures` flag to avoid running tests (just prints fixtures).
+    result = runner.invoke(ape_cli, ("test", "--verbosity", "DEBUG", "--fixtures"))
+    assert result.exit_code == 0, result.output
+
+
 @skip_projects_except("test", "with-contracts")
 def test_fixture_docs(setup_pytester, integ_project, pytester, eth_tester_provider):
     _ = eth_tester_provider  # Ensure using EthTester for this test.


### PR DESCRIPTION
### What I did

For some reason, `ape test -v debug` was no longer working - I was getting an Invalid Integer problem.

### How I did it

Hack click to ignore type checking..
I wish the callback was enough for this but I guess click does what it wants.

### How to verify it

Run:

```sh
ape test -v debug
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
