### PR TITLE
build(eth-typing): pin version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(
         # All version pins dependent on web3[tester]
         "eth-abi",
         "eth-account",
-        "eth-typing",
+        "eth-typing==4.1.0  ",
         "eth-utils",
         "hexbytes",
         "py-geth>=5.0.0-beta.2,<6",


### PR DESCRIPTION
ContractName is depecrated from version 4.2.0

### What I did
I pinned eth-typing version 4.1.0