### PR TITLE
fix: mistaken blob receipt causing serialization problems

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -598,9 +598,18 @@ class Ethereum(EcosystemAPI):
                 "blob_gas_used",
             )
         ):
-            receipt_cls = SharedBlobReceipt
-            receipt_kwargs["blobGasPrice"] = data.get("blob_gas_price", data.get("blobGasPrice"))
-            receipt_kwargs["blobGasUsed"] = data.get("blob_gas_used", data.get("blobGasUsed")) or 0
+
+            blob_gas_price = data.get("blob_gas_price", data.get("blobGasPrice"))
+            if blob_gas_price is None:
+                # Not actually a blob-receipt? Some providers may give you
+                # empty values here when meaning the other types of receipts.
+                receipt_cls = Receipt
+
+            else:
+                receipt_cls = SharedBlobReceipt
+                receipt_kwargs["blobGasPrice"] = blob_gas_price
+                receipt_kwargs["blobGasUsed"] = data.get("blob_gas_used", data.get("blobGasUsed")) or 0
+
         else:
             receipt_cls = Receipt
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -598,7 +598,6 @@ class Ethereum(EcosystemAPI):
                 "blob_gas_used",
             )
         ):
-
             blob_gas_price = data.get("blob_gas_price", data.get("blobGasPrice"))
             if blob_gas_price is None:
                 # Not actually a blob-receipt? Some providers may give you
@@ -608,7 +607,9 @@ class Ethereum(EcosystemAPI):
             else:
                 receipt_cls = SharedBlobReceipt
                 receipt_kwargs["blobGasPrice"] = blob_gas_price
-                receipt_kwargs["blobGasUsed"] = data.get("blob_gas_used", data.get("blobGasUsed")) or 0
+                receipt_kwargs["blobGasUsed"] = (
+                    data.get("blob_gas_used", data.get("blobGasUsed")) or 0
+                )
 
         else:
             receipt_cls = Receipt

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -631,12 +631,37 @@ def test_decode_receipt_shared_blob(ethereum, blob_gas_used, blob_gas_key):
         assert actual.blob_gas_used == 0
 
 
-def test_decode_receipt_blob_gas_price_none():
+def test_decode_receipt_misleading_blob_receipt(ethereum):
     """
-    Tests a strange situation where the blob-related keys are in the
-    data but a required key is None. In this case, the provider is returning
-    empty data for these values and we should use the regular receipt.
+    Tests a strange situation (noticed on Tenderly nodes) where _some_
+    of the keys indicate blob-related fields, set to ``0``, and others
+    are missing, because it's not actually a blob receipt. In this case,
+    don't use the blob-receipt class.
     """
+    data = {
+        "type": 2,
+        "status": 1,
+        "cumulativeGasUsed": 10565720,
+        "logsBloom": HexBytes(
+            "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"  # noqa: E501
+        ),
+        "logs": [],
+        "transactionHash": HexBytes(
+            "0x62fc9991bc7fb0c76bc83faaa8d1c17fc5efb050542e58ac358932f80aa7a087"
+        ),
+        "from": "0x1f9090aaE28b8a3dCeaDf281B0F12828e676c326",
+        "to": "0xeBec795c9c8bBD61FFc14A6662944748F299cAcf",
+        "contractAddress": None,
+        "gasUsed": 21055,
+        "effectiveGasPrice": 7267406643,
+        "blockHash": HexBytes("0xa47fc133f829183b751488c1146f1085451bcccd247db42066dc6c89eaf5ebac"),
+        "blockNumber": 21051245,
+        "transactionIndex": 130,
+        "blobGasUsed": 0,
+    }
+    actual = ethereum.decode_receipt(data)
+    assert not isinstance(actual, SharedBlobReceipt)
+    assert isinstance(actual, Receipt)
 
 
 def test_default_transaction_type_not_connected_used_default_network(project, ethereum, networks):

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -631,6 +631,14 @@ def test_decode_receipt_shared_blob(ethereum, blob_gas_used, blob_gas_key):
         assert actual.blob_gas_used == 0
 
 
+def test_decode_receipt_blob_gas_price_none():
+    """
+    Tests a strange situation where the blob-related keys are in the
+    data but a required key is None. In this case, the provider is returning
+    empty data for these values and we should use the regular receipt.
+    """
+
+
 def test_default_transaction_type_not_connected_used_default_network(project, ethereum, networks):
     value = TransactionType.STATIC.value
     config_dict = {"ethereum": {"mainnet_fork": {"default_transaction_type": value}}}


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #2329

basically the problem was that tenderly nodes gave us a field `blobGasUsed: 0` for non-blob receipts (didn't see that field from other nodes so assuming is a bug).

### How I did it

in this case, if there is no blobGasPrice at all, just use the regular receipt cls instead, which makes the detection for shared blob receipt data extra strict

### How to verify it

```yaml
node:
  ethereum:
    mainnet:
      uri: https://gateway.tenderly.co/public/mainnet
```

and

```python
In [1]: txn_hash = '0x62fc9991bc7fb0c76bc83faaa8d1c17fc5efb050542e58ac358932f80aa7a087'

In [2]: provider.get_receipt(txn_hash)
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
