### PR TITLE
refactor: move ape-test cfg to config module

### DIFF
--- a/src/ape_test/__init__.py
+++ b/src/ape_test/__init__.py
@@ -1,168 +1,13 @@
-from typing import NewType, Optional, Union
-
-from pydantic import NonNegativeInt, field_validator
-
 from ape import plugins
-from ape.api.config import PluginConfig
-from ape.utils.basemodel import ManagerAccessMixin
-from ape.utils.testing import (
-    DEFAULT_NUMBER_OF_TEST_ACCOUNTS,
-    DEFAULT_TEST_ACCOUNT_BALANCE,
-    DEFAULT_TEST_HD_PATH,
-    DEFAULT_TEST_MNEMONIC,
-)
 from ape_test.accounts import TestAccount, TestAccountContainer
+from ape_test.config import (
+    ApeTestConfig,
+    CoverageConfig,
+    CoverageReportsConfig,
+    GasConfig,
+    GasExclusion,
+)
 from ape_test.provider import EthTesterProviderConfig, LocalProvider
-
-
-class GasExclusion(PluginConfig):
-    contract_name: str = "*"  # If only given method, searches across all contracts.
-    method_name: Optional[str] = None  # By default, match all methods in a contract
-
-
-CoverageExclusion = NewType("CoverageExclusion", GasExclusion)
-
-
-class GasConfig(PluginConfig):
-    """
-    Configuration related to test gas reports.
-    """
-
-    exclude: list[GasExclusion] = []
-    """
-    Contract methods patterns to skip. Specify ``contract_name:`` and not
-    ``method_name:`` to skip all methods in the contract. Only specify
-    ``method_name:`` to skip all methods across all contracts. Specify
-    both to skip methods in a certain contracts. Entries use glob-rules;
-    use ``prefix_*`` to skip all items with a certain prefix.
-    """
-
-    reports: list[str] = []
-    """
-    Report-types to use. Currently, only supports `terminal`.
-    """
-
-    @field_validator("reports", mode="before")
-    @classmethod
-    def validate_reports(cls, values):
-        values = list(set(values or []))
-        valid = ("terminal",)
-        for val in values:
-            if val not in valid:
-                valid_str = ", ".join(valid)
-                raise ValueError(f"Invalid gas-report format '{val}'. Valid: {valid_str}")
-
-        return values
-
-    @property
-    def show(self) -> bool:
-        return "terminal" in self.reports
-
-
-_ReportType = Union[bool, dict]
-"""Dict is for extra report settings."""
-
-
-class CoverageReportsConfig(PluginConfig):
-    """
-    Enable reports.
-    """
-
-    terminal: _ReportType = True
-    """
-    Set to ``False`` to hide the terminal coverage report.
-    """
-
-    xml: _ReportType = False
-    """
-    Set to ``True`` to generate an XML coverage report in your .build folder.
-    """
-
-    html: _ReportType = False
-    """
-    Set to ``True`` to generate HTML coverage reports.
-    """
-
-    @property
-    def has_any(self) -> bool:
-        return any(x not in ({}, None, False) for x in (self.html, self.terminal, self.xml))
-
-
-class CoverageConfig(PluginConfig):
-    """
-    Configuration related to contract coverage.
-    """
-
-    track: bool = False
-    """
-    Setting this to ``True`` is the same as always running with
-    the ``--coverage`` flag.
-    """
-
-    reports: CoverageReportsConfig = CoverageReportsConfig()
-    """
-    Enable reports.
-    """
-
-    exclude: list[CoverageExclusion] = []
-    """
-    Contract methods patterns to skip. Specify ``contract_name:`` and not
-    ``method_name:`` to skip all methods in the contract. Only specify
-    ``method_name:`` to skip all methods across all contracts. Specify
-    both to skip methods in a certain contracts. Entries use glob-rules;
-    use ``prefix_*`` to skip all items with a certain prefix.
-    """
-
-
-class ApeTestConfig(PluginConfig):
-    balance: int = DEFAULT_TEST_ACCOUNT_BALANCE
-    """
-    The starting-balance of every test account in Wei (NOT Ether).
-    """
-
-    coverage: CoverageConfig = CoverageConfig()
-    """
-    Configuration related to coverage reporting.
-    """
-
-    disconnect_providers_after: bool = True
-    """
-    Set to ``False`` to keep providers connected at the end of the test run.
-    """
-
-    gas: GasConfig = GasConfig()
-    """
-    Configuration related to gas reporting.
-    """
-
-    hd_path: str = DEFAULT_TEST_HD_PATH
-    """
-    The hd_path to use when generating the test accounts.
-    """
-
-    mnemonic: str = DEFAULT_TEST_MNEMONIC
-    """
-    The mnemonic to use when generating the test accounts.
-    """
-
-    number_of_accounts: NonNegativeInt = DEFAULT_NUMBER_OF_TEST_ACCOUNTS
-    """
-    The number of test accounts to generate in the provider.
-    """
-
-    provider: EthTesterProviderConfig = EthTesterProviderConfig()
-    """
-    Settings for the provider.
-    """
-
-    @field_validator("balance", mode="before")
-    @classmethod
-    def validate_balance(cls, value):
-        return (
-            value
-            if isinstance(value, int)
-            else ManagerAccessMixin.conversion_manager.convert(value, int)
-        )
 
 
 @plugins.register(plugins.Config)
