### PR TITLE
fix: recursion error when a bad URI was configured in `node:`

### DIFF
--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -68,7 +68,6 @@ from ape_ethereum.transactions import AccessList, AccessListTransaction, Transac
 if TYPE_CHECKING:
     from ethpm_types import EventABI
 
-    from ape.api.config import PluginConfig
     from ape.api.trace import TraceAPI
     from ape.types.address import AddressType
     from ape.types.vm import BlockID, ContractCode
@@ -1341,7 +1340,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
             else:
                 raise TypeError(f"Not an URI: {uri}")
 
-        config: "PluginConfig" = self.config.get(self.network.ecosystem.name, None)
+        config: dict = self.config.get(self.network.ecosystem.name, None)
         if config is None:
             if rpc := self._get_random_rpc():
                 return rpc
@@ -1352,7 +1351,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
             raise ProviderError(f"Please configure a URL for '{self.network_choice}'.")
 
         # Use value from config file
-        network_config = (config or {}).get(self.network.name) or DEFAULT_SETTINGS
+        network_config: dict = (config or {}).get(self.network.name) or DEFAULT_SETTINGS
 
         if "url" in network_config:
             raise ConfigError("Unknown provider setting 'url'. Did you mean 'uri'?")

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1340,7 +1340,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
             else:
                 raise TypeError(f"Not an URI: {uri}")
 
-        config = self.config.model_dump().get(self.network.ecosystem.name, None)
+        config = self.config.get(self.network.ecosystem.name, None)
         if config is None:
             if rpc := self._get_random_rpc():
                 return rpc

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1530,7 +1530,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
                 is_likely_poa = True
                 break
 
-            except BlockNotFoundError:
+            except Exception:
                 # Some chains are "light" and we may not be able to detect
                 # if it need PoA middleware.
                 continue

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from typing import cast
 
@@ -137,7 +138,7 @@ def test_uri_invalid(geth_provider, project, ethereum):
     try:
         with project.temp_config(**config):
             # Assert we use the config value.
-            expected = f"Invalid URI (not HTTP, WS, or IPC): {value}"
+            expected = rf"Invalid URI \(not HTTP, WS, or IPC\): {re.escape(value)}"
             with pytest.raises(ConfigError, match=expected):
                 _ = geth_provider.uri
 

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -16,6 +16,7 @@ from web3.providers import HTTPProvider
 from ape.exceptions import (
     APINotImplementedError,
     BlockNotFoundError,
+    ConfigError,
     ContractLogicError,
     NetworkMismatchError,
     ProviderError,
@@ -125,6 +126,23 @@ def test_uri_non_dev_and_not_configured(mocker, ethereum):
 
     actual = provider.uri
     assert actual == expected
+
+
+def test_uri_invalid(geth_provider, project, ethereum):
+    settings = geth_provider.provider_settings
+    geth_provider.provider_settings = {}
+    value = "I AM NOT A URI OF ANY KIND!"
+    config = {"node": {"ethereum": {"local": {"uri": value}}}}
+
+    try:
+        with project.temp_config(**config):
+            # Assert we use the config value.
+            expected = f"Invalid URI (not HTTP, WS, or IPC): {value}"
+            with pytest.raises(ConfigError, match=expected):
+                _ = geth_provider.uri
+
+    finally:
+        geth_provider.provider_settings = settings
 
 
 @geth_process_test


### PR DESCRIPTION
### What I did

I put in a very non-URI value in my config to demo something and it blew up not how i expected.
This PR fixes it.

### How I did it

Noticed a comment was wrong, that was where to fix.
Basically make it error if given a value that is neither HTTP, WS, or IPC.

### How to verify it

```yaml
node:
  ethereum:
    mainnet:
      uri: asdfasdf
```

```sh
ape console --network ethereum:mainnet:node
```

Before, it would recurse until it failed.
Now, you get:

```
ERROR:    (ConfigError) Invalid URI (not HTTP, WS, or IPC): asdfasdf
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
