### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/userguides/projects.md
+++ b/docs/userguides/projects.md
@@ -14,7 +14,7 @@ project                             # The root project directory
 └── ape-config.yaml                 # The ape project configuration file
 ```
 
-Notice that you can configure you ape project using the `ape-config.yaml` file.
+Notice that you can configure your ape project using the `ape-config.yaml` file.
 See the [configuration guide](./config.html) for a more detailed explanation of settings you can adjust.
 
 ## The Local Project


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "Notice that you can configure `you` ape project" to "Notice that you can configure `your` ape project".

Please review the changes and let me know if any additional changes are needed.

