### PR TITLE
perf: make `ape run --help` faster

### DIFF
--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -14,13 +14,12 @@ from ape.cli.commands import ConnectedProviderCommand
 from ape.cli.options import _VERBOSITY_VALUES, _create_verbosity_kwargs, verbosity_option
 from ape.exceptions import ApeException, handle_ape_exception
 from ape.logging import logger
-from ape.utils.basemodel import ManagerAccessMixin as access
-from ape.utils.os import get_relative_path, use_temp_sys_path
-from ape_console._cli import console
 
 
 @contextmanager
 def use_scripts_sys_path(path: Path):
+    from ape.utils.os import use_temp_sys_path
+
     # First, ensure there is not an existing scripts module.
     scripts = sys.modules.get("scripts")
     if scripts:
@@ -71,6 +70,8 @@ class ScriptCommand(click.MultiCommand):
         self._has_warned_missing_hook: set[Path] = set()
 
     def invoke(self, ctx: Context) -> Any:
+        from ape.utils.basemodel import ManagerAccessMixin as access
+
         try:
             return super().invoke(ctx)
         except Exception as err:
@@ -95,6 +96,9 @@ class ScriptCommand(click.MultiCommand):
                 raise
 
     def _get_command(self, filepath: Path) -> Union[click.Command, click.Group, None]:
+        from ape.utils.basemodel import ManagerAccessMixin as access
+        from ape.utils.os import get_relative_path
+
         relative_filepath = get_relative_path(filepath, access.local_project.path)
 
         # First load the code module by compiling it
@@ -175,6 +179,8 @@ class ScriptCommand(click.MultiCommand):
 
     @property
     def commands(self) -> dict[str, Union[click.Command, click.Group]]:
+        from ape.utils.basemodel import ManagerAccessMixin as access
+
         if not access.local_project.scripts_folder.is_dir():
             return {}
 
@@ -223,6 +229,8 @@ class ScriptCommand(click.MultiCommand):
         return result
 
     def _launch_console(self):
+        from ape.utils.basemodel import ManagerAccessMixin as access
+
         trace = inspect.trace()
         trace_frames = [
             x for x in trace if x.filename.startswith(str(access.local_project.scripts_folder))
@@ -246,6 +254,8 @@ class ScriptCommand(click.MultiCommand):
             # Avoid keeping a reference to a frame to avoid reference cycles.
             if frame:
                 del frame
+
+        from ape_console._cli import console
 
         return console(project=access.local_project, extra_locals=extra_locals, embed=True)
 

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -17,6 +17,7 @@ from ape.logging import logger
 
 @contextmanager
 def use_scripts_sys_path(path: Path):
+    # perf: avoid importing at top of module so `--help` is faster.
     from ape.utils.os import use_temp_sys_path
 
     # First, ensure there is not an existing scripts module.
@@ -176,7 +177,7 @@ class ScriptCommand(click.MultiCommand):
 
     @property
     def commands(self) -> dict[str, Union[click.Command, click.Group]]:
-        # perf: Don't references `.local_project.scripts_folder` here;
+        # perf: Don't reference `.local_project.scripts_folder` here;
         #   it's too slow when doing just doing `--help`.
         scripts_folder = Path.cwd() / "scripts"
         if not scripts_folder.is_dir():

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -179,12 +179,13 @@ class ScriptCommand(click.MultiCommand):
 
     @property
     def commands(self) -> dict[str, Union[click.Command, click.Group]]:
-        from ape.utils.basemodel import ManagerAccessMixin as access
-
-        if not access.local_project.scripts_folder.is_dir():
+        # perf: Don't references `.local_project.scripts_folder` here;
+        #   it's too slow when doing just doing `--help`.
+        scripts_folder = Path.cwd() / "scripts"
+        if not scripts_folder.is_dir():
             return {}
 
-        return self._get_cli_commands(access.local_project.scripts_folder)
+        return self._get_cli_commands(scripts_folder)
 
     def _get_cli_commands(self, base_path: Path) -> dict:
         commands: dict[str, Command] = {}


### PR DESCRIPTION
### What I did

`ape run --help` was still slow because of a few reasons, mostly was the project access that i may look into on another PR.

### How I did it

Use `Path.cwd()` / "scripts"` locally.
Localize some imports as well.

Note: if you have a script module that is just slow to load, this wont help that ofc

### How to verify it

(in a project with zero scripts)

BEFORE:

```
ape run --help  4.47s user 0.99s system 98% cpu 5.542 total
```

AFTER:

```
ape run --help  0.29s user 0.09s system 59% cpu 0.638 total
```

With scripts is also much faster, but you wil only be as fast as your slowest script to load in a project. CLI users should have the same knowledge that lazy imports are better for CLIs.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
