### PR TITLE
fix: prevent running tests on mainnet if configured as the default network

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -1000,6 +1000,9 @@ class NetworkAPI(BaseInterfaceModel):
 
     @property
     def is_mainnet(self) -> bool:
+        """
+        True when the network is the mainnet network for the ecosystem.
+        """
         cfg_is_mainnet = self.config.get("is_mainnet")
         if cfg_is_mainnet is not None:
             return cfg_is_mainnet

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -1003,7 +1003,7 @@ class NetworkAPI(BaseInterfaceModel):
         """
         True when the network is the mainnet network for the ecosystem.
         """
-        cfg_is_mainnet = self.config.get("is_mainnet")
+        cfg_is_mainnet: Optional[bool] = self.config.get("is_mainnet")
         if cfg_is_mainnet is not None:
             return cfg_is_mainnet
 

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -999,6 +999,14 @@ class NetworkAPI(BaseInterfaceModel):
         return None  # May not have an block explorer
 
     @property
+    def is_mainnet(self) -> bool:
+        cfg_is_mainnet = self.config.get("is_mainnet")
+        if cfg_is_mainnet is not None:
+            return cfg_is_mainnet
+
+        return self.name == "mainnet"
+
+    @property
     def is_fork(self) -> bool:
         """
         True when using a forked network.

--- a/src/ape/pytest/plugin.py
+++ b/src/ape/pytest/plugin.py
@@ -10,6 +10,16 @@ from ape.pytest.runners import PytestApeRunner
 from ape.utils.basemodel import ManagerAccessMixin
 
 
+def _get_default_network() -> str:
+    default_ecosystem = ManagerAccessMixin.network_manager.default_ecosystem
+    if default_ecosystem.default_network.is_mainnet:
+        # Don't use mainnet for tests, even if it configured as
+        # the default.
+        return "ethereum:local:test"
+
+    return default_ecosystem.name
+
+
 def pytest_addoption(parser):
     def add_option(*names, **kwargs):
         try:
@@ -29,7 +39,7 @@ def pytest_addoption(parser):
     add_option(
         "--network",
         action="store",
-        default=ManagerAccessMixin.network_manager.default_ecosystem.name,
+        default=_get_default_network(),
         help="Override the default network and provider (see ``ape networks list`` for options).",
     )
     add_option(

--- a/src/ape/pytest/plugin.py
+++ b/src/ape/pytest/plugin.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
+from typing import Optional
 
+from ape.api import EcosystemAPI
 from ape.exceptions import ConfigError
 from ape.pytest.config import ConfigWrapper
 from ape.pytest.coverage import CoverageTracker
@@ -10,14 +12,20 @@ from ape.pytest.runners import PytestApeRunner
 from ape.utils.basemodel import ManagerAccessMixin
 
 
-def _get_default_network() -> str:
-    default_ecosystem = ManagerAccessMixin.network_manager.default_ecosystem
-    if default_ecosystem.default_network.is_mainnet:
+def _get_default_network(ecosystem: Optional[EcosystemAPI] = None) -> str:
+    if ecosystem is None:
+        ecosystem = ManagerAccessMixin.network_manager.default_ecosystem
+
+    if ecosystem.default_network.is_mainnet:
         # Don't use mainnet for tests, even if it configured as
         # the default.
-        return "ethereum:local:test"
+        raise ConfigError(
+            "Default network is mainnet; unable to run tests on mainnet. "
+            "Please specify the network using the `--network` flag or "
+            "configure a different default network."
+        )
 
-    return default_ecosystem.name
+    return ecosystem.name
 
 
 def pytest_addoption(parser):

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -36,7 +36,11 @@ class PytestApeRunner(ManagerAccessMixin):
 
     @property
     def _provider_context(self) -> ProviderContextManager:
-        return self.network_manager.parse_network_choice(self.config_wrapper.network)
+        ctx = self.network_manager.parse_network_choice(self.config_wrapper.network)
+        if ctx._provider.network.is_mainnet:
+            pytest.exit("Unable to run tests on mainnet.")
+
+        return ctx
 
     @property
     def _coverage_report(self) -> Optional[CoverageReport]:

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -36,11 +36,7 @@ class PytestApeRunner(ManagerAccessMixin):
 
     @property
     def _provider_context(self) -> ProviderContextManager:
-        ctx = self.network_manager.parse_network_choice(self.config_wrapper.network)
-        if ctx._provider.network.is_mainnet:
-            pytest.exit("Unable to run tests on mainnet.")
-
-        return ctx
+        return self.network_manager.parse_network_choice(self.config_wrapper.network)
 
     @property
     def _coverage_report(self) -> Optional[CoverageReport]:

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -236,3 +236,27 @@ def test_providers_custom_non_fork_network_does_not_use_fork_provider(
         finally:
             network._get_plugin_providers = orig
             network.__dict__.pop("providers", None)  # de-cache
+
+
+def test_is_local(ethereum):
+    assert ethereum.local.is_local
+    assert not ethereum.mainnet.is_local
+    assert not ethereum.mainnet_fork.is_local
+
+
+def test_is_fork(ethereum):
+    assert not ethereum.local.is_fork
+    assert not ethereum.mainnet.is_fork
+    assert ethereum.mainnet_fork.is_fork
+
+
+def test_is_dev(ethereum):
+    assert ethereum.local.is_dev
+    assert not ethereum.mainnet.is_dev
+    assert ethereum.mainnet_fork.is_dev
+
+
+def test_is_mainnet(ethereum):
+    assert not ethereum.local.is_mainnet
+    assert ethereum.mainnet.is_mainnet
+    assert not ethereum.mainnet_fork.is_mainnet

--- a/tests/functional/test_test.py
+++ b/tests/functional/test_test.py
@@ -1,3 +1,7 @@
+import pytest
+
+from ape.exceptions import ConfigError
+from ape.pytest.plugin import _get_default_network
 from ape_test import ApeTestConfig
 
 
@@ -9,3 +13,19 @@ class TestApeTestConfig:
         actual = cfg.balance
         expected = 10_000_000_000_000_000_000  # 10 ETH in WEI
         assert actual == expected
+
+
+def test_get_default_network(mocker):
+    # NOTE: Using this weird test to avoid actually
+    #  using mainnet in any test, even accidentally.
+    mock_ecosystem = mocker.MagicMock()
+    mock_mainnet = mocker.MagicMock()
+    mock_mainnet.name = "mainnet"
+    mock_ecosystem.default_network = mock_mainnet
+    expected = (
+        "Default network is mainnet; unable to run tests on mainnet. "
+        "Please specify the network using the `--network` flag or "
+        "configure a different default network."
+    )
+    with pytest.raises(ConfigError, match=expected):
+        _get_default_network(mock_mainnet)


### PR DESCRIPTION
### What I did

Prevents running tests on mainnet network

1. If you default network is a mainnet, use Ape's regular default for ape test (eth:local:test or make them specify).
2. If the user passed in --network mainnet type network, exit out right away.
3. dont ask about 3

### How to verify it

to test 1:

```yaml
ethereum:
   default_network: mainnet
```

to test 2:

```sh
ape test --network ethereum:mainnet:alchemy
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [ ] Documentation has been updated
