### PR TITLE
perf: move no-capture check to the inside of the `ConfigWrapper` constructor; avoid when only `--help`

### DIFF
--- a/src/ape/pytest/config.py
+++ b/src/ape/pytest/config.py
@@ -27,6 +27,18 @@ class ConfigWrapper(ManagerAccessMixin):
 
     def __init__(self, pytest_config: "PytestConfig"):
         self.pytest_config = pytest_config
+        if not self.verbosity:
+            # Enable verbose output if stdout capture is disabled
+            self.verbosity = self.pytest_config.getoption("capture") == "no"
+        # else: user has already changes verbosity to an equal or higher level; avoid downgrading.
+
+    @property
+    def verbosity(self) -> int:
+        return self.pytest_config.option.verbose
+
+    @verbosity.setter
+    def verbosity(self, value):
+        self.pytest_config.option.verbose = value
 
     @cached_property
     def supports_tracing(self) -> bool:

--- a/src/ape/pytest/plugin.py
+++ b/src/ape/pytest/plugin.py
@@ -68,11 +68,6 @@ def pytest_configure(config):
                 except AttributeError:
                     pass
 
-    if not config.option.verbose:
-        # Enable verbose output if stdout capture is disabled
-        config.option.verbose = config.getoption("capture") == "no"
-    # else: user has already changes verbosity to an equal or higher level; avoid downgrading.
-
     if "--help" in config.invocation_params.args:
         # perf: Don't bother setting up runner if only showing help.
         return

--- a/tests/functional/test_test.py
+++ b/tests/functional/test_test.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from ape.exceptions import ConfigError
+from ape.pytest.config import ConfigWrapper
 from ape.pytest.runners import PytestApeRunner
 from ape_test import ApeTestConfig
 from ape_test._watch import run_with_observer
@@ -16,6 +17,32 @@ class TestApeTestConfig:
         actual = cfg.balance
         expected = 10_000_000_000_000_000_000  # 10 ETH in WEI
         assert actual == expected
+
+
+class TestConfigWrapper:
+    def test_verbosity(self, mocker):
+        """
+        Show it returns the same as pytest_config's.
+        """
+        pytest_cfg = mocker.MagicMock()
+        pytest_cfg.option.verbose = False
+        wrapper = ConfigWrapper(pytest_cfg)
+        assert wrapper.verbosity is False
+
+    def test_verbosity_when_no_capture(self, mocker):
+        """
+        Shows we enable verbose output when no-capture is set.
+        """
+
+        def get_opt(name: str):
+            return "no" if name == "capture" else None
+
+        pytest_cfg = mocker.MagicMock()
+        pytest_cfg.option.verbose = False  # Start off as False
+        pytest_cfg.getoption.side_effect = get_opt
+
+        wrapper = ConfigWrapper(pytest_cfg)
+        assert wrapper.verbosity is True
 
 
 def test_connect_to_mainnet_by_default(mocker):


### PR DESCRIPTION
### What I did

Really small perf but doing it anyway.
Small in that you can't really see it when measuring, but slightly less stuff happens now when passing --help and code is cleaner feeling and more testable. So all good things.

### How I did it

Move logic to ctor

### How to verify it

things still work as they did

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
