### PR TITLE
feat: allow ``--show-internal`` to be configured and use in framework's tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = ["setuptools>=75.0.0", "wheel", "setuptools_scm[toml]>=5.0"]
 
+[tool.ape.test]
+show_internal = true
+
 [tool.mypy]
 exclude = ["build/", "dist/", "docs/", "tests/integration/cli/projects/"]
 check_untyped_defs = true

--- a/src/ape/pytest/config.py
+++ b/src/ape/pytest/config.py
@@ -86,7 +86,7 @@ class ConfigWrapper(ManagerAccessMixin):
 
     @cached_property
     def show_internal(self) -> bool:
-        return self.pytest_config.getoption("--show-internal")
+        return self.pytest_config.getoption("--show-internal") or self.ape_test_config.show_internal
 
     @cached_property
     def gas_exclusions(self) -> list["ContractFunctionPath"]:

--- a/src/ape_test/config.py
+++ b/src/ape_test/config.py
@@ -158,6 +158,12 @@ class ApeTestConfig(PluginConfig):
     Settings for the provider.
     """
 
+    show_internal: bool = False
+    """
+    Set to ``True`` to always show Ape's internal stack-trace in errors,
+    useful for debugging the framework itself.
+    """
+
     @field_validator("balance", mode="before")
     @classmethod
     def validate_balance(cls, value):

--- a/tests/functional/test_test.py
+++ b/tests/functional/test_test.py
@@ -61,6 +61,19 @@ class TestApeTestConfig:
 
 
 class TestConfigWrapper:
+    @pytest.mark.parametrize(
+        "cli_value,config_value", [(True, False), (False, True), (False, False)]
+    )
+    def test_show_internal(self, mocker, cli_value, config_value):
+        pytest_cfg = mocker.MagicMock()
+        ape_test_cfg = mocker.MagicMock()
+        wrapper = ConfigWrapper(pytest_cfg)
+        wrapper.__dict__["ape_test_config"] = ape_test_cfg
+        expected = cli_value or config_value  # True if there is a True
+        pytest_cfg.getoption.return_value = cli_value
+        ape_test_cfg.show_internal = config_value
+        assert wrapper.show_internal is expected
+
     def test_verbosity(self, mocker):
         """
         Show it returns the same as pytest_config's.

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -428,7 +428,7 @@ def test_fails():
     pytester.makepyfile(test)
     stdin = "print(foo)\nexit\n"
     monkeypatch.setattr("sys.stdin", io.StringIO(stdin))
-    result = pytester.runpytest("--interactive", "-s")
+    result = pytester.runpytest_subprocess("--interactive", "-s")
     result.assert_outcomes(failed=1)
     actual = str(result.stdout)
     assert secret in actual


### PR DESCRIPTION
### What I did

I noticed the last fail on merge to main failed...
I then realized some of the stack-trace is missing.. hmm..
Coincidentally, I also noticed this in `ape-safe`, which also uses Ape to test itself.
Thus, I remember the cursed `--show-internal` flag.
How can I just configured this on? Well I could use pytest's `addopts` but that always messy to me and is more of a last resort.
Instead, I made it so you can configure ape this way.
Then I remember I can configure Ape right in the Ape pyproject.toml file. Rad.
This makes sense to be configured for the framework itself, since that is its point

- [x] All changes are completed
- [x] New test cases have been added
