### PR TITLE
feat: include proxy ABIs in contract-type ABIs

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -87,8 +87,6 @@ class ProxyInfoAPI(BaseModel):
 
         return model
 
-        # else: no way of knowing name.
-
     @log_instead_of_fail(default="<ProxyInfoAPI>")
     def __repr__(self) -> str:
         if _type := self.type_name:

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -13,7 +13,7 @@ from eth_account._utils.signing import (
 from eth_pydantic_types import HexBytes
 from eth_utils import keccak, to_int
 from evmchains import PUBLIC_CHAIN_META
-from pydantic import field_validator, model_validator
+from pydantic import model_validator
 
 from ape.exceptions import (
     CustomError,

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -65,6 +65,14 @@ class ProxyInfoAPI(BaseModel):
     target: AddressType
     """The address of the implementation contract."""
 
+    @property
+    def abi(self) -> Optional["MethodABI"]:
+        """
+        Some proxies have special ABIs which may not exist in their
+        contract-types by default, such as Safe's ``masterCopy()``.
+        """
+        return None
+
 
 class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
     """

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -796,7 +796,6 @@ class ContractCache(BaseManager):
             contract_instance (:class:`~ape.contracts.base.ContractInstance`): The contract
               to cache.
         """
-
         address = contract_instance.address
         contract_type = contract_instance.contract_type  # may be a proxy
 
@@ -809,20 +808,18 @@ class ContractCache(BaseManager):
             self.cache_proxy_info(address, proxy_info)
             if implementation_contract := self.get(proxy_info.target):
                 # Include proxy ABIs but ignore fallback/ctor etc.
-                abis = list(implementation_contract.abi)
                 proxy_abis = [
                     abi for abi in contract_type.abi if abi.type in ("error", "event", "function")
                 ]
-                abis.extend(proxy_abis)
 
                 # Include "hidden" ABIs, such as Safe's `masterCopy()`.
                 if proxy_info.abi and proxy_info.abi.signature not in [
                     abi.signature for abi in contract_type.abi
                 ]:
-                    abis.append(proxy_info.abi)
+                    proxy_abis.append(proxy_info.abi)
 
-                updated_proxy_contract = implementation_contract.model_copy()
-                updated_proxy_contract.abi = abis
+                updated_proxy_contract = implementation_contract.model_copy(deep=True)
+                updated_proxy_contract.abi.extend(proxy_abis)
                 self._cache_contract_type(address, updated_proxy_contract)
 
                 # Use this contract type in the user's contract instance.

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -1375,14 +1375,14 @@ class ContractCache(BaseManager):
         if not address_file.is_file():
             return None
 
-        return ProxyInfoAPI.model_validate_json(address_file.read_text())
+        return ProxyInfoAPI.model_validate_json(address_file.read_text(encoding="utf8"))
 
     def _get_blueprint_from_disk(self, blueprint_id: str) -> Optional[ContractType]:
         contract_file = self._blueprint_cache / f"{blueprint_id}.json"
         if not contract_file.is_file():
             return None
 
-        return ContractType.model_validate_json(contract_file.read_text())
+        return ContractType.model_validate_json(contract_file.read_text(encoding="utf8"))
 
     def _get_contract_type_from_explorer(self, address: AddressType) -> Optional[ContractType]:
         if not self._network.explorer:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -514,7 +514,7 @@ class Ethereum(EcosystemAPI):
             if _type == ProxyType.Beacon:
                 target = ContractCall(IMPLEMENTATION_ABI, target)(skip_trace=True)
 
-            return ProxyInfo(type=_type, target=target, abi=MASTER_COPY_ABI)
+            return ProxyInfo(type=_type, target=target, abi=IMPLEMENTATION_ABI)
 
         # safe >=1.1.0 provides `masterCopy()`, which is also stored in slot 0
         # call it and check that target matches

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -462,8 +462,7 @@ class Ethereum(EcosystemAPI):
         if isinstance(contract_code, bytes):
             contract_code = to_hex(contract_code)
 
-        code = contract_code[2:]
-        if not code:
+        if not (code := contract_code[2:]):
             return None
 
         patterns = {
@@ -515,7 +514,7 @@ class Ethereum(EcosystemAPI):
             if _type == ProxyType.Beacon:
                 target = ContractCall(IMPLEMENTATION_ABI, target)(skip_trace=True)
 
-            return ProxyInfo(type=_type, target=target)
+            return ProxyInfo(type=_type, target=target, abi=MASTER_COPY_ABI)
 
         # safe >=1.1.0 provides `masterCopy()`, which is also stored in slot 0
         # call it and check that target matches
@@ -525,7 +524,8 @@ class Ethereum(EcosystemAPI):
             target = self.conversion_manager.convert(slot_0[-20:], AddressType)
             # NOTE: `target` is set in initialized proxies
             if target != ZERO_ADDRESS and target == singleton:
-                return ProxyInfo(type=ProxyType.GnosisSafe, target=target)
+                return ProxyInfo(type=ProxyType.GnosisSafe, target=target, abi=MASTER_COPY_ABI)
+
         except ApeException:
             pass
 
@@ -541,7 +541,7 @@ class Ethereum(EcosystemAPI):
                 target = ContractCall(IMPLEMENTATION_ABI, address)(skip_trace=True)
                 # avoid recursion
                 if target != ZERO_ADDRESS:
-                    return ProxyInfo(type=ProxyType.Delegate, target=target)
+                    return ProxyInfo(type=ProxyType.Delegate, target=target, abi=IMPLEMENTATION_ABI)
 
             except (ApeException, ValueError):
                 pass

--- a/src/ape_ethereum/proxies.py
+++ b/src/ape_ethereum/proxies.py
@@ -1,5 +1,5 @@
 from enum import IntEnum, auto
-from typing import cast
+from typing import Optional, cast
 
 from eth_pydantic_types.hex import HexStr
 from ethpm_types import ContractType, MethodABI
@@ -68,6 +68,15 @@ class ProxyType(IntEnum):
 
 class ProxyInfo(ProxyInfoAPI):
     type: ProxyType
+
+    def __init__(self, **kwargs):
+        abi = kwargs.pop("abi", None)
+        super().__init__(**kwargs)
+        self._abi = abi
+
+    @property
+    def abi(self) -> Optional[MethodABI]:
+        return self._abi
 
 
 MASTER_COPY_ABI = MethodABI(

--- a/tests/functional/geth/conftest.py
+++ b/tests/functional/geth/conftest.py
@@ -8,6 +8,12 @@ from ape_node.provider import Node
 from tests.functional.data.python import TRACE_RESPONSE
 
 
+@pytest.fixture(scope="session")
+def safe_proxy_container(get_contract_type):
+    proxy_type = get_contract_type("SafeProxy")
+    return ContractContainer(proxy_type)
+
+
 @pytest.fixture
 def parity_trace_response():
     return TRACE_RESPONSE

--- a/tests/functional/geth/test_contracts_cache.py
+++ b/tests/functional/geth/test_contracts_cache.py
@@ -1,0 +1,55 @@
+import pytest
+
+from ape.exceptions import ContractNotFoundError
+from tests.conftest import geth_process_test
+
+
+@geth_process_test
+def test_get_proxy_from_explorer(
+    mock_explorer,
+    create_mock_sepolia,
+    safe_proxy_container,
+    geth_account,
+    vyper_contract_container,
+    geth_provider,
+    chain,
+):
+    """
+    Simulated when you get a contract from Etherscan for the first time
+    but that contract is a proxy. We expect both proxy and target ABIs
+    to be cached under the proxy's address.
+    """
+    target_contract = geth_account.deploy(vyper_contract_container, 10011339315)
+    proxy_contract = geth_account.deploy(safe_proxy_container, target_contract.address)
+
+    # Ensure both of these are not cached so we have to rely on our fake explorer.
+    del chain.contracts[target_contract.address]
+    del chain.contracts[proxy_contract.address]
+    # Sanity check.
+    with pytest.raises(ContractNotFoundError):
+        _ = chain.contracts.instance_at(proxy_contract.address)
+
+    def get_contract_type(address, *args, **kwargs):
+        # Mock etherscan backend.
+        if address == target_contract.address:
+            return target_contract.contract_type
+        elif address == proxy_contract.address:
+            return proxy_contract.contract_type
+
+        raise ValueError("Fake explorer only knows about proxy and target contracts.")
+
+    with create_mock_sepolia() as network:
+        # Setup our network to use our fake explorer.
+        mock_explorer.get_contract_type.side_effect = get_contract_type
+        network.__dict__["explorer"] = mock_explorer
+
+        # Typical flow: user attempts to get an un-cached contract type from Etherscan.
+        # That contract may be a proxy, in which case we should get a type
+        # w/ both proxy ABIs and the target ABIs.
+        contract_from_explorer = chain.contracts.instance_at(proxy_contract.address)
+
+        # Ensure we can call proxy methods!
+        assert contract_from_explorer.masterCopy  # No attr error!
+
+        # Ensure we can call target methods!
+        assert contract_from_explorer.myNumber  # No attr error!

--- a/tests/functional/geth/test_proxy.py
+++ b/tests/functional/geth/test_proxy.py
@@ -79,16 +79,6 @@ def test_gnosis_safe(safe_proxy_container, geth_contract, owner, ethereum, chain
     assert proxy_instance_ref_2.masterCopy()
     assert isinstance(proxy_instance_ref_2.myNumber(), int)
 
-    # Same - but clear the proxy ABI from the cached type.
-    chain.contracts._local_contract_types[proxy_instance.address].abi = [
-        x
-        for x in chain.contracts._local_contract_types[proxy_instance.address].abi
-        if x.type == "function" and x.name != "masterCopy"
-    ]
-    proxy_instance_ref_3 = chain.contracts.instance_at(proxy_instance.address)
-    assert proxy_instance_ref_3.masterCopy()
-    assert isinstance(proxy_instance_ref_3.myNumber(), int)
-
 
 @geth_process_test
 def test_openzeppelin(get_contract_type, geth_contract, owner, ethereum, sender):

--- a/tests/functional/geth/test_proxy.py
+++ b/tests/functional/geth/test_proxy.py
@@ -73,7 +73,7 @@ def test_gnosis_safe(get_contract_type, geth_contract, owner, ethereum, chain):
     # Ensure we can call the proxy-method.
     assert proxy_instance.masterCopy()
 
-    # Ensure we can target methods.
+    # Ensure we can call target methods.
     assert isinstance(proxy_instance.myNumber(), int)
 
     # Ensure this works with new instances.

--- a/tests/functional/geth/test_proxy.py
+++ b/tests/functional/geth/test_proxy.py
@@ -57,12 +57,10 @@ def test_uups_proxy(get_contract_type, geth_contract, owner, ethereum):
 
 
 @geth_process_test
-def test_gnosis_safe(get_contract_type, geth_contract, owner, ethereum, chain):
+def test_gnosis_safe(safe_proxy_container, geth_contract, owner, ethereum, chain):
     # Setup a proxy contract.
-    _type = get_contract_type("SafeProxy")
-    contract = ContractContainer(_type)
     target = geth_contract.address
-    proxy_instance = owner.deploy(contract, target)
+    proxy_instance = owner.deploy(safe_proxy_container, target)
 
     # (test)
     actual = ethereum.get_proxy_info(proxy_instance.address)

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -100,20 +100,33 @@ def test_deployments(owner, eth_tester_provider, vyper_contract_container):
 
 
 def test_deploy_proxy(
-    owner, project, vyper_contract_instance, proxy_contract_container, chain, eth_tester_provider
+    owner, vyper_contract_instance, proxy_contract_container, chain, eth_tester_provider
 ):
     target = vyper_contract_instance.address
     proxy = proxy_contract_container.deploy(target, sender=owner)
+
+    # Ensure we can call both proxy and target methods on it.
+    assert proxy.implementation  # No attr err
+    assert proxy.myNumber  # No attr err
+
+    # Ensure caching works.
     assert proxy.address in chain.contracts._local_contract_types
     assert proxy.address in chain.contracts._local_proxies
 
-    actual = chain.contracts._local_proxies[proxy.address]
-    assert actual.target == target
-    assert actual.type == ProxyType.Delegate
+    # Show the cached proxy info is correct.
+    proxy_info = chain.contracts._local_proxies[proxy.address]
+    assert proxy_info.target == target
+    assert proxy_info.type == ProxyType.Delegate
 
     # Show we get the implementation contract type using the proxy address
-    implementation = chain.contracts.instance_at(proxy.address)
-    assert implementation.contract_type == vyper_contract_instance.contract_type
+    re_contract = chain.contracts.instance_at(proxy.address)
+    assert re_contract.contract_type == proxy.contract_type
+
+    # Show proxy methods are not available on target alone.
+    target = chain.contracts.instance_at(proxy_info.target)
+    assert target.myNumber  # No attr err
+    with pytest.raises(AttributeError):
+        _ = target.implementation
 
 
 def test_source_path_in_project(project_with_contract):

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -819,7 +819,7 @@ def test_get_error_by_signature(error_contract):
 
 
 def test_selector_identifiers(vyper_contract_instance):
-    assert len(vyper_contract_instance.selector_identifiers.keys()) == 54
+    assert len(vyper_contract_instance.selector_identifiers.keys()) >= 54
     assert vyper_contract_instance.selector_identifiers["balances(address)"] == "0x27e235e3"
     assert vyper_contract_instance.selector_identifiers["owner()"] == "0x8da5cb5b"
     assert (
@@ -829,7 +829,7 @@ def test_selector_identifiers(vyper_contract_instance):
 
 
 def test_identifier_lookup(vyper_contract_instance):
-    assert len(vyper_contract_instance.identifier_lookup.keys()) == 54
+    assert len(vyper_contract_instance.identifier_lookup.keys()) >= 54
     assert vyper_contract_instance.identifier_lookup["0x27e235e3"].selector == "balances(address)"
     assert vyper_contract_instance.identifier_lookup["0x8da5cb5b"].selector == "owner()"
     assert (

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -5,9 +5,12 @@ NOTE: Most proxy tests are in `geth/test_proxy.py`.
 """
 
 
-def test_minimal_proxy(ethereum, minimal_proxy):
+def test_minimal_proxy(ethereum, minimal_proxy, chain):
     actual = ethereum.get_proxy_info(minimal_proxy.address)
     assert actual is not None
     assert actual.type == ProxyType.Minimal
     # It is the placeholder value still.
     assert actual.target == "0xBEbeBeBEbeBebeBeBEBEbebEBeBeBebeBeBebebe"
+    # Show getting the contract using the proxy address.
+    contract = chain.contracts.instance_at(minimal_proxy.address)
+    assert contract.abi == []  # No target ABIs; no proxy ABIs either.

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -13,4 +13,4 @@ def test_minimal_proxy(ethereum, minimal_proxy, chain):
     assert actual.target == "0xBEbeBeBEbeBebeBeBEBEbebEBeBeBebeBeBebebe"
     # Show getting the contract using the proxy address.
     contract = chain.contracts.instance_at(minimal_proxy.address)
-    assert contract.abi == []  # No target ABIs; no proxy ABIs either.
+    assert contract.contract_type.abi == []  # No target ABIs; no proxy ABIs either.


### PR DESCRIPTION
### What I did

fixes: #1249

I could no longer call `masterCopy()` in a safe proxy since https://github.com/ApeWorX/ape/pull/2400
I not 100% sure why but this PR fixes it.
I think before, it was never actually recognized as a safe proxy...

Anyway, the `masterCopy()` ABI is sort of hidden.
And proxy ABIs in general (that were not hidden) were not included in the contract-types ABIs you could call.
This PR makes both of those things work.

### How I did it

1. When detecting proxies, allow a place for ABIs to be included (not in the cache but just in the API). This helps `masterCopy()` be included.
2. When looking up a contract-type, also check to see if there is proxy info. If there is, it includes some of the ABIs if it is not already there. This way, past cached contract types (safes) will also suddenly work when calling `.masterCopy()`.
3. Also when caching a deployment, such as local testing environment using Safe (ape-safe's tests), include the ABIs so the returned instance can use `masterCopy()`

Can get ape-safe tests to pass again, altho this all started because was debuggin a different problem...

### Show it Working

```
In [7]: contract = Contract("0x4Fabb145d64652a948d72533023f6E7A623C7C53")

In [8]: contract.implementation
Out[8]: implementation() -> address


In [9]: contract.balanceOf
Out[9]: balanceOf(address _addr) -> uint256
```

**Example of Safe!**

First, delete any cached contract. This also deletes the proxy info that is cached, you can check!
```
In [1]: del chain.contracts['0x872Df5f6CF2C2Eaa9e7511AB079D263AB8fdc79f']
```

Next, get this contract as if it is the first time! Notice it uses Etherscan...
```
In [2]: contract = Contract("0x872Df5f6CF2C2Eaa9e7511AB079D263AB8fdc79f")
contract.
```

Show you can call both proxy ABIs as well as the actual safe ABIs:

```
In [3]: contract.masterCopy()
Out[3]: '0xfb1bffC9d739B8D520DaF37dF666da4C687191EA'

In [4]: contract.setGuard
Out[4]: setGuard(address guard)
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
