### PR TITLE
perf: make contracts load faster

### DIFF
--- a/src/ape/contracts/__init__.py
+++ b/src/ape/contracts/__init__.py
@@ -1,4 +1,8 @@
-from .base import ContractContainer, ContractEvent, ContractInstance, ContractLog, ContractNamespace
+def __getattr__(name: str):
+    import ape.contracts.base as module
+
+    return getattr(module, name)
+
 
 __all__ = [
     "ContractContainer",

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 import click
 from eth_pydantic_types import HexBytes
 from eth_utils import to_hex
+from ethpm_types.abi import EventABI
 
 from ape.api.address import Address, BaseAddress
 from ape.api.query import (
@@ -32,7 +33,7 @@ from ape.logging import get_rich_console, logger
 from ape.types.events import ContractLog, LogFilter, MockContractLog
 from ape.utils.abi import StructParser, _enrich_natspec
 from ape.utils.basemodel import (
-    BaseInterface,
+    BaseInterfaceModel,
     ExtraAttributesMixin,
     ExtraModelAttributes,
     ManagerAccessMixin,
@@ -43,7 +44,7 @@ from ape.utils.basemodel import (
 from ape.utils.misc import log_instead_of_fail
 
 if TYPE_CHECKING:
-    from ethpm_types.abi import ConstructorABI, ErrorABI, EventABI, MethodABI
+    from ethpm_types.abi import ConstructorABI, ErrorABI, MethodABI
     from ethpm_types.contract_type import ABI_W_SELECTOR_T, ContractType
     from pandas import DataFrame
 
@@ -435,7 +436,8 @@ class ContractTransactionHandler(ContractMethodHandler):
         )
 
 
-class ContractEvent(BaseInterface):
+# TODO: In Ape 0.9 - make not a BaseModel - no reason to.
+class ContractEvent(BaseInterfaceModel):
     """
     The types of events on a :class:`~ape.contracts.base.ContractInstance`.
     Use the event types via ``.`` access on the contract instances.
@@ -447,7 +449,7 @@ class ContractEvent(BaseInterface):
     """
 
     contract: "ContractTypeWrapper"
-    abi: "EventABI"
+    abi: EventABI
     _logs: Optional[list[ContractLog]] = None
 
     def __init__(self, *args, **kwargs):

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -32,7 +32,7 @@ from ape.logging import get_rich_console, logger
 from ape.types.events import ContractLog, LogFilter, MockContractLog
 from ape.utils.abi import StructParser, _enrich_natspec
 from ape.utils.basemodel import (
-    BaseInterfaceModel,
+    BaseInterface,
     ExtraAttributesMixin,
     ExtraModelAttributes,
     ManagerAccessMixin,
@@ -435,7 +435,7 @@ class ContractTransactionHandler(ContractMethodHandler):
         )
 
 
-class ContractEvent(BaseInterfaceModel):
+class ContractEvent(BaseInterface):
     """
     The types of events on a :class:`~ape.contracts.base.ContractInstance`.
     Use the event types via ``.`` access on the contract instances.

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -11,7 +11,6 @@ from eth_pydantic_types import HexBytes
 from eth_utils import to_hex
 from ethpm_types.abi import EventABI, MethodABI
 from ethpm_types.contract_type import ABI_W_SELECTOR_T, ContractType
-from IPython.lib.pretty import for_type
 
 from ape.api.accounts import AccountAPI
 from ape.api.address import Address, BaseAddress
@@ -900,6 +899,9 @@ class ContractTypeWrapper(ManagerAccessMixin):
         info = _get_info()
         error_type.info = error_type.__doc__ = info  # type: ignore
         if info:
+            # perf: Avoid forcing everyone to import from IPython.
+            from IPython.lib.pretty import for_type
+
             error_type._repr_pretty_ = repr_pretty_for_assignment  # type: ignore
 
             # Register the dynamically-created type with IPython so it integrates.

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import click
-import pandas as pd
 from eth_pydantic_types import HexBytes
 from eth_utils import to_hex
 from ethpm_types.abi import EventABI, MethodABI
@@ -50,6 +49,7 @@ from ape.utils.misc import log_instead_of_fail
 
 if TYPE_CHECKING:
     from ethpm_types.abi import ConstructorABI, ErrorABI
+    from pandas import DataFrame
 
     from ape.api.transactions import ReceiptAPI, TransactionAPI
 
@@ -616,7 +616,7 @@ class ContractEvent(BaseInterfaceModel):
         stop_block: Optional[int] = None,
         step: int = 1,
         engine_to_use: Optional[str] = None,
-    ) -> pd.DataFrame:
+    ) -> "DataFrame":
         """
         Iterate through blocks for log events
 
@@ -635,6 +635,8 @@ class ContractEvent(BaseInterfaceModel):
         Returns:
             pd.DataFrame
         """
+        # perf: pandas import is really slow. Avoid importing at module level.
+        import pandas as pd
 
         if start_block < 0:
             start_block = self.chain_manager.blocks.height + start_block

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 import click
 from eth_pydantic_types import HexBytes
 from eth_utils import to_hex
-from ethpm_types.contract_type import ABI_W_SELECTOR_T, ContractType
 
 from ape.api.address import Address, BaseAddress
 from ape.api.query import (
@@ -44,10 +43,9 @@ from ape.utils.basemodel import (
 from ape.utils.misc import log_instead_of_fail
 
 if TYPE_CHECKING:
-    from ethpm_types.abi import ConstructorABI, ErrorABI
+    from ethpm_types.abi import ConstructorABI, ErrorABI, EventABI, MethodABI
+    from ethpm_types.contract_type import ABI_W_SELECTOR_T, ContractType
     from pandas import DataFrame
-
-    from ethpm_types.abi import EventABI, MethodABI
 
     from ape.api.transactions import ReceiptAPI, TransactionAPI
     from ape.types.address import AddressType
@@ -798,7 +796,7 @@ class ContractEvent(BaseInterfaceModel):
 
 
 class ContractTypeWrapper(ManagerAccessMixin):
-    contract_type: ContractType
+    contract_type: "ContractType"
     base_path: Optional[Path] = None
 
     @property
@@ -810,7 +808,7 @@ class ContractTypeWrapper(ManagerAccessMixin):
         return self.contract_type.selector_identifiers
 
     @property
-    def identifier_lookup(self) -> dict[str, ABI_W_SELECTOR_T]:
+    def identifier_lookup(self) -> dict[str, "ABI_W_SELECTOR_T"]:
         """
         Provides a mapping of method, error, and event selector identifiers to
         ABI Types.
@@ -924,7 +922,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
     def __init__(
         self,
         address: "AddressType",
-        contract_type: ContractType,
+        contract_type: "ContractType",
         txn_hash: Optional[Union[str, HexBytes]] = None,
     ) -> None:
         super().__init__()
@@ -958,7 +956,9 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
         return super().__call__(*args, **kwargs)
 
     @classmethod
-    def from_receipt(cls, receipt: "ReceiptAPI", contract_type: ContractType) -> "ContractInstance":
+    def from_receipt(
+        cls, receipt: "ReceiptAPI", contract_type: "ContractType"
+    ) -> "ContractInstance":
         """
         Create a contract instance from the contract deployment receipt.
         """
@@ -1076,7 +1076,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
 
         else:
             # Didn't find anything that matches
-            name = self.contract_type.name or ContractType.__name__
+            name = self.contract_type.name or "ContractType"
             raise ApeAttributeError(f"'{name}' has no attribute '{method_name}'.")
 
     def invoke_transaction(self, method_name: str, *args, **kwargs) -> "ReceiptAPI":
@@ -1111,7 +1111,7 @@ class ContractInstance(BaseAddress, ContractTypeWrapper):
 
         else:
             # Didn't find anything that matches
-            name = self.contract_type.name or ContractType.__name__
+            name = self.contract_type.name or "ContractType"
             raise ApeAttributeError(f"'{name}' has no attribute '{method_name}'.")
 
     def get_event_by_signature(self, signature: str) -> ContractEvent:
@@ -1340,7 +1340,7 @@ class ContractContainer(ContractTypeWrapper, ExtraAttributesMixin):
         contract_container = project.MyContract  # Assuming there is a contract named "MyContract"
     """
 
-    def __init__(self, contract_type: ContractType) -> None:
+    def __init__(self, contract_type: "ContractType") -> None:
         self.contract_type = contract_type
 
     @log_instead_of_fail(default="<ContractContainer>")

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -208,7 +208,7 @@ class GethDevProcess(BaseGethProcess):
 
     def _clean(self):
         if self._data_dir.is_dir():
-            shutil.rmtree(self._data_dir)
+            shutil.rmtree(self._data_dir, ignore_errors=True)
 
         # dir must exist when initializing chain.
         self._data_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -673,8 +673,12 @@ class TestProject:
     def test_init(self, with_dependencies_project_path):
         # Purpose not using `project_with_contracts` fixture.
         project = Project(with_dependencies_project_path)
-        project.manifest_path.unlink(missing_ok=True)
         assert project.path == with_dependencies_project_path
+        project.manifest_path.unlink(missing_ok=True)
+
+        #  Re-init to show it doesn't create the manifest file.
+        project = Project(with_dependencies_project_path)
+
         # Manifest should have been created by default.
         assert not project.manifest_path.is_file()
 


### PR DESCRIPTION
### What I did

before:

```
time python -c "import ape.contracts.base"
python -c "import ape.contracts.base"  2.48s user 0.61s system 143% cpu 2.145 total
```

after:

```
python -c "import ape.contracts.base"  1.17s user 0.17s system 99% cpu 1.338 total
```

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
