### PR TITLE
fix: better repr string for pythonic projects

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2167,7 +2167,7 @@ class LocalProject(Project):
 
     @log_instead_of_fail(default="<ProjectManager>")
     def __repr__(self):
-        path = f" {clean_path(self.path)}"
+        path = f" {clean_path(self._base_path)}"
         # NOTE: 'Project' is meta for 'ProjectManager' (mixin magic).
         return f"<ProjectManager{path}>"
 

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import shutil
 from pathlib import Path
 
@@ -107,14 +108,17 @@ def test_path_configured(project):
         abi = [{"name": "foo", "type": "fallback", "stateMutability": "nonpayable"}]
         contract.write_text(json.dumps(abi), encoding="utf8")
 
-        snekmate = Project(
+        snakemate = Project(
             temp_dir, config_override={"base_path": "src", "contracts_folder": madeup_name}
         )
-        assert snekmate.name == madeup_name
-        assert snekmate.path == subdir
-        assert snekmate.contracts_folder == contracts_folder
+        assert snakemate.name == madeup_name
+        assert snakemate.path == subdir
+        assert snakemate.contracts_folder == contracts_folder
 
-        actual = snekmate.load_contracts()
+        # The repr should show `/snakemate` and not `/snakemate/src/`.
+        assert re.match(r"<ProjectManager [\w|/]*/snakemate>", repr(snakemate))
+
+        actual = snakemate.load_contracts()
         assert "snake" in actual
         assert actual["snake"].source_id == f"{madeup_name}/snake.json"
 


### PR DESCRIPTION
### What I did

Was showing `/snekmate/src` and not `/snekmate` when using that fancy package dir

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
