### PR TITLE
fix: issue where couldn't use ape test -vvv

### DIFF
--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -77,7 +77,10 @@ def _create_verbosity_kwargs(
             if value.startswith("LOGLEVEL."):
                 value = value.split(".")[-1].strip()
 
-        cli_logger._load_from_sys_argv(default=value)
+        if cli_logger._did_parse_sys_argv:
+            cli_logger.set_level(value)
+        else:
+            cli_logger._load_from_sys_argv(default=value)
 
     level_names = [lvl.name for lvl in LogLevel]
     names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -77,11 +77,7 @@ def _create_verbosity_kwargs(
             if value.startswith("LOGLEVEL."):
                 value = value.split(".")[-1].strip()
 
-        if cli_logger._did_parse_sys_argv:
-            cli_logger.set_level(value)
-        else:
-            # Avoid callback without fully parsing sys argv first.
-            cli_logger._load_from_sys_argv(default=value)
+        cli_logger._load_from_sys_argv(default=value)
 
     level_names = [lvl.name for lvl in LogLevel]
     names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -80,6 +80,7 @@ def _create_verbosity_kwargs(
         if cli_logger._did_parse_sys_argv:
             cli_logger.set_level(value)
         else:
+            # Avoid callback without fully parsing sys argv first.
             cli_logger._load_from_sys_argv(default=value)
 
     level_names = [lvl.name for lvl in LogLevel]

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -127,6 +127,7 @@ class ApeLogger:
         self.info = _logger.info
         self.debug = _logger.debug
         self._logger = _logger
+        self._did_parse_sys_argv = False
         self._load_from_sys_argv()
         self.fmt = fmt
 
@@ -145,22 +146,34 @@ class ApeLogger:
         """
         Load from sys.argv to beat race condition with `click`.
         """
+        if self._did_parse_sys_argv:
+            # Already parsed.
+            return
 
         log_level = _get_level(level=default)
         level_names = [lvl.name for lvl in LogLevel]
-        for arg_i in range(len(sys.argv) - 1):
+
+        #  Minus 2 because if `-v` is the last arg, it is not our verbosity `-v`.
+        num_args = len(sys.argv) - 2
+
+        for arg_i in range(num_args):
             if sys.argv[arg_i] == "-v" or sys.argv[arg_i] == "--verbosity":
-                level = _get_level(sys.argv[arg_i + 1].upper())
+                try:
+                    level = _get_level(sys.argv[arg_i + 1].upper())
+                except Exception:
+                    # Let it fail in a better spot, or is not our level.
+                    continue
 
                 if level in level_names:
+                    self._sys_argv = level
                     log_level = level
                     break
                 else:
-                    names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"
-                    self._logger.error(f"Must be one of '{names_str}', not '{level}'.")
-                    sys.exit(2)
+                    # Not our level.
+                    continue
 
         self.set_level(log_level)
+        self._did_parse_sys_argv = True
 
     @property
     def level(self) -> int:

--- a/tests/functional/test_logging.py
+++ b/tests/functional/test_logging.py
@@ -33,6 +33,7 @@ def test_info_level_higher(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.info("this is a test")
 
+    logger._did_parse_sys_argv = False
     result = simple_runner.invoke(group_for_testing, ("cmd", "-v", "WARNING"))
 
     # You don't get INFO log when log level is higher
@@ -57,6 +58,7 @@ def test_warning_level_higher(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.warning("this is a test")
 
+    logger._did_parse_sys_argv = False
     result = simple_runner.invoke(group_for_testing, ("cmd", "-v", "ERROR"))
     assert "WARNING" not in result.output
     assert "this is a test" not in result.output
@@ -71,6 +73,7 @@ def test_success(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.success("this is a test")
 
+    logger._did_parse_sys_argv = False
     result = simple_runner.invoke(group_for_testing, "cmd")
     assert "SUCCESS" in result.output
     assert "this is a test" in result.output
@@ -82,6 +85,7 @@ def test_success_level_higher(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.success("this is a test")
 
+    logger._did_parse_sys_argv = False
     result = simple_runner.invoke(group_for_testing, ("cmd", "-v", "WARNING"))
     assert "SUCCESS" not in result.output
     assert "this is a test" not in result.output

--- a/tests/functional/test_logging.py
+++ b/tests/functional/test_logging.py
@@ -33,6 +33,7 @@ def test_info_level_higher(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.info("this is a test")
 
+    logger._did_parse_sys_argv = False
     result = simple_runner.invoke(group_for_testing, ("cmd", "-v", "WARNING"))
 
     # You don't get INFO log when log level is higher
@@ -57,6 +58,7 @@ def test_warning_level_higher(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.warning("this is a test")
 
+    logger._did_parse_sys_argv = False
     result = simple_runner.invoke(group_for_testing, ("cmd", "-v", "ERROR"))
     assert "WARNING" not in result.output
     assert "this is a test" not in result.output
@@ -71,6 +73,7 @@ def test_success(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.success("this is a test")
 
+    logger._did_parse_sys_argv = False
     result = simple_runner.invoke(group_for_testing, "cmd")
     assert "SUCCESS" in result.output
     assert "this is a test" in result.output
@@ -82,6 +85,7 @@ def test_success_level_higher(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.success("this is a test")
 
+    logger._did_parse_sys_argv = False
     result = simple_runner.invoke(group_for_testing, ("cmd", "-v", "WARNING"))
     assert "SUCCESS" not in result.output
     assert "this is a test" not in result.output
@@ -97,6 +101,7 @@ def test_format(simple_runner):
         finally:
             cli_ctx.logger.format()
 
+    logger._did_parse_sys_argv = False
     result = simple_runner.invoke(group_for_testing, ("cmd", "-v", "SUCCESS"))
     assert "SUCCESS" not in result.output
 

--- a/tests/functional/test_logging.py
+++ b/tests/functional/test_logging.py
@@ -33,7 +33,6 @@ def test_info_level_higher(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.info("this is a test")
 
-    logger._did_parse_sys_argv = False
     result = simple_runner.invoke(group_for_testing, ("cmd", "-v", "WARNING"))
 
     # You don't get INFO log when log level is higher
@@ -58,7 +57,6 @@ def test_warning_level_higher(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.warning("this is a test")
 
-    logger._did_parse_sys_argv = False
     result = simple_runner.invoke(group_for_testing, ("cmd", "-v", "ERROR"))
     assert "WARNING" not in result.output
     assert "this is a test" not in result.output
@@ -73,7 +71,6 @@ def test_success(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.success("this is a test")
 
-    logger._did_parse_sys_argv = False
     result = simple_runner.invoke(group_for_testing, "cmd")
     assert "SUCCESS" in result.output
     assert "this is a test" in result.output
@@ -85,7 +82,6 @@ def test_success_level_higher(simple_runner):
     def cmd(cli_ctx):
         cli_ctx.logger.success("this is a test")
 
-    logger._did_parse_sys_argv = False
     result = simple_runner.invoke(group_for_testing, ("cmd", "-v", "WARNING"))
     assert "SUCCESS" not in result.output
     assert "this is a test" not in result.output

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -238,7 +238,7 @@ def test_vvv(runner, ape_cli):
     Showing you can somehow use pytest's -v flag without
     messing up Ape.
     """
-    result = runner.invoke(ape_cli, ("test", "-vvv", "--fixtures"))
+    result = runner.invoke(ape_cli, ("test", "-vvv", "--fixtures"), catch_exceptions=False)
     assert result.exit_code == 0, result.output
 
 

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -232,6 +232,16 @@ def test_verbosity(runner, ape_cli):
     assert result.exit_code == 0, result.output
 
 
+@skip_projects_except("test")
+def test_vvv(runner, ape_cli):
+    """
+    Showing you can somehow use pytest's -v flag without
+    messing up Ape.
+    """
+    result = runner.invoke(ape_cli, ("test", "-vvv", "--fixtures"))
+    assert result.exit_code == 0, result.output
+
+
 @skip_projects_except("test", "with-contracts")
 def test_fixture_docs(setup_pytester, integ_project, pytester, eth_tester_provider):
     _ = eth_tester_provider  # Ensure using EthTester for this test.


### PR DESCRIPTION
### What I did

Allows you to use pytest's -v option without clobbering.
Also fixes a perf where would parse sys argv more than once.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
