### PR TITLE
fix: use str type with bytes validator

### DIFF
--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -7,6 +7,7 @@ from enum import Enum
 from functools import cached_property
 from typing import IO, Any, Optional, Union
 
+from eth_pydantic_types import HexStr
 from eth_utils import is_0x_prefixed, to_hex
 from ethpm_types import ContractType, MethodABI
 from evm_trace import (
@@ -447,7 +448,7 @@ class Trace(TraceAPI):
 
 
 class TransactionTrace(Trace):
-    transaction_hash: str
+    transaction_hash: HexStr
     debug_trace_transaction_parameters: dict = {"enableMemory": True}
     _frames: list[dict] = []
 

--- a/tests/functional/test_trace.py
+++ b/tests/functional/test_trace.py
@@ -134,8 +134,9 @@ def test_get_gas_report_with_sub_calls(simple_trace_cls):
     assert len(actual) > 1  # Sub-contract calls!
 
 
-def test_transaction_trace_create(vyper_contract_instance):
-    tx_hash = vyper_contract_instance.creation_metadata.txn_hash
+@pytest.mark.parametrize("txn_hash_callback", (str, HexBytes))
+def test_transaction_trace_create(vyper_contract_instance, txn_hash_callback):
+    tx_hash = txn_hash_callback(vyper_contract_instance.creation_metadata.txn_hash)
     trace = TransactionTrace(transaction_hash=tx_hash)
     actual = f"{trace}"
     expected = r"VyperContract\.__new__\(num=0\) \[\d+ gas\]"


### PR DESCRIPTION
### What I did

Allow bytes in TransactionTrace hash

### How I did it

Use `HexStr` pydantic type

### How to verify it

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
