### PR TITLE
chore: Fix Grammar and Spelling Issues

### DIFF
--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -6,7 +6,7 @@ There are two locations you can place config files.
 1. In the root of your project
 2. In your `$HOME/.ape` directory (global)
 
-Project settings take precedent, but global settings allow you to configure preferences across all projects, such as your default mainnet provider (e.g. Alchemy versus running your own node).
+Project settings take precedence, but global settings allow you to configure preferences across all projects, such as your default mainnet provider (e.g. Alchemy versus running your own node).
 
 This guide serves as an index of some settings you can include in any `ape-config.yaml` file.
 This guide is **PURPOSELY** alphabetized to facilitate easier look-up of keys.

--- a/docs/userguides/proxy.md
+++ b/docs/userguides/proxy.md
@@ -1,7 +1,7 @@
 # Proxy Contracts
 
 Ape is able to detect proxy contracts so that it uses the target interface when interacting with a contract.
-The following proxies are supporting in `ape-ethereum`:
+The following proxies are supported in `ape-ethereum`:
 
 | Proxy Type   | Short Description                 |
 | ------------ | --------------------------------- |
@@ -27,7 +27,7 @@ from ape import Contract
 my_contract = Contract("0x...")
 ```
 
-Ape will check the address you give it and detect if hosts a proxy contract.
+Ape will check the address you give it and detect if it hosts a proxy contract.
 In the case where it determines the address is a proxy contract, it resolves the address of the implementation (every proxy is different) and returns the interface for the implementation contract.
 This allows you to still call methods as you normally do on proxy contracts.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,7 +4,7 @@ Due to its plugin-based architecture and registration as a pytest plugin, testin
 
 ### MyPy Type Annotations
 
-This codebase uses MyPy extensively, not only to help aide in finding typing issues within the codebase, but also as a means to help plugin writers avoid integration issues with the library.
+This codebase uses MyPy extensively, not only to help aid in finding typing issues within the codebase, but also as a means to help plugin writers avoid integration issues with the library.
 Please try to use MyPy Type Annotations as much as possible in the Core codebase, except where there exists an issue that would hugely complicate its use from a lack of available machinery.
 
 ### Functional Tests


### PR DESCRIPTION
Changes Overview
This PR addresses several grammatical and spelling issues across multiple documentation files to improve clarity and correctness.
1. docs/userguides/config.md
Old: "Project settings take precedent"
New: "Project settings take precedence"
Reason: Corrected usage of "precedence" (priority/importance) vs "precedent" (previous example/case)
2. docs/methoddocs/proxy.md
Old: "The following proxies are supporting in ape-ethereum"
New: "The following proxies are supported in ape-ethereum"
Reason: Corrected verb tense to passive voice for better technical documentation clarity
3. docs/methoddocs/proxy.md
Old: "Ape will check the address you give it and detect if hosts a proxy contract"
New: "Ape will check the address you give it and detect if it hosts a proxy contract"
Reason: Added missing subject "it" to complete the grammatical structure of the sentence
4. tests/README.md
Old: "to help aide in finding typing issues"
New: "to help aid in finding typing issues"
Reason: Corrected usage of "aid" (verb: to help) vs "aide" (noun: assistant/helper)