### PR TITLE
fix: auto fork evmchains networks and better access

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         ]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.18
+    rev: 0.7.19
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter, mdformat-pyproject]

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ extras_require = {
         "flake8-pydantic",  # For detecting issues with Pydantic models
         "flake8-type-checking",  # Detect imports to move in/out of type-checking blocks
         "isort>=5.13.2,<6",  # Import sorting linter
-        "mdformat>=0.7.18",  # Auto-formatter for markdown
+        "mdformat==0.7.18",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
         "mdformat-pyproject>=0.0.1",  # Allows configuring in pyproject.toml

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -325,7 +325,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
             for network_name, data in PUBLIC_CHAIN_META.get(self.name, {}).items()
             if network_name not in self._networks_from_plugins
         }
-        forked_networks: dict[str, type[ForkedNetworkAPI]] = {}
+        forked_networks: dict[str, ForkedNetworkAPI] = {}
         for network_name, network in networks.items():
             if network_name.endswith("-fork"):
                 # Already a fork.
@@ -336,7 +336,9 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
                 # The forked version of this network is already known.
                 continue
 
-            forked_networks[fork_network_name] = ForkedNetworkAPI
+            forked_networks[fork_network_name] = ForkedNetworkAPI(
+                name=fork_network_name, ecosystem=self
+            )
 
         return {**networks, **forked_networks}
 

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -241,13 +241,37 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
             )
             plugin_ecosystems[ecosystem_name] = ecosystem_cls
 
-        return plugin_ecosystems
+        return {**plugin_ecosystems, **self._evmchains_ecosystems}
 
     @cached_property
     def _plugin_ecosystems(self) -> dict[str, EcosystemAPI]:
         # Load plugins.
         plugins = self.plugin_manager.ecosystems
         return {n: cls(name=n) for n, cls in plugins}  # type: ignore[operator]
+
+    @cached_property
+    def _evmchains_ecosystems(self) -> dict[str, EcosystemAPI]:
+        ecosystems: dict[str, EcosystemAPI] = {}
+        for name in PUBLIC_CHAIN_META:
+            ecosystem_name = name.lower().replace(" ", "-")
+            symbol = None
+            for net in PUBLIC_CHAIN_META[ecosystem_name].values():
+                if not (native_currency := net.get("nativeCurrency")):
+                    continue
+
+                if "symbol" not in native_currency:
+                    continue
+
+                symbol = native_currency["symbol"]
+                break
+
+            symbol = symbol or "ETH"
+
+            # Is an EVM chain, can automatically make a class using evm-chains.
+            evm_class = self._plugin_ecosystems["ethereum"].__class__
+            ecosystems[name] = evm_class(name=ecosystem_name, fee_token_symbol=symbol)
+
+        return ecosystems
 
     def create_custom_provider(
         self,
@@ -437,28 +461,8 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         Returns:
             :class:`~ape.api.networks.EcosystemAPI`
         """
-
         if ecosystem_name in self.ecosystem_names:
             return self.ecosystems[ecosystem_name]
-
-        elif ecosystem_name.lower().replace(" ", "-") in PUBLIC_CHAIN_META:
-            ecosystem_name = ecosystem_name.lower().replace(" ", "-")
-            symbol = None
-            for net in PUBLIC_CHAIN_META[ecosystem_name].values():
-                if not (native_currency := net.get("nativeCurrency")):
-                    continue
-
-                if "symbol" not in native_currency:
-                    continue
-
-                symbol = native_currency["symbol"]
-                break
-
-            symbol = symbol or "ETH"
-
-            # Is an EVM chain, can automatically make a class using evm-chains.
-            evm_class = self._plugin_ecosystems["ethereum"].__class__
-            return evm_class(name=ecosystem_name, fee_token_symbol=symbol)
 
         raise EcosystemNotFoundError(ecosystem_name, options=self.ecosystem_names)
 
@@ -606,7 +610,6 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
             ecosystem_name (str): The name of the ecosystem to set
               as the default.
         """
-
         if ecosystem_name in self.ecosystem_names:
             self._default_ecosystem_name = ecosystem_name
 

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -353,4 +353,4 @@ def test_explorer_when_adhoc_network_supported(networks, mocker):
 
 def test_evm_chains_auto_forked_networks_exist(networks):
     # NOTE: Moonbeam networks exist in evmchains only; that is how Ape knows about them.
-    assert issubclass(networks.moonbeam.moonriver_fork, ForkedNetworkAPI)
+    assert isinstance(networks.moonbeam.moonriver_fork, ForkedNetworkAPI)

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -349,3 +349,8 @@ def test_explorer_when_adhoc_network_supported(networks, mocker):
     ]
     assert network.explorer is not None
     assert network.explorer.name == NAME
+
+
+def test_evm_chains_auto_forked_networks_exist(networks):
+    # NOTE: Moonbeam networks exist in evmchains only; that is how Ape knows about them.
+    assert issubclass(networks.moonbeam.moonriver_fork, ForkedNetworkAPI)

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -240,7 +240,7 @@ def test_parse_network_choice_multiple_contexts(
 
 
 def test_getattr_ecosystem_with_hyphenated_name(networks, ethereum):
-    networks.ecosystems["hyphen-in-name"] = networks.ecosystems["ethereum"]
+    networks._plugin_ecosystems["hyphen-in-name"] = networks.ecosystems["ethereum"]
     assert networks.hyphen_in_name  # Make sure does not raise AttributeError
     del networks.ecosystems["hyphen-in-name"]
 

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -438,7 +438,26 @@ def test_custom_networks_defined_in_non_local_project(custom_networks_config_dic
 
     with ape.Project.create_temporary_project(config_override=custom_networks) as temp_project:
         nm = temp_project.network_manager
+
+        # Tests `.get_ecosystem()` for custom networks.
         ecosystem = nm.get_ecosystem(eco_name)
         assert ecosystem.name == eco_name
+
         network = ecosystem.get_network(net_name)
         assert network.name == net_name
+
+
+def test_get_ecosystem(networks):
+    ethereum = networks.get_ecosystem("ethereum")
+    assert isinstance(ethereum, EcosystemAPI)
+    assert ethereum.name == "ethereum"
+
+
+def test_get_ecosystem_from_evmchains(networks):
+    """
+    Show we can call `.get_ecosystem()` for an ecosystem only
+    defined in evmchains.
+    """
+    moonbeam = networks.get_ecosystem("moonbeam")
+    assert isinstance(moonbeam, EcosystemAPI)
+    assert moonbeam.name == "moonbeam"


### PR DESCRIPTION
### What I did

* fixes: issue where couldnt use `getattr` approach for ecosystems from evmchains - only worked on connection but not when access.

* feat: make auto-forked networks happen for evm-chains based ecosystems (like we did for custom)

### How I did it

move some logic around
copy some idea from 1 place to another

### How to verify it

```
moony = networks.moonbeam
rivery = moony.moonriver-fork
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
