### PR TITLE
perf: getting `ape console` to launch faster

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ setup(
         "ijson>=3.1.4,<4",
         "ipython>=8.18.1,<9",
         "lazyasd>=0.1.4",
+        "asttokens>=2.4.1,<3",  # Peer dependency; w/o pin container build fails.
         # Pandas peer-dep: Numpy 2.0 causes issues for some users.
         "numpy<2",
         "packaging>=23.0,<24",
@@ -120,7 +121,7 @@ setup(
         # All version pins dependent on web3[tester]
         "eth-abi",
         "eth-account",
-        "eth-typing",
+        "eth-typing>=3.5.2,<4",
         "eth-utils",
         "hexbytes",
         "py-geth>=5.1.0,<6",

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -1083,7 +1083,7 @@ class NetworkAPI(BaseInterfaceModel):
         """
         return self.name == "custom" and not self._is_custom
 
-    @property
+    @cached_property
     def providers(self):  # -> dict[str, Partial[ProviderAPI]]
         """
         The providers of the network, such as Infura, Alchemy, or Node.

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 import click
 from click import Choice, Context, Parameter
 
-from ape.exceptions import AccountsError
+from ape.exceptions import (
+    AccountsError,
+    EcosystemNotFoundError,
+    NetworkNotFoundError,
+    ProviderNotFoundError,
+)
 
 if TYPE_CHECKING:
     from ape.api.accounts import AccountAPI
@@ -396,7 +401,10 @@ class NetworkChoice(click.Choice):
             from ape.utils.basemodel import ManagerAccessMixin as access
 
             networks = access.network_manager
-            value = networks.get_provider_from_choice(network_choice=value)
+            try:
+                value = networks.get_provider_from_choice(network_choice=value)
+            except (EcosystemNotFoundError, NetworkNotFoundError, ProviderNotFoundError) as err:
+                self.fail(str(err))
 
         return self.callback(ctx, param, value) if self.callback else value
 

--- a/src/ape/cli/choices.py
+++ b/src/ape/cli/choices.py
@@ -6,14 +6,9 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import click
-from click import BadParameter, Choice, Context, Parameter
+from click import Choice, Context, Parameter
 
-from ape.exceptions import (
-    AccountsError,
-    EcosystemNotFoundError,
-    NetworkNotFoundError,
-    ProviderNotFoundError,
-)
+from ape.exceptions import AccountsError
 
 if TYPE_CHECKING:
     from ape.api.accounts import AccountAPI
@@ -360,7 +355,7 @@ class NetworkChoice(click.Choice):
         ecosystem: _NETWORK_FILTER = None,
         network: _NETWORK_FILTER = None,
         provider: _NETWORK_FILTER = None,
-        base_type: Optional[type] = None,
+        base_type: Optional[Union[type, str]] = None,
         callback: Optional[Callable] = None,
     ):
         self._base_type = base_type
@@ -372,15 +367,14 @@ class NetworkChoice(click.Choice):
         # NOTE: Purposely avoid super().init for performance reasons.
 
     @property
-    def base_type(self) -> type["ProviderAPI"]:
+    def base_type(self) -> Union[type["ProviderAPI"], str]:
         if self._base_type is not None:
             return self._base_type
 
-        # perf: property exists to delay import ProviderAPI at init time.
-        from ape.api.providers import ProviderAPI
-
-        self._base_type = ProviderAPI
-        return ProviderAPI
+        # perf: Keep base-type as a forward-ref when only using the default.
+        #   so things load faster.
+        self._base_type = "ProviderAPI"
+        return self._base_type
 
     @base_type.setter
     def base_type(self, value):
@@ -394,62 +388,17 @@ class NetworkChoice(click.Choice):
         return "[ecosystem-name][:[network-name][:[provider-name]]]"
 
     def convert(self, value: Any, param: Optional[Parameter], ctx: Optional[Context]) -> Any:
-        from ape.utils.basemodel import ManagerAccessMixin as access
+        if not value or value.lower() in ("none", "null"):
+            return self.callback(ctx, param, _NONE_NETWORK) if self.callback else _NONE_NETWORK
 
-        choice: Optional[Union[str, "ProviderAPI"]]
-        networks = access.network_manager
-        if not value:
-            choice = None
+        if self.base_type == "ProviderAPI" or isinstance(self.base_type, type):
+            # Return the provider.
+            from ape.utils.basemodel import ManagerAccessMixin as access
 
-        elif value.lower() in ("none", "null"):
-            choice = _NONE_NETWORK
+            networks = access.network_manager
+            value = networks.get_provider_from_choice(network_choice=value)
 
-        elif self.is_custom_value(value):
-            # By-pass choice constraints when using custom network.
-            choice = value
-
-        else:
-            # Regular conditions.
-            try:
-                # Validate result.
-                choice = super().convert(value, param, ctx)
-            except BadParameter:
-                # Attempt to get the provider anyway.
-                # Sometimes, depending on the provider, it'll still work.
-                # (as-is the case for custom-forked networks).
-                try:
-                    choice = networks.get_provider_from_choice(network_choice=value)
-
-                except (EcosystemNotFoundError, NetworkNotFoundError, ProviderNotFoundError) as err:
-                    # This error makes more sense, as it has attempted parsing.
-                    # Show this message as the BadParameter message.
-                    raise click.BadParameter(str(err)) from err
-
-                except Exception as err:
-                    # If an error was not raised for some reason, raise a simpler error.
-                    # NOTE: Still avoid showing the massive network options list.
-                    raise click.BadParameter(
-                        "Invalid network choice. Use `ape networks list` to see options."
-                    ) from err
-
-        if choice not in (None, _NONE_NETWORK) and isinstance(choice, str):
-            from ape.api.providers import ProviderAPI
-
-            if issubclass(self.base_type, ProviderAPI):
-                # Return the provider.
-                choice = networks.get_provider_from_choice(network_choice=value)
-
-        return self.callback(ctx, param, choice) if self.callback else choice
-
-    @classmethod
-    def is_custom_value(cls, value) -> bool:
-        return (
-            value is not None
-            and isinstance(value, str)
-            and cls.CUSTOM_NETWORK_PATTERN.match(value) is not None
-            or str(value).startswith("http://")
-            or str(value).startswith("https://")
-        )
+        return self.callback(ctx, param, value) if self.callback else value
 
 
 class OutputFormat(Enum):

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -528,6 +528,10 @@ def incompatible_with(incompatible_opts) -> type[click.Option]:
     return IncompatibleOption
 
 
+def _project_path_callback(ctx, param, val):
+    return Path(val) if val else Path.cwd()
+
+
 def _project_callback(ctx, param, val):
     if "--help" in sys.argv or "-h" in sys.argv:
         # Perf: project option is eager; have to check sys.argv to
@@ -560,10 +564,12 @@ def _project_callback(ctx, param, val):
 
 
 def project_option(**kwargs):
+    _type = kwargs.pop("type", None)
+    callback = _project_path_callback if issubclass(_type, Path) else _project_callback
     return click.option(
         "--project",
         help="The path to a local project or manifest",
-        callback=_project_callback,
+        callback=callback,
         metavar="PATH",
         is_eager=True,
         **kwargs,

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -264,7 +264,10 @@ def network_option(
 
         def callback(ctx, param, value):
             keep_as_choice_str = param.type.base_type is str
-            provider_obj = _get_provider(value, default, keep_as_choice_str)
+            try:
+                provider_obj = _get_provider(value, default, keep_as_choice_str)
+            except Exception as err:
+                raise click.BadOptionUsage("--network", str(err), ctx)
 
             if provider_obj:
                 _update_context_with_network(ctx, provider_obj, requested_network_objects)

--- a/src/ape/cli/options.py
+++ b/src/ape/cli/options.py
@@ -565,7 +565,11 @@ def _project_callback(ctx, param, val):
 
 def project_option(**kwargs):
     _type = kwargs.pop("type", None)
-    callback = _project_path_callback if issubclass(_type, Path) else _project_callback
+    callback = (
+        _project_path_callback
+        if (isinstance(_type, type) and issubclass(_type, Path))
+        else _project_callback
+    )
     return click.option(
         "--project",
         help="The path to a local project or manifest",

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -538,7 +538,6 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         Returns:
             :class:`~ape.api.providers.ProviderAPI`
         """
-
         if network_choice is None:
             default_network = self.default_ecosystem.default_network
             return default_network.get_provider(provider_settings=provider_settings)

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 from evmchains import PUBLIC_CHAIN_META
 
-from ape.api.networks import EcosystemAPI, NetworkAPI, ProviderContextManager
+from ape.api.networks import ProviderContextManager
 from ape.exceptions import EcosystemNotFoundError, NetworkError, NetworkNotFoundError
 from ape.managers.base import BaseManager
 from ape.utils.basemodel import (
@@ -17,6 +17,7 @@ from ape.utils.misc import _dict_overlay, log_instead_of_fail
 from ape_ethereum.provider import EthereumNodeProvider
 
 if TYPE_CHECKING:
+    from ape.api.networks import EcosystemAPI, NetworkAPI
     from ape.api.providers import ProviderAPI
     from ape.utils.rpc import RPCHeaders
 
@@ -62,7 +63,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         self._active_provider = new_value
 
     @property
-    def network(self) -> NetworkAPI:
+    def network(self) -> "NetworkAPI":
         """
         The current network if connected to one.
 
@@ -76,7 +77,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         return self.provider.network
 
     @property
-    def ecosystem(self) -> EcosystemAPI:
+    def ecosystem(self) -> "EcosystemAPI":
         """
         The current ecosystem if connected to one.
 
@@ -203,7 +204,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         ]
 
     @property
-    def ecosystems(self) -> dict[str, EcosystemAPI]:
+    def ecosystems(self) -> dict[str, "EcosystemAPI"]:
         """
         All the registered ecosystems in ``ape``, such as ``ethereum``.
         """
@@ -244,7 +245,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         return {**self._evmchains_ecosystems, **plugin_ecosystems}
 
     @cached_property
-    def _plugin_ecosystems(self) -> dict[str, EcosystemAPI]:
+    def _plugin_ecosystems(self) -> dict[str, "EcosystemAPI"]:
         # Load plugins.
         plugins = self.plugin_manager.ecosystems
         return {n: cls(name=n) for n, cls in plugins}  # type: ignore[operator]
@@ -347,7 +348,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         )
 
     @only_raise_attribute_error
-    def __getattr__(self, attr_name: str) -> EcosystemAPI:
+    def __getattr__(self, attr_name: str) -> "EcosystemAPI":
         """
         Get an ecosystem via ``.`` access.
 
@@ -448,7 +449,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
             if ecosystem_has_providers:
                 yield ecosystem_name
 
-    def get_ecosystem(self, ecosystem_name: str) -> EcosystemAPI:
+    def get_ecosystem(self, ecosystem_name: str) -> "EcosystemAPI":
         """
         Get the ecosystem for the given name.
 
@@ -589,7 +590,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         return self.config_manager.default_ecosystem or "ethereum"
 
     @property
-    def default_ecosystem(self) -> EcosystemAPI:
+    def default_ecosystem(self) -> "EcosystemAPI":
         """
         The default ecosystem. Call
         :meth:`~ape.managers.networks.NetworkManager.set_default_ecosystem` to

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -259,7 +259,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
             )
             custom_ecosystems[ecosystem_name] = ecosystem_cls
 
-        return {**self._evmchains_ecosystems, **plugin_ecosystems, **custom_ecosystems}
+        return custom_ecosystems
 
     @cached_property
     def _evmchains_ecosystems(self) -> dict[str, "EcosystemAPI"]:

--- a/src/ape/managers/plugins.py
+++ b/src/ape/managers/plugins.py
@@ -133,7 +133,7 @@ class PluginManager:
             handled.add(module_name)
             try:
                 module = import_module(module_name)
-                pluggy_manager.register(module)
+                pluggy_manager.register(module, name=module_name)
             except Exception as err:
                 if module_name in CORE_PLUGINS or module_name == "ape":
                     # Always raise core plugin registration errors.

--- a/src/ape/managers/plugins.py
+++ b/src/ape/managers/plugins.py
@@ -124,8 +124,13 @@ class PluginManager:
         if self.__registered:
             return
 
-        plugins = ({n.replace("-", "_") for n in get_plugin_dists()})
+        handled = set()
+        plugins = (n.replace("-", "_") for n in get_plugin_dists())
         for module_name in chain(plugins, iter(CORE_PLUGINS)):
+            if module_name in handled:
+                continue
+
+            handled.add(module_name)
             try:
                 module = import_module(module_name)
                 pluggy_manager.register(module)

--- a/src/ape/managers/plugins.py
+++ b/src/ape/managers/plugins.py
@@ -1,6 +1,7 @@
 from collections.abc import Generator, Iterable, Iterator
 from functools import cached_property
 from importlib import import_module
+from itertools import chain
 from typing import Any, Optional
 
 from ape.exceptions import ApeAttributeError
@@ -123,10 +124,8 @@ class PluginManager:
         if self.__registered:
             return
 
-        plugins = list({n.replace("-", "_") for n in get_plugin_dists()})
-        plugin_modules = tuple([*plugins, *CORE_PLUGINS])
-
-        for module_name in plugin_modules:
+        plugins = ({n.replace("-", "_") for n in get_plugin_dists()})
+        for module_name in chain(plugins, iter(CORE_PLUGINS)):
             try:
                 module = import_module(module_name)
                 pluggy_manager.register(module)

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2281,10 +2281,10 @@ class LocalProject(Project):
             return default_project
 
         # ape-config.yaml does no exist. Check for another ProjectAPI type.
-        project_classes: list[type[ProjectAPI]] = [
-            t[1] for t in list(self.plugin_manager.projects)  # type: ignore
-        ]
-        plugins = [t for t in project_classes if not issubclass(t, ApeProject)]
+        project_classes: Iterator[type[ProjectAPI]] = (
+            t[1] for t in self.plugin_manager.projects  # type: ignore
+        )
+        plugins = (t for t in project_classes if not issubclass(t, ApeProject))
         for api in plugins:
             if instance := api.attempt_validate(path=self._base_path):
                 return instance

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -1941,6 +1941,7 @@ class Project(ProjectManager):
         self._config_override = overrides
         _ = self.config
         self.account_manager.test_accounts.reset()
+        self.network_manager._invalidate_cache()
 
     def extract_manifest(self) -> PackageManifest:
         # Attempt to compile, if needed.

--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -102,10 +102,10 @@ class ApeConsoleNamespace(dict):
         # Override to set items directly into the dictionary
         super().__setitem__(key, value)
 
-    def __contains__(self, item: str):
+    def __contains__(self, item: str) -> bool:  # type: ignore
         return self.get(item) is not None
 
-    def update(self, mapping, **kwargs) -> None:
+    def update(self, mapping, **kwargs) -> None:  # type: ignore
         # Override to update the dictionary directly
         super().update(mapping, **kwargs)
 

--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -66,6 +66,8 @@ def import_extras_file(file_path) -> ModuleType:
 class ApeConsoleNamespace(dict):
     def __init__(self, **kwargs):
         # Initialize the dictionary with provided keyword arguments
+        project = kwargs.get("project", self._ape.project)
+        kwargs["project"] = self._ape.Project(project) if isinstance(project, Path) else project
         super().__init__(**kwargs)
 
     def __getitem__(self, key: str):
@@ -115,11 +117,11 @@ class ApeConsoleNamespace(dict):
 
     @cached_property
     def _local_path(self) -> Path:
-        return self._ape.project.path.joinpath(CONSOLE_EXTRAS_FILENAME)
+        return self["project"].path.joinpath(CONSOLE_EXTRAS_FILENAME)
 
     @cached_property
     def _global_path(self) -> Path:
-        return self._ape.project.config_manager.DATA_FOLDER.joinpath(CONSOLE_EXTRAS_FILENAME)
+        return self._ape.config.DATA_FOLDER.joinpath(CONSOLE_EXTRAS_FILENAME)
 
     @cached_property
     def _local_extras(self) -> dict:

--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -207,8 +207,13 @@ def console(
         # Required for click.testing.CliRunner support.
         embed = True
 
-    namespace = ApeConsoleNamespace(**(extra_locals or {}))
+    namespace = _create_namespace(**(extra_locals or {}))
     _launch_console(namespace, ipy_config, embed, banner, code=code)
+
+
+def _create_namespace(**values) -> dict:
+    # Abstracted for testing purposes.
+    return ApeConsoleNamespace(**values)
 
 
 def _launch_console(

--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -2,11 +2,14 @@ import faulthandler
 import inspect
 import logging
 import sys
+from functools import cached_property
+from importlib import import_module
 from importlib.machinery import SourceFileLoader
 from importlib.util import module_from_spec, spec_from_loader
 from os import environ
+from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import click
 
@@ -39,7 +42,7 @@ def _code_callback(ctx, param, value) -> list[str]:
     context_settings=dict(ignore_unknown_options=True),
 )
 @ape_cli_context()
-@project_option(hidden=True)  # Hidden as mostly used for test purposes.
+@project_option(hidden=True, type=Path)  # Hidden as mostly used for test purposes.
 @click.option("-c", "--code", help="Program passed in as a string", callback=_code_callback)
 def cli(cli_ctx, project, code):
     """Opens a console for the local project."""
@@ -60,51 +63,103 @@ def import_extras_file(file_path) -> ModuleType:
     return module
 
 
-def load_console_extras(**namespace: Any) -> dict[str, Any]:
-    """load and return namespace updates from ape_console_extras.py  files if
-    they exist"""
-    from ape.utils.basemodel import ManagerAccessMixin as access
+class ApeConsoleNamespace(dict):
+    def __init__(self, **kwargs):
+        # Initialize the dictionary with provided keyword arguments
+        super().__init__(**kwargs)
 
-    pm = namespace.get("project", access.local_project)
-    global_extras = pm.config_manager.DATA_FOLDER.joinpath(CONSOLE_EXTRAS_FILENAME)
-    project_extras = pm.path.joinpath(CONSOLE_EXTRAS_FILENAME)
+    def __getitem__(self, key: str):
+        # First, attempt to retrieve the key from the dictionary itself
+        if super().__contains__(key):
+            return super().__getitem__(key)
 
-    for extras_file in [global_extras, project_extras]:
+        # Custom behavior for "ape" key
+        if key == "ape":
+            res = self._ape
+            self[key] = res  # Cache the result
+            return res
+
+        # Attempt to get the key from extras
+        try:
+            res = self._get_extra(key)
+        except KeyError:
+            pass
+        else:
+            self[key] = res  # Cache the result
+            return res
+
+        # Attempt to retrieve the key from the Ape module
+        try:
+            res = self._get_from_ape(key)
+        except AttributeError:
+            raise KeyError(key)
+
+        # Cache the result and return
+        self[key] = res
+        return res
+
+    def __setitem__(self, key, value):
+        # Override to set items directly into the dictionary
+        super().__setitem__(key, value)
+
+    def __contains__(self, item: str):
+        return self.get(item) is not None
+
+    def update(self, mapping, **kwargs) -> None:
+        # Override to update the dictionary directly
+        super().update(mapping, **kwargs)
+
+    @property
+    def _ape(self) -> ModuleType:
+        return import_module("ape")
+
+    @cached_property
+    def _local_extras(self) -> dict:
+        path = self._ape.project.path.joinpath(CONSOLE_EXTRAS_FILENAME)
+        return self._load_extras_file(path)
+
+    @cached_property
+    def _global_extras(self) -> dict:
+        path = self._ape.project.config_manager.DATA_FOLDER.joinpath(CONSOLE_EXTRAS_FILENAME)
+        return self._load_extras_file(path)
+
+    def get(self, key: str, default: Optional[Any] = None):
+        try:
+            return self.__getitem__(key)
+        except KeyError:
+            return default
+
+    def _get_extra(self, key: str):
+        try:
+            return self._local_extras[key]
+        except KeyError:
+            return self._global_extras[key]
+
+    def _get_from_ape(self, key: str):
+        return getattr(self._ape, key)
+
+    def _load_extras_file(self, extras_file: Path) -> dict:
         if not extras_file.is_file():
-            continue
+            return {}
 
         module = import_extras_file(extras_file)
         ape_init_extras = getattr(module, "ape_init_extras", None)
+        all_extras: dict = {}
 
-        # If found, execute ape_init_extras() function.
         if ape_init_extras is not None:
-            # Figure out the kwargs the func is looking for and assemble
-            # from the original namespace
             func_spec = inspect.getfullargspec(ape_init_extras)
-            init_kwargs: dict[str, Any] = {k: namespace.get(k) for k in func_spec.args}
-
-            # Execute functionality with existing console namespace as
-            # kwargs.
+            init_kwargs: dict[str, Any] = {k: self._get_from_ape(k) for k in func_spec.args}
             extras = ape_init_extras(**init_kwargs)
 
-            # If ape_init_extras returned a dict expect it to be new symbols
             if isinstance(extras, dict):
-                namespace.update(extras)
+                all_extras.update(extras)
 
-        # Add any public symbols from the module into the console namespace
-        for k in dir(module):
-            if k != "ape_init_extras" and not k.startswith("_"):
-                # Prevent override of existing namespace symbols
-                if k in namespace:
-                    continue
-
-                namespace[k] = getattr(module, k)
-
-    return namespace
+        all_extras.update({k: getattr(module, k) for k in dir(module) if k not in all_extras})
+        return all_extras
 
 
 def console(
-    project: Optional["ProjectManager"] = None,
+    project: Optional[Union["ProjectManager", Path]] = None,
     verbose: bool = False,
     extra_locals: Optional[dict] = None,
     embed: bool = False,
@@ -113,11 +168,15 @@ def console(
     import IPython
     from IPython.terminal.ipapp import Config as IPythonConfig
 
-    import ape
     from ape.utils.misc import _python_version
     from ape.version import version as ape_version
 
-    project = project or ape.project
+    if project is None:
+        from ape.utils.basemodel import ManagerAccessMixin
+
+        project = ManagerAccessMixin.local_project
+
+    project_path: Path = project if isinstance(project, Path) else project.path
     banner = ""
     if verbose:
         banner = """
@@ -131,29 +190,14 @@ def console(
             python_version=_python_version,
             ipython_version=IPython.__version__,
             ape_version=ape_version,
-            project_path=project.path,
+            project_path=project_path,
         )
 
         if not environ.get("APE_TESTING"):
             faulthandler.enable()  # NOTE: In case we segfault
 
-    namespace = {component: getattr(ape, component) for component in ape.__all__}
-    namespace["project"] = project  # Use the given project.
-    namespace["ape"] = ape
-
     # Allows modules relative to the project.
-    sys.path.insert(0, f"{project.path}")
-
-    # NOTE: `ape_console_extras` only is meant to work with default namespace.
-    #  Load extras before local namespace to avoid console extras receiving
-    #  the wrong values for its arguments.
-    console_extras = load_console_extras(**namespace)
-
-    if extra_locals:
-        namespace.update(extra_locals)
-
-    if console_extras:
-        namespace.update(console_extras)
+    sys.path.insert(0, f"{project_path}")
 
     ipy_config = IPythonConfig()
     ape_testing = environ.get("APE_TESTING")
@@ -163,6 +207,7 @@ def console(
         # Required for click.testing.CliRunner support.
         embed = True
 
+    namespace = ApeConsoleNamespace(**(extra_locals or {}))
     _launch_console(namespace, ipy_config, embed, banner, code=code)
 
 

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -7,7 +7,9 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 
 from eth.exceptions import HeaderNotFound
 from eth_pydantic_types import HexBytes
+from eth_tester import EthereumTester  # type: ignore
 from eth_tester.backends import PyEVMBackend  # type: ignore
+from eth_tester.backends.pyevm.main import setup_tester_chain  # type: ignore
 from eth_tester.exceptions import TransactionFailed  # type: ignore
 from eth_utils import is_0x_prefixed, to_hex
 from eth_utils.exceptions import ValidationError
@@ -41,6 +43,89 @@ if TYPE_CHECKING:
     from ape.api.transactions import ReceiptAPI, TransactionAPI
     from ape.types.events import ContractLog, LogFilter
     from ape.types.vm import BlockID, SnapshotID
+    from ape_test.config import ApeTestConfig
+
+
+class ApeEVMBackend(PyEVMBackend):
+    """
+    A lazier version of PyEVMBackend for the Ape framework.
+    """
+
+    def __init__(self, config: "ApeTestConfig"):
+        self.config = config
+        # Lazily set.
+        self._chain = None
+
+    @property
+    def hd_path(self) -> str:
+        return (self.config.hd_path or DEFAULT_TEST_HD_PATH).rstrip("/")
+
+    @property
+    def balance(self) -> int:
+        return self.config.balance
+
+    @property
+    def genesis_state(self) -> dict:
+        return self.generate_genesis_state(
+            mnemonic=self.config.mnemonic,
+            overrides={"balance": self.balance},
+            num_accounts=self.config.number_of_accounts,
+            hd_path=self.hd_path,
+        )
+
+    @cached_property
+    def _setup_tester_chain(self):
+        return setup_tester_chain(
+            None,
+            self.genesis_state,
+            self.config.number_of_accounts,
+            None,
+            self.config.mnemonic,
+            self.config.hd_path,
+        )
+
+    @property
+    def account_keys(self):
+        return self._setup_tester_chain[0]
+
+    @property
+    def chain(self):
+        if self._chain is None:
+            # Initial chain.
+            self._chain = self._setup_tester_chain[1]
+
+        return self._chain
+
+    @chain.setter
+    def chain(self, value):
+        self._chain = value  # Changes during snapshot reverting.
+
+
+class ApeTester(EthereumTesterProvider):
+    def __init__(
+        self, config: "ApeTestConfig", chain_id: int, backend: Optional[ApeEVMBackend] = None
+    ):
+        self.config = config
+        self.chain_id = chain_id
+        self._ethereum_tester = None if backend is None else EthereumTester(backend)
+
+    @property
+    def ethereum_tester(self) -> EthereumTester:
+        if self._ethereum_tester is None:
+            backend = ApeEVMBackend(self.config)
+            self._ethereum_tester = EthereumTester(backend)
+
+        return self._ethereum_tester
+
+    @ethereum_tester.setter
+    def ethereum_tester(self, value):
+        self._ethereum_tester = value
+
+    @cached_property
+    def api_endpoints(self) -> dict:  # type: ignore
+        endpoints = {**API_ENDPOINTS}
+        endpoints["eth"] = merge(endpoints["eth"], {"chainId": static_return(self.chain_id)})
+        return endpoints
 
 
 class LocalProvider(TestProviderAPI, Web3Provider):
@@ -53,32 +138,16 @@ class LocalProvider(TestProviderAPI, Web3Provider):
     )
 
     @property
-    def evm_backend(self) -> PyEVMBackend:
-        if self._evm_backend is None:
-            raise ProviderNotConnectedError()
+    def config(self) -> "ApeTestConfig":  # type: ignore
+        return super().config  # type: ignore
 
-        return self._evm_backend
+    @property
+    def evm_backend(self) -> ApeEVMBackend:
+        return self.tester.ethereum_tester.backend
 
     @cached_property
-    def tester(self):
-        chain_id = self.settings.chain_id
-        if self._web3 is not None:
-            connected_chain_id = self.make_request("eth_chainId")
-            if connected_chain_id == chain_id:
-                # Is already connected and settings have not changed.
-                return
-
-        hd_path = (self.config.hd_path or DEFAULT_TEST_HD_PATH).rstrip("/")
-        state_overrides = {"balance": self.test_config.balance}
-        self._evm_backend = PyEVMBackend.from_mnemonic(
-            genesis_state_overrides=state_overrides,
-            hd_path=hd_path,
-            mnemonic=self.config.mnemonic,
-            num_accounts=self.config.number_of_accounts,
-        )
-        endpoints = {**API_ENDPOINTS}
-        endpoints["eth"] = merge(endpoints["eth"], {"chainId": static_return(chain_id)})
-        return EthereumTesterProvider(ethereum_tester=self._evm_backend, api_endpoints=endpoints)
+    def tester(self) -> ApeTester:
+        return ApeTester(self.config, self.settings.chain_id)
 
     @property
     def auto_mine(self) -> bool:
@@ -98,12 +167,10 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         return self.evm_backend.get_block_by_number("latest")["gas_limit"]
 
     def connect(self):
-        if "tester" in self.__dict__:
-            del self.__dict__["tester"]
-
+        self.__dict__.pop("tester", None)
         self._web3 = Web3(self.tester)
         # Handle disabling auto-mine if the user requested via config.
-        if self.config.provider.auto_mine is False:
+        if self.settings.auto_mine is False:
             self.auto_mine = False  # type: ignore[misc]
 
     def disconnect(self):

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -314,7 +314,9 @@ def test_network_option_specify_custom_network(
         def cmd(network):
             click.echo(f"Value is '{getattr(network, 'name', network)}'")
 
-        result = runner.invoke(cmd, ("--network", f"ethereum:{network_name}:node"))
+        result = runner.invoke(
+            cmd, ("--network", f"ethereum:{network_name}:node"), catch_exceptions=False
+        )
         assert result.exit_code == 0
         assert f"Value is '{network_name}'" in result.output
 

--- a/tests/functional/test_console.py
+++ b/tests/functional/test_console.py
@@ -3,8 +3,10 @@ import sys
 import pytest
 
 from ape import Project
+from ape.managers.accounts import AccountManager
+from ape.managers.project import LocalProject
 from ape.utils import ManagerAccessMixin, create_tempdir
-from ape_console._cli import ApeConsoleNamespace, console
+from ape_console._cli import CONSOLE_EXTRAS_FILENAME, ApeConsoleNamespace, console
 from ape_console.plugin import custom_exception_handler
 
 
@@ -27,21 +29,17 @@ def test_console_extras_uses_ape_namespace(mocker, mock_console):
     actual = namespace_patch.call_args[1]
     assert actual["accounts"] == accounts_custom
 
-    extras = ApeConsoleNamespace()
-    assert extras["accounts"]
 
-
-def test_console_custom_project(mock_console, mock_ape_console_extras):
+def test_console_custom_project(mock_console):
     with create_tempdir() as path:
         project = Project(path)
+        extras_file = path / CONSOLE_EXTRAS_FILENAME
+        extras_file.touch()
         console(project=project)
-        actuals = (
-            mock_console.call_args[0][0]["project"],  # Launch namespace
-            mock_ape_console_extras.call_args[1]["project"],  # extras-load namespace
-        )
+        extras = mock_console.call_args[0][0]
+        actual = extras["project"]
 
-    for actual in actuals:
-        assert actual == project
+    assert actual == project
 
     # Ensure sys.path was updated correctly.
     assert sys.path[0] == str(project.path)
@@ -66,3 +64,31 @@ def test_custom_exception_handler_handles_non_ape_project(mocker):
     # We are expecting the local project's path in the handler.
     expected_path = ManagerAccessMixin.local_project.path
     handler_patch.assert_called_once_with(err, [expected_path])
+
+
+class TestApeConsoleNamespace:
+    def test_accounts(self):
+        extras = ApeConsoleNamespace()
+        assert isinstance(extras["accounts"], AccountManager)
+
+    @pytest.mark.parametrize("scope", ("local", "global"))
+    def test_extras(self, scope):
+        extras = ApeConsoleNamespace()
+        _ = getattr(extras, f"_{scope}_extras")
+        extras.__dict__[f"_{scope}_extras"] = {"foo": "123"}
+        assert extras["foo"] == "123"
+
+    @pytest.mark.parametrize("scope", ("local", "global"))
+    def test_extras_load_using_ape_namespace(self, scope):
+        extras = ApeConsoleNamespace()
+        _ = getattr(extras, f"_{scope}_path")
+        extras_content = """
+def ape_init_extras(project):
+    return {"foo": type(project)}
+"""
+        with create_tempdir() as temp:
+            extras_file = temp / CONSOLE_EXTRAS_FILENAME
+            extras_file.write_text(extras_content)
+            extras.__dict__[f"_{scope}_path"] = extras_file
+            extras.__dict__.pop(f"_{scope}_extras", None)
+            assert extras["foo"] is LocalProject

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -978,8 +978,8 @@ def test_networks_when_custom_ecosystem(
 
 def test_networks_multiple_networks_with_same_name(custom_networks_config_dict, ethereum, project):
     data = copy.deepcopy(custom_networks_config_dict)
-    data["networks"]["custom"][0]["name"] = "foonet"  # There already is a foonet in "ethereum".
-    data["networks"]["custom"][1]["name"] = "foonet"  # There already is a foonet in "ethereum".
+    data["networks"]["custom"][0]["name"] = "foonet"
+    data["networks"]["custom"][1]["name"] = "foonet"
     expected = ".*More than one network named 'foonet' in ecosystem 'ethereum'.*"
     with project.temp_config(**data):
         with pytest.raises(NetworkError, match=expected):

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -978,8 +978,9 @@ def test_networks_when_custom_ecosystem(
 
 def test_networks_multiple_networks_with_same_name(custom_networks_config_dict, ethereum, project):
     data = copy.deepcopy(custom_networks_config_dict)
-    data["networks"]["custom"][0]["name"] = "mainnet"  # There already is a mainnet in "ethereum".
-    expected = ".*More than one network named 'mainnet' in ecosystem 'ethereum'.*"
+    data["networks"]["custom"][0]["name"] = "foonet"  # There already is a foonet in "ethereum".
+    data["networks"]["custom"][1]["name"] = "foonet"  # There already is a foonet in "ethereum".
+    expected = ".*More than one network named 'foonet' in ecosystem 'ethereum'.*"
     with project.temp_config(**data):
         with pytest.raises(NetworkError, match=expected):
             _ = ethereum.networks


### PR DESCRIPTION
### What I did

doing what i can to get `ape console` to launch faster.
Mostly centers around connecting to networks faster
Also some other small perfs...
Am still working on the main bottle neck..

Before:

```
(ape_no_plugins) ➜  ape git:(main) time ape console

In [1]: exit
ape console  4.79s user 0.61s system 91% cpu 5.916 total
(ape_no_plugins) ➜  ape git:(main) time ape console

In [1]: exit
ape console  4.49s user 0.55s system 94% cpu 5.333 total
```

After:

```
ape console  3.87s user 0.64s system 101% cpu 4.460 total
(ape) ➜  ape git:(perf/console) time ape console

In [1]: exit
ape console  3.74s user 0.57s system 100% cpu 4.274 total
```

obviously this network dependent and such

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
