### PR TITLE
fix: more helpful traceback for `__getattr__` on `project`

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2216,8 +2216,10 @@ class LocalProject(Project):
                         "missing compilers for extensions: " + f'{", ".join(sorted(missing_exts))}?'
                     )
 
-            err.args = (message,)
-            raise  # The same exception (keep the stack the same height).
+            # NOTE: Purposely discard the stack-trace and raise a new exception.
+            #   This shows a better stack-trace to the user (rather than weird
+            #   BaseModel internals).
+            raise AttributeError(message)
 
     @property
     def _contract_sources(self) -> list[ContractSource]:

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -215,6 +215,8 @@ def test_getattr_not_exists(tmp_project):
     with pytest.raises(AttributeError, match=expected) as err:
         _ = tmp_project.nope
 
+    # Was the case where the last entry was from Ape's basemodel stuff.
+    # Now, it points at the project manager last.
     assert "ape/managers/project.py:" in repr(err.traceback[-1])
 
 

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -209,8 +209,13 @@ def test_getattr(tmp_project):
 
 
 def test_getattr_not_exists(tmp_project):
-    with pytest.raises(AttributeError):
+    expected = (
+        r"'LocalProject' object has no attribute 'nope'\. Also checked extra\(s\) 'contracts'\."
+    )
+    with pytest.raises(AttributeError, match=expected) as err:
         _ = tmp_project.nope
+
+    assert "ape/managers/project.py:" in repr(err.traceback[-1])
 
 
 def test_getattr_detects_changes(tmp_project):


### PR DESCRIPTION
### What I did

Eliminate some internal nonsense users won't care about

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
