### PR TITLE
fix: delay hex-int validation error when None values for non-optional

### DIFF
--- a/src/ape/types/basic.py
+++ b/src/ape/types/basic.py
@@ -6,7 +6,13 @@ from pydantic import BeforeValidator
 
 
 def _hex_int_validator(value, info):
+    if value is None:
+        # If not optional, will allow pydantic to (better) handle the error.
+        return value
+
+    # NOTE: Allows this module to load lazier.
     access = import_module("ape.utils.basemodel").ManagerAccessMixin
+
     convert = access.conversion_manager.convert
     return convert(value, int)
 

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -4,7 +4,7 @@ import pytest
 from eth_utils import to_hex
 from ethpm_types.abi import EventABI
 from hexbytes import HexBytes
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from ape.types.address import AddressType
 from ape.types.basic import HexInt
@@ -143,6 +143,19 @@ class TestHexInt:
         expected = 291  # Base-10 form of 0x123.
         assert act.ual == expected
         assert act.ual_optional is None
+
+    def test_none(self):
+        """
+        Was getting unhelpful conversion errors here. We should instead
+        let Pydantic fail as it normally does in this situation.
+        """
+
+        class MyModel(BaseModel):
+            an_int: HexInt
+
+        expected = ".*Input should be a valid integer.*"
+        with pytest.raises(ValidationError, match=expected):
+            _ = MyModel(an_int=None)
 
 
 class TestCurrencyValueComparable:


### PR DESCRIPTION
### What I did

was just getting mehh conversion errors that didnt help much in this context.
was expecting pydantic errors instead

### How I did it

if None, dont try to convert. instead let it fail later on in pydantic

### How to verify it

have a model using non-optional HexInt
ignore that key
ensure you get a nice pydantic validation error instead of a conversion error

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
