### PR TITLE
perf: ape compile --help wasnt fast

### DIFF
--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -1,4 +1,5 @@
 import inspect
+import sys
 from collections.abc import Callable
 from functools import partial
 from pathlib import Path
@@ -528,6 +529,11 @@ def incompatible_with(incompatible_opts) -> type[click.Option]:
 
 
 def _project_callback(ctx, param, val):
+    if "--help" in sys.argv or "-h" in sys.argv:
+        # Perf: project option is eager; have to check sys.argv to
+        #  know to exit early when only doing --help.
+        return
+
     from ape.utils.basemodel import ManagerAccessMixin
 
     pm = None


### PR DESCRIPTION
### What I did

Noticed `ape compile --help` was slow and I learned a thing or two about eager click options

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
