### PR TITLE
fix: `ape test -vvv` was not using correct pytest verbosity

### DIFF
--- a/src/ape/pytest/plugin.py
+++ b/src/ape/pytest/plugin.py
@@ -80,8 +80,10 @@ def pytest_configure(config):
     gas_tracker = GasTracker(config_wrapper)
     coverage_tracker = CoverageTracker(config_wrapper)
 
-    # Enable verbose output if stdout capture is disabled
-    config.option.verbose = config.getoption("capture") == "no"
+    if not config.option.verbose:
+        # Enable verbose output if stdout capture is disabled
+        config.option.verbose = config.getoption("capture") == "no"
+    # else: user has already changes verbosity to an equal or higher level; avoid downgrading.
 
     # Register the custom Ape test runner
     runner = PytestApeRunner(config_wrapper, receipt_capture, gas_tracker, coverage_tracker)

--- a/src/ape_test/_cli.py
+++ b/src/ape_test/_cli.py
@@ -173,7 +173,7 @@ def cli(cli_ctx, watch, watch_folders, watch_delay, pytest_args):
     if pytest_verbosity := cli_ctx.get("pytest_verbosity"):
         pytest_arg_ls.append(pytest_verbosity)
 
-    pytest_arg_ls = _validate_pytest_args(*pytest_arg_ls, pytest_verbosity)
+    pytest_arg_ls = _validate_pytest_args(*pytest_arg_ls)
     if watch:
         event_handler = _create_event_handler()
         observer = _create_observer()

--- a/src/ape_test/_cli.py
+++ b/src/ape_test/_cli.py
@@ -4,9 +4,11 @@ import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from subprocess import run as run_subprocess
+from typing import Any
 
 import click
 import pytest
+from click import Command
 from watchdog import events
 from watchdog.observers import Observer
 
@@ -89,9 +91,8 @@ def _validate_pytest_args(*pytest_args) -> list[str]:
             # Ensure this is a pytest -v and not ape's -v.
             next_arg = next(args_iter)
             lvl_name = _get_level(next_arg)
-            if lvl_name in [x.name for x in LogLevel]:
-                # Ape log level found, cannot use.
-                continue
+            if not _is_ape_loglevel(lvl_name):
+                valid_args.append(argument)
 
         else:
             valid_args.append(argument)
@@ -99,13 +100,50 @@ def _validate_pytest_args(*pytest_args) -> list[str]:
     return valid_args
 
 
+def _is_ape_loglevel(value: Any) -> bool:
+    if isinstance(value, (int, LogLevel)):
+        return True
+
+    elif isinstance(value, str):
+        return (
+            value.upper() in [x.name for x in LogLevel]
+            or (value.isnumeric() and int(value) in LogLevel)
+            or value.lower().startswith("loglevel.")
+        )
+
+    return False
+
+
+class ApeTestCommand(Command):
+    def parse_args(self, ctx, args: list[str]) -> list[str]:
+        num_args = len(args)
+        for idx, argument in enumerate(args):
+            if not argument.startswith("-v"):
+                continue
+            elif (idx == num_args - 1) or argument in ("-vv", "-vvv"):
+                # Definitely for pytest.
+                ctx.obj["pytest_verbosity"] = argument
+                args = [a for a in args if a != argument]
+            else:
+                # -v with a following arg; ensure not Ape's.
+                next_arg = args[idx + 1]
+                if not _is_ape_loglevel(next_arg):
+                    ctx.obj["pytest_verbosity"] = "-v"
+                    args = [a for a in args if a != argument]
+
+        return super().parse_args(ctx, args)
+
+
 @click.command(
     add_help_option=False,  # NOTE: This allows pass-through to pytest's help
     short_help="Launches pytest and runs the tests for a project",
     context_settings=dict(ignore_unknown_options=True),
+    cls=ApeTestCommand,
 )
 # NOTE: Using '.value' because more performant.
-@ape_cli_context(default_log_level=LogLevel.WARNING.value)
+@ape_cli_context(
+    default_log_level=LogLevel.WARNING.value,
+)
 @click.option(
     "-w",
     "--watch",
@@ -131,6 +169,11 @@ def _validate_pytest_args(*pytest_args) -> list[str]:
 )
 @click.argument("pytest_args", nargs=-1, type=click.UNPROCESSED)
 def cli(cli_ctx, watch, watch_folders, watch_delay, pytest_args):
