### PR TITLE
fix: `-v debug` wasn't working when at end of some commands

### DIFF
--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -103,7 +103,11 @@ def _create_verbosity_kwargs(
         if callback is not None:
             value = callback(ctx, param, value)
 
-        cli_logger._load_from_sys_argv(default=value)
+        if cli_logger._did_parse_sys_argv:
+            # Changing mid-session somehow (tests?)
+            cli_logger.set_level(value)
+        else:
+            cli_logger._load_from_sys_argv(default=value)
 
     level_names = [lvl.name for lvl in LogLevel]
     names_str = f"{', '.join(level_names[:-1])}, or {level_names[-1]}"

--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -161,7 +161,7 @@ class ApeLogger:
         #  Minus 2 because if `-v` is the last arg, it is not our verbosity `-v`.
         num_args = len(sys.argv) - 2
 
-        for arg_i in range(num_args):
+        for arg_i in range(1, 1 + num_args):
             if sys.argv[arg_i] == "-v" or sys.argv[arg_i] == "--verbosity":
                 try:
                     level = _get_level(sys.argv[arg_i + 1].upper())

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -428,14 +428,17 @@ def test_prompt_choice(runner, opt):
     assert "__expected_foo" in result.output
 
 
-def test_verbosity_option(runner):
+@pytest.mark.parametrize("name", ("-v", "--verbosity"))
+def test_verbosity_option(runner, name):
+    logger._did_parse_sys_argv = False  # Force re-parse
+
     @click.command()
     @verbosity_option()
     def cmd():
         click.echo(f"__expected_{logger.level}")
 
-    result = runner.invoke(cmd, ("--verbosity", logger.level))
-    assert f"__expected_{logger.level}" in result.output
+    result = runner.invoke(cmd, (name, "debug"))
+    assert f"__expected_10" in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -438,7 +438,7 @@ def test_verbosity_option(runner, name):
         click.echo(f"__expected_{logger.level}")
 
     result = runner.invoke(cmd, (name, "debug"))
-    assert f"__expected_10" in result.output
+    assert "__expected_10" in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/cli/test_console.py
+++ b/tests/integration/cli/test_console.py
@@ -2,8 +2,9 @@ from pathlib import Path
 
 import pytest
 
+from ape.logging import logger
 from ape import __all__
-from tests.integration.cli.utils import skip_projects, skip_projects_except
+from tests.integration.cli.utils import skip_projects, skip_projects_except, run_once
 
 
 @pytest.fixture(params=("path", "root"))

--- a/tests/integration/cli/test_console.py
+++ b/tests/integration/cli/test_console.py
@@ -2,9 +2,8 @@ from pathlib import Path
 
 import pytest
 
-from ape.logging import logger
 from ape import __all__
-from tests.integration.cli.utils import skip_projects, skip_projects_except, run_once
+from tests.integration.cli.utils import skip_projects, skip_projects_except
 
 
 @pytest.fixture(params=("path", "root"))


### PR DESCRIPTION
### What I did

noticed `ape console -v debug` was not in debug mode...

### How I did it

index in range was wrong, it never change the final character.

### How to verify it

```sh
ape console -v debug
```

should see the anon message thing

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
