### PR TITLE
fix: issue where snapshots lingered on disconnect

### DIFF
--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -136,7 +136,7 @@ class PytestApeFixtures(ManagerAccessMixin):
 
     @allow_disconnected
     def _restore(self, snapshot_id: SnapshotID):
-        if snapshot_id not in self.chain_manager._snapshots:
+        if snapshot_id not in self.chain_manager._snapshots[self.provider.chain_id]:
             return
         try:
             self.chain_manager.restore(snapshot_id)

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -332,6 +332,7 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
         if self.is_connected:
             self._complete_connect()
         else:
+            # Starting the process.
             self.start()
 
     def start(self, timeout: int = 20):
@@ -389,6 +390,9 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
         # Also unset the subprocess-provider reference.
         # NOTE: Type ignore is wrong; TODO: figure out why.
         self.process = None  # type: ignore[assignment]
+
+        # Clear any snapshots.
+        self.chain_manager._snapshots[self.chain_id] = []
 
         super().disconnect()
 

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -111,6 +111,9 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         self._evm_backend = None
         self.provider_settings = {}
 
+        # Invalidate snapshots.
+        self.chain_manager._snapshots[self.chain_id] = []
+
     def update_settings(self, new_settings: dict):
         self.provider_settings = {**self.provider_settings, **new_settings}
         self.disconnect()

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -1,10 +1,12 @@
+from collections import defaultdict
 from datetime import datetime, timedelta
 
 import pytest
 
-from ape.exceptions import APINotImplementedError, ChainError
+from ape.exceptions import APINotImplementedError, ChainError, UnknownSnapshotError
 from ape.managers.chain import AccountHistory
 from ape.types import AddressType
+from tests.conftest import geth_process_test
 
 
 def test_snapshot_and_restore(chain, owner, receiver, vyper_contract_instance):
@@ -61,16 +63,30 @@ def test_snapshot_and_restore_unknown_snapshot_id(chain):
     # After restoring to the second ID, the third ID is now invalid.
     chain.restore(snapshot_id_2)
 
-    with pytest.raises(ChainError) as err:
+    with pytest.raises(UnknownSnapshotError) as err:
         chain.restore(snapshot_id_3)
 
     assert "Unknown snapshot ID" in str(err.value)
 
 
 def test_snapshot_and_restore_no_snapshots(chain):
-    chain._snapshots = []  # Ensure empty (gets set in test setup)
+    chain._snapshots = defaultdict(list)  # Ensure empty (gets set in test setup)
     with pytest.raises(ChainError, match="There are no snapshots to revert to."):
         chain.restore()
+
+
+def test_snapshot_and_restore_switched_chains(networks, chain):
+    """
+    Ensuring things work as expected when we switch chains after snapshotting
+    and before restoring.
+    """
+    snapshot = chain.snapshot()
+    # Switch chains.
+    with networks.ethereum.local.use_provider(
+        "test", provider_settings={"chain_id": 11191919191991918223773}
+    ):
+        with pytest.raises(UnknownSnapshotError):
+            chain.restore(snapshot)
 
 
 def test_isolate(chain, vyper_contract_instance, owner):

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -6,7 +6,6 @@ import pytest
 from ape.exceptions import APINotImplementedError, ChainError, UnknownSnapshotError
 from ape.managers.chain import AccountHistory
 from ape.types import AddressType
-from tests.conftest import geth_process_test
 
 
 def test_snapshot_and_restore(chain, owner, receiver, vyper_contract_instance):

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -589,3 +589,10 @@ def test_ipc_per_network(project, key):
         # TODO: 0.9 investigate not using random if ipc set.
 
         assert node.ipc_path == Path(ipc)
+
+
+def test_update_settings_invalidates_snapshots(eth_tester_provider, chain):
+    snapshot = chain.snapshot()
+    assert snapshot in chain._snapshots[eth_tester_provider.chain_id]
+    eth_tester_provider.update_settings({})
+    assert snapshot not in chain._snapshots[eth_tester_provider.chain_id]


### PR DESCRIPTION
### What I did

this bug is preventing us from using `ape test` to test ape.
this may fix other oddities with multi-chain tests and isolation.

### How I did it

* use chain ID when keeping track of snaps
* when disconnecting, also clear snaps from that cache

probably 

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
