### PR TITLE
feat: support for non-mainnet named mainnet networks

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -875,7 +875,7 @@ class NetworkAPI(BaseInterfaceModel):
         The configuration of the network. See :class:`~ape.managers.config.ConfigManager`
         for more information on plugin configurations.
         """
-        return self.config_manager.get_config(self.ecosystem.name)
+        return self.ecosystem.config
 
     @property
     def config(self) -> PluginConfig:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -147,6 +147,12 @@ class NetworkConfig(PluginConfig):
     base_fee_multiplier: float = 1.0
     """A multiplier to apply to a transaction base fee."""
 
+    is_mainnet: Optional[bool] = None
+    """
+    Set to ``True`` to declare as a mainnet or ``False`` to ensure
+    it isn't detected as one.
+    """
+
     request_headers: dict = {}
     """Optionally config extra request headers whenever using this network."""
 

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -6,7 +6,8 @@ import pytest
 from ape.api.networks import ForkedNetworkAPI, NetworkAPI, create_network_type
 from ape.api.providers import ProviderAPI
 from ape.exceptions import NetworkError, ProviderNotFoundError
-from ape_ethereum import EthereumConfig
+from ape_ethereum import Ethereum, EthereumConfig
+from ape_ethereum.ecosystem import BaseEthereumConfig, NetworkConfig, create_network_config
 from ape_ethereum.transactions import TransactionType
 
 
@@ -260,3 +261,28 @@ def test_is_mainnet(ethereum):
     assert not ethereum.local.is_mainnet
     assert ethereum.mainnet.is_mainnet
     assert not ethereum.mainnet_fork.is_mainnet
+
+
+def test_is_mainnet_from_config(project):
+    """
+    Simulate an EVM plugin with a weird named mainnet that properly
+    configured it.
+    """
+    chain_id = 9191919191919919121177171
+    ecosystem_name = "ismainnettest"
+    network_name = "primarynetwork"
+    network_type = create_network_type(chain_id, chain_id)
+
+    class MyConfig(BaseEthereumConfig):
+        primarynetwork: NetworkConfig = create_network_config(is_mainnet=True)
+
+    class MyEcosystem(Ethereum):
+        name: str = ecosystem_name
+
+        @property
+        def config(self):
+            return MyConfig()
+
+    ecosystem = MyEcosystem()
+    network = network_type(name=network_name, ecosystem=ecosystem)
+    assert network.is_mainnet

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -890,7 +890,9 @@ class TestSourceManager:
 
             # Top-level match.
             for base in (source_path, str(source_path), "Contract", "Contract.json"):
-                assert pm.sources.lookup(base) == source_path, f"Failed to lookup {base}"
+                # Using stem in case it returns `Contract.__mock__`, which is
+                # added / removed as part of other tests (running x-dist).
+                assert pm.sources.lookup(base).stem == source_path.stem, f"Failed to lookup {base}"
 
             # Nested: 1st level
             for closest in (
@@ -901,6 +903,8 @@ class TestSourceManager:
             ):
                 actual = pm.sources.lookup(closest)
                 expected = nested_source_a
+                # Using stem in case it returns `Contract.__mock__`, which is
+                # added / removed as part of other tests (running x-dist).
                 assert actual.stem == expected.stem, f"Failed to lookup {closest}"
 
             # Nested: 2nd level


### PR DESCRIPTION
### What I did

I need to be able to tell `ape-bsc` that `opbnb` should also be treated as a mainnet but i need this to do it.

So far, mainnet is used as a guard when set as default network to avoid accidentally running tests on it.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

See https://github.com/ApeWorX/ape-bsc/pull/29 as an example

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
