### PR TITLE
fix: handle when log address is not checksummed when decoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ extras_require = {
         "flake8-pydantic",  # For detecting issues with Pydantic models
         "flake8-type-checking",  # Detect imports to move in/out of type-checking blocks
         "isort>=5.13.2,<6",  # Import sorting linter
-        "mdformat>=0.7.19",  # Auto-formatter for markdown
+        "mdformat==0.7.19",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
         "mdformat-pyproject>=0.0.2",  # Allows configuring in pyproject.toml

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ extras_require = {
         "flake8-pydantic",  # For detecting issues with Pydantic models
         "flake8-type-checking",  # Detect imports to move in/out of type-checking blocks
         "isort>=5.13.2,<6",  # Import sorting linter
-        "mdformat==0.7.19",  # Auto-formatter for markdown
+        "mdformat>=0.7.19",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
         "mdformat-pyproject>=0.0.2",  # Allows configuring in pyproject.toml

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -314,7 +314,9 @@ class Receipt(ReceiptAPI):
             contract_types = self.chain_manager.contracts.get_multiple(addresses)
             # address → selector → abi
             selectors = {
-                address: {encode_hex(keccak(text=abi.selector)): abi for abi in contract.events}
+                address.lower(): {
+                    encode_hex(keccak(text=abi.selector)): abi for abi in contract.events
+                }
                 for address, contract in contract_types.items()
             }
 
@@ -339,10 +341,11 @@ class Receipt(ReceiptAPI):
             decoded_logs: ContractLogContainer = ContractLogContainer()
             for log in self.logs:
                 if contract_address := log.get("address"):
-                    if contract_address in selectors and (topics := log.get("topics")):
+                    lower_address = contract_address.lower()
+                    if lower_address in selectors and (topics := log.get("topics")):
                         selector = encode_hex(topics[0])
-                        if selector in selectors[contract_address]:
-                            event_abi = selectors[contract_address][selector]
+                        if selector in selectors[lower_address]:
+                            event_abi = selectors[lower_address][selector]
                             decoded_logs.extend(
                                 self.provider.network.ecosystem.decode_logs([log], event_abi)
                             )

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -87,6 +87,26 @@ def test_show_events(trace_print_capture, invoke_receipt):
     assert "newNum=[bright_magenta]1" in label
 
 
+
+def test_decode_logs(owner, contract_instance, assert_log_values):
+    event_type = contract_instance.NumberChange
+
+    # Invoke a transaction 3 times that generates 3 logs.
+    receipt_0 = contract_instance.setNumber(1, sender=owner)
+    receipt_1 = contract_instance.setNumber(2, sender=owner)
+    receipt_2 = contract_instance.setNumber(3, sender=owner)
+
+    def assert_receipt_logs(receipt: "ReceiptAPI", num: int):
+        logs = receipt.decode_logs(event_type)
+        assert len(logs) == 1
+        assert_log_values(logs[0], num)
+        assert receipt.timestamp == logs[0].timestamp
+
+    assert_receipt_logs(receipt_0, 1)
+    assert_receipt_logs(receipt_1, 2)
+    assert_receipt_logs(receipt_2, 3)
+
+
 def test_decode_logs_specify_abi(invoke_receipt, vyper_contract_instance):
     abi = vyper_contract_instance.NumberChange.abi
     logs = invoke_receipt.decode_logs(abi=abi)
@@ -111,6 +131,30 @@ def test_decode_logs_specify_abi_as_event(
 
     # Tests against a bug where the API was called unnecessarily
     assert spy.call_count == 0
+
+
+def test_decode_logs_multiple_event_types(owner, contract_instance, assert_log_values):
+    foo_happened = contract_instance.FooHappened
+    bar_happened = contract_instance.BarHappened
+    receipt = contract_instance.fooAndBar(sender=owner)
+    logs = receipt.decode_logs([foo_happened, bar_happened])
+    assert len(logs) == 2
+    assert logs[0].foo == 0
+    assert logs[1].bar == 1
+
+
+def test_decode_logs_unspecified_abi_gets_all_logs(owner, contract_instance):
+    receipt = contract_instance.fooAndBar(sender=owner)
+    logs = receipt.decode_logs()  # Same as doing `receipt.events`
+    assert len(logs) == 2
+    assert logs[0].foo == 0
+    assert logs[1].bar == 1
+
+
+def test_events(owner, contract_instance, assert_log_values):
+    receipt = contract_instance.setNumber(1, sender=owner)
+    assert len(receipt.events) == 1
+    assert_log_values(receipt.events[0], 1)
 
 
 def test_events_with_ds_notes(ds_note_test_contract, owner):
@@ -141,49 +185,6 @@ def test_events_with_ds_notes(ds_note_test_contract, owner):
     assert receipt.events[0].event_arguments == {"a": 1, "b": 2, "c": 3}
     assert receipt.events[0].log_index == 0
     assert receipt.events[0].transaction_index == 0
-
-
-def test_decode_logs(owner, contract_instance, assert_log_values):
-    event_type = contract_instance.NumberChange
-
-    # Invoke a transaction 3 times that generates 3 logs.
-    receipt_0 = contract_instance.setNumber(1, sender=owner)
-    receipt_1 = contract_instance.setNumber(2, sender=owner)
-    receipt_2 = contract_instance.setNumber(3, sender=owner)
-
-    def assert_receipt_logs(receipt: "ReceiptAPI", num: int):
-        logs = receipt.decode_logs(event_type)
-        assert len(logs) == 1
-        assert_log_values(logs[0], num)
-        assert receipt.timestamp == logs[0].timestamp
-
-    assert_receipt_logs(receipt_0, 1)
-    assert_receipt_logs(receipt_1, 2)
-    assert_receipt_logs(receipt_2, 3)
-
-
-def test_events(owner, contract_instance, assert_log_values):
-    receipt = contract_instance.setNumber(1, sender=owner)
-    assert len(receipt.events) == 1
-    assert_log_values(receipt.events[0], 1)
-
-
-def test_decode_logs_multiple_event_types(owner, contract_instance, assert_log_values):
-    foo_happened = contract_instance.FooHappened
-    bar_happened = contract_instance.BarHappened
-    receipt = contract_instance.fooAndBar(sender=owner)
-    logs = receipt.decode_logs([foo_happened, bar_happened])
-    assert len(logs) == 2
-    assert logs[0].foo == 0
-    assert logs[1].bar == 1
-
-
-def test_decode_logs_unspecified_abi_gets_all_logs(owner, contract_instance):
-    receipt = contract_instance.fooAndBar(sender=owner)
-    logs = receipt.decode_logs()  # Same as doing `receipt.events`
-    assert len(logs) == 2
-    assert logs[0].foo == 0
-    assert logs[1].bar == 1
 
 
 def test_get_failed_receipt(owner, vyper_contract_instance, eth_tester_provider):

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -87,7 +87,6 @@ def test_show_events(trace_print_capture, invoke_receipt):
     assert "newNum=[bright_magenta]1" in label
 
 
-
 def test_decode_logs(owner, contract_instance, assert_log_values):
     event_type = contract_instance.NumberChange
 
@@ -141,6 +140,23 @@ def test_decode_logs_multiple_event_types(owner, contract_instance, assert_log_v
     assert len(logs) == 2
     assert logs[0].foo == 0
     assert logs[1].bar == 1
+
+
+def test_decode_logs_not_checksummed_addresses(owner, contract_instance, assert_log_values):
+    """
+    If an RPC returns non-checksummed logs with non-checksummed addresses,
+    show we can still decode them.
+    """
+    start_number = contract_instance.myNumber()
+    tx = contract_instance.setNumber(1, sender=owner)
+    assert len(tx.logs) == 1
+
+    # Hack to make the address lower-case.
+    tx.logs[0]["address"] = tx.logs[0]["address"].lower()
+
+    events = tx.decode_logs()
+    assert len(events) == 1
+    assert_log_values(events[0], 1, start_number)
 
 
 def test_decode_logs_unspecified_abi_gets_all_logs(owner, contract_instance):


### PR DESCRIPTION
### What I did

providers should not be expected to checksum addresses the user doesnt need to deal with yet
(for performance reasons)
raw log data seems acceptable to not require checksumming

### How I did it

use lower for decoding logs match checks

### How to verify it

my thing in ape-titanoboa works now
see test as well...

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
