### PR TITLE
feat: allow forking a forked network

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -780,7 +780,7 @@ class ProviderContextManager(ManagerAccessMixin):
         current_id = self.provider_stack.pop()
 
         # Disconnect the provider in same cases.
-        if self.disconnect_map[current_id]:
+        if self.disconnect_map.get(current_id):
             if provider := self.network_manager.active_provider:
                 provider.disconnect()
 

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -126,15 +126,19 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
             :class:`~ape.api.networks.ProviderContextManager`
         """
         network_name = self.network.name
-        forked_network_name = (
-            network_name if network_name.endswith("-fork") else f"{network_name}-fork"
-        )
+        is_fork_already = network_name.endswith("-fork")
+        forked_network_name = network_name if is_fork_already else f"{network_name}-fork"
         try:
             forked_network = self.ecosystem.get_network(forked_network_name)
         except NetworkNotFoundError as err:
             raise NetworkError(f"Unable to fork network '{network_name}'.") from err
 
         provider_settings = provider_settings or {}
+        if is_fork_already:
+            # Forking a fork- to ensure is using a different Port,
+            # use the "auto-port" feature.
+            provider_settings["uri"] = "auto"
+
         fork_settings = {}
         if block_number is not None:
             # Negative block_number means relative to HEAD

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -125,10 +125,14 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         Returns:
             :class:`~ape.api.networks.ProviderContextManager`
         """
+        network_name = self.network.name
+        forked_network_name = (
+            network_name if network_name.endswith("-fork") else f"{network_name}-fork"
+        )
         try:
-            forked_network = self.ecosystem.get_network(f"{self.network.name}-fork")
+            forked_network = self.ecosystem.get_network(forked_network_name)
         except NetworkNotFoundError as err:
-            raise NetworkError(f"Unable to fork network '{self.network.name}'.") from err
+            raise NetworkError(f"Unable to fork network '{network_name}'.") from err
 
         provider_settings = provider_settings or {}
         fork_settings = {}

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -134,7 +134,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
             raise NetworkError(f"Unable to fork network '{network_name}'.") from err
 
         provider_settings = provider_settings or {}
-        if is_fork_already:
+        if is_fork_already and "host" not in provider_settings:
             # Forking a fork- to ensure is using a different Port,
             # use the "auto-port" feature.
             provider_settings["host"] = "auto"

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -137,7 +137,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         if is_fork_already:
             # Forking a fork- to ensure is using a different Port,
             # use the "auto-port" feature.
-            provider_settings["uri"] = "auto"
+            provider_settings["host"] = "auto"
 
         fork_settings = {}
         if block_number is not None:

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -354,6 +354,7 @@ def test_fork(networks, mock_sepolia, mock_fork_provider):
         # Fork the fork.
         ctx2 = networks.fork()
         with ctx2 as provider2:
+            assert provider2.partial_call[1]["provider_settings"]["uri"] == "auto"
             assert provider2.name == "mock"
             assert provider2.network.name == "sepolia-fork"
 

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -354,7 +354,7 @@ def test_fork(networks, mock_sepolia, mock_fork_provider):
         # Fork the fork.
         ctx2 = networks.fork()
         with ctx2 as provider2:
-            assert provider2.partial_call[1]["provider_settings"]["uri"] == "auto"
+            assert provider2.partial_call[1]["provider_settings"]["host"] == "auto"
             assert provider2.name == "mock"
             assert provider2.network.name == "sepolia-fork"
 

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -351,6 +351,11 @@ def test_fork(networks, mock_sepolia, mock_fork_provider):
     with ctx as provider:
         assert provider.name == "mock"
         assert provider.network.name == "sepolia-fork"
+        # Fork the fork.
+        ctx2 = networks.fork()
+        with ctx2 as provider2:
+            assert provider2.name == "mock"
+            assert provider2.network.name == "sepolia-fork"
 
 
 def test_fork_specify_provider(networks, mock_sepolia, mock_fork_provider):


### PR DESCRIPTION
### What I did

Instead of `mainnet-fork-fork`, you just get another `mainnet-fork` process with a different port

### How I did it

Fix name and use auto host

### How to verify it

(ape) ➜  ape git:(feat/allow-forking-a-fork) ✗ ape console --network ethereum:sepolia

```
In [1]: with networks.fork("foundry") as provider:
   ...:     print(provider.uri)
   ...:     with networks.fork("foundry") as prov2:
   ...:         print(prov2.uri)
   ...: 
INFO:     Starting 'anvil' process.
INFO:     Connecting to existing Geth node at https://eth-sepolia.g.alchemy.com/[hidden].
http://127.0.0.1:8545
INFO:     Starting 'anvil' process.
http://127.0.0.1:52015
INFO:     Stopping 'anvil' process.
INFO:     Stopping 'anvil' process.
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
