### PR TITLE
perf: make `ape console --help` faster

### DIFF
--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -373,11 +373,11 @@ class NetworkChoice(click.Choice):
 
     @property
     def base_type(self) -> type["ProviderAPI"]:
-        # perf: property exists to delay import ProviderAPI at init time.
-        from ape.api.providers import ProviderAPI
-
         if self._base_type is not None:
             return self._base_type
+
+        # perf: property exists to delay import ProviderAPI at init time.
+        from ape.api.providers import ProviderAPI
 
         self._base_type = ProviderAPI
         return ProviderAPI

--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -71,10 +71,8 @@ class ConnectedProviderCommand(click.Command):
         super().__init__(*args, **kwargs)
 
     def parse_args(self, ctx: "Context", args: list[str]) -> list[str]:
-        from ape.api.providers import ProviderAPI
-
         arguments = args  # Renamed for better pdb support.
-        base_type = ProviderAPI if self._use_cls_types else str
+        base_type = None if self._use_cls_types else str
         if existing_option := next(
             iter(
                 x
@@ -85,13 +83,20 @@ class ConnectedProviderCommand(click.Command):
             ),
             None,
         ):
+            if base_type is None:
+                from ape.api.providers import ProviderAPI
+
+                base_type = ProviderAPI
+
             # Checking instance above, not sure why mypy still mad.
             existing_option.type.base_type = base_type  # type: ignore
 
         else:
             # Add the option automatically.
+            # NOTE: Local import here only avoids circular import issues.
             from ape.cli.options import NetworkOption
 
+            # NOTE: None base-type will default to `ProviderAPI`.
             option = NetworkOption(base_type=base_type, callback=self._network_callback)
             self.params.append(option)
 

--- a/src/ape/cli/commands.py
+++ b/src/ape/cli/commands.py
@@ -72,7 +72,7 @@ class ConnectedProviderCommand(click.Command):
 
     def parse_args(self, ctx: "Context", args: list[str]) -> list[str]:
         arguments = args  # Renamed for better pdb support.
-        base_type = None if self._use_cls_types else str
+        base_type: Optional[type] = None if self._use_cls_types else str
         if existing_option := next(
             iter(
                 x


### PR DESCRIPTION
### What I did

Before:

```
ape console --help  0.84s user 0.12s system 99% cpu 0.968 total
```

After:

```
ape console --help  0.27s user 0.05s system 97% cpu 0.322 total
```

### How I did it

Mostly by avoiding needing to import something from `ape.api.providers`

### How to verify it

```sh
ape console --help
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
