### PR TITLE
fix(ape-test): issue where couldn't transact when `auto_mine=False`

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -32,7 +32,7 @@ from ape.managers._contractscache import ContractCache
 from ape.managers.base import BaseManager
 from ape.types.address import AddressType
 from ape.utils.basemodel import BaseInterfaceModel
-from ape.utils.misc import is_evm_precompile, is_zero_hex, log_instead_of_fail
+from ape.utils.misc import ZERO_ADDRESS, is_evm_precompile, is_zero_hex, log_instead_of_fail
 
 if TYPE_CHECKING:
     from rich.console import Console as RichConsole
@@ -591,12 +591,12 @@ class TransactionHistory(BaseManager):
         """
 
         self._hash_to_receipt_map[txn_receipt.txn_hash] = txn_receipt
-        if txn_receipt.sender:
-            address = self.conversion_manager.convert(txn_receipt.sender, AddressType)
-            if address not in self._account_history_cache:
-                self._account_history_cache[address] = AccountHistory(address=address)
+        key = txn_receipt.sender or ZERO_ADDRESS
+        address = self.conversion_manager.convert(key, AddressType)
+        if address not in self._account_history_cache:
+            self._account_history_cache[address] = AccountHistory(address=address)
 
-            self._account_history_cache[address].append(txn_receipt)
+        self._account_history_cache[address].append(txn_receipt)
 
     def revert_to_block(self, block_number: int):
         """

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -591,11 +591,12 @@ class TransactionHistory(BaseManager):
         """
 
         self._hash_to_receipt_map[txn_receipt.txn_hash] = txn_receipt
-        address = self.conversion_manager.convert(txn_receipt.sender, AddressType)
-        if address not in self._account_history_cache:
-            self._account_history_cache[address] = AccountHistory(address=address)
+        if txn_receipt.sender:
+            address = self.conversion_manager.convert(txn_receipt.sender, AddressType)
+            if address not in self._account_history_cache:
+                self._account_history_cache[address] = AccountHistory(address=address)
 
-        self._account_history_cache[address].append(txn_receipt)
+            self._account_history_cache[address].append(txn_receipt)
 
     def revert_to_block(self, block_number: int):
         """

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -722,6 +722,14 @@ class Web3Provider(ProviderAPI, ABC):
 
     def _create_receipt(self, **kwargs) -> ReceiptAPI:
         data = {"provider": self, **kwargs}
+
+        if "block_number" not in data:
+            # Likely not a confirmed receipt.
+            data["block_number"] = 1
+        if "status" not in data:
+            # May change if not yet confirmed.
+            data["status"] = TransactionStatusEnum.NO_ERROR
+
         return self.network.ecosystem.decode_receipt(data)
 
     def get_transactions_by_block(self, block_id: "BlockID") -> Iterator[TransactionAPI]:

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -722,14 +722,6 @@ class Web3Provider(ProviderAPI, ABC):
 
     def _create_receipt(self, **kwargs) -> ReceiptAPI:
         data = {"provider": self, **kwargs}
-
-        if "block_number" not in data:
-            # Likely not a confirmed receipt.
-            data["block_number"] = 1
-        if "status" not in data:
-            # May change if not yet confirmed.
-            data["status"] = TransactionStatusEnum.NO_ERROR
-
         return self.network.ecosystem.decode_receipt(data)
 
     def get_transactions_by_block(self, block_id: "BlockID") -> Iterator[TransactionAPI]:

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -342,8 +342,15 @@ class LocalProvider(TestProviderAPI, Web3Provider):
                 txn_hash = to_hex(txn.txn_hash)
 
         required_confirmations = txn.required_confirmations or 0
+        txn_dict = txn_dict or txn.model_dump(mode="json")
+
+        # Signature is typically excluded from the model fields,
+        # so we have to include it manually.
+        txn_dict["signature"] = txn.signature
+
         if vm_err or not self.auto_mine:
             receipt_data = {
+                **txn_dict,
                 "block_number": -1,  # Not yet confirmed,
                 "error": vm_err,
                 "provider": self,
@@ -353,12 +360,6 @@ class LocalProvider(TestProviderAPI, Web3Provider):
             }
             receipt = self.network.ecosystem.decode_receipt(receipt_data)
         else:
