### PR TITLE
fix(unreleased): bug where evm-chains ecosystems overrode plugin ecosystems.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
         "packaging>=23.0,<24",
         "pandas>=2.2.2,<3",
         "pluggy>=1.3,<2",
-        "pydantic>=2.6.4,<3",
+        "pydantic>=2.6.4,<2.10",
         "pydantic-settings>=2.5.2,<3",
         "pytest>=8.0,<9.0",
         "python-dateutil>=2.8.2,<3",

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -241,7 +241,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
             )
             plugin_ecosystems[ecosystem_name] = ecosystem_cls
 
-        return {**plugin_ecosystems, **self._evmchains_ecosystems}
+        return {**self._evmchains_ecosystems, **plugin_ecosystems}
 
     @cached_property
     def _plugin_ecosystems(self) -> dict[str, EcosystemAPI]:

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -254,6 +254,38 @@ def test_getattr_custom_ecosystem(networks, custom_networks_config_dict, project
         assert isinstance(actual, EcosystemAPI)
 
 
+def test_getattr_plugin_ecosystem_same_as_evm_chains(mocker, networks):
+    """
+    Simulated having a plugin ecosystem installed.
+    """
+    optimismy = mocker.MagicMock()
+    networks._plugin_ecosystems["optimismy"] = optimismy
+    actual = networks.optimismy
+    del networks._plugin_ecosystems["optimismy"]
+    assert actual == optimismy
+
+
+def test_getattr_evm_chains_ecosystem(networks):
+    """
+    Show we can getattr evm-chains only ecosystems.
+    """
+    actual = networks.moonbeam
+    assert actual.name == "moonbeam"
+
+
+def test_getattr_plugin_ecosystem_same_name_as_evm_chains(mocker, networks):
+    """
+    Show when an ecosystem is both in evm-chains and an installed plugin
+    that Ape prefers the installed plugin.
+    """
+    moonbeam_plugin = mocker.MagicMock()
+    networks._plugin_ecosystems["moonbeam"] = moonbeam_plugin
+    actual = networks.moonbeam
+    del networks._plugin_ecosystems["moonbeam"]
+    assert actual == moonbeam_plugin
+    assert actual != networks._evmchains_ecosystems["moonbeam"]
+
+
 @pytest.mark.parametrize("scheme", ("http", "https"))
 def test_create_custom_provider_http(networks, scheme):
     provider = networks.create_custom_provider(f"{scheme}://example.com")


### PR DESCRIPTION
### What I did

Thanks @bitwise-constructs for finding this before we released.
Fixed bug where evm-chains ecosystems were overriding ecosystems from plugins.

### How I did it

change order of dict comprenhension

### How to verify it

have plugin installed
make sure uses plugin

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
