### PR TITLE
feat: allow provider plugins to define NAME at class-level

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -1154,6 +1154,7 @@ class NetworkAPI(BaseInterfaceModel):
                 )
             ):
                 # NOTE: Lazily load provider config
+                provider_name = provider_class.NAME or provider_name
                 providers[provider_name] = partial(
                     provider_class,
                     name=provider_name,

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -14,7 +14,7 @@ from logging import FileHandler, Formatter, Logger, getLogger
 from pathlib import Path
 from signal import SIGINT, SIGTERM, signal
 from subprocess import DEVNULL, PIPE, Popen
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union, cast
 
 from pydantic import Field, computed_field, field_serializer, model_validator
 
@@ -179,8 +179,12 @@ class ProviderAPI(BaseInterfaceModel):
     plugin or the `ape-hardhat <https://github.com/ApeWorX/ape-hardhat>`__ plugin.
     """
 
+    # TODO: In 0.9, make not optional.
+    NAME: ClassVar[Optional[str]] = None
+
+    # TODO: Remove in 0.9 and have NAME be defined at the class-level (in plugins).
     name: str
-    """The name of the provider (should be the plugin name)."""
+    """(deprecated: use NAME). The name of the provider (should be the plugin name)."""
 
     network: NetworkAPI
     """A reference to the network this provider provides."""

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -379,6 +379,7 @@ class NodeSoftwareNotInstalledError(ConnectionError):
 
 
 # NOTE: Using EthereumNodeProvider because of it's geth-derived default behavior.
+# TODO: In 0.9, change NAME to be `gethdev`, so for local networks it is more obvious.
 class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
     _process: Optional[GethDevProcess] = None
     name: str = "node"


### PR DESCRIPTION
### What I did

this allow plugins like `ape-titanoboa` use the name `boa` instead of `titanoboa`.

### How I did it

NAME
(also see the TODOS, itll be cleaner in 0.9)

### How to verify it

```
pip install path/to/ape-titanoboa
ape console --network ::boa
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