+    pytest_arg_ls = [*pytest_args]
+    if pytest_verbosity := cli_ctx.get("pytest_verbosity"):
+        pytest_arg_ls.append(pytest_verbosity)
+
+    pytest_arg_ls = _validate_pytest_args(*pytest_arg_ls, pytest_verbosity)
     if watch:
         event_handler = _create_event_handler()
         observer = _create_observer()
@@ -142,19 +185,18 @@ def cli(cli_ctx, watch, watch_folders, watch_delay, pytest_args):
                 cli_ctx.logger.warning(f"Folder '{folder}' doesn't exist or isn't a folder.")
 
         observer.start()
-        pytest_args = _validate_pytest_args(*pytest_args)
 
         try:
-            _run_ape_test(*pytest_args)
+            _run_ape_test(*pytest_arg_ls)
             while True:
-                _run_main_loop(watch_delay, *pytest_args)
+                _run_main_loop(watch_delay, *pytest_arg_ls)
 
         finally:
             observer.stop()
             observer.join()
 
     else:
-        return_code = pytest.main([*pytest_args], ["ape_test"])
+        return_code = pytest.main([*pytest_arg_ls], ["ape_test"])
         if return_code:
             # only exit with non-zero status to make testing easier
             sys.exit(return_code)

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -233,14 +233,41 @@ def test_verbosity(runner, ape_cli):
 
 
 @skip_projects_except("test")
-def test_vvv(runner, ape_cli):
+@pytest.mark.parametrize("v_arg", ("-v", "-vv", "-vvv"))
+def test_vvv(runner, ape_cli, integ_project, v_arg):
     """
     Showing you can somehow use pytest's -v flag without
     messing up Ape.
     """
-    result = runner.invoke(ape_cli, ("test", "-vvv", "--fixtures"), catch_exceptions=False)
-    breakpoint()
+    here = integ_project.path
+    os.chdir(integ_project.path)
+    name = f"test_{v_arg.replace('-', '_')}"
+
+    TEST = f"""
+    def {name}():
+        assert True
+    """.lstrip()
+
+    # Have to create a new test each time to avoid .pycs issues
+    new_test_file = integ_project.tests_folder / f"{name}.py"
+    new_test_file.write_text(TEST)
+
+    try:
+        # NOTE: v_arg purposely at the end because testing doesn't interfere
+        #   with click's option parsing "requires value" error.
+        result = runner.invoke(
+            ape_cli,
+            ("test", f"tests/{new_test_file.name}::{name}", v_arg),
+            catch_exceptions=False,
+        )
+    finally:
+        new_test_file.unlink(missing_ok=True)
+        os.chdir(here)
+
     assert result.exit_code == 0, result.output
+    # Prove `-vvv` worked via the output.
+    # It shows PASSED instead of the little green dot.
+    assert "PASSED" in result.output
 
 
 @skip_projects_except("test", "with-contracts")

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -239,6 +239,7 @@ def test_vvv(runner, ape_cli):
     messing up Ape.
     """
     result = runner.invoke(ape_cli, ("test", "-vvv", "--fixtures"), catch_exceptions=False)
+    breakpoint()
     assert result.exit_code == 0, result.output
 
 

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -228,7 +228,8 @@ def test_verbosity(runner, ape_cli):
     for some reason.
     """
     # NOTE: Only using `--fixtures` flag to avoid running tests (just prints fixtures).
-    result = runner.invoke(ape_cli, ("test", "--verbosity", "DEBUG", "--fixtures"))
+    cmd = ("test", "--verbosity", "DEBUG", "--fixtures")
+    result = runner.invoke(ape_cli, cmd, catch_exceptions=False)
     assert result.exit_code == 0, result.output
 
 


### PR DESCRIPTION
### What I did

`-vvv` was no longer failing as of recent changes but it also wasn't using the correct pytest verbosity.
The PR makes it actually work in pytest.

Actually really need this for the work I am doing with the snapshotting

### How I did it

a few things had to be fixed, was more difficult than would have liked:

1. In the Pytest plugin itself, verbosity was always getting downgraded in certain conditions; had to make it not do that if the verbosity was already higher than what it would set if it was doing that shit.
2. Make a custom command for ape test to handle parsing args. It needed to parse the -v before click otherwise couldnt get it to work with -v without a value error, even with callback.
3. The validaion of pytest args was ignoing the case of -v by itself in the middle where the next arg isnt an ape verbosity lvl

### How to verify it

Run:

```
ape test -vvv
```
### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
