### PR TITLE
refactor: set `ConfigManager.request_header` in ctor instead of in module namespace

### DIFF
--- a/src/ape/managers/config.py
+++ b/src/ape/managers/config.py
@@ -16,7 +16,7 @@ from ape.utils.basemodel import (
 )
 from ape.utils.misc import log_instead_of_fail
 from ape.utils.os import create_tempdir, in_tempdir
-from ape.utils.rpc import RPCHeaders
+from ape.utils.rpc import USER_AGENT, RPCHeaders
 
 if TYPE_CHECKING:
     from ethpm_types import PackageManifest
@@ -39,6 +39,10 @@ class ConfigManager(ExtraAttributesMixin, BaseManager):
         else:
             self.DATA_FOLDER = data_folder or Path.home() / ".ape"
 
+        request_header = request_header or {
+            "User-Agent": USER_AGENT,
+            "Content-Type": "application/json",
+        }
         self.REQUEST_HEADER = request_header or {}
 
     def __ape_extra_attributes__(self):

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -17,7 +17,6 @@ from pydantic import ConfigDict
 from ape.exceptions import ApeAttributeError, ApeIndexError, ProviderNotConnectedError
 from ape.logging import logger
 from ape.utils.misc import log_instead_of_fail, raises_not_implemented
-from ape.utils.rpc import USER_AGENT
 
 if TYPE_CHECKING:
     from pydantic.main import Model
@@ -173,9 +172,7 @@ class ManagerAccessMixin:
         The :class:`~ape.managers.config.ConfigManager`.
         """
         config = import_module("ape.managers.config")
-        return config.ConfigManager(
-            request_header={"User-Agent": USER_AGENT, "Content-Type": "application/json"},
-        )
+        return config.ConfigManager()
 
     @manager_access
     def conversion_manager(cls) -> "ConversionManager":


### PR DESCRIPTION
### What I did

Small refactor, moves an import to a place that makes more sense. Noticed while doing some 0.9 stuff

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
