### PR TITLE
perf: hardcoded trusted plugin during `--help` check

### DIFF
--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -91,7 +91,7 @@ class ApeCLI(click.MultiCommand):
 
             if plugin.in_core:
                 sections["Core"].append((cli_name, help))
-            elif plugin.is_installed and not plugin.is_third_party:
+            elif plugin.check_trusted(use_web=False):
                 sections["Plugin"].append((cli_name, help))
             else:
                 sections["3rd-Party Plugin"].append((cli_name, help))

--- a/src/ape/plugins/_utils.py
+++ b/src/ape/plugins/_utils.py
@@ -39,9 +39,9 @@ CORE_PLUGINS = [
 ]
 # Hardcoded for performance reasons. Functionality in plugins commands
 # and functions won't use this; they use GitHub to check directly.
-# This hardcoded list is useful for `ape --help` for performance reasons;
-# If ApeWorX adds a new trusted plugin, it should be added to this list
-# or else it may just show-up as un-trusted in `ape --help`.
+# This hardcoded list is useful for `ape --help`. If ApeWorX adds a new
+# trusted plugin, it should be added to this list; else it will show
+# as 3rd-party in `ape --help`.
 TRUSTED_PLUGINS = [
     "addressbook",
     "alchemy",
@@ -419,10 +419,16 @@ class PluginMetadata(BaseInterfaceModel):
 
     @property
     def is_third_party(self) -> bool:
-        return self.is_installed and not self.is_available
+        """
+        ``True`` when is an installed plugin that is not from ApeWorX.
+        """
+        return self.is_installed and not self.is_trusted
 
     @cached_property
     def is_trusted(self) -> bool:
+        """
+        ``True`` when is a plugin from ApeWorX.
+        """
         return self.check_trusted()
 
     @property

--- a/src/ape/plugins/_utils.py
+++ b/src/ape/plugins/_utils.py
@@ -37,7 +37,7 @@ CORE_PLUGINS = [
     "ape_run",
     "ape_test",
 ]
-# Hardcoded for performance reasons. Functionality in plugins command
+# Hardcoded for performance reasons. Functionality in plugins commands
 # and functions won't use this; they use GitHub to check directly.
 # This hardcoded list is useful for `ape --help` for performance reasons;
 # If ApeWorX adds a new trusted plugin, it should be added to this list


### PR DESCRIPTION
### What I did

when you have a trusted plugin installed, even if that plugin is also optimized like we did for the ones with core, it is still has a  small slowdown because of the trusted check, which makes 1 request to GitHub during `--help`

this PR hardcoded the trusted plugin to avoid the request altogether.

### How I did it

hardcode the trusted plugin

### How to verify it

first install ape-tokens==0.8.1 (to get the full benefit, will still work on 0.8.0)

then

```sh
ape --help
```

Before i was seeing like 2.23 seconds..
Now I am seeing like 2 seconds

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
