### PR TITLE
fix: Python & NPM dependencies when not installed in Python/NPM cause `ape pm list` to fail

### DIFF
--- a/src/ape/api/projects.py
+++ b/src/ape/api/projects.py
@@ -29,7 +29,7 @@ class DependencyAPI(BaseInterfaceModel):
     def package_id(self) -> str:
         """
         The full name of the package, used for storage.
-        Example: ``OpenZeppelin/openzepplin-contracts``.
+        Example: ``OpenZeppelin/openzeppelin-contracts``.
         """
 
     @property

--- a/src/ape_pm/__init__.py
+++ b/src/ape_pm/__init__.py
@@ -15,7 +15,7 @@ def dependencies():
     yield "github", _dependencies.GithubDependency
     yield "local", _dependencies.LocalDependency
     yield "npm", _dependencies.NpmDependency
-    yield ("python", "pypi"), _dependencies.PythonDependency
+    yield ("python", "pypi", "site_package"), _dependencies.PythonDependency
 
 
 @plugins.register(plugins.ProjectPlugin)

--- a/src/ape_pm/_cli.py
+++ b/src/ape_pm/_cli.py
@@ -27,7 +27,6 @@ def _list(cli_ctx, list_all):
     """
     List installed packages
     """
-
     dm = cli_ctx.dependency_manager
     packages = []
     dependencies = [*list(dm.get_project_dependencies(use_cache=True, allow_install=False))]
@@ -56,9 +55,14 @@ def _list(cli_ctx, list_all):
             else dependency.package_id
         )
 
+        try:
+            version = dependency.version
+        except ProjectError:
+            version = "<error>"
+
         item = {
             "name": name,
-            "version": dependency.version,
+            "version": version,
             "installed": is_installed,
             "compiled": is_compiled,
         }

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -681,12 +681,10 @@ class TestDependency:
         assert dependency.installed
 
     def test_installed_version_id_fails(self, project):
-        class BadDependency(LocalDependency):
-            @property
-            def version_id(self) -> str:
-                raise ValueError("boo!")
-
-        api = BadDependency(local=Path.cwd(), name="bad")
+        api = PythonDependency(
+            site_package="apethisdependencyisnotinstalled",
+            name="apethisdependencyisnotinstalled",
+        )
         dependency = Dependency(api, project)
         assert not dependency.installed
 

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -216,6 +216,22 @@ def test_add_dependency_with_dependencies(project, with_dependencies_project_pat
     assert actual.version == "local"
 
 
+def test_get_project_dependencies(project, with_dependencies_project_path):
+    installed_package = {"name": "web3", "site_package": "web3"}
+    not_installed_package = {
+        "name": "apethisisnotarealpackageape",
+        "site_package": "apethisisnotarealpackageape",
+    }
+    with project.temp_config(dependencies=[installed_package, not_installed_package]):
+        dm = project.dependencies
+        actual = list(dm.get_project_dependencies())
+        assert len(actual) == 2
+        assert actual[0].name == "web3"
+        assert actual[0].installed
+        assert actual[1].name == "apethisisnotarealpackageape"
+        assert not actual[1].installed
+
+
 def test_install(project, mocker):
     with project.isolate_in_tempdir() as tmp_project:
         contracts_path = tmp_project.path / "src"
@@ -663,6 +679,15 @@ class TestDependency:
         assert not dependency.installed
         dependency.install()
         assert dependency.installed
+
+    def test_installed_version_id_fails(self, project):
+        class BadDependency(LocalDependency):
+            def version_id(self) -> str:
+                raise ValueError("boo!")
+
+        api = BadDependency(local=Path.cwd(), name="bad")
+        dependency = Dependency(api, project)
+        assert not dependency.installed
 
     def test_compile(self, project):
         with create_tempdir() as path:

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -682,6 +682,7 @@ class TestDependency:
 
     def test_installed_version_id_fails(self, project):
         class BadDependency(LocalDependency):
+            @property
             def version_id(self) -> str:
                 raise ValueError("boo!")
 

--- a/tests/integration/cli/projects/only-dependencies/ape-config.yaml
+++ b/tests/integration/cli/projects/only-dependencies/ape-config.yaml
@@ -7,6 +7,9 @@ dependencies:
     config_override:
       contracts_folder: sources
 
+  - name: dependency-that-is-not-installed
+    site_package: apedependencythatisnotinstalledape
+
 compile:
   # NOTE: this should say `include_dependencies: false` below.
   # (it gets replaced with `true` in a test temporarily)

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -363,8 +363,11 @@ def test_compile_only_dependency(ape_cli, runner, integ_project, clean_cache, ap
         "--include-dependencies",
     )
     result = runner.invoke(ape_cli, arguments, catch_exceptions=False)
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 1, result.output  # exit_code=1 because 1 dependency is bad.
     assert expected_log_message in result.output
+
+    error_str = "Dependency 'apedependencythatisnotinstalledape' not installed."
+    assert error_str in result.output
 
 
 @skip_projects_except("with-contracts")

--- a/tests/integration/cli/test_pm.py
+++ b/tests/integration/cli/test_pm.py
@@ -308,8 +308,9 @@ def test_list(pm_runner, integ_project):
 
     # NOTE: Not using f-str here so we can see the spacing.
     expected = """
-NAME                        VERSION  INSTALLED  COMPILED
-dependency-in-project-only  local    False      False
+NAME                                VERSION  INSTALLED  COMPILED
+apedependencythatisnotinstalledape  <error>  False      False
+dependency-in-project-only          local    False      False
     """.strip()
     assert expected in result.output
 
@@ -318,8 +319,9 @@ dependency-in-project-only  local    False      False
     dependency.install()
 
     expected = """
-NAME                        VERSION  INSTALLED  COMPILED
-dependency-in-project-only  local    True       False
+NAME                                VERSION  INSTALLED  COMPILED
+apedependencythatisnotinstalledape  <error>  False      False
+dependency-in-project-only          local    True       False
     """.strip()
     result = pm_runner.invoke("list")
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
### What I did

If you have a project that lists a site-package based dependency, such as `snekmate:` (OR an `npm` dependency such as OZ), but that package is not installed in your site-packages / node_modules, the `version_id` will fail, causing complete madness in Ape.

### How I did it

basically handle exceptions everywhere

### How to verify it

tbd
### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