@@ -185,8 +30,8 @@ __all__ = [
     "TestAccount",
     "EthTesterProviderConfig",
     "LocalProvider",
-    "GasExclusion",
     "GasConfig",
+    "GasExclusion",
     "CoverageReportsConfig",
     "CoverageConfig",
     "ApeTestConfig",

--- a/src/ape_test/config.py
+++ b/src/ape_test/config.py
@@ -1,0 +1,168 @@
+from typing import NewType, Optional, Union
+
+from pydantic import NonNegativeInt, field_validator
+
+from ape.api.config import PluginConfig
+from ape.utils.basemodel import ManagerAccessMixin
+from ape.utils.testing import (
+    DEFAULT_NUMBER_OF_TEST_ACCOUNTS,
+    DEFAULT_TEST_ACCOUNT_BALANCE,
+    DEFAULT_TEST_CHAIN_ID,
+    DEFAULT_TEST_HD_PATH,
+    DEFAULT_TEST_MNEMONIC,
+)
+
+
+class EthTesterProviderConfig(PluginConfig):
+    chain_id: int = DEFAULT_TEST_CHAIN_ID
+    auto_mine: bool = True
+
+
+class GasExclusion(PluginConfig):
+    contract_name: str = "*"  # If only given method, searches across all contracts.
+    method_name: Optional[str] = None  # By default, match all methods in a contract
+
+
+CoverageExclusion = NewType("CoverageExclusion", GasExclusion)
+
+
+class GasConfig(PluginConfig):
+    """
+    Configuration related to test gas reports.
+    """
+
+    exclude: list[GasExclusion] = []
+    """
+    Contract methods patterns to skip. Specify ``contract_name:`` and not
+    ``method_name:`` to skip all methods in the contract. Only specify
+    ``method_name:`` to skip all methods across all contracts. Specify
+    both to skip methods in a certain contracts. Entries use glob-rules;
+    use ``prefix_*`` to skip all items with a certain prefix.
+    """
+
+    reports: list[str] = []
+    """
+    Report-types to use. Currently, only supports `terminal`.
+    """
+
+    @field_validator("reports", mode="before")
+    @classmethod
+    def validate_reports(cls, values):
+        values = list(set(values or []))
+        valid = ("terminal",)
+        for val in values:
+            if val not in valid:
+                valid_str = ", ".join(valid)
+                raise ValueError(f"Invalid gas-report format '{val}'. Valid: {valid_str}")
+
+        return values
+
+    @property
+    def show(self) -> bool:
+        return "terminal" in self.reports
+
+
+_ReportType = Union[bool, dict]
+"""Dict is for extra report settings."""
+
+
+class CoverageReportsConfig(PluginConfig):
+    """
+    Enable reports.
+    """
+
+    terminal: _ReportType = True
+    """
+    Set to ``False`` to hide the terminal coverage report.
+    """
+
+    xml: _ReportType = False
+    """
+    Set to ``True`` to generate an XML coverage report in your .build folder.
+    """
+
+    html: _ReportType = False
+    """
+    Set to ``True`` to generate HTML coverage reports.
+    """
+
+    @property
+    def has_any(self) -> bool:
+        return any(x not in ({}, None, False) for x in (self.html, self.terminal, self.xml))
+
+
+class CoverageConfig(PluginConfig):
+    """
+    Configuration related to contract coverage.
+    """
+
+    track: bool = False
+    """
+    Setting this to ``True`` is the same as always running with
+    the ``--coverage`` flag.
+    """
+
+    reports: CoverageReportsConfig = CoverageReportsConfig()
+    """
+    Enable reports.
+    """
+
+    exclude: list[CoverageExclusion] = []
+    """
+    Contract methods patterns to skip. Specify ``contract_name:`` and not
+    ``method_name:`` to skip all methods in the contract. Only specify
+    ``method_name:`` to skip all methods across all contracts. Specify
+    both to skip methods in a certain contracts. Entries use glob-rules;
+    use ``prefix_*`` to skip all items with a certain prefix.
+    """
+
+
+class ApeTestConfig(PluginConfig):
+    balance: int = DEFAULT_TEST_ACCOUNT_BALANCE
+    """
+    The starting-balance of every test account in Wei (NOT Ether).
+    """
+
+    coverage: CoverageConfig = CoverageConfig()
+    """
+    Configuration related to coverage reporting.
+    """
+
+    disconnect_providers_after: bool = True
+    """
+    Set to ``False`` to keep providers connected at the end of the test run.
+    """
+
+    gas: GasConfig = GasConfig()
+    """
+    Configuration related to gas reporting.
+    """
+
+    hd_path: str = DEFAULT_TEST_HD_PATH
+    """
+    The hd_path to use when generating the test accounts.
+    """
+
+    mnemonic: str = DEFAULT_TEST_MNEMONIC
+    """
+    The mnemonic to use when generating the test accounts.
+    """
+
+    number_of_accounts: NonNegativeInt = DEFAULT_NUMBER_OF_TEST_ACCOUNTS
+    """
+    The number of test accounts to generate in the provider.
+    """
+
+    provider: EthTesterProviderConfig = EthTesterProviderConfig()
+    """
+    Settings for the provider.
+    """
+
+    @field_validator("balance", mode="before")
+    @classmethod
+    def validate_balance(cls, value):
+        return (
+            value
+            if isinstance(value, int)
+            else ManagerAccessMixin.conversion_manager.convert(value, int)
+        )

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -17,7 +17,6 @@ from web3.exceptions import ContractLogicError as Web3ContractLogicError
 from web3.providers.eth_tester.defaults import API_ENDPOINTS, static_return
 from web3.types import TxParams
 
-from ape.api.config import PluginConfig
 from ape.api.providers import BlockAPI, TestProviderAPI
 from ape.api.trace import TraceAPI
 from ape.api.transactions import ReceiptAPI, TransactionAPI
@@ -35,17 +34,13 @@ from ape.types.address import AddressType
 from ape.types.events import ContractLog, LogFilter
 from ape.types.vm import BlockID, SnapshotID
 from ape.utils.misc import gas_estimation_error_message
-from ape.utils.testing import DEFAULT_TEST_CHAIN_ID, DEFAULT_TEST_HD_PATH
+from ape.utils.testing import DEFAULT_TEST_HD_PATH
 from ape_ethereum.provider import Web3Provider
 from ape_ethereum.trace import TraceApproach, TransactionTrace
+from ape_test.config import EthTesterProviderConfig
 
 if TYPE_CHECKING:
     from ape.api.accounts import TestAccountAPI
-
-
-class EthTesterProviderConfig(PluginConfig):
-    chain_id: int = DEFAULT_TEST_CHAIN_ID
-    auto_mine: bool = True
 
 
 class LocalProvider(TestProviderAPI, Web3Provider):


### PR DESCRIPTION
### What I did

this makes it easier to do the necessary performance stuff on https://github.com/ApeWorX/ape/pull/2333/files#diff-a76530a2b0343d95792c603a53d55f5d38d7fe3466bebea906bec26bba0a86a3

### How I did it

make a new module in ape_test plugin config.py and put all config stuff in there

### How to verify it

things work as they did before

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
