### PR TITLE
fix: issue where checking `.auto_mine` in `geth --dev` raised `NotImplementedError`

### DIFF
--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -313,7 +313,15 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
 
     @property
     def auto_mine(self) -> bool:
-        return self.make_request("eth_mining", [])
+        if self.process is not None:
+            # Geth --dev auto mines.
+            return True
+
+        try:
+            return self.make_request("eth_mining", [])
+        except NotImplementedError:
+            # Assume true; unlikely to be off. Geth --dev automines.
+            return True
 
     @auto_mine.setter
     def auto_mine(self, value):

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -778,3 +778,8 @@ def test_start(mocker, convert, project, geth_provider):
 
         actual = spy.call_args[1]["balance"]
         assert actual == amount
+
+
+@geth_process_test
+def test_auto_mine(geth_provider):
+    assert geth_provider.auto_mine is True


### PR DESCRIPTION
### What I did

Was getting not-implemented error when would expect it to return True

### How I did it

if we started the process, ret true
if we get not impl error, assume true

### How to verify it

```sh
ape console --network ethereum:local:node
```

```python
res = provider.auto_mine
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
