### PR TITLE
test: rerun random URL connection test if need-be

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ extras_require = {
         "pytest-cov>=4.0.0,<5",  # Coverage analyzer plugin
         "pytest-mock",  # For creating mocks
         "pytest-benchmark",  # For performance tests
+        "pytest-rerunfailures",  # For flakey tests
         "pytest-timeout>=2.2.0,<3",  # For avoiding timing out during tests
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
         "hypothesis-jsonschema==0.19.0",  # JSON Schema fuzzer extension

--- a/tests/functional/geth/test_network_manager.py
+++ b/tests/functional/geth/test_network_manager.py
@@ -39,6 +39,8 @@ def test_fork_upstream_provider(networks, mock_geth_sepolia, geth_provider, mock
             del geth_provider.provider_settings["uri"]
 
 
+# NOTE: Test is flakey because random URLs may be offline when test runs; avoid CI failure.
+@pytest.mark.flaky(reruns=5)
 @geth_process_test
 @pytest.mark.parametrize(
     "connection_str", ("moonbeam:moonriver", "https://moonriver.api.onfinality.io/public")


### PR DESCRIPTION
### What I did

Had a CI failure but the URL was actually fine, just was offline for a split second or something.

### How I did it

pytest-rerunfailures plugin

**NOTE:** Personally, plugins like this are a slippery slope and I think they should be avoided. If someone uses `flakey` markers, I will likely object and poke. However, in this situation, it makes sense because it involves an outside URL; I think that element really makes this test rich so I'd like to keep it, but ya it should be considered flakey since it is outside of our control.

### How to verify it

CI doesnt fail now.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
