### PR TITLE
refactor: use new types from `eth_pydantic_types`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,10 +121,10 @@ setup(
         "web3[tester]>=6.20.1,<8",
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.2.10,<0.3",
-        "ethpm-types>=0.6.25,<0.7",
+        "ethpm-types>=0.6.26,<0.7",
         "eth_pydantic_types>=0.2.0,<0.3",
         "evmchains>=0.1.0,<0.2",
-        "evm-trace>=0.2.3,<0.3",
+        "evm-trace>=0.2.5,<0.3",
     ],
     entry_points={
         "console_scripts": ["ape=ape._cli:cli"],

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.2.10,<0.3",
         "ethpm-types>=0.6.25,<0.7",
-        "eth_pydantic_types>=0.1.3,<0.2",
+        "eth_pydantic_types>=0.2.0,<0.3",
         "evmchains>=0.1.0,<0.2",
         "evm-trace>=0.2.3,<0.3",
     ],

--- a/src/ape/types/address.py
+++ b/src/ape/types/address.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Annotated, Any, Optional, Union
 
 from eth_pydantic_types import Address as _Address
-from eth_pydantic_types import HashBytes20, HashStr20
+from eth_pydantic_types import HexBytes20, HexStr20
 from eth_typing import ChecksumAddress
 
 from ape.utils.basemodel import ManagerAccessMixin
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from pydantic_core.core_schema import ValidationInfo
 
 
-RawAddress = Union[str, int, HashStr20, HashBytes20]
+RawAddress = Union[str, int, HexStr20, HexBytes20]
 """
 A raw data-type representation of an address.
 """

--- a/src/ape/utils/abi.py
+++ b/src/ape/utils/abi.py
@@ -11,7 +11,7 @@ from eth_abi.encoding import UnsignedIntegerEncoder
 from eth_abi.exceptions import DecodingError, InsufficientDataBytes
 from eth_abi.registry import BaseEquals, registry
 from eth_pydantic_types import HexBytes, HexStr
-from eth_pydantic_types.validators import validate_bytes_size
+from eth_pydantic_types.utils import validate_bytes_size
 from eth_utils import decode_hex
 from ethpm_types.abi import ABIType, ConstructorABI, EventABI, EventABIType, MethodABI
 

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Optional, cast
 
 import pytest
-from eth_pydantic_types import HashBytes32
+from eth_pydantic_types import HexBytes32
 from eth_typing import HexStr
 from eth_utils import keccak, to_hex
 from hexbytes import HexBytes
@@ -556,7 +556,7 @@ def test_send_transaction_when_no_error_and_receipt_fails(
     geth_provider._web3 = mock_web3
     # Getting a receipt "works", but you get a failed one.
     # NOTE: Value is meaningless.
-    tx_hash = HashBytes32.__eth_pydantic_validate__(123**36)
+    tx_hash = HexBytes32.__eth_pydantic_validate__(123**36)
     receipt_data = {
         "failed": True,
         "blockNumber": 0,

--- a/tests/functional/geth/test_trace.py
+++ b/tests/functional/geth/test_trace.py
@@ -14,7 +14,7 @@ from tests.conftest import geth_process_test
 LOCAL_TRACE = r"""
 Call trace for '0x([A-Fa-f0-9]{64})'
 tx\.origin=0x[a-fA-F0-9]{40}
-ContractA\.methodWithoutArguments\(\) -> 0x[A-Fa-f0-9]{2,}..[A-Fa-f0-9]{4} \[\d+ gas\]
+ContractA\.methodWithoutArguments\(\) -> 0x[A-Fa-f0-9]{4}..[A-Fa-f0-9]{4} \[\d+ gas\]
 ├── SYMBOL\.supercluster\(x=234444\) -> \[
 │       \[23523523235235, 11111111111, 234444\],
 │       \[

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -3,8 +3,7 @@ from queue import Queue
 from typing import TYPE_CHECKING, Optional
 
 import pytest
-from eth_pydantic_types import HexBytes
-from eth_pydantic_types.hash import HashBytes20
+from eth_pydantic_types import HexBytes, HexBytes20
 from eth_utils import to_hex
 from ethpm_types import ContractType
 
@@ -474,7 +473,7 @@ def test_model_dump(solidity_contract_container, owner):
 def test_model_dump_hexbytes(mode):
     # NOTE: There was an issue when using HexBytes for Any.
     event_arguments = {"key": 123, "validators": [HexBytes(123)]}
-    txn_hash = HashBytes20.__eth_pydantic_validate__(347374237412374174)
+    txn_hash = HexBytes20.__eth_pydantic_validate__(347374237412374174)
     event = ContractLog(
         block_number=123,
         block_hash="block-hash",
@@ -497,7 +496,7 @@ def test_model_dump_json():
         event_arguments=event_arguments,
         event_name="MyEvent",
         log_index=0,
-        transaction_hash=HashBytes20.__eth_pydantic_validate__(347374237412374174),
+        transaction_hash=HexBytes20.__eth_pydantic_validate__(347374237412374174),
     )
     actual = event.model_dump_json()
     assert actual == (

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -3,7 +3,7 @@ import re
 from typing import Any, ClassVar, cast
 
 import pytest
-from eth_pydantic_types import HashBytes32, HexBytes
+from eth_pydantic_types import HexBytes, HexBytes32
 from eth_typing import HexAddress, HexStr
 from ethpm_types import ContractType, ErrorABI
 from ethpm_types.abi import ABIType, EventABI, MethodABI
@@ -744,7 +744,7 @@ def test_encode_blueprint_contract(ethereum, vyper_contract_type):
 
 def test_decode_returndata(ethereum):
     abi = make_method_abi("doThing", outputs=[{"name": "", "type": "bool"}])
-    data = HashBytes32.__eth_pydantic_validate__(0)
+    data = HexBytes32.__eth_pydantic_validate__(0)
     actual = ethereum.decode_returndata(abi, data)
     assert actual == (False,)
 

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-from eth_pydantic_types import HashBytes32
+from eth_pydantic_types import HexBytes32
 from eth_tester.exceptions import TransactionFailed  # type: ignore
 from eth_typing import HexStr
 from eth_utils import ValidationError, to_hex
@@ -434,7 +434,7 @@ def test_send_transaction_when_no_error_and_receipt_fails(
 
     try:
         # NOTE: Value is meaningless.
-        tx_hash = HashBytes32.__eth_pydantic_validate__(123**36)
+        tx_hash = HexBytes32.__eth_pydantic_validate__(123**36)
 
         # Sending tx "works" meaning no vm error.
         mock_eth_tester.ethereum_tester.send_raw_transaction.return_value = tx_hash


### PR DESCRIPTION
### What I did

Uses the new names of classes after eth_pydantic_types overhaul

fixes: #

### How I did it

in coordination with: https://github.com/ApeWorX/eth-pydantic-types/pull/11

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
