### PR TITLE
fix: use already set level as default

### DIFF
--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -454,6 +454,18 @@ def test_verbosity_option_change_default(runner, level):
     assert verbosity_parameter.default == level
 
 
+def test_verbosity_option_uses_logger_level_as_default(runner):
+    @click.command()
+    @verbosity_option(default=None)
+    def cmd():
+        click.echo(f"LogLevel={logger.level}")
+        pass
+
+    with logger.at_level(LogLevel.DEBUG):
+        result = runner.invoke(cmd)
+        assert "LogLevel=10" in result.output
+
+
 def test_account_prompt_name():
     """
     It is very important for this class to have the `name` attribute,

--- a/tests/functional/test_logging.py
+++ b/tests/functional/test_logging.py
@@ -69,7 +69,7 @@ def test_success(simple_runner):
     # this test also ensures that we get SUCCESS logs
     # without having to specify verbosity
     @group_for_testing.command()
-    @ape_cli_context()
+    @ape_cli_context(default_log_level=LogLevel.INFO.value)
     def cmd(cli_ctx):
         cli_ctx.logger.success("this is a test")
 


### PR DESCRIPTION
### What I did

more weird issues i guess where `-v debug` is not working... getting very annoyed at this.
the default was trigger the callback after was already set

### How I did it

use the default as the already set level to avoid resetting to INFO

### How to verify it

use `-v debug`

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
