### PR TITLE
feat: allow creating `MockContractLog` when multiple events have the same name

### DIFF
--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -551,7 +551,7 @@ class ContractEvent(BaseInterfaceModel):
 
     def __call__(self, *args: Any, **kwargs: Any) -> MockContractLog:
         """
-        Create a mock-instance of a log using this event ABI and contract-instance.
+        Create a mock-instance of a log using this event ABI and the contract address.
 
         Args:
             *args: Position arguments for the event.
@@ -807,6 +807,8 @@ class ContractEvent(BaseInterfaceModel):
             )
 
 
+# TODO: In 0.9, just make `_events_` or ContractEvent possibly handle multiple ABIs
+#   much like the transactions handlers do. OR at least take the opportunty to refactor.
 class ContractEventWrapper:
     """
     A wrapper used when multiple events have the same so that

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -8,8 +8,9 @@ from eth_pydantic_types.hash import HashBytes20
 from eth_utils import to_hex
 from ethpm_types import ContractType
 
+from ape.contracts.base import ContractEventWrapper
 from ape.exceptions import ProviderError
-from ape.types.events import ContractLog
+from ape.types.events import ContractLog, MockContractLog
 from ape.types.units import CurrencyValueComparable
 
 if TYPE_CHECKING:
@@ -265,12 +266,11 @@ def test_contract_two_events_with_same_name(
     impl_container = chain.contracts.get_container(impl_contract_type)
     impl_instance = owner.deploy(impl_container)
 
-    expected_err = (
-        f"Multiple events named '{event_name}' in '{impl_contract_type.name}'.\n"
-        f"Use 'get_event_by_signature' look-up."
-    )
-    with pytest.raises(AttributeError, match=expected_err):
-        _ = impl_instance.FooEvent
+    # Show some features still work when referencing by __getattr__.
+    wrapper = impl_instance.FooEvent
+    assert isinstance(wrapper, ContractEventWrapper)
+    mock_log = wrapper(bar=16)
+    assert isinstance(mock_log, MockContractLog)
 
     expected_sig_from_impl = "FooEvent(uint256 bar, uint256 baz)"
     expected_sig_from_interface = "FooEvent(uint256 bar)"


### PR DESCRIPTION
### What I did

If I have a contract with multiple event ABIs in the contract with the same, it becomes awkward to try and create mock contract logs, as we doo

For example, this:

```
assert tx.events == [c.FooEvent(bar=123)]
```

becomes:

```
assert tx.events == [c.get_event_by_signature("FooEvent(uint256 bar)"(123)]
```

So with this PR, the top one will work. Before, the top one would error out ˙◠˙ x`x`

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
