### PR TITLE
perf: minor `trace` improvements

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -345,7 +345,7 @@ class ReceiptAPI(ExtraAttributesMixin, BaseInterfaceModel):
             same amount of gas as the given ``gas_limit``.
         """
 
-    @property
+    @cached_property
     def trace(self) -> "TraceAPI":
         """
         The :class:`~ape.api.trace.TraceAPI` of the transaction.

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -489,7 +489,7 @@ class ReceiptAPI(ExtraAttributesMixin, BaseInterfaceModel):
         """
         return None
 
-    @property
+    @cached_property
     def return_value(self) -> Any:
         """
         Obtain the final return value of the call. Requires tracing to function,

--- a/src/ape_ethereum/trace.py
+++ b/src/ape_ethereum/trace.py
@@ -261,7 +261,9 @@ class Trace(TraceAPI):
                 try:
                     return self._ecosystem.decode_returndata(abi, HexBytes(raw_return_data))
                 except Exception as err:
-                    logger.debug(f"Failed decoding raw returndata: {raw_return_data}. Error: {err}")
+                    logger.debug(
+                        f"Failed decoding raw returndata: {to_hex(raw_return_data)}. Error: {err}"
+                    )
                     return tuple([None for _ in range(num_outputs)])
 
         return tuple([None for _ in range(num_outputs)])

--- a/tests/functional/geth/test_trace.py
+++ b/tests/functional/geth/test_trace.py
@@ -4,6 +4,7 @@ from typing import Optional
 import pytest
 from ethpm_types import MethodABI
 from ethpm_types.abi import ABIType
+from evm_trace import CallTreeNode
 from hexbytes import HexBytes
 
 from ape.utils import run_in_tempdir
@@ -494,8 +495,8 @@ def test_return_value_tuple(geth_provider):
         def transaction(self) -> dict:
             return transaction
 
-        def get_raw_calltree(self) -> dict:
-            return calltree
+        def get_calltree(self) -> CallTreeNode:
+            return CallTreeNode.model_validate(calltree)
 
         @property
         def root_method_abi(self) -> Optional[MethodABI]:


### PR DESCRIPTION
small perf but just to get me started:

```
before:

10 passed in 74.92s (0:01:14)
10 passed in 74.68s

after:

10 passed in 73.99s (0:01:13)
10 passed in 73.17s (0:01:13)
```

must also use https://github.com/ApeWorX/ape-foundry/pull/121

* caching
* avoid some unnecessary computes