### PR TITLE
feat: support Pydantic 2.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
         "web3[tester]>=6.17.2,<7",
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.2.10,<0.3",
-        "ethpm-types>=0.6.17,<0.7",
+        "ethpm-types>=0.6.19,<0.7",
         "eth_pydantic_types>=0.1.3,<0.2",
         "evmchains>=0.1.0,<0.2",
         "evm-trace>=0.2.3,<0.3",

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
         "packaging>=23.0,<24",
         "pandas>=2.2.2,<3",
         "pluggy>=1.3,<2",
-        "pydantic>=2.6.4,<3",
+        "pydantic>=2.10.0,<3",
         "pydantic-settings>=2.5.2,<3",
         "pytest>=8.0,<9.0",
         "python-dateutil>=2.8.2,<3",

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -23,7 +23,7 @@ QueryType = Union[
 
 @cache
 def _basic_columns(Model: type[BaseInterfaceModel]) -> set[str]:
-    columns = set(Model.model_fields)
+    columns = set(Model.__pydantic_fields__)
 
     # TODO: Remove once `ReceiptAPI` fields cleaned up for better processing
     if Model == ReceiptAPI:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -649,7 +649,7 @@ class ContractEvent(BaseInterfaceModel):
                 f"the chain length ({self.chain_manager.blocks.height})."
             )
         query: dict = {
-            "columns": list(ContractLog.model_fields) if columns[0] == "*" else columns,
+            "columns": list(ContractLog.__pydantic_fields__) if columns[0] == "*" else columns,
             "event": self.abi,
             "start_block": start_block,
             "stop_block": stop_block,
@@ -720,7 +720,7 @@ class ContractEvent(BaseInterfaceModel):
 
         addresses = list(set([contract_address] + (extra_addresses or [])))
         contract_event_query = ContractEventQuery(
-            columns=list(ContractLog.model_fields.keys()),
+            columns=list(ContractLog.__pydantic_fields__),
             contract=addresses,
             event=self.abi,
             search_topics=search_topics,

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -433,7 +433,7 @@ class AccountHistory(BaseInterfaceModel):
                 next(
                     self.query_manager.query(
                         AccountTransactionQuery(
-                            columns=list(ReceiptAPI.model_fields),
+                            columns=list(ReceiptAPI.__pydantic_fields__),
                             account=self.address,
                             start_nonce=index,
                             stop_nonce=index,
@@ -471,7 +471,7 @@ class AccountHistory(BaseInterfaceModel):
             list(
                 self.query_manager.query(
                     AccountTransactionQuery(
-                        columns=list(ReceiptAPI.model_fields),
+                        columns=list(ReceiptAPI.__pydantic_fields__),
                         account=self.address,
                         start_nonce=start,
                         stop_nonce=stop - 1,

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -419,7 +419,7 @@ class ConversionManager(BaseManager):
         return converted_arguments
 
     def convert_method_kwargs(self, kwargs) -> dict:
-        fields = TransactionAPI.model_fields
+        fields = TransactionAPI.__pydantic_fields__
 
         def get_real_type(type_):
             all_types = getattr(type_, "_typevar_types", [])

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -4,7 +4,7 @@ TODO: In 0.9, move this module to `ape.types`.
 
 import inspect
 from abc import ABC
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from importlib import import_module
 from pathlib import Path
 from sys import getrecursionlimit
@@ -413,7 +413,7 @@ class BaseModel(EthpmTypesBaseModel):
     def model_copy(
         self: "Model",
         *,
-        update: Optional[dict[str, Any]] = None,
+        update: Optional[Mapping[str, Any]] = None,
         deep: bool = False,
         cache_clear: Optional[Sequence[str]] = None,
     ) -> "Model":

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -8,7 +8,6 @@ import pytest
 from eth_utils import to_hex
 from ethpm_types import Compiler, ContractType, PackageManifest, Source
 from ethpm_types.manifest import PackageName
-from pydantic_core import Url
 
 import ape
 from ape import Project
@@ -305,7 +304,8 @@ def test_meta(project):
         assert project.meta.license == "MIT"
         assert project.meta.description == "Zoologist meme protocol"
         assert project.meta.keywords == ["Indiana", "Knight's Templar"]
-        assert project.meta.links == {"apeworx.io": Url("https://apeworx.io")}
+        assert len(project.meta.links) == 1
+        assert f"{project.meta.links['apeworx.io']}" == "https://apeworx.io/"
 
 
 def test_extract_manifest(tmp_project, mock_sepolia, vyper_contract_instance):


### PR DESCRIPTION
### What I did

Pydantic 2.10 is a bit strange...
model_fields return type changed, according to mypy, but couldn really find it.
also had to fix a URL change in ethpm-types were file urls were no longer considered urls
also model_copy signature changed, but that wasnt a huge deal

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
