### PR TITLE
fix: updates setuptools to version compatible with PEP-625

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0,<8"]
+requires = ["setuptools>=70.2.0", "wheel", "setuptools_scm[toml]>=5.0"]
 
 [tool.mypy]
 exclude = ["build/", "dist/", "docs/", "tests/integration/cli/projects/"]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ extras_require = {
     ],
     "doc": ["sphinx-ape"],
     "release": [  # `release` GitHub Action job uses this
-        "setuptools",  # Installation tool
+        "setuptools==70.2.0",  # Installation tool
         "wheel",  # Packaging tool
         "twine==3.8.0",  # Package upload tool
     ],


### PR DESCRIPTION
### What I did

Bumps setuptools to version that normalizes names for sdist correctly, per PEP-625

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
