### PR TITLE
feat: automatically calculate GitHub dependency name when not provided

### DIFF
--- a/src/ape_pm/dependency.py
+++ b/src/ape_pm/dependency.py
@@ -138,10 +138,15 @@ class GithubDependency(DependencyAPI):
 
     @model_validator(mode="before")
     @classmethod
-    def branch_to_ref(cls, model):
+    def _validate_model(cls, model):
+        # branch -> ref
         if "branch" in model and "ref" not in model:
             # Handle branch as an alias.
             model["ref"] = model.pop("branch")
+
+        if "name" not in model and "github" in model:
+            # Calculate a default name.
+            model["name"] = model["github"].split("/")[-1].lower()
 
         return model
 

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -474,7 +474,9 @@ class TestGitHubDependency:
         """
         When not given a name, it is derived from the github suffix.
         """
-        dependency = GithubDependency(github="ApeWorX/ApeNotAThing", version="3.0.0")  # type: ignore
+        dependency = GithubDependency(  # type: ignore
+            github="ApeWorX/ApeNotAThing", version="3.0.0"
+        )
         assert dependency.name == "apenotathing"
 
     def test_fetch_given_version(self, mock_client):

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -470,6 +470,13 @@ class TestGitHubDependency:
         with pytest.raises(ValidationError, match=expected):
             _ = GithubDependency(name="foo", github="asdf")
 
+    def test_name_from_github(self):
+        """
+        When not given a name, it is derived from the github suffix.
+        """
+        dependency = GithubDependency(github="ApeWorX/ApeNotAThing", version="3.0.0")  # type: ignore
+        assert dependency.name == "apenotathing"
+
     def test_fetch_given_version(self, mock_client):
         dependency = GithubDependency(
             github="ApeWorX/ApeNotAThing", version="3.0.0", name="apetestdep"


### PR DESCRIPTION
### What I did

allows

```yaml
dependencies:
  - github: ApeWorX/ApePay
    ref: main
```

to work, where `name:` is not configured.
In this case, it uses he name `apepay` automatically from the GH input.

### How I did it

model validator

### How to verify it

use config i just said

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [ ] Documentation has been updated
