### PR TITLE
fix: test-account negative index did not refer to correct account

### DIFF
--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -14,6 +14,7 @@ from ape.api.accounts import TestAccountAPI, TestAccountContainerAPI
 from ape.exceptions import ProviderNotConnectedError, SignatureError
 from ape.types.signatures import MessageSignature, TransactionSignature
 from ape.utils._web3_compat import sign_hash
+from ape.utils.misc import log_instead_of_fail
 from ape.utils.testing import (
     DEFAULT_NUMBER_OF_TEST_ACCOUNTS,
     DEFAULT_TEST_HD_PATH,
@@ -112,6 +113,10 @@ class TestAccount(TestAccountAPI):
     @property
     def address(self) -> "AddressType":
         return self.network_manager.ethereum.decode_address(self.address_str)
+
+    @log_instead_of_fail(default="<TestAccount>")
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}_{self.index} {self.address_str}>"
 
     def sign_message(self, msg: Any, **signer_options) -> Optional[MessageSignature]:
         # Convert str and int to SignableMessage if needed


### PR DESCRIPTION
fixes an issue where negative indices could get cached thus causing them to no longer refer to their calculated index.
also fixes the performance of the repr methods in both account managers, as it was very slow with some experimental account plugins installed.

basically just a bunch of fixes to test-accounts that i found when working on the new `ape-titanoboa` plugin.

fixes: #2436 
Fixes: APE-1865

```
BEFORE:

In [1]: %time accounts.test_accounts
Wall time: 17.1 ms
Wall time: 10 μs

In [1]: %time accounts.test_accounts[5]
Wall time: 329 ms
Wall time: 30 μs

In [1]: %time accounts.test_accounts[0].address
Wall time: 344 ms
Wall time: 250 μs


AFTER:

In [1]: %time accounts.test_accounts
Wall time: 10.4 ms
Wall time: 7.87 μs

In [1]: %time accounts.test_accounts[5]
Wall time: 335 ms
Wall time: 34.1 μs

In [1]: %time accounts.test_accounts[0].address
Wall time: 325 ms
Wall time: 38.9 μs
```