### PR TITLE
feat: alias `tx.gas` for `tx.gas_limit` and `tx.hash` for `tx.txn_hash`

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -134,6 +134,13 @@ class TransactionAPI(BaseInterfaceModel):
         """
 
     @property
+    def hash(self) -> HexBytes:
+        """
+        Alias for ``self.txn_hash``.
+        """
+        return self.txn_hash
+
+    @property
     def receipt(self) -> Optional["ReceiptAPI"]:
         """
         This transaction's associated published receipt, if it exists.

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -133,6 +133,7 @@ class TransactionAPI(BaseInterfaceModel):
         The calculated hash of the transaction.
         """
 
+    # TODO: In 0.9, simply rename txn_hash to hash.
     @property
     def hash(self) -> HexBytes:
         """

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -96,7 +96,18 @@ class TransactionAPI(BaseInterfaceModel):
         return value
 
     @property
+    def gas(self) -> int:
+        """
+        Alias for ``.gas_limit``.
+        """
+        return self.gas_limit
+
+    @property
     def raise_on_revert(self) -> bool:
+        """
+        ``True`` means VM-reverts should raise exceptions.
+        ``False`` allows getting failed receipts.
+        """
         return self._raise_on_revert
 
     @raise_on_revert.setter

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -96,7 +96,7 @@ class TransactionAPI(BaseInterfaceModel):
         return value
 
     @property
-    def gas(self) -> int:
+    def gas(self) -> Optional[int]:
         """
         Alias for ``.gas_limit``.
         """

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -406,3 +406,10 @@ def test_override_annotated_fields():
     my_tx = MyTransaction.model_validate({"chain_id": chain_id, "type": tx_type})
     assert my_tx.chain_id == chain_id
     assert my_tx.type == tx_type
+
+
+def test_gas(ethereum):
+    tx = ethereum.create_transaction(gas_limit=123)
+    assert tx.gas_limit == 123
+    # Show the `gas` alias works.
+    assert tx.gas == 123

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -225,6 +225,10 @@ def test_txn_hash_and_receipt(owner, eth_tester_provider, ethereum, kwargs):
     txn = owner.prepare_transaction(txn)
     txn = owner.sign_transaction(txn)
     assert txn
+
+    # Show the .hash alias works.
+    assert txn.hash == txn.txn_hash
+
     actual = to_hex(txn.txn_hash)
     receipt = eth_tester_provider.send_transaction(txn)
 


### PR DESCRIPTION
### What I did

THIS ALLOWS US TO USE OUR TRANSACTION MODEL IN THE EVM DIRECTLY.
sorry idk why i put that in all caps...

simple alias to make transactions work better in vm directly for performance, hoping to avoid having to use so many models in boa.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
