### PR TITLE
fix: issue with Block transactions when `block.hash` was `None`

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -95,7 +95,11 @@ class BlockAPI(BaseInterfaceModel):
 
     @log_instead_of_fail(default="<BlockAPI>")
     def __repr__(self) -> str:
-        return super().__repr__()
+        repr_str = f"BlockAPI number={self.number}"
+        if hash := self.hash:
+            repr_str = f"{repr_str} hash={hash}"
+
+        return f"<{repr_str}>"
 
     @property
     def datetime(self) -> datetime.datetime:

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -151,12 +151,12 @@ class BlockAPI(BaseInterfaceModel):
         """
         All transactions in a block.
         """
-        if not (block_hash := self.hash):
+        if self.hash is None:
             # Unable to query transactions.
             return []
 
         try:
-            query = BlockTransactionQuery(columns=["*"], block_id=block_hash)
+            query = BlockTransactionQuery(columns=["*"], block_id=self.hash)
             return cast(list[TransactionAPI], list(self.query_manager.query(query)))
         except QueryEngineError as err:
             # NOTE: Re-raising a better error here because was confusing

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -151,8 +151,12 @@ class BlockAPI(BaseInterfaceModel):
         """
         All transactions in a block.
         """
+        if not (block_hash := self.hash):
+            # Unable to query transactions.
+            return []
+
         try:
-            query = BlockTransactionQuery(columns=["*"], block_id=self.hash)
+            query = BlockTransactionQuery(columns=["*"], block_id=block_hash)
             return cast(list[TransactionAPI], list(self.query_manager.query(query)))
         except QueryEngineError as err:
             # NOTE: Re-raising a better error here because was confusing

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -16,6 +16,7 @@ from signal import SIGINT, SIGTERM, signal
 from subprocess import DEVNULL, PIPE, Popen
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
+from eth_utils import to_hex
 from pydantic import Field, computed_field, field_serializer, model_validator
 
 from ape.api.networks import NetworkAPI
@@ -95,9 +96,9 @@ class BlockAPI(BaseInterfaceModel):
 
     @log_instead_of_fail(default="<BlockAPI>")
     def __repr__(self) -> str:
-        repr_str = f"BlockAPI number={self.number}"
+        repr_str = f"{self.__class__.__name__} number={self.number}"
         if hash := self.hash:
-            repr_str = f"{repr_str} hash={hash}"
+            repr_str = f"{repr_str} hash={to_hex(hash)}"
 
         return f"<{repr_str}>"
 

--- a/tests/functional/test_block.py
+++ b/tests/functional/test_block.py
@@ -128,3 +128,15 @@ def test_model_validate_web3_block():
     data = BlockData(number=123, timestamp=123, gasLimit=123, gasUsed=100)  # type: ignore
     actual = Block.model_validate(data)
     assert actual.number == 123
+
+
+def test_transactions(block):
+    actual = block.transactions
+    expected = []
+    assert actual == expected
+
+    # Ensure still works when hash is None (was a bug where this crashed).
+    block.hash = None
+    block.__dict__.pop("transactions", None)  # Ensure not cached.
+    assert block.transactions == []
+

--- a/tests/functional/test_block.py
+++ b/tests/functional/test_block.py
@@ -132,11 +132,10 @@ def test_model_validate_web3_block():
 
 def test_transactions(block):
     actual = block.transactions
-    expected = []
+    expected: list = []
     assert actual == expected
 
     # Ensure still works when hash is None (was a bug where this crashed).
     block.hash = None
     block.__dict__.pop("transactions", None)  # Ensure not cached.
     assert block.transactions == []
-

--- a/tests/functional/test_block.py
+++ b/tests/functional/test_block.py
@@ -20,13 +20,13 @@ def test_block(eth_tester_provider, vyper_contract_instance):
 
 def test_repr(block):
     actual = repr(block)
-    expected = f"<BlockAPI number={block.number} hash={block.hash}>"
+    expected = f"<Block number={block.number} hash={to_hex(block.hash)}>"
     assert actual == expected
 
     # Show it works when there is no hash.
     block.hash = None
     actual = repr(block)
-    expected = f"<BlockAPI number={block.number}>"
+    expected = f"<Block number={block.number}>"
     assert actual == expected
 
 

--- a/tests/functional/test_block.py
+++ b/tests/functional/test_block.py
@@ -18,6 +18,18 @@ def test_block(eth_tester_provider, vyper_contract_instance):
     assert actual.number == data["number"]
 
 
+def test_repr(block):
+    actual = repr(block)
+    expected = f"<BlockAPI number={block.number} hash={block.hash}>"
+    assert actual == expected
+
+    # Show it works when there is no hash.
+    block.hash = None
+    actual = repr(block)
+    expected = f"<BlockAPI number={block.number}>"
+    assert actual == expected
+
+
 @pytest.mark.parametrize("mode", ("json", "python"))
 def test_model_dump(block, mode):
     actual = block.model_dump(mode=mode)

--- a/tests/integration/cli/test_run.py
+++ b/tests/integration/cli/test_run.py
@@ -121,7 +121,10 @@ def test_run_interactive(scripts_runner, integ_project):
     scripts = [integ_project.scripts_folder / f"{s}.py" for s in error_names]
 
     # Show that the variable namespace from the script is available in the console.
-    user_input = "local_variable\nape.chain.provider.mine()\nape.chain.blocks.head\nexit\n"
+    user_input = (
+        "local_variable\nape.chain.provider.mine()\n"
+        "print(f'timestamp={ape.chain.blocks.head.timestamp}')\nexit\n"
+    )
 
     result = scripts_runner.invoke("--interactive", scripts[0].stem, input=user_input)
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
### What I did

Got a weird error in my boa provider because dont have hashes yet for blocks, tracked it down to the transactions.
Also fixed repr so wouldnt even need to bother with txns during repr. double fix...

### How to verify it

```
block.hash = None
repr(block)
block.transactions
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
