### PR TITLE
perf: able to load local project faster

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2217,7 +2217,7 @@ class LocalProject(Project):
             err.args = (message,)
             raise  # The same exception (keep the stack the same height).
 
-    @property
+    @cached_property
     def path(self) -> Path:
         """
         The path to the project's "base" (where contract source IDs are relative to).

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2132,8 +2132,6 @@ class LocalProject(Project):
 
         super().__init__(manifest, config_override=self._config_override)
 
-        self.path = self._base_path / (self.config.base_path or "")
-
         # NOTE: Avoid pointlessly adding info to the __local__ manifest.
         # This is mainly for dependencies.
         if self.manifest_path.stem != "__local__" and not manifest.sources:
@@ -2218,6 +2216,13 @@ class LocalProject(Project):
 
             err.args = (message,)
             raise  # The same exception (keep the stack the same height).
+
+    @property
+    def path(self) -> Path:
+        """
+        The path to the project's "base" (where contract source IDs are relative to).
+        """
+        return self._base_path / (self.config.base_path or "")
 
     @property
     def _contract_sources(self) -> list[ContractSource]:

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -72,15 +72,22 @@ class PytestApeRunner(ManagerAccessMixin):
             # Else, it gets way too noisy.
             show_locals = not self.config_wrapper.show_internal
 
-            report.longrepr = call.excinfo.getrepr(
-                funcargs=True,
-                abspath=Path.cwd(),
-                showlocals=show_locals,
-                style="short",
-                tbfilter=False,
-                truncate_locals=True,
-                chain=False,
-            )
+            try:
+                here = Path.cwd()
+
+            except FileNotFoundError:
+                pass  # In a temp-folder, most likely.
+
+            else:
+                report.longrepr = call.excinfo.getrepr(
+                    funcargs=True,
+                    abspath=here,
+                    showlocals=show_locals,
+                    style="short",
+                    tbfilter=False,
+                    truncate_locals=True,
+                    chain=False,
+                )
 
         if self.config_wrapper.interactive and report.failed:
             traceback = call.excinfo.traceback[-1]

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -680,9 +680,10 @@ class TestProject:
 
             os.chdir(temp_dir)
             expected = r"[.\n]*Input should be a valid string\n-->1: name:\n   2:   {asdf}[.\n]*"
+            weird_project = Project(temp_dir)
             try:
                 with pytest.raises(ConfigError, match=expected):
-                    _ = Project(temp_dir)
+                    _ = weird_project.path
             finally:
                 os.chdir(here)
 


### PR DESCRIPTION
### What I did

crushing bottle necks 1 by 1

Avoids config processing in the `project` init and move to `path` to property to make loading project faster

### How to verify it

easiest way:

ipython

before:

```
In [1]: %time from ape import project
CPU times: user 2.93 s, sys: 580 ms, total: 3.51 s
Wall time: 2.57 s
```

after

```
%time from ape import project
CPU times: user 1.97 s, sys: 554 ms, total: 2.52 s
Wall time: 1.6 s
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
