### PR TITLE
fix: handle when a provider is not `TestProviderAPI` subclass during ape-test fixture setup

### DIFF
--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -119,6 +119,9 @@ class FixtureManager(ManagerAccessMixin):
         except (NotImplementedError, ProviderNotConnectedError):
             # Assume it's on since it can't be turned off.
             is_auto_mine = True
+        except AttributeError:
+            # If not a test-provider, we don't know.
+            return None
 
         if not is_auto_mine:
             # When auto-mine is disabled, it's unknown.

--- a/tests/functional/test_test.py
+++ b/tests/functional/test_test.py
@@ -168,6 +168,16 @@ class TestFixtureManager:
         fixture_manager.add_fixture_info("bar", setup_block=1, teardown_block=2)
         assert fixture_manager.is_stateful("bar") is True
 
+    def test_is_stateful_when_not_using_test_provider(self, networks, fixture_manager, item):
+        fixture_manager._stateful_fixtures_cache = {}
+        live_provider = networks.ethereum.sepolia.get_provider("node")
+        provider = networks.active_provider
+        networks.active_provider = live_provider
+        for fixture in ("foo", "bar"):
+            actual = fixture_manager.is_stateful(fixture)
+            networks.active_provider = provider
+            assert actual is None
+
     def test_rebase(self, mocker, fixture_manager, fixture_map, create_fixture_info):
         # We must have already started our module-scope isolation.
         isolation_manager = IsolationManager(fixture_manager.config_wrapper, mocker.MagicMock())


### PR DESCRIPTION
### What I did

Received an `AttributeError` for a provider that hadn't used `TestProviderAPI` as a sub-class (stuck to `ProviderAPI`).
This is the only thing really stopping it so worth fixing it. The downside to not using `TestProviderAPI` as a base is you don't opt in to many of the features, but that should still be allowed

### How I did it

handle attribute error; return None (unknown) for statefulness

### How to verify it

make and use a provider that isnt a TestProviderAPI subclass

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