-            txn_dict = txn_dict or txn.model_dump(mode="json")
-
-            # Signature is typically excluded from the model fields,
-            # so we have to include it manually.
-            txn_dict["signature"] = txn.signature
-
             receipt = self.get_receipt(
                 txn_hash, required_confirmations=required_confirmations, transaction=txn_dict
             )

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -35,6 +35,7 @@ from ape.utils.misc import gas_estimation_error_message
 from ape.utils.testing import DEFAULT_TEST_HD_PATH
 from ape_ethereum.provider import Web3Provider
 from ape_ethereum.trace import TraceApproach, TransactionTrace
+from ape_ethereum.transactions import TransactionStatusEnum
 from ape_test.config import EthTesterProviderConfig
 
 if TYPE_CHECKING:
@@ -342,11 +343,15 @@ class LocalProvider(TestProviderAPI, Web3Provider):
 
         required_confirmations = txn.required_confirmations or 0
         if vm_err or not self.auto_mine:
-            receipt = self._create_receipt(
-                required_confirmations=required_confirmations,
-                error=vm_err,
-                txn_hash=txn_hash,
-            )
+            receipt_data = {
+                "block_number": -1,  # Not yet confirmed,
+                "error": vm_err,
+                "provider": self,
+                "required_confirmations": required_confirmations,
+                "status": TransactionStatusEnum.NO_ERROR,
+                "txn_hash": txn_hash,
+            }
+            receipt = self.network.ecosystem.decode_receipt(receipt_data)
         else:
             txn_dict = txn_dict or txn.model_dump(mode="json")
 

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -341,9 +341,11 @@ class LocalProvider(TestProviderAPI, Web3Provider):
                 txn_hash = to_hex(txn.txn_hash)
 
         required_confirmations = txn.required_confirmations or 0
-        if vm_err:
+        if vm_err or not self.auto_mine:
             receipt = self._create_receipt(
-                required_confirmations=required_confirmations, error=vm_err, txn_hash=txn_hash
+                required_confirmations=required_confirmations,
+                error=vm_err,
+                txn_hash=txn_hash,
             )
         else:
             txn_dict = txn_dict or txn.model_dump(mode="json")

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -525,7 +525,10 @@ def test_auto_mine(eth_tester_provider, owner):
     #  when auto mine is off, `ape-test` provider still waited
     #  for the receipt during send_transaction(). It should
     #  instead return early.
-    owner.transfer(owner, 123)
+    tx = owner.transfer(owner, 123)
+    assert not tx.confirmed
+    assert tx.sender == owner.address
+    assert tx.txn_hash is not None
 
     nonce_after_tx = owner.nonce
     block_after_tx = eth_tester_provider.get_block("latest").number

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -514,15 +514,27 @@ def test_create_access_list(eth_tester_provider, vyper_contract_instance, owner)
         eth_tester_provider.create_access_list(tx)
 
 
-def test_auto_mine(eth_tester_provider):
+def test_auto_mine(eth_tester_provider, owner):
     eth_tester_provider.auto_mine = False
     assert not eth_tester_provider.auto_mine
 
-    # Ensure can still manually mine.
-    block = eth_tester_provider.get_block("latest").number
+    block_before = eth_tester_provider.get_block("latest").number
+    nonce_before = owner.nonce
+
+    # NOTE: Before, this would wait until it timed out, because
+    #  when auto mine is off, `ape-test` provider still waited
+    #  for the receipt during send_transaction(). It should
+    #  instead return early.
+    owner.transfer(owner, 123)
+
+    nonce_after_tx = owner.nonce
+    block_after_tx = eth_tester_provider.get_block("latest").number
+    assert nonce_before == nonce_after_tx, "Transaction should not have been mined."
+    assert block_before == block_after_tx, "Block height should not have increased."
+
     eth_tester_provider.mine()
-    next_block = eth_tester_provider.get_block("latest").number
-    assert next_block > block
+    block_after_mine = eth_tester_provider.get_block("latest").number
+    assert block_after_mine > block_after_tx
 
     eth_tester_provider.auto_mine = True
     assert eth_tester_provider.auto_mine


### PR DESCRIPTION
### What I did

I couldnt really send transactions when auto mine was off.
All testing providers should be audited for this.

fixes: #2439 

### How I did it

early return when auto_mine is False rather than waiting and timing out.
note: some more work is needed for the smart-receipt stuff to be better in 0.9, but this at least allows you to transact with auto_mine is False.

### How to verify it

1. turn auto mine off
2. make transactions
3. mine
4. ensure transactions went through

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
