### PR TITLE
feat(pytest): allow disabling fixture rebasing

### DIFF
--- a/src/ape/pytest/config.py
+++ b/src/ape/pytest/config.py
@@ -89,6 +89,10 @@ class ConfigWrapper(ManagerAccessMixin):
         return self.pytest_config.getoption("--show-internal") or self.ape_test_config.show_internal
 
     @cached_property
+    def enable_fixture_rebasing(self) -> bool:
+        return self.ape_test_config.enable_fixture_rebasing
+
+    @cached_property
     def gas_exclusions(self) -> list["ContractFunctionPath"]:
         """
         The combination of both CLI values and config values.

--- a/src/ape/pytest/fixtures.py
+++ b/src/ape/pytest/fixtures.py
@@ -162,6 +162,11 @@ class FixtureManager(ManagerAccessMixin):
     def _get_cached_fixtures(self, nodeid: str) -> Optional["FixtureMap"]:
         return self._nodeid_to_fixture_map.get(nodeid)
 
+    def needs_rebase(self, new_fixtures: list[str], snapshot: "Snapshot") -> bool:
+        return self.config_wrapper.enable_fixture_rebasing and bool(
+            new_fixtures and snapshot.fixtures
+        )
+
     def rebase(self, scope: Scope, fixtures: "FixtureMap"):
         if not (rebase := self._get_rebase(scope)):
             # Rebase avoided: nothing would change.

--- a/src/ape/pytest/runners.py
+++ b/src/ape/pytest/runners.py
@@ -201,8 +201,7 @@ class PytestApeRunner(ManagerAccessMixin):
 
             # Rebase if there are new fixtures found of non-function scope.
             # And there are stateful fixtures of lower scopes that need resetting.
-            may_need_rebase = bool(new_fixtures and snapshot.fixtures)
-            if may_need_rebase:
+            if self.fixture_manager.needs_rebase(new_fixtures, snapshot):
                 self.fixture_manager.rebase(scope, fixtures)
 
             # Append these fixtures so we know when new ones arrive

--- a/src/ape_test/config.py
+++ b/src/ape_test/config.py
@@ -128,6 +128,12 @@ class ApeTestConfig(PluginConfig):
     Configuration related to coverage reporting.
     """
 
+    enable_fixture_rebasing: bool = True
+    """
+    Set to ``False`` to ignore fixture rebasing when non-function
+    scoped fixtures become invalidated.
+    """
+
     disconnect_providers_after: bool = True
     """
     Set to ``False`` to keep providers connected at the end of the test run.

--- a/tests/functional/test_test.py
+++ b/tests/functional/test_test.py
@@ -178,6 +178,24 @@ class TestFixtureManager:
             networks.active_provider = provider
             assert actual is None
 
+    def test_needs_rebase(self, mocker, fixture_manager):
+        new_fixtures = ["new_fixture_1"]
+        snapshot = mocker.MagicMock()
+        actual = fixture_manager.needs_rebase(new_fixtures, snapshot)
+        assert actual
+
+        # Show you can disable fixture-rebasing.
+        original_value = fixture_manager.config_wrapper.__dict__.pop(
+            "enable_fixture_rebasing", True
+        )
+        fixture_manager.config_wrapper.__dict__["enable_fixture_rebasing"] = False
+        actual = fixture_manager.needs_rebase(new_fixtures, snapshot)
+
+        # (put back)
+        fixture_manager.config_wrapper.__dict__["enable_fixture_rebasing"] = original_value
+
+        assert not actual
+
     def test_rebase(self, mocker, fixture_manager, fixture_map, create_fixture_info):
         # We must have already started our module-scope isolation.
         isolation_manager = IsolationManager(fixture_manager.config_wrapper, mocker.MagicMock())

--- a/tests/integration/cli/test_test.py
+++ b/tests/integration/cli/test_test.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import pytest
 
+from ape.logging import logger
 from ape.pytest.fixtures import PytestApeFixtures
 from tests.conftest import GETH_URI, geth_process_test
 from tests.integration.cli.utils import skip_projects_except
@@ -178,10 +179,9 @@ def test_test(setup_pytester, integ_project, pytester, eth_tester_provider):
     _ = eth_tester_provider  # Ensure using EthTester for this test.
     passed, failed = setup_pytester(integ_project)
 
-    from ape.logging import logger
+    with logger.at_level("DEBUG"):
+        result = pytester.runpytest_subprocess(timeout=120)
 
-    logger.set_level("DEBUG")
-    result = pytester.runpytest_subprocess(timeout=120)
     outcomes = result.parseoutcomes()
     assert "failed" not in outcomes if failed == 0 else outcomes["failed"] == failed
     if integ_project.name != "test":


### PR DESCRIPTION
### What I did

kinda a use-at-your-own risk feature of disabling fixture rebasing, maybe some users be ok with that and will have somewhat invalid state but if it works and is fasster, perhaps is ok.. cannot yet atest to this being helpful but i think having the ability to disable will at least help meeee debug crap

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
