### PR TITLE
perf: `ape_node` plugin load time improvement

### DIFF
--- a/docs/userguides/developing_plugins.md
+++ b/docs/userguides/developing_plugins.md
@@ -61,6 +61,9 @@ from ape import plugins
 # Here, we register our provider plugin so we can use it in 'ape'.
 @plugins.register(plugins.ProviderPlugin)
 def providers():
+    # NOTE: By keeping this import local, we avoid slower plugin load times.
+    from ape_my_plugin.provider import MyProvider
+    
     # NOTE: 'MyProvider' defined in a prior code-block.
     yield "ethereum", "local", MyProvider
 ```
@@ -68,6 +71,11 @@ def providers():
 This decorator hooks into ape core and ties everything together by looking for all local installed site-packages that start with `ape_`.
 Then, it will loop through these potential `ape` plugins and see which ones have created a plugin type registration.
 If the plugin type registration is found, then `ape` knows this package is a plugin and attempts to process it according to its registration interface.
+
+```{warning}
+Ensure your plugin's `__init__.py` file imports quickly by keeping all expensive imports in the hook functions locally.
+This helps Ape register plugins faster, which is required when checking for API implementations.
+```
 
 ### CLI Plugins
 

--- a/src/ape_node/__init__.py
+++ b/src/ape_node/__init__.py
@@ -1,16 +1,17 @@
 from ape import plugins
 
-from .provider import EthereumNetworkConfig, EthereumNodeConfig, GethDev, Node
-from .query import OtterscanQueryEngine
-
 
 @plugins.register(plugins.Config)
 def config_class():
+    from ape_node.provider import EthereumNodeConfig
+
     return EthereumNodeConfig
 
 
 @plugins.register(plugins.ProviderPlugin)
 def providers():
+    from ape_node.provider import EthereumNetworkConfig, GethDev, Node
+
     networks_dict = EthereumNetworkConfig().model_dump()
     networks_dict.pop("local")
     for network_name in networks_dict:
@@ -21,7 +22,20 @@ def providers():
 
 @plugins.register(plugins.QueryPlugin)
 def query_engines():
+    from ape_node.query import OtterscanQueryEngine
+
     yield OtterscanQueryEngine
+
+
+def __getattr__(name: str):
+    if name == "OtterscanQueryEngine":
+        from ape_node.query import OtterscanQueryEngine
+
+        return OtterscanQueryEngine
+
+    import ape_node.provider as module
+
+    return getattr(module, name)
 
 
 __all__ = [


### PR DESCRIPTION
### What I did

noooooo i wish this was in the last release, so close to have a faster default Ape ecosystem..

(ipython)

before

```
In [1]: %time import ape_node
CPU times: user 1.14 s, sys: 142 ms, total: 1.28 s
Wall time: 1.29 s
```

after:

```
In [1]: %time import ape_node
CPU times: user 7.93 ms, sys: 3.39 ms, total: 11.3 ms
Wall time: 10 ms
```

BASICALLY once all our plugins have this treatment, stuff like `ape console` will be able to launch faster, if my research is correct. And i already have ideas of where the bottleneck moves to. We're optimizing.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
