### PR TITLE
fix: `ContractName` import issue on eth-typing==5.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(
         # All unspecified version pins dependent on web3.py and eth-tester.
         "eth-abi",
         "eth-account",
-        "eth-typing>=5.0.1,<6",
+        "eth-typing",
         "eth-utils",
         "hexbytes",
         "py-geth>=5.0.0-beta.2,<6",

--- a/setup.py
+++ b/setup.py
@@ -115,10 +115,10 @@ setup(
         "urllib3>=2.0.0,<3",
         "watchdog>=3.0,<4",
         # ** Dependencies maintained by Ethereum Foundation **
-        # All version pins dependent on web3[tester]
+        # All unspecified version pins dependent on web3.py and eth-tester.
         "eth-abi",
         "eth-account",
-        "eth-typing",
+        "eth-typing>=5.0.0,<6",
         "eth-utils",
         "hexbytes",
         "py-geth>=5.0.0-beta.2,<6",

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(
         # All unspecified version pins dependent on web3.py and eth-tester.
         "eth-abi",
         "eth-account",
-        "eth-typing>=5.0.0,<6",
+        "eth-typing>=5.0.1,<6",
         "eth-utils",
         "hexbytes",
         "py-geth>=5.0.0-beta.2,<6",

--- a/src/ape_test/_cli.py
+++ b/src/ape_test/_cli.py
@@ -97,6 +97,11 @@ def _validate_pytest_args(*pytest_args) -> list[str]:
         else:
             valid_args.append(argument)
 
+    # Disable the pytest_ethereum plugin.
+    if "no:pytest_ethereum" not in valid_args:
+        valid_args.extend(("-p", "no:pytest_ethereum"))
+
+    breakpoint()
     return valid_args
 
 

--- a/src/ape_test/_cli.py
+++ b/src/ape_test/_cli.py
@@ -101,7 +101,6 @@ def _validate_pytest_args(*pytest_args) -> list[str]:
     if "no:pytest_ethereum" not in valid_args:
         valid_args.extend(("-p", "no:pytest_ethereum"))
 
-    breakpoint()
     return valid_args
 
 


### PR DESCRIPTION
### What I did

I believe the fix is just to bump to 5.0.1 so you can't use 5.0.0

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
