### PR TITLE
fix: issue where used `SharedBlobReceipt` instead of `Receipt`

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -588,30 +588,14 @@ class Ethereum(EcosystemAPI):
             "transaction": self.create_transaction(**data),
         }
 
-        receipt_cls: type[Receipt]
-        if any(
-            x in data
-            for x in (
-                "blobGasPrice",
-                "blobGasUsed",
-                "blobVersionedHashes",
-                "maxFeePerBlobGas",
-                "blob_gas_price",
-                "blob_gas_used",
-            )
-        ):
-            blob_gas_price = data.get("blob_gas_price", data.get("blobGasPrice"))
+        if data.get("type") == 3:
+            receipt_cls = SharedBlobReceipt
+            blob_gas_price = data.get("blob_gas_price")
             if blob_gas_price is None:
-                # Not actually a blob-receipt? Some providers may give you
-                # empty values here when meaning the other types of receipts.
-                receipt_cls = Receipt
+                blob_gas_price = data.get("blobGasPrice")
 
-            else:
-                receipt_cls = SharedBlobReceipt
-                receipt_kwargs["blobGasPrice"] = blob_gas_price
-                receipt_kwargs["blobGasUsed"] = (
-                    data.get("blob_gas_used", data.get("blobGasUsed")) or 0
-                )
+            receipt_kwargs["blobGasPrice"] = blob_gas_price
+            receipt_kwargs["blobGasUsed"] = data.get("blob_gas_used", data.get("blobGasUsed")) or 0
 
         else:
             receipt_cls = Receipt

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -588,6 +588,7 @@ class Ethereum(EcosystemAPI):
             "transaction": self.create_transaction(**data),
         }
 
+        receipt_cls: type[Receipt]
         if data.get("type") == 3:
             receipt_cls = SharedBlobReceipt
             blob_gas_price = data.get("blob_gas_price")

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -630,6 +630,12 @@ def test_decode_receipt_shared_blob(ethereum, blob_gas_used, blob_gas_key):
         # when None, should also default to 0.
         assert actual.blob_gas_used == 0
 
+    # Show type=3 is required.
+    data["type"] = 2
+    actual = ethereum.decode_receipt(data)
+    assert not isinstance(actual, SharedBlobReceipt)
+    assert isinstance(actual, Receipt)
+
 
 def test_decode_receipt_misleading_blob_receipt(ethereum):
     """


### PR DESCRIPTION
### What I did

some tests in foundry show up using `SharedBlobReceipt` which seemed odd.. They had 1 field `blob_gas_price: 1`, seems like just random data coming along.. hoping this solution is more precise

### How I did it

rely on type being 3

### How to verify it

tell me if im wrong i guess, i havent fully researched and am just going off my understanding, i dont really blob

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
