### PR TITLE
docs: order guides and put back python-plugin separation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,1 +1,2 @@
 .. dynamic-toc-tree::
+    :userguides: accounts, clis, dependencies, data

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,2 +1,25 @@
 .. dynamic-toc-tree::
-    :userguides: accounts, clis, dependencies, data
+    :plugin-prefix: ape_
+    :userguides:
+        - quickstart
+        - accounts
+        - networks
+        - forking_networks
+        - contracts
+        - proxy
+        - installing_plugins
+        - projects
+        - dependencies
+        - config
+        - compile
+        - console
+        - transactions
+        - trace
+        - scripts
+        - testing
+        - reverts
+        - publishing
+        - clis
+        - data
+        - developing_plugins
+        - logging


### PR DESCRIPTION
### What I did

Uses new features from https://github.com/ApeWorX/sphinx-ape/pulls to improve the docs.

* Adds a book-like order to the userguides.
* Adds a plugin prefix so plugin python docs can be separated

### How I did it

auto TOC directive inputs

### How to verify it

Use that sphinx-ape branch and build the docs:

<img width="309" alt="Screenshot 2024-10-04 at 11 43 41" src="https://github.com/user-attachments/assets/9ce14d7a-0f7b-4f3e-ab58-17f17b14ab97">
<img width="337" alt="Screenshot 2024-10-04 at 11 43 55" src="https://github.com/user-attachments/assets/f1da1f8f-55ed-44ba-aa08-3d6bea27996e">


### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
