### PR TITLE
feat: fix + retry transaction for `geth --dev` when gas limit exceeds block gas limit

### DIFF
--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -538,6 +538,22 @@ def test_send_transaction_when_no_error_and_receipt_fails(
 
 
 @geth_process_test
+def test_send_transaction_exceed_block_gas_limit(chain, geth_provider, geth_contract, geth_account):
+    """
+    Shows that the local geth node will retry the transaction
+    with a new gas if this happens, automatically.
+    """
+    transaction = geth_contract.setNumber.as_transaction(23333322101, sender=geth_account)
+    prepared = geth_account.prepare_transaction(transaction)
+    prepared.gas_limit += 100000
+    signed = geth_account.sign_transaction(prepared)
+    expected_gas_limit = chain.blocks.head.gas_limit
+    geth_provider.send_transaction(signed)
+    tx_sent = geth_account.history[-1]
+    assert tx_sent.gas_limit == expected_gas_limit
+
+
+@geth_process_test
 def test_send_call(geth_provider, ethereum, tx_for_call):
     actual = geth_provider.send_call(tx_for_call)
     assert to_int(actual) == 0


### PR DESCRIPTION
### What I did

how many times have you seen intermittent failures like:

```
(32000) gas exceeds block gas limit
```

We get intermittent failures in the tests I think because of x-dist used with geth --dev and the gas limit changing somehow.
This PRs adds a retry mechanism here (only for geth --dev).

### How I did it

Detect the error.
Reset the gas limit + resign if it can
Resend


### How to verify it

no more intermittent failures in tests (Will know after a while)
also - adds a unit test

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
