### PR TITLE
refactor: move basemodel types to `ape.types`

### DIFF
--- a/src/ape/types/__init__.py
+++ b/src/ape/types/__init__.py
@@ -26,12 +26,26 @@ from ape.types.signatures import MessageSignature, SignableMessage, TransactionS
 from ape.types.trace import ContractFunctionPath, ControlFlow, GasReport, SourceTraceback
 from ape.types.units import CurrencyValue, CurrencyValueComparable
 from ape.types.vm import BlockID, ContractCode, SnapshotID
+from ape.utils.basemodel import (
+    BaseInterface,
+    BaseInterfaceModel,
+    BaseModel,
+    ExtraAttributesMixin,
+    ExtraModelAttributes,
+    ManagerAccessMixin,
+    get_attribute_with_extras,
+    get_item_with_extras,
+    only_raise_attribute_error,
+)
 
 __all__ = [
     "_LazySequence",
     "ABI",
     "AddressType",
     "AutoGasLimit",
+    "BaseInterface",
+    "BaseInterfaceModel",
+    "BaseModel",
     "BlockID",
     "Bytecode",
     "Checksum",
@@ -50,13 +64,19 @@ __all__ = [
     "CoverageStatement",
     "CurrencyValue",
     "CurrencyValueComparable",
+    "ExtraAttributesMixin",
+    "ExtraModelAttributes",
     "GasLimit",
     "GasReport",
+    "get_attribute_with_extras",
+    "get_item_with_extras",
     "HexInt",
     "HexBytes",
     "LogFilter",
+    "ManagerAccessMixin",
     "MessageSignature",
     "MockContractLog",
+    "only_raise_attribute_error",
     "PackageManifest",
     "PackageMeta",
     "RawAddress",

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -1,3 +1,7 @@
+"""
+TODO: In 0.9, move this module to `ape.types`.
+"""
+
 import inspect
 from abc import ABC
 from collections.abc import Callable, Iterator, Sequence


### PR DESCRIPTION
since some of yall insist in importing things from wherever you damn please.
