### PR TITLE
perf: only load necessary plugins for CLI

### DIFF
--- a/src/ape/_cli.py
+++ b/src/ape/_cli.py
@@ -65,7 +65,6 @@ class ApeCLI(click.MultiCommand):
 
     def format_commands(self, ctx, formatter) -> None:
         from ape.plugins._utils import PluginMetadataList
-        from ape.utils.basemodel import ManagerAccessMixin as access
 
         commands = []
         for subcommand in self.list_commands(ctx):
@@ -86,8 +85,7 @@ class ApeCLI(click.MultiCommand):
             "Plugin": [],
             "3rd-Party Plugin": [],
         }
-        plugin_manager = access.plugin_manager
-        pl_metadata = PluginMetadataList.load(plugin_manager, include_available=False)
+        pl_metadata = PluginMetadataList.from_package_names(f"ape_{c[0]}" for c in commands)
         for cli_name, cmd in commands:
             help = cmd.get_short_help_str(limit)
             plugin = pl_metadata.get_plugin(cli_name, check_available=False)

--- a/src/ape/plugins/_utils.py
+++ b/src/ape/plugins/_utils.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from enum import Enum
 from functools import cached_property
 from shutil import which
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urlparse
 
 import click
@@ -18,6 +18,9 @@ from ape.utils._github import github_client
 from ape.utils.basemodel import BaseInterfaceModel, BaseModel
 from ape.utils.misc import _get_distributions, get_package_version, log_instead_of_fail
 from ape.version import version as ape_version_str
+
+if TYPE_CHECKING:
+    from ape.managers.plugins import PluginManager
 
 # Plugins maintained OSS by ApeWorX (and trusted)
 # Use `uv pip` if installed, otherwise `python -m pip`
@@ -202,7 +205,7 @@ class PluginMetadataList(BaseModel):
     third_party: "PluginGroup"
 
     @classmethod
-    def load(cls, plugin_manager, include_available: bool = True):
+    def load(cls, plugin_manager: "PluginManager", include_available: bool = True):
         plugins = plugin_manager.registered_plugins
         if include_available:
             plugins = plugins.union(github_client.available_plugins)


### PR DESCRIPTION
### What I did

Another big performance improvement for `ape --help`
Just when you thought you were no more...

### How I did it

Only load plugins for given CLIs, not all plugins

### How to verify it

noticed it wasnt scaling very well, especially when you installed like every plugin in Ape
even none-cli ones

now, you can avoid tht by only processing the cli plugins.

we went from 1.5 seconds to show help o 1 second (when all plugins installed)
when no CLI plugins are installed, it is like 0.6 seconds

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
