### PR TITLE
feat: lookup network in evmchains; plugin-less networks, adhoc networks w/ correct name

### DIFF
--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -1,8 +1,9 @@
 # Networks
 
 When interacting with a blockchain, you will have to select an ecosystem (e.g. Ethereum, Arbitrum, or Fantom), a network (e.g. Mainnet or Sepolia) and a provider (e.g. Eth-Tester, Node (Geth), or Alchemy).
-Networks are part of ecosystems and typically defined in plugins.
-For example, the `ape-ethereum` plugin comes with Ape and can be used for handling EVM-like behavior.
+The `ape-ethereum` ecosystem and network(s) plugin comes with Ape and can be used for handling EVM-like behavior.
+Networks are part of ecosystems and typically defined in plugins or custom-network configurations.
+However, Ape works out-of-the-box (in a limited way) with any network defined in the [evmchains](https://github.com/ApeWorX/evmchains) library.
 
 ## Selecting a Network
 
@@ -25,7 +26,7 @@ ape test --network ethereum:local:foundry
 ape console --network arbitrum:testnet:alchemy # NOTICE: All networks, even from other ecosystems, use this.
 ```
 
-To see all possible values for `--network`, run the command:
+To see all networks that work with the `--network` flag (besides those _only_ defined in `evmchains`), run the command:
 
 ```shell
 ape networks list
@@ -99,6 +100,20 @@ ape networks list
 ```
 
 In the remainder of this guide, any example below using Ethereum, you can replace with an L2 ecosystem's name and network combination.
+
+## evmchains Networks
+
+If a network is in the [evmchains](https://github.com/ApeWorX/evmchains) library, it will work in Ape automatically, even without a plugin or any custom configuration for that network.
+
+```shell
+ape console --network moonbeam
+```
+
+This works because the `moonbeam` network data is available in the `evmchains` library, and Ape is able to look it up.
+
+```{warning}
+Support for networks from evm-chains alone may be limited and require additional configuration to work in production use-cases.
+```
 
 ## Custom Network Connection
 

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -12,6 +12,7 @@ from eth_account._utils.signing import (
 )
 from eth_pydantic_types import HexBytes
 from eth_utils import keccak, to_int
+from evmchains import PUBLIC_CHAIN_META
 from pydantic import model_validator
 
 from ape.exceptions import (
@@ -109,7 +110,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
         """
         return self.config_manager.DATA_FOLDER / self.name
 
-    @cached_property
+    @property
     def custom_network(self) -> "NetworkAPI":
         """
         A :class:`~ape.api.networks.NetworkAPI` for custom networks where the
@@ -125,13 +126,11 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
         if ethereum_class is None:
             raise NetworkError("Core Ethereum plugin missing.")
 
-        request_header = self.config_manager.REQUEST_HEADER
-        init_kwargs = {"name": "ethereum", "request_header": request_header}
-        ethereum = ethereum_class(**init_kwargs)  # type: ignore
+        init_kwargs = {"name": "ethereum"}
+        evm_ecosystem = ethereum_class(**init_kwargs)  # type: ignore
         return NetworkAPI(
             name="custom",
-            ecosystem=ethereum,
-            request_header=request_header,
+            ecosystem=evm_ecosystem,
             _default_provider="node",
             _is_custom=True,
         )
@@ -301,6 +300,11 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
             network_api._is_custom = True
             networks[net_name] = network_api
 
+        # Add any remaining networks from EVM chains here (but don't override).
+        # NOTE: Only applicable to EVM-based ecosystems, of course.
+        #   Otherwise, this is a no-op.
+        networks = {**self._networks_from_evmchains, **networks}
+
         return networks
 
     @cached_property
@@ -309,6 +313,17 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
             network_name: network_class(name=network_name, ecosystem=self)
             for _, (ecosystem_name, network_name, network_class) in self.plugin_manager.networks
             if ecosystem_name == self.name
+        }
+
+    @cached_property
+    def _networks_from_evmchains(self) -> dict[str, "NetworkAPI"]:
+        # NOTE: Purposely exclude plugins here so we also prefer plugins.
+        return {
+            network_name: create_network_type(data["chainId"], data["chainId"])(
+                name=network_name, ecosystem=self
+            )
+            for network_name, data in PUBLIC_CHAIN_META.get(self.name, {}).items()
+            if network_name not in self._networks_from_plugins
         }
 
     def __post_init__(self):
@@ -1057,7 +1072,6 @@ class NetworkAPI(BaseInterfaceModel):
         Returns:
             dict[str, partial[:class:`~ape.api.providers.ProviderAPI`]]
         """
-
         from ape.plugins._utils import clean_plugin_name
 
         providers = {}
@@ -1088,6 +1102,12 @@ class NetworkAPI(BaseInterfaceModel):
                     name=provider_name,
                     network=self,
                 )
+
+        # Any EVM-chain works with node provider.
+        if "node" not in providers and self.name in self.ecosystem._networks_from_evmchains:
+            # NOTE: Arbitrarily using sepolia to access the Node class.
+            node_provider_cls = self.network_manager.ethereum.sepolia.get_provider("node").__class__
+            providers["node"] = partial(node_provider_cls, name="node", network=self)
 
         return providers
 

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -441,7 +441,8 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         if ecosystem_name in self.ecosystem_names:
             return self.ecosystems[ecosystem_name]
 
-        elif ecosystem_name in PUBLIC_CHAIN_META:
+        elif ecosystem_name.lower().replace(" ", "-") in PUBLIC_CHAIN_META:
+            ecosystem_name = ecosystem_name.lower().replace(" ", "-")
             symbol = None
             for net in PUBLIC_CHAIN_META[ecosystem_name].values():
                 if not (native_currency := net.get("nativeCurrency")):

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -1940,7 +1940,6 @@ class Project(ProjectManager):
 
         self._config_override = overrides
         _ = self.config
-
         self.account_manager.test_accounts.reset()
 
     def extract_manifest(self) -> PackageManifest:

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -22,7 +22,6 @@ from requests import HTTPError
 from web3 import HTTPProvider, IPCProvider, Web3
 from web3 import WebsocketProvider as WebSocketProvider
 from web3._utils.http import construct_user_agent
-from web3.exceptions import BlockNotFound
 from web3.exceptions import ContractLogicError as Web3ContractLogicError
 from web3.exceptions import (
     ExtraDataLengthError,

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1525,13 +1525,16 @@ class EthereumNodeProvider(Web3Provider, ABC):
         for option in ("earliest", "latest"):
             try:
                 block = self.web3.eth.get_block(option)  # type: ignore[arg-type]
+            
             except ExtraDataLengthError:
                 is_likely_poa = True
                 break
-            except BlockNotFound:
-                # Weird node implementation.
-                is_likely_poa = False
-                break
+            
+            except Exception:
+                # Some chains are "light" and we may not be able to detect
+                # if it need PoA middleware.
+                continue
+            
             else:
                 is_likely_poa = (
                     "proofOfAuthorityData" in block

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1525,16 +1525,16 @@ class EthereumNodeProvider(Web3Provider, ABC):
         for option in ("earliest", "latest"):
             try:
                 block = self.web3.eth.get_block(option)  # type: ignore[arg-type]
-            
+
             except ExtraDataLengthError:
                 is_likely_poa = True
                 break
-            
+
             except Exception:
                 # Some chains are "light" and we may not be able to detect
                 # if it need PoA middleware.
                 continue
-            
+
             else:
                 is_likely_poa = (
                     "proofOfAuthorityData" in block

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -22,6 +22,7 @@ from requests import HTTPError
 from web3 import HTTPProvider, IPCProvider, Web3
 from web3 import WebsocketProvider as WebSocketProvider
 from web3._utils.http import construct_user_agent
+from web3.exceptions import BlockNotFound
 from web3.exceptions import ContractLogicError as Web3ContractLogicError
 from web3.exceptions import (
     ExtraDataLengthError,
@@ -1526,6 +1527,10 @@ class EthereumNodeProvider(Web3Provider, ABC):
                 block = self.web3.eth.get_block(option)  # type: ignore[arg-type]
             except ExtraDataLengthError:
                 is_likely_poa = True
+                break
+            except BlockNotFound:
+                # Weird node implementation.
+                is_likely_poa = False
                 break
             else:
                 is_likely_poa = (

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -16,7 +16,7 @@ import requests
 from eth_pydantic_types import HexBytes
 from eth_typing import BlockNumber, HexStr
 from eth_utils import add_0x_prefix, is_hex, to_hex
-from evmchains import get_random_rpc
+from evmchains import PUBLIC_CHAIN_META, get_random_rpc
 from pydantic.dataclasses import dataclass
 from requests import HTTPError
 from web3 import HTTPProvider, IPCProvider, Web3
@@ -1539,6 +1539,18 @@ class EthereumNodeProvider(Web3Provider, ABC):
             self.web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
         self.network.verify_chain_id(chain_id)
+
+        # Correct network name, if using custom-URL approach.
+        if self.network.name == "custom":
+            for ecosystem_name, network in PUBLIC_CHAIN_META.items():
+                for network_name, meta in network.items():
+                    if "chainId" not in meta or meta["chainId"] != chain_id:
+                        continue
+
+                    # Network found.
+                    self.network.name = network_name
+                    self.network.ecosystem.name = ecosystem_name
+                    break
 
     def disconnect(self):
         self._call_trace_approach = None

--- a/tests/functional/geth/test_network_manager.py
+++ b/tests/functional/geth/test_network_manager.py
@@ -37,3 +37,17 @@ def test_fork_upstream_provider(networks, mock_geth_sepolia, geth_provider, mock
             geth_provider.provider_settings["uri"] = orig
         else:
             del geth_provider.provider_settings["uri"]
+
+
+@geth_process_test
+@pytest.mark.parametrize(
+    "connection_str", ("moonbeam:moonriver", "https://moonriver.api.onfinality.io/public")
+)
+def test_parse_network_choice_evmchains(networks, connection_str):
+    """
+    Show we can (without having a plugin installed) connect to a network
+    that evm-chains knows about.
+    """
+    with networks.parse_network_choice(connection_str) as moon_provider:
+        assert moon_provider.network.name == "moonriver"
+        assert moon_provider.network.ecosystem.name == "moonbeam"


### PR DESCRIPTION
### What I did

* Make it so if you connect to a network Ape hasn't an installed plugin for, it will look it up in evmchains and "just work"
* Make it so if you use a custom network e.g. connecting using a URL only, and that network is found in evmchains, it will set the correct names for the network

### How I did it

Use `evmchains` library.

### How to verify it

First, I have no plugin for moonbeam installed, but yet i can do this:

```sh
ape console --network moonbeam
```

and it "just works"

Second, if I connect to a URL in the same fashion:

```sh
ape console --network "https://moonriver.unitedbloc.com"
```

Not only does it work (did before), but the network name and stuff is correct:

```
In [1]: provider.network.name
Out[1]: 'moonriver'

In [2]: provider.network.ecosystem.name
Out[2]: 'moonbeam'
```

taa daaaa

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
