### PR TITLE
fix: transaction was missing signature / couldn't get hash when came from receipt

### DIFF
--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1047,6 +1047,10 @@ class Web3Provider(ProviderAPI, ABC):
             else self.network.required_confirmations
         )
         txn_data = txn_data or txn.model_dump(by_alias=True, mode="json")
+
+        # Signature is excluded from the model fields, so we have to include it manually.
+        txn_data["signature"] = txn.signature
+
         if vm_err:
             receipt = self._create_receipt(
                 block_number=-1,  # Not in a block.

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1080,6 +1080,9 @@ class Web3Provider(ProviderAPI, ABC):
             #   `nonce`, it's not needed anyway.
             txn_data.pop("nonce", None)
 
+            # Signature causes issues when making call (instead of tx)
+            txn_data.pop("signature", None)
+
             # NOTE: Using JSON mode since used as request data.
             txn_params = cast(TxParams, txn_data)
 

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -112,6 +112,8 @@ class BaseTransaction(TransactionAPI):
 
         return signed_txn
 
+    # TODO: In 0.9, either use hex-str or hex-bytes between both this
+    #   and ReceiptAPI (make consistent).
     @property
     def txn_hash(self) -> HexBytes:
         txn_bytes = self.serialize_transaction()

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -348,7 +348,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         else:
             txn_dict = txn_dict or txn.model_dump(mode="json")
 
-            # Signature is typically excluded from the model fields,
+            # Signature is excluded from the model fields,
             # so we have to include it manually.
             txn_dict["signature"] = txn.signature
 

--- a/tests/functional/geth/test_receipt.py
+++ b/tests/functional/geth/test_receipt.py
@@ -1,3 +1,5 @@
+from eth_utils import to_hex
+
 from ape.api import TraceAPI
 from ape.utils import ManagerAccessMixin
 from tests.conftest import geth_process_test
@@ -73,3 +75,10 @@ def test_await_confirmations_zero_confirmations(mocker, geth_account, geth_contr
     tx.await_confirmations()
     assert tx.confirmed
     assert spy.call_count == 1
+
+
+def test_transaction(geth_account, geth_contract):
+    receipt = geth_contract.setNumber(1998, sender=geth_account)
+    actual = receipt.transaction
+    assert actual.sender == geth_account.address
+    assert to_hex(actual.txn_hash) == receipt.txn_hash

--- a/tests/functional/geth/test_receipt.py
+++ b/tests/functional/geth/test_receipt.py
@@ -77,6 +77,7 @@ def test_await_confirmations_zero_confirmations(mocker, geth_account, geth_contr
     assert spy.call_count == 1
 
 
+@geth_process_test
 def test_transaction(geth_account, geth_contract):
     receipt = geth_contract.setNumber(1998, sender=geth_account)
     actual = receipt.transaction

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 import pytest
+from eth_utils import to_hex
 from rich.table import Table
 from rich.tree import Tree
 
@@ -268,6 +269,13 @@ def test_track_coverage(deploy_receipt, mocker):
 def test_access_from_tx(deploy_receipt):
     actual = deploy_receipt.transaction.receipt
     assert actual == deploy_receipt
+
+
+def test_transaction(owner, vyper_contract_instance):
+    receipt = vyper_contract_instance.setNumber(1999, sender=owner)
+    actual = receipt.transaction
+    assert actual.sender == owner.address
+    assert to_hex(actual.txn_hash) == receipt.txn_hash
 
 
 def test_transaction_validated_from_dict(ethereum, owner, deploy_receipt):


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #2438 
Fixes: APE-1867

### How I did it

add it in manually

### How to verify it

`receipt.transaction.txn_hash` should not fail with sig error

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
