### PR TITLE
perf: localize import for `ape console`

### DIFF
--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -9,7 +9,6 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 import click
-from IPython import InteractiveShell
 
 from ape.cli.commands import ConnectedProviderCommand
 from ape.cli.options import ape_cli_context, project_option
@@ -195,6 +194,8 @@ def _launch_console(
 
 
 def _execute_code(code: list[str], **ipython_kwargs):
+    from IPython import InteractiveShell
+
     shell = InteractiveShell.instance(**ipython_kwargs)
     # NOTE: Using `store_history=True` just so the cell IDs are accurate.
     for line in code:


### PR DESCRIPTION
### What I did

accidentally did a top level import in https://github.com/ApeWorX/ape/pull/2370
which caused a significant enough slow down to all of `ape --help`


```
ape --help  1.30s user 0.17s system 60% cpu 2.425 total
```


```
ape --help  0.95s user 0.13s system 57% cpu 1.887 total
```

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
