### PR TITLE
perf: make all commands faster, especially `ape init`, adds `--name` flag to `init` cmd

### DIFF
--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -6,19 +6,15 @@ from functools import cached_property
 from gettext import gettext
 from importlib.metadata import entry_points
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 from warnings import catch_warnings, simplefilter
 
 import click
-import rich
 import yaml
 
 from ape.cli.options import ape_cli_context
-from ape.exceptions import Abort, ApeException, ConfigError, handle_ape_exception
+from ape.exceptions import Abort, ApeException, handle_ape_exception
 from ape.logging import logger
-
-if TYPE_CHECKING:
-    from click import Context
 
 _DIFFLIB_CUT_OFF = 0.6
 
@@ -39,29 +35,8 @@ def display_config(ctx, param, value):
     ctx.exit()  # NOTE: Must exit to bypass running ApeCLI
 
 
-def _validate_config():
-    from ape.utils.basemodel import ManagerAccessMixin as access
-
-    project = access.local_project
-    try:
-        _ = project.config
-    except ConfigError as err:
-        rich.print(err)
-        # Exit now to avoid weird problems.
-        sys.exit(1)
-
-
 class ApeCLI(click.MultiCommand):
     _CLI_GROUP_NAME = "ape_cli_subcommands"
-
-    def parse_args(self, ctx: "Context", args: list[str]) -> list[str]:
-        # Validate the config before any argument parsing,
-        # as arguments may utilize config.
-        if "--help" not in args and args != []:
-            # perf: don't bother w/ config if only doing --help.
-            _validate_config()
-
-        return super().parse_args(ctx, args)
 
     def format_commands(self, ctx, formatter) -> None:
         from ape.plugins._utils import PluginMetadataList

--- a/src/ape_init/_cli.py
+++ b/src/ape_init/_cli.py
@@ -5,7 +5,6 @@ import click
 from click import BadParameter
 
 from ape.cli.options import ape_cli_context
-from ape.utils._github import github_client
 
 GITIGNORE_CONTENT = """
 # Ape stuff
@@ -45,12 +44,15 @@ def validate_github_repo(ctx, param, value):
     help="Clone a template from Github",
     callback=validate_github_repo,
 )
-def cli(cli_ctx, github):
+@click.option("--name", "project_name", prompt=True, help="A project name")
+def cli(cli_ctx, github, project_name):
     """
     ``ape init`` allows the user to create an ape project with
     default folders and ape-config.yaml.
     """
     if github:
+        from ape.utils._github import github_client
+
         org, repo = github
         github_client.clone_repo(org, repo, Path.cwd())
         shutil.rmtree(Path.cwd() / ".git", ignore_errors=True)
@@ -76,6 +78,5 @@ def cli(cli_ctx, github):
         if ape_config.exists():
             cli_ctx.logger.warning(f"'{ape_config}' exists")
         else:
-            project_name = click.prompt("Please enter project name")
             ape_config.write_text(f"name: {project_name}\n", encoding="utf8")
             cli_ctx.logger.success(f"{project_name} is written in ape-config.yaml")


### PR DESCRIPTION
### What I did

this may be problematic, not sure.
but the reason commands are so slow, like `ape init` is because of the pre-execution config validation.
i believe that was added as part of showing config errors and such, otherwise you may  run into weird problems and not really know why. but oh well, better to have a faster  command. Hopefully we can come up with a better config validation system, if we have to.

also adds `--name` flag to init so you can automate

Before:

```
ape init --name poop  3.46s
```

Now:

```
ape init --name poop  0.29s
```

### How I did it

delete helpful validation

### How to verify it

things whip

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
