### PR TITLE
fix: serialized `HexBytes` for `Any` types in `ContractLog`

### DIFF
--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, TypeVar, Union, cast, overload
 
@@ -265,7 +265,28 @@ class BaseContractLog(BaseInterfaceModel):
         (https://github.com/pydantic/pydantic/issues/10152)
         we have to ensure these are regular ints.
         """
-        return {k: int(v) if isinstance(v, int) else v for k, v in event_arguments.items()}
+        return self._serialize_value(event_arguments)
+
+    def _serialize_value(self, value: Any) -> Any:
+        if isinstance(value, int):
+            # Handle custom ints.
+            return int(value)
+
+        elif isinstance(value, HexBytes):
+            return to_hex(value)
+
+        elif isinstance(value, str):
+            # Avoiding str triggering iterable condition.
+            return value
+
+        elif isinstance(value, dict):
+            # Also, avoid handling dict in the iterable case.
+            return {k: self._serialize_value(v) for k, v in value.items()}
+
+        elif isinstance(value, Iterable):
+            return [self._serialize_value(v) for v in value]
+
+        return value
 
 
 class ContractLog(ExtraAttributesMixin, BaseContractLog):
@@ -290,6 +311,10 @@ class ContractLog(ExtraAttributesMixin, BaseContractLog):
     The index of the transaction's position when the log was created.
     Is `None` when from the pending block.
     """
+
+    @field_serializer("transaction_hash", "block_hash")
+    def _serialize_hashes(self, value):
+        return self._serialize_value(value)
 
     # NOTE: This class has an overridden `__getattr__` method, but `block` is a reserved keyword
     #       in most smart contract languages, so it is safe to use. Purposely avoid adding

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import pytest
 from eth_pydantic_types import HexBytes
+from eth_pydantic_types.hash import HashBytes20
 from ethpm_types import ContractType
 
 from ape.api import ReceiptAPI
@@ -382,3 +383,24 @@ def test_model_dump(solidity_contract_container, owner):
     # This next assertion is important because of this Pydantic bug:
     # https://github.com/pydantic/pydantic/issues/10152
     assert not isinstance(actual["newNum"], CurrencyValueComparable)
+
+
+def test_model_dump_json():
+    # NOTE: There was an issue when using HexBytes for Any.
+    event_arguments = {"key": 123, "validators": [HexBytes(123)]}
+    event = ContractLog(
+        block_number=123,
+        block_hash="block-hash",
+        event_arguments=event_arguments,
+        event_name="MyEvent",
+        log_index=0,
+        transaction_hash=HashBytes20.__eth_pydantic_validate__(347374237412374174),
+    )
+    actual = event.model_dump_json()
+    assert actual == (
+        '{"block_hash":"block-hash","block_number":123,'
+        '"contract_address":"0x0000000000000000000000000000000000000000",'
+        '"event_arguments":{"key":123,"validators":["0x7b"]},"event_name":'
+        '"MyEvent","log_index":0,'
+        '"transaction_hash":"0x00000000000000000000000004d21f074916369e"}'
+    )


### PR DESCRIPTION
### What I did

When annotating with `Any` and validating with `HexBytes` types, the serializers will fail.
This is because Pydantic hasn't a way of knowing.
The fix is custom serializers in `ContractLog`.
Models annotating with `HexBytes` do no have this problem (what it was made for).

fixes: https://github.com/ApeWorX/eth-pydantic-types/issues/14

### How I did it

Custom serializers on contract log models

### How to verify it

@fubuloubu knows
also see test

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
