### PR TITLE
perf: more things that make `ape --help` way faster

### DIFF
--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -67,6 +67,7 @@ class ApeCLI(click.MultiCommand):
 
         commands = []
         for subcommand in self.list_commands(ctx):
+            print(subcommand)
             cmd = self.get_command(ctx, subcommand)
             if cmd is None or cmd.hidden:
                 continue

--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -18,7 +18,6 @@ from click import Context
 from ape.cli.options import ape_cli_context
 from ape.exceptions import Abort, ApeException, ConfigError, handle_ape_exception
 from ape.logging import logger
-from ape.utils.basemodel import ManagerAccessMixin as access
 
 _DIFFLIB_CUT_OFF = 0.6
 
@@ -27,6 +26,8 @@ def display_config(ctx, param, value):
     # NOTE: This is necessary not to interrupt how version or help is intercepted
     if not value or ctx.resilient_parsing:
         return
+
+    from ape.utils.basemodel import ManagerAccessMixin as access
 
     click.echo("# Current configuration")
 
@@ -38,6 +39,8 @@ def display_config(ctx, param, value):
 
 
 def _validate_config():
+    from ape.utils.basemodel import ManagerAccessMixin as access
+
     project = access.local_project
     try:
         _ = project.config
@@ -60,6 +63,8 @@ class ApeCLI(click.MultiCommand):
         return super().parse_args(ctx, args)
 
     def format_commands(self, ctx, formatter) -> None:
+        from ape.utils.basemodel import ManagerAccessMixin as access
+
         commands = []
         for subcommand in self.list_commands(ctx):
             cmd = self.get_command(ctx, subcommand)

--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -67,7 +67,6 @@ class ApeCLI(click.MultiCommand):
 
         commands = []
         for subcommand in self.list_commands(ctx):
-            print(subcommand)
             cmd = self.get_command(ctx, subcommand)
             if cmd is None or cmd.hidden:
                 continue

