### PR TITLE
perf: lazy load treatment for `ape-ethereum` core plugin

### DIFF
--- a/src/ape_ethereum/__init__.py
+++ b/src/ape_ethereum/__init__.py
@@ -1,49 +1,32 @@
 from ape import plugins
-from ape.api.networks import ForkedNetworkAPI, NetworkAPI, create_network_type
-
-from ._converters import WeiConversions
-from .ecosystem import (
-    NETWORKS,
-    BaseEthereumConfig,
-    Block,
-    Ethereum,
-    EthereumConfig,
-    ForkedNetworkConfig,
-    NetworkConfig,
-)
-from .provider import EthereumNodeProvider, Web3Provider, assert_web3_provider_uri_env_var_not_set
-from .query import EthereumQueryProvider
-from .trace import CallTrace, Trace, TransactionTrace
-from .transactions import (
-    AccessListTransaction,
-    BaseTransaction,
-    DynamicFeeTransaction,
-    Receipt,
-    SharedBlobReceipt,
-    SharedBlobTransaction,
-    StaticFeeTransaction,
-    TransactionStatusEnum,
-    TransactionType,
-)
 
 
 @plugins.register(plugins.Config)
 def config_class():
+    from ape_ethereum.ecosystem import EthereumConfig
+
     return EthereumConfig
 
 
 @plugins.register(plugins.ConversionPlugin)
 def converters():
+    from ape_ethereum._converters import WeiConversions
+
     yield int, WeiConversions
 
 
 @plugins.register(plugins.EcosystemPlugin)
 def ecosystems():
+    from ape_ethereum.ecosystem import Ethereum
+
     yield Ethereum
 
 
 @plugins.register(plugins.NetworkPlugin)
 def networks():
+    from ape.api.networks import ForkedNetworkAPI, NetworkAPI, create_network_type
+    from ape_ethereum.ecosystem import NETWORKS
+
     for network_name, network_params in NETWORKS.items():
         yield "ethereum", network_name, create_network_type(*network_params)
         yield "ethereum", f"{network_name}-fork", ForkedNetworkAPI
@@ -54,29 +37,78 @@ def networks():
 
 @plugins.register(plugins.QueryPlugin)
 def query_engines():
+    from .query import EthereumQueryProvider
+
     yield EthereumQueryProvider
 
 
+def __getattr__(name):
+    if name in (
+        "BaseEthereumConfig",
+        "Block",
+        "Ethereum",
+        "EthereumConfig",
+        "ForkedNetworkConfig",
+        "NetworkConfig",
+    ):
+        import ape_ethereum.ecosystem as ecosystem_module
+
+        return getattr(ecosystem_module, name)
+
+    elif name in (
+        "EthereumNodeProvider",
+        "Web3Provider",
+        "assert_web3_provider_uri_env_var_not_set",
+    ):
+        import ape_ethereum.provider as provider_module
+
+        return getattr(provider_module, name)
+
+    elif name in (
+        "AccessListTransaction",
+        "BaseTransaction",
+        "DynamicFeeTransaction",
+        "Receipt",
+        "SharedBlobReceipt",
+        "SharedBlobTransaction",
+        "StaticFeeTransaction",
+        "TransactionStatusEnum",
+        "TransactionType",
+    ):
+        import ape_ethereum.transactions as tx_module
+
+        return getattr(tx_module, name)
+
+    elif name in ("CallTrace", "Trace", "TransactionTrace"):
+        import ape_ethereum.trace as trace_module
+
+        return getattr(trace_module, name)
+
+    else:
+        raise AttributeError(name)
+
+
 __all__ = [
+    "AccessListTransaction",
+    "assert_web3_provider_uri_env_var_not_set",
+    "BaseEthereumConfig",
+    "BaseTransaction",
+    "Block",
+    "CallTrace",
+    "DynamicFeeTransaction",
     "Ethereum",
     "EthereumConfig",
-    "NetworkConfig",
-    "ForkedNetworkConfig",
-    "BaseEthereumConfig",
-    "Block",
-    "assert_web3_provider_uri_env_var_not_set",
-    "Web3Provider",
     "EthereumNodeProvider",
-    "Trace",
-    "TransactionTrace",
-    "CallTrace",
-    "TransactionStatusEnum",
-    "TransactionType",
-    "BaseTransaction",
-    "StaticFeeTransaction",
-    "AccessListTransaction",
-    "DynamicFeeTransaction",
-    "SharedBlobTransaction",
+    "ForkedNetworkConfig",
+    "NetworkConfig",
     "Receipt",
     "SharedBlobReceipt",
+    "SharedBlobTransaction",
+    "StaticFeeTransaction",
+    "Trace",
+    "TransactionStatusEnum",
+    "TransactionTrace",
+    "TransactionType",
+    "SharedBlobTransaction",
+    "Web3Provider",
 ]


### PR DESCRIPTION
### What I did

this plugin is heavily imported from

before

```python
In [1]: %time import ape_ethereum
CPU times: user 2.09 s, sys: 545 ms, total: 2.63 s
Wall time: 1.71 s
```

after

```python
In [1]: %time import ape_ethereum
CPU times: user 8.22 ms, sys: 2.44 ms, total: 10.7 ms
Wall time: 9.53 ms
```

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
