### PR TITLE
fix: issue running tests when `mainnet` is default network and specifying a different network

### DIFF
--- a/src/ape/pytest/plugin.py
+++ b/src/ape/pytest/plugin.py
@@ -16,15 +16,6 @@ def _get_default_network(ecosystem: Optional[EcosystemAPI] = None) -> str:
     if ecosystem is None:
         ecosystem = ManagerAccessMixin.network_manager.default_ecosystem
 
-    if ecosystem.default_network.is_mainnet:
-        # Don't use mainnet for tests, even if it configured as
-        # the default.
-        raise ConfigError(
-            "Default network is mainnet; unable to run tests on mainnet. "
-            "Please specify the network using the `--network` flag or "
-            "configure a different default network."
-        )
-
     return ecosystem.name
 
 

--- a/tests/functional/test_test.py
+++ b/tests/functional/test_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ape.exceptions import ConfigError
-from ape.pytest.plugin import _get_default_network
+from ape.pytest.runners import PytestApeRunner
 from ape_test import ApeTestConfig
 
 
@@ -15,17 +15,21 @@ class TestApeTestConfig:
         assert actual == expected
 
 
-def test_get_default_network(mocker):
-    # NOTE: Using this weird test to avoid actually
-    #  using mainnet in any test, even accidentally.
-    mock_ecosystem = mocker.MagicMock()
-    mock_mainnet = mocker.MagicMock()
-    mock_mainnet.name = "mainnet"
-    mock_ecosystem.default_network = mock_mainnet
+def test_connect_to_mainnet_by_default(mocker):
+    """
+    Tests the condition where mainnet is configured as the default network
+    and no --network option is passed. It should avoid running the tests
+    to be safe.
+    """
+
+    cfg = mocker.MagicMock()
+    cfg.network = "ethereum:mainnet:node"
+    runner = PytestApeRunner(cfg, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock())
+
     expected = (
         "Default network is mainnet; unable to run tests on mainnet. "
         "Please specify the network using the `--network` flag or "
         "configure a different default network."
     )
     with pytest.raises(ConfigError, match=expected):
-        _get_default_network(mock_mainnet)
+        runner._connect()


### PR DESCRIPTION
### What I did

fixes: #2342

### How I did it

Move the config error to a later point, check for the `--network` flag.

### How to verify it

cfg:

```yaml
ethereum:
  default_network: mainnet
  mainnet:
    default_provider: node
  mainnet_fork:
    default_provider: foundry
```

then run

```
ape test
```

should fail

and run

```
ape test --network ethereum:local:test
```

should not fail

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [ ] Documentation has been updated