--- a/src/ape/cli/__init__.py
+++ b/src/ape/cli/__init__.py
@@ -6,6 +6,7 @@ from ape.cli.arguments import (
 from ape.cli.choices import (
     AccountAliasPromptChoice,
     Alias,
+    LazyChoice,
     NetworkChoice,
     OutputFormat,
     PromptChoice,
@@ -42,6 +43,7 @@ __all__ = [
     "existing_alias_argument",
     "incompatible_with",
     "JSON",
+    "LazyChoice",
     "network_option",
     "NetworkChoice",
     "NetworkOption",

--- a/src/ape/cli/arguments.py
+++ b/src/ape/cli/arguments.py
@@ -27,7 +27,6 @@ def existing_alias_argument(account_type: _ACCOUNT_TYPE_FILTER = None, **kwargs)
           If given, limits the type of account the user may choose from.
         **kwargs: click.argument overrides.
     """
-
     type_ = kwargs.pop("type", Alias(key=account_type))
     return click.argument("alias", type=type_, **kwargs)
 

--- a/src/ape/cli/arguments.py
+++ b/src/ape/cli/arguments.py
@@ -7,15 +7,14 @@ from click import BadArgumentUsage
 
 from ape.cli.choices import _ACCOUNT_TYPE_FILTER, Alias
 from ape.logging import logger
-from ape.utils.basemodel import ManagerAccessMixin
-from ape.utils.os import get_full_extension
-from ape.utils.validators import _validate_account_alias
 
 if TYPE_CHECKING:
     from ape.managers.project import ProjectManager
 
 
 def _alias_callback(ctx, param, value):
+    from ape.utils.validators import _validate_account_alias
+
     return _validate_account_alias(value)
 
 
@@ -45,12 +44,14 @@ def non_existing_alias_argument(**kwargs):
     return click.argument("alias", callback=callback, **kwargs)
 
 
-class _ContractPaths(ManagerAccessMixin):
+class _ContractPaths:
     """
     Helper callback class for handling CLI-given contract paths.
     """
 
     def __init__(self, value, project: Optional["ProjectManager"] = None):
+        from ape.utils.basemodel import ManagerAccessMixin
+
         self.value = value
         self.missing_compilers: set[str] = set()  # set of .ext
         self.project = project or ManagerAccessMixin.local_project
@@ -105,14 +106,21 @@ class _ContractPaths(ManagerAccessMixin):
 
     @property
     def exclude_patterns(self) -> set[str]:
-        return self.config_manager.get_config("compile").exclude or set()
+        from ape.utils.basemodel import ManagerAccessMixin as access
+
+        return access.config_manager.get_config("compile").exclude or set()
 
     def do_exclude(self, path: Union[Path, str]) -> bool:
         return self.project.sources.is_excluded(path)
 
     def compiler_is_unknown(self, path: Union[Path, str]) -> bool:
+        from ape.utils.basemodel import ManagerAccessMixin
+        from ape.utils.os import get_full_extension
+
         ext = get_full_extension(path)
-        unknown_compiler = ext and ext not in self.compiler_manager.registered_compilers
+        unknown_compiler = (
+            ext and ext not in ManagerAccessMixin.compiler_manager.registered_compilers
+        )
         if unknown_compiler and ext not in self.missing_compilers:
             self.missing_compilers.add(ext)
 

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -14,7 +14,6 @@ from ape.exceptions import (
     NetworkNotFoundError,
     ProviderNotFoundError,
 )
-from ape.utils.basemodel import ManagerAccessMixin as access
 
 if TYPE_CHECKING:
     from ape.api.accounts import AccountAPI
@@ -26,6 +25,8 @@ _ACCOUNT_TYPE_FILTER = Union[
 
 
 def _get_accounts(key: _ACCOUNT_TYPE_FILTER) -> list["AccountAPI"]:
+    from ape.utils.basemodel import ManagerAccessMixin as access
+
     accounts = access.account_manager
 
     add_test_accounts = False
@@ -206,6 +207,8 @@ class AccountAliasPromptChoice(PromptChoice):
         else:
             alias = value
 
+        from ape.utils.basemodel import ManagerAccessMixin as access
+
         accounts = access.account_manager
         if isinstance(alias, str) and alias.upper().startswith("TEST::"):
             idx_str = alias.upper().replace("TEST::", "")
@@ -235,6 +238,8 @@ class AccountAliasPromptChoice(PromptChoice):
                 click.echo(f"{idx}. {choice}")
                 did_print = True
 
+        from ape.utils.basemodel import ManagerAccessMixin as access
+
         accounts = access.account_manager
         len_test_accounts = len(accounts.test_accounts) - 1
         if len_test_accounts > 0:
@@ -261,6 +266,7 @@ class AccountAliasPromptChoice(PromptChoice):
         Returns:
             :class:`~ape.api.accounts.AccountAPI`
         """
+        from ape.utils.basemodel import ManagerAccessMixin as access
 
         accounts = access.account_manager
         if not self.choices or len(self.choices) == 0:
@@ -369,6 +375,8 @@ class NetworkChoice(click.Choice):
         return "[ecosystem-name][:[network-name][:[provider-name]]]"
 
     def convert(self, value: Any, param: Optional[Parameter], ctx: Optional[Context]) -> Any:
+        from ape.utils.basemodel import ManagerAccessMixin as access
+
         choice: Optional[Union[str, "ProviderAPI"]]
         networks = access.network_manager
         if not value:

--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -7,7 +7,6 @@ from click import Context
 
 from ape.cli.choices import _NONE_NETWORK, NetworkChoice
 from ape.exceptions import NetworkError
-from ape.utils.basemodel import ManagerAccessMixin as access
 
 if TYPE_CHECKING:
     from ape.api.networks import ProviderContextManager
@@ -26,6 +25,8 @@ def get_param_from_ctx(ctx: Context, param: str) -> Optional[Any]:
 
 
 def parse_network(ctx: Context) -> Optional["ProviderContextManager"]:
+    from ape.utils.basemodel import ManagerAccessMixin as access
+
     interactive = get_param_from_ctx(ctx, "interactive")
 
     # Handle if already parsed (as when using network-option)

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -21,12 +21,11 @@ from ape.cli.commands import ConnectedProviderCommand
 from ape.cli.paramtype import JSON, Noop
 from ape.exceptions import Abort, ProjectError
 from ape.logging import DEFAULT_LOG_LEVEL, ApeLogger, LogLevel, logger
-from ape.utils.basemodel import ManagerAccessMixin
 
 _VERBOSITY_VALUES = ("--verbosity", "-v")
 
 
-class ApeCliContextObject(ManagerAccessMixin, dict):
+class ApeCliContextObject(dict):
     """
     A ``click`` context object class. Use via :meth:`~ape.cli.options.ape_cli_context()`.
     It provides common CLI utilities for ape, such as logging or
@@ -45,6 +44,8 @@ class ApeCliContextObject(ManagerAccessMixin, dict):
         try:
             return self.__getattribute__(item)
         except AttributeError:
+            from ape.utils.basemodel import ManagerAccessMixin
+
             return getattr(ManagerAccessMixin, item)
 
     @staticmethod
@@ -204,6 +205,8 @@ class NetworkOption(Option):
             else:
                 # NOTE: Use a function as the default so it is calculated lazily
                 def fn():
+                    from ape.utils.basemodel import ManagerAccessMixin
+
                     return ManagerAccessMixin.network_manager.default_ecosystem.name
 
                 default = fn
@@ -344,6 +347,8 @@ def _update_context_with_network(ctx, provider, requested_network_objects):
 
 
 def _get_provider(value, default, keep_as_choice_str):
+    from ape.utils.basemodel import ManagerAccessMixin
+
     use_default = value is None and default == "auto"
     provider_module = import_module("ape.api.providers")
     ProviderAPI = provider_module.ProviderAPI
@@ -435,6 +440,8 @@ def _load_contracts(ctx, param, value) -> Optional[Union[ContractType, list[Cont
     if not value:
         return None
 
+    from ape.utils.basemodel import ManagerAccessMixin
+
     if len(ManagerAccessMixin.local_project.contracts) == 0:
         raise ProjectError("Project has no contracts.")
 
@@ -523,6 +530,8 @@ def incompatible_with(incompatible_opts) -> type[click.Option]:
 
 
 def _project_callback(ctx, param, val):
+    from ape.utils.basemodel import ManagerAccessMixin
+
     pm = None
     if not val:
         pm = ManagerAccessMixin.local_project

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -3,11 +3,10 @@ from collections.abc import Callable
 from functools import partial
 from importlib import import_module
 from pathlib import Path
-from typing import Any, NoReturn, Optional, Union
+from typing import TYPE_CHECKING, Any, NoReturn, Optional, Union
 
 import click
 from click import Option
-from ethpm_types import ContractType
 
 from ape.cli.choices import (
     _ACCOUNT_TYPE_FILTER,
@@ -21,6 +20,10 @@ from ape.cli.commands import ConnectedProviderCommand
 from ape.cli.paramtype import JSON, Noop
 from ape.exceptions import Abort, ProjectError
 from ape.logging import DEFAULT_LOG_LEVEL, ApeLogger, LogLevel, logger
+
+if TYPE_CHECKING:
+    # perf: Avoid importing these if not needed to make CLIs load faster.
+    from ethpm_types.contract_type import ContractType
 
 _VERBOSITY_VALUES = ("--verbosity", "-v")
 
@@ -436,7 +439,7 @@ def account_option(account_type: _ACCOUNT_TYPE_FILTER = None) -> Callable:
     )
 
 
-def _load_contracts(ctx, param, value) -> Optional[Union[ContractType, list[ContractType]]]:
+def _load_contracts(ctx, param, value) -> Optional[Union["ContractType", list["ContractType"]]]:
     if not value:
         return None
 
@@ -449,7 +452,7 @@ def _load_contracts(ctx, param, value) -> Optional[Union[ContractType, list[Cont
     # and therefore we should also return a list.
     is_multiple = isinstance(value, (tuple, list))
 
-    def get_contract(contract_name: str) -> ContractType:
+    def get_contract(contract_name: str) -> "ContractType":
         if contract_name not in ManagerAccessMixin.local_project.contracts:
             raise ProjectError(f"No contract named '{value}'")
 

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -178,14 +178,12 @@ class NetworkOption(Option):
         provider = kwargs.pop("provider", None)
         default = kwargs.pop("default", "auto")
 
-        provider_module = import_module("ape.api.providers")
-        base_type = kwargs.pop("base_type", provider_module.ProviderAPI)
-
         callback = kwargs.pop("callback", None)
 
         # NOTE: If using network_option, this part is skipped
         #  because parsing happens earlier to handle advanced usage.
         if not kwargs.get("type"):
+            base_type = kwargs.pop("base_type", None)
             kwargs["type"] = NetworkChoice(
                 case_sensitive=False,
                 ecosystem=ecosystem,

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -14,13 +14,15 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
 import click
 from eth_typing import Hash32, HexStr
 from eth_utils import humanize_hash, to_hex
-from ethpm_types import ContractType
-from ethpm_types.abi import ConstructorABI, ErrorABI, MethodABI
 from rich import print as rich_print
 
 from ape.logging import LogLevel, logger
 
 if TYPE_CHECKING:
+    # perf: some of these are only here to make this module load faster.
+    from ethpm_types.abi import ConstructorABI, ErrorABI, MethodABI
+    from ethpm_types.contract_type import ContractType
+
     from ape.api.networks import NetworkAPI
     from ape.api.providers import SubprocessProvider
     from ape.api.trace import TraceAPI
@@ -90,7 +92,7 @@ class MissingDeploymentBytecodeError(ContractDataError):
     Raised when trying to deploy an interface or empty data.
     """
 
-    def __init__(self, contract_type: ContractType):
+    def __init__(self, contract_type: "ContractType"):
         message = "Cannot deploy: contract"
         if name := contract_type.name:
             message = f"{message} '{name}'"
@@ -109,7 +111,7 @@ class ArgumentsLengthError(ContractDataError):
     def __init__(
         self,
         arguments_length: int,
-        inputs: Union[MethodABI, ConstructorABI, int, list, None] = None,
+        inputs: Union["MethodABI", "ConstructorABI", int, list, None] = None,
         **kwargs,
     ):
         prefix = (
@@ -120,7 +122,7 @@ class ArgumentsLengthError(ContractDataError):
             super().__init__(f"{prefix}.")
             return
 
-        inputs_ls: list[Union[MethodABI, ConstructorABI, int]] = (
+        inputs_ls: list[Union["MethodABI", "ConstructorABI", int]] = (
             inputs if isinstance(inputs, list) else [inputs]
         )
         if not inputs_ls:
@@ -223,7 +225,7 @@ class TransactionError(ApeException):
         return receiver
 
     @cached_property
-    def contract_type(self) -> Optional[ContractType]:
+    def contract_type(self) -> Optional["ContractType"]:
         if not (address := self.address):
             # Contract address not found.
             return None
@@ -849,7 +851,7 @@ class CustomError(ContractLogicError):
 
     def __init__(
         self,
-        abi: ErrorABI,
+        abi: "ErrorABI",
         inputs: dict[str, Any],
         txn: Optional[FailedTxn] = None,
         trace: _TRACE_ARG = None,

--- a/src/ape/plugins/account.py
+++ b/src/ape/plugins/account.py
@@ -1,6 +1,10 @@
-from ape.api.accounts import AccountAPI, AccountContainerAPI
+from typing import TYPE_CHECKING
 
 from .pluggy_patch import PluginType, hookspec
+
+if TYPE_CHECKING:
+    # perf: Load only for type-checking; makes registering plugins faster.
+    from ape.api.accounts import AccountAPI, AccountContainerAPI
 
 
 class AccountPlugin(PluginType):
@@ -13,7 +17,7 @@ class AccountPlugin(PluginType):
     @hookspec
     def account_types(  # type: ignore[empty-body]
         self,
-    ) -> tuple[type[AccountContainerAPI], type[AccountAPI]]:
+    ) -> tuple[type["AccountContainerAPI"], type["AccountAPI"]]:
         """
         A hook for returning a tuple of an account container and an account type.
         Each account-base plugin defines and returns their own types here.

--- a/src/ape/plugins/compiler.py
+++ b/src/ape/plugins/compiler.py
@@ -1,6 +1,10 @@
-from ape.api.compiler import CompilerAPI
+from typing import TYPE_CHECKING
 
 from .pluggy_patch import PluginType, hookspec
+
+if TYPE_CHECKING:
+    # perf: Load only for type-checking; makes registering plugins faster.
+    from ape.api.compiler import CompilerAPI
 
 
 class CompilerPlugin(PluginType):
@@ -11,7 +15,9 @@ class CompilerPlugin(PluginType):
     """
 
     @hookspec
-    def register_compiler(self) -> tuple[tuple[str], type[CompilerAPI]]:  # type: ignore[empty-body]
+    def register_compiler(  # type: ignore[empty-body]
+        self,
+    ) -> tuple[tuple[str], type["CompilerAPI"]]:
         """
         A hook for returning the set of file extensions the plugin handles
         and the compiler class that can be used to compile them.

--- a/src/ape/plugins/config.py
+++ b/src/ape/plugins/config.py
@@ -1,6 +1,10 @@
-from ape.api.config import PluginConfig
+from typing import TYPE_CHECKING
 
 from .pluggy_patch import PluginType, hookspec
+
+if TYPE_CHECKING:
+    # perf: Load only for type-checking; makes registering plugins faster.
+    from ape.api.config import PluginConfig
 
 
 class Config(PluginType):
@@ -12,7 +16,7 @@ class Config(PluginType):
     """
 
     @hookspec
-    def config_class(self) -> type[PluginConfig]:  # type: ignore[empty-body]
+    def config_class(self) -> type["PluginConfig"]:  # type: ignore[empty-body]
         """
         A hook that returns a :class:`~ape.api.config.PluginConfig` parser class that can be
         used to deconstruct the user config options for this plugins.

--- a/src/ape/plugins/converter.py
+++ b/src/ape/plugins/converter.py
@@ -1,8 +1,11 @@
 from collections.abc import Iterator
-
-from ape.api.convert import ConverterAPI
+from typing import TYPE_CHECKING
 
 from .pluggy_patch import PluginType, hookspec
+
+if TYPE_CHECKING:
+    # perf: Load only for type-checking; makes registering plugins faster.
+    from ape.api.convert import ConverterAPI
 
 
 class ConversionPlugin(PluginType):
@@ -12,7 +15,7 @@ class ConversionPlugin(PluginType):
     """
 
     @hookspec
-    def converters(self) -> Iterator[tuple[str, type[ConverterAPI]]]:  # type: ignore[empty-body]
+    def converters(self) -> Iterator[tuple[str, type["ConverterAPI"]]]:  # type: ignore[empty-body]
         """
         A hook that returns an iterator of tuples of a string ABI type and a
         ``ConverterAPI`` subclass.

--- a/src/ape/plugins/network.py
+++ b/src/ape/plugins/network.py
@@ -1,10 +1,13 @@
 from collections.abc import Iterator
-
-from ape.api.explorers import ExplorerAPI
-from ape.api.networks import EcosystemAPI, NetworkAPI
-from ape.api.providers import ProviderAPI
+from typing import TYPE_CHECKING
 
 from .pluggy_patch import PluginType, hookspec
+
+if TYPE_CHECKING:
+    # perf: Load only for type-checking; makes registering plugins faster.
+    from ape.api.explorers import ExplorerAPI
+    from ape.api.networks import EcosystemAPI, NetworkAPI
+    from ape.api.providers import ProviderAPI
 
 
 class EcosystemPlugin(PluginType):
@@ -15,7 +18,7 @@ class EcosystemPlugin(PluginType):
     """
 
     @hookspec  # type: ignore[empty-body]
-    def ecosystems(self) -> Iterator[type[EcosystemAPI]]:
+    def ecosystems(self) -> Iterator[type["EcosystemAPI"]]:
         """
         A hook that must return an iterator of :class:`ape.api.networks.EcosystemAPI`
         subclasses.
@@ -39,7 +42,7 @@ class NetworkPlugin(PluginType):
     """
 
     @hookspec  # type: ignore[empty-body]
-    def networks(self) -> Iterator[tuple[str, str, type[NetworkAPI]]]:
+    def networks(self) -> Iterator[tuple[str, str, type["NetworkAPI"]]]:
         """
         A hook that must return an iterator of tuples of:
 
@@ -67,7 +70,9 @@ class ProviderPlugin(PluginType):
     """
 
     @hookspec
-    def providers(self) -> Iterator[tuple[str, str, type[ProviderAPI]]]:  # type: ignore[empty-body]
+    def providers(  # type: ignore[empty-body]
+        self,
+    ) -> Iterator[tuple[str, str, type["ProviderAPI"]]]:
         """
         A hook that must return an iterator of tuples of:
 
@@ -93,7 +98,9 @@ class ExplorerPlugin(PluginType):
     """
 
     @hookspec
-    def explorers(self) -> Iterator[tuple[str, str, type[ExplorerAPI]]]:  # type: ignore[empty-body]
+    def explorers(  # type: ignore[empty-body]
+        self,
+    ) -> Iterator[tuple[str, str, type["ExplorerAPI"]]]:
         """
         A hook that must return an iterator of tuples of:
 

--- a/src/ape/plugins/project.py
+++ b/src/ape/plugins/project.py
@@ -1,8 +1,11 @@
 from collections.abc import Iterator
-
-from ape.api.projects import DependencyAPI, ProjectAPI
+from typing import TYPE_CHECKING
 
 from .pluggy_patch import PluginType, hookspec
+
+if TYPE_CHECKING:
+    # perf: Load only for type-checking; makes registering plugins faster.
+    from ape.api.projects import DependencyAPI, ProjectAPI
 
 
 class ProjectPlugin(PluginType):
@@ -15,7 +18,7 @@ class ProjectPlugin(PluginType):
     """
 
     @hookspec  # type: ignore[empty-body]
-    def projects(self) -> Iterator[type[ProjectAPI]]:
+    def projects(self) -> Iterator[type["ProjectAPI"]]:
         """
         A hook that returns a :class:`~ape.api.projects.ProjectAPI` subclass type.
 
@@ -31,7 +34,7 @@ class DependencyPlugin(PluginType):
     """
 
     @hookspec
-    def dependencies(self) -> dict[str, type[DependencyAPI]]:  # type: ignore[empty-body]
+    def dependencies(self) -> dict[str, type["DependencyAPI"]]:  # type: ignore[empty-body]
         """
         A hook that returns a :class:`~ape.api.projects.DependencyAPI` mapped
         to its ``ape-config.yaml`` file dependencies special key. For example,

--- a/src/ape/utils/testing.py
+++ b/src/ape/utils/testing.py
@@ -1,8 +1,5 @@
 from collections import namedtuple
 
-from eth_account import Account
-from eth_account.hdaccount import HDPath
-from eth_account.hdaccount.mnemonic import Mnemonic
 from eth_utils import to_hex
 
 DEFAULT_NUMBER_OF_TEST_ACCOUNTS = 10
@@ -47,6 +44,9 @@ def generate_dev_accounts(
     Returns:
         list[:class:`~ape.utils.GeneratedDevAccount`]: List of development accounts.
     """
+    # perf: lazy imports so module loads faster.
+    from eth_account.hdaccount.mnemonic import Mnemonic
+
     seed = Mnemonic.to_seed(mnemonic)
     hd_path_format = (
         hd_path if "{}" in hd_path or "{0}" in hd_path else f"{hd_path.rstrip('/')}/{{}}"
@@ -58,6 +58,10 @@ def generate_dev_accounts(
 
 
 def _generate_dev_account(hd_path, index: int, seed: bytes) -> GeneratedDevAccount:
+    # perf: lazy imports so module loads faster.
+    from eth_account.account import Account
+    from eth_account.hdaccount import HDPath
+
     return GeneratedDevAccount(
         address=Account.from_key(
             private_key := to_hex(HDPath(hd_path.format(index)).derive(seed))

--- a/src/ape_accounts/__init__.py
+++ b/src/ape_accounts/__init__.py
@@ -1,17 +1,18 @@
-from ape import plugins
+from importlib import import_module
+from typing import Any
 
-from .accounts import (
-    AccountContainer,
-    KeyfileAccount,
-    generate_account,
-    import_account_from_mnemonic,
-    import_account_from_private_key,
-)
+from ape import plugins
 
 
 @plugins.register(plugins.AccountPlugin)
 def account_types():
+    from ape_accounts.accounts import AccountContainer, KeyfileAccount
+
     return AccountContainer, KeyfileAccount
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(import_module("ape_accounts.accounts"), name)
 
 
 __all__ = [

--- a/src/ape_accounts/__init__.py
+++ b/src/ape_accounts/__init__.py
@@ -1,10 +1,10 @@
 from importlib import import_module
 from typing import Any
 
-from ape import plugins
+from ape.plugins import AccountPlugin, register
 
 
-@plugins.register(plugins.AccountPlugin)
+@register(AccountPlugin)
 def account_types():
     from ape_accounts.accounts import AccountContainer, KeyfileAccount
 

--- a/src/ape_accounts/_cli.py
+++ b/src/ape_accounts/_cli.py
@@ -3,21 +3,23 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Optional
 
 import click
-from eth_account import Account as EthAccount
-from eth_account.hdaccount import ETHEREUM_DEFAULT_PATH
 from eth_utils import to_checksum_address, to_hex
 
 from ape.cli.arguments import existing_alias_argument, non_existing_alias_argument
 from ape.cli.options import ape_cli_context
 from ape.logging import HIDDEN_MESSAGE
-from ape.utils.basemodel import ManagerAccessMixin as access
 
 if TYPE_CHECKING:
     from ape.api.accounts import AccountAPI
     from ape_accounts.accounts import AccountContainer, KeyfileAccount
 
 
+ETHEREUM_DEFAULT_PATH = "m/44'/60'/0'/0/0"
+
+
 def _get_container() -> "AccountContainer":
+    from ape.utils.basemodel import ManagerAccessMixin as access
+
     # NOTE: Must used the instantiated version of `AccountsContainer` in `accounts`
     return access.account_manager.containers["accounts"]
 
@@ -146,6 +148,8 @@ def _import(cli_ctx, alias, import_from_mnemonic, custom_hd_path):
 
     account_module = import_module("ape_accounts.accounts")
     if import_from_mnemonic:
+        from eth_account import Account as EthAccount
+
         mnemonic = click.prompt("Enter mnemonic seed phrase", hide_input=True)
         EthAccount.enable_unaudited_hdwallet_features()
         try:
@@ -180,6 +184,8 @@ def _load_account_type(account: "AccountAPI") -> bool:
 @ape_cli_context()
 @existing_alias_argument(account_type=_load_account_type)
 def export(cli_ctx, alias):
+    from eth_account import Account as EthAccount
+
     path = _get_container().data_folder.joinpath(f"{alias}.json")
     account = json.loads(path.read_text())
     password = click.prompt("Enter password to decrypt account", hide_input=True)

--- a/src/ape_cache/__init__.py
+++ b/src/ape_cache/__init__.py
@@ -1,19 +1,16 @@
 from importlib import import_module
 
-from ape import plugins
-from ape.api.config import PluginConfig
+from ape.plugins import Config, QueryPlugin, register
 
 
-class CacheConfig(PluginConfig):
-    size: int = 1024**3  # 1gb
-
-
-@plugins.register(plugins.Config)
+@register(Config)
 def config_class():
+    from ape_cache.config import CacheConfig
+
     return CacheConfig
 
 
-@plugins.register(plugins.QueryPlugin)
+@register(QueryPlugin)
 def query_engines():
     query = import_module("ape_cache.query")
     return query.CacheQueryProvider
@@ -21,13 +18,18 @@ def query_engines():
 
 def __getattr__(name):
     if name == "CacheQueryProvider":
-        query = import_module("ape_cache.query")
-        return query.CacheQueryProvider
+        module = import_module("ape_cache.query")
+        return module.CacheQueryProvider
+
+    elif name == "CacheConfig":
+        module = import_module("ape_cache.config")
+        return module.CacheConfig
 
     else:
         raise AttributeError(name)
 
 
 __all__ = [
+    "CacheConfig",
     "CacheQueryProvider",
 ]

--- a/src/ape_cache/config.py
+++ b/src/ape_cache/config.py
@@ -1,0 +1,5 @@
+from ape.api.config import PluginConfig
+
+
+class CacheConfig(PluginConfig):
+    size: int = 1024**3  # 1gb

--- a/src/ape_compile/__init__.py
+++ b/src/ape_compile/__init__.py
@@ -1,95 +1,26 @@
-import re
-from re import Pattern
-from typing import Union
+from typing import Any
 
-from pydantic import field_serializer, field_validator
-
-from ape import plugins
-from ape.api.config import ConfigEnum, PluginConfig
-from ape.utils.misc import SOURCE_EXCLUDE_PATTERNS
+from ape.plugins import Config as RConfig
+from ape.plugins import register
 
 
-class OutputExtras(ConfigEnum):
-    """
-    Extra stuff you can output. It will
-    appear in ``.build/{key.lower()/``
-    """
-
-    ABI = "ABI"
-    """
-    Include this value to output the ABIs of your contracts
-    to minified JSONs. This is useful for hosting purposes
-    for web-apps.
-    """
-
-
-class Config(PluginConfig):
-    """
-    Configure general compiler settings.
-    """
-
-    exclude: set[Union[str, Pattern]] = set()
-    """
-    Source exclusion globs or regex patterns across all file types.
-    To use regex, start your values with ``r"`` and they'll be turned
-    into regex pattern objects.
-
-    **NOTE**: ``ape.utils.misc.SOURCE_EXCLUDE_PATTERNS`` are automatically
-    included in this set.
-    """
-
-    include_dependencies: bool = False
-    """
-    Set to ``True`` to compile dependencies during ``ape compile``.
-    Generally, dependencies are not compiled during ``ape compile``
-    This is because dependencies may not compile in Ape on their own,
-    but you can still reference them in your project's contracts' imports.
-    Some projects may be more dependency-based and wish to have the
-    contract types always compiled during ``ape compile``, and these projects
-    should configure ``include_dependencies`` to be ``True``.
-    """
-
-    output_extra: list[OutputExtras] = []
-    """
-    Extra selections to output. Outputs to ``.build/{key.lower()}``.
-    """
-
-    @field_validator("exclude", mode="before")
-    @classmethod
-    def validate_exclude(cls, value):
-        given_values = []
-
-        # Convert regex to Patterns.
-        for given in value or []:
-            if (given.startswith('r"') and given.endswith('"')) or (
-                given.startswith("r'") and given.endswith("'")
-            ):
-                value_clean = given[2:-1]
-                pattern = re.compile(value_clean)
-                given_values.append(pattern)
-
-            else:
-                given_values.append(given)
-
-        # Include defaults.
-        return {*given_values, *SOURCE_EXCLUDE_PATTERNS}
-
-    @field_serializer("exclude", when_used="json")
-    def serialize_exclude(self, exclude, info):
-        """
-        Exclude is put back with the weird r-prefix so we can
-        go to-and-from.
-        """
-        result: list[str] = []
-        for excl in exclude:
-            if isinstance(excl, Pattern):
-                result.append(f'r"{excl.pattern}"')
-            else:
-                result.append(excl)
-
-        return result
-
-
-@plugins.register(plugins.Config)
+@register(RConfig)
 def config_class():
+    from ape_compile.config import Config
+
     return Config
+
+
+def __getattr__(name: str) -> Any:
+    if name == "Config":
+        from ape_compile.config import Config
+
+        return Config
+
+    else:
+        raise AttributeError(name)
+
+
+__all__ = [
+    "Config",
+]

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -1,12 +1,14 @@
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
-from ethpm_types import ContractType
 
 from ape.cli.arguments import contract_file_paths_argument
 from ape.cli.options import ape_cli_context, config_override_option, project_option
-from ape.utils.os import clean_path
+
+if TYPE_CHECKING:
+    from ethpm_types import ContractType
 
 
 def _include_dependencies_callback(ctx, param, value):
@@ -93,6 +95,8 @@ def cli(
                 _display_byte_code_sizes(cli_ctx, contract_types)
 
     if not compiled:
+        from ape.utils.os import clean_path  # perf: lazy import
+
         folder = clean_path(project.contracts_folder)
         cli_ctx.logger.warning(f"Nothing to compile ({folder}).")
 
@@ -101,7 +105,7 @@ def cli(
         sys.exit(1)
 
 
-def _display_byte_code_sizes(cli_ctx, contract_types: dict[str, ContractType]):
+def _display_byte_code_sizes(cli_ctx, contract_types: dict[str, "ContractType"]):
     # Display bytecode size for *all* contract types (not just ones we compiled)
     code_size = []
     for contract in contract_types.values():

--- a/src/ape_compile/config.py
+++ b/src/ape_compile/config.py
@@ -1,0 +1,89 @@
+import re
+from re import Pattern
+from typing import Union
+
+from pydantic import field_serializer, field_validator
+
+from ape.api.config import ConfigEnum, PluginConfig
+from ape.utils.misc import SOURCE_EXCLUDE_PATTERNS
+
+
+class OutputExtras(ConfigEnum):
+    """
+    Extra stuff you can output. It will
+    appear in ``.build/{key.lower()/``
+    """
+
+    ABI = "ABI"
+    """
+    Include this value to output the ABIs of your contracts
+    to minified JSONs. This is useful for hosting purposes
+    for web-apps.
+    """
+
+
+class Config(PluginConfig):
+    """
+    Configure general compiler settings.
+    """
+
+    exclude: set[Union[str, Pattern]] = set()
+    """
+    Source exclusion globs or regex patterns across all file types.
+    To use regex, start your values with ``r"`` and they'll be turned
+    into regex pattern objects.
+
+    **NOTE**: ``ape.utils.misc.SOURCE_EXCLUDE_PATTERNS`` are automatically
+    included in this set.
+    """
+
+    include_dependencies: bool = False
+    """
+    Set to ``True`` to compile dependencies during ``ape compile``.
+    Generally, dependencies are not compiled during ``ape compile``
+    This is because dependencies may not compile in Ape on their own,
+    but you can still reference them in your project's contracts' imports.
+    Some projects may be more dependency-based and wish to have the
+    contract types always compiled during ``ape compile``, and these projects
+    should configure ``include_dependencies`` to be ``True``.
+    """
+
+    output_extra: list[OutputExtras] = []
+    """
+    Extra selections to output. Outputs to ``.build/{key.lower()}``.
+    """
+
+    @field_validator("exclude", mode="before")
+    @classmethod
+    def validate_exclude(cls, value):
+        given_values = []
+
+        # Convert regex to Patterns.
+        for given in value or []:
+            if (given.startswith('r"') and given.endswith('"')) or (
+                given.startswith("r'") and given.endswith("'")
+            ):
+                value_clean = given[2:-1]
+                pattern = re.compile(value_clean)
+                given_values.append(pattern)
+
+            else:
+                given_values.append(given)
+
+        # Include defaults.
+        return {*given_values, *SOURCE_EXCLUDE_PATTERNS}
+
+    @field_serializer("exclude", when_used="json")
+    def serialize_exclude(self, exclude, info):
+        """
+        Exclude is put back with the weird r-prefix so we can
+        go to-and-from.
+        """
+        result: list[str] = []
+        for excl in exclude:
+            if isinstance(excl, Pattern):
+                result.append(f'r"{excl.pattern}"')
+            else:
+                result.append(excl)
+
+        return result

--- a/src/ape_console/__init__.py
+++ b/src/ape_console/__init__.py
@@ -1,7 +1,8 @@
-from ape import plugins
-from ape_console.config import ConsoleConfig
+from ape.plugins import Config, register
 
 
-@plugins.register(plugins.Config)
+@register(Config)
 def config_class():
+    from ape_console.config import ConsoleConfig
+
     return ConsoleConfig

--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -12,10 +12,6 @@ import click
 
 from ape.cli.commands import ConnectedProviderCommand
 from ape.cli.options import ape_cli_context, project_option
-from ape.utils.basemodel import ManagerAccessMixin as access
-from ape.utils.misc import _python_version
-from ape.version import version as ape_version
-from ape_console.config import ConsoleConfig
 
 if TYPE_CHECKING:
     from IPython.terminal.ipapp import Config as IPythonConfig
@@ -54,6 +50,8 @@ def import_extras_file(file_path) -> ModuleType:
 def load_console_extras(**namespace: Any) -> dict[str, Any]:
     """load and return namespace updates from ape_console_extras.py  files if
     they exist"""
+    from ape.utils.basemodel import ManagerAccessMixin as access
+
     pm = namespace.get("project", access.local_project)
     global_extras = pm.config_manager.DATA_FOLDER.joinpath(CONSOLE_EXTRAS_FILENAME)
     project_extras = pm.path.joinpath(CONSOLE_EXTRAS_FILENAME)
@@ -102,6 +100,8 @@ def console(
     from IPython.terminal.ipapp import Config as IPythonConfig
 
     import ape
+    from ape.utils.misc import _python_version
+    from ape.version import version as ape_version
 
     project = project or ape.project
     banner = ""
@@ -154,6 +154,8 @@ def console(
 
 def _launch_console(namespace: dict, ipy_config: "IPythonConfig", embed: bool, banner: str):
     import IPython
+
+    from ape_console.config import ConsoleConfig
 
     ipython_kwargs = {"user_ns": namespace, "config": ipy_config}
     if embed:

--- a/src/ape_networks/__init__.py
+++ b/src/ape_networks/__init__.py
@@ -1,44 +1,23 @@
-from typing import Optional
+from typing import Any
 
-from ape import plugins
-from ape.api.config import PluginConfig
-
-
-class CustomNetwork(PluginConfig):
-    """
-    A custom network config.
-    """
-
-    name: str
-    """Name of the network e.g. mainnet."""
-
-    chain_id: int
-    """Chain ID (required)."""
-
-    ecosystem: str
-    """The name of the ecosystem."""
-
-    base_ecosystem_plugin: Optional[str] = None
-    """The base ecosystem plugin to use, when applicable. Defaults to the default ecosystem."""
-
-    default_provider: str = "node"
-    """The default provider plugin to use. Default is the default node provider."""
-
-    request_header: dict = {}
-    """The HTTP request header."""
-
-    @property
-    def is_fork(self) -> bool:
-        """
-        ``True`` when the name of the network ends in ``"-fork"``.
-        """
-        return self.name.endswith("-fork")
+from ape.plugins import Config, register
 
 
-class NetworksConfig(PluginConfig):
-    custom: list[CustomNetwork] = []
-
-
-@plugins.register(plugins.Config)
+@register(Config)
 def config_class():
+    from ape_networks.config import NetworksConfig
+
     return NetworksConfig
+
+
+def __getattr__(name: str) -> Any:
+    if name == "NetworksConfig":
+        from ape_networks.config import NetworksConfig
+
+        return NetworksConfig
+
+    else:
+        raise AttributeError(name)
+
+
+__all__ = ["NetworksConfig"]

--- a/src/ape_networks/_cli.py
+++ b/src/ape_networks/_cli.py
@@ -1,5 +1,5 @@
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from importlib import import_module
 from typing import TYPE_CHECKING
 
@@ -8,24 +8,22 @@ import yaml
 from rich import print as echo_rich_text
 from rich.tree import Tree
 
-from ape.cli.choices import OutputFormat
+from ape.cli.choices import OutputFormat, LazyChoice
 from ape.cli.options import ape_cli_context, network_option, output_format_option
 from ape.exceptions import NetworkError
 from ape.logging import LogLevel
-from ape.types.basic import _LazySequence
-from ape.utils.basemodel import ManagerAccessMixin as access
 
 if TYPE_CHECKING:
     from ape.api.providers import SubprocessProvider
 
 
-def _filter_option(name: str, options):
+def _filter_option(name: str, get_options: Callable[[], list[str]]):
     return click.option(
         f"--{name}",
         f"{name}_filter",
         multiple=True,
         help=f"Filter the results by {name}",
-        type=click.Choice(options),
+        type=LazyChoice(get_options),
     )
 
 
@@ -36,10 +34,14 @@ def cli():
     """
 
 
-def _lazy_get(name: str) -> _LazySequence:
+def _lazy_get(name: str) -> Sequence:
     # NOTE: Using fn generator to maintain laziness.
     def gen():
+        from ape.utils.basemodel import ManagerAccessMixin as access
+
         yield from getattr(access.network_manager, f"{name}_names")
+
+    from ape.types.basic import _LazySequence
 
     return _LazySequence(gen)
 
@@ -47,9 +49,9 @@ def _lazy_get(name: str) -> _LazySequence:
 @cli.command(name="list", short_help="List registered networks")
 @ape_cli_context()
 @output_format_option()
-@_filter_option("ecosystem", _lazy_get("ecosystem"))
-@_filter_option("network", _lazy_get("network"))
-@_filter_option("provider", _lazy_get("provider"))
+@_filter_option("ecosystem", lambda: _lazy_get("ecosystem"))
+@_filter_option("network", lambda: _lazy_get("network"))
+@_filter_option("provider", lambda: _lazy_get("provider"))
 def _list(cli_ctx, output_format, ecosystem_filter, network_filter, provider_filter):
     """
     List all the registered ecosystems, networks, and providers.

--- a/src/ape_networks/config.py
+++ b/src/ape_networks/config.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+from ape.api.config import PluginConfig
+
+
+class CustomNetwork(PluginConfig):
+    """
+    A custom network config.
+    """
+
+    name: str
+    """Name of the network e.g. mainnet."""
+
+    chain_id: int
+    """Chain ID (required)."""
+
+    ecosystem: str
+    """The name of the ecosystem."""
+
+    base_ecosystem_plugin: Optional[str] = None
+    """The base ecosystem plugin to use, when applicable. Defaults to the default ecosystem."""
+
+    default_provider: str = "node"
+    """The default provider plugin to use. Default is the default node provider."""
+
+    request_header: dict = {}
+    """The HTTP request header."""
+
+    @property
+    def is_fork(self) -> bool:
+        """
+        ``True`` when the name of the network ends in ``"-fork"``.
+        """
+        return self.name.endswith("-fork")
+
+
+class NetworksConfig(PluginConfig):
+    custom: list[CustomNetwork] = []

--- a/src/ape_plugins/__init__.py
+++ b/src/ape_plugins/__init__.py
@@ -1,7 +1,8 @@
-from ape import plugins
-from ape.api.config import ConfigDict
+from ape.plugins import register, Config
 
 
-@plugins.register(plugins.Config)
+@register(Config)
 def config_class():
+    from ape.api.config import ConfigDict
+
     return ConfigDict

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -8,7 +8,7 @@ from ethpm_types import ContractType, ErrorABI
 from ape.contracts import ContractContainer
 from ape.exceptions import APINotImplementedError, CompilerError, ContractLogicError, CustomError
 from ape.types.address import AddressType
-from ape_compile import Config
+from ape_compile.config import Config
 
 
 def test_get_imports(project, compilers):


### PR DESCRIPTION
### What I did

Seeing `ape --help` taking less than a second now. 

### How I did it

<img width="600" alt="Screenshot 2024-10-28 at 14 30 52" src="https://github.com/user-attachments/assets/0a8d079d-eb1f-4fc5-856e-060f032d6223">


<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
