### PR TITLE
fix: unable to send transactions during manual mining in other providers

### DIFF
--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1051,12 +1051,13 @@ class Web3Provider(ProviderAPI, ABC):
         # Signature is excluded from the model fields, so we have to include it manually.
         txn_data["signature"] = txn.signature
 
-        if vm_err:
+        manual_mining = not getattr(self, "auto_mine", True)
+        if vm_err or manual_mining:
             receipt = self._create_receipt(
                 block_number=-1,  # Not in a block.
                 error=vm_err,
                 required_confirmations=required_confirmations,
-                status=TransactionStatusEnum.FAILING,
+                status=TransactionStatusEnum.NO_ERROR,
                 txn_hash=txn_hash,
                 **txn_data,
             )

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1057,7 +1057,7 @@ class Web3Provider(ProviderAPI, ABC):
                 block_number=-1,  # Not in a block.
                 error=vm_err,
                 required_confirmations=required_confirmations,
-                status=TransactionStatusEnum.NO_ERROR,
+                status=TransactionStatusEnum.FAILING if vm_err else TransactionStatusEnum.NO_ERROR,
                 txn_hash=txn_hash,
                 **txn_data,
             )

--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -355,7 +355,9 @@ class LocalProvider(TestProviderAPI, Web3Provider):
                 "error": vm_err,
                 "provider": self,
                 "required_confirmations": required_confirmations,
-                "status": TransactionStatusEnum.NO_ERROR,
+                "status": (
+                    TransactionStatusEnum.FAILING if vm_err else TransactionStatusEnum.NO_ERROR
+                ),
                 "txn_hash": txn_hash,
             }
             receipt = self.network.ecosystem.decode_receipt(receipt_data)

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -856,8 +856,26 @@ def test_start_from_ws_uri(process_factory_patch, project, geth_provider, key):
 
 
 @geth_process_test
-def test_auto_mine(geth_provider):
+def test_auto_mine(geth_provider, geth_account, geth_contract):
     assert geth_provider.auto_mine is True
+
+    class MyEthereumTestProvider(EthereumNodeProvider):
+        """
+        Simulates a provider like ape-foundry w/ auto-mine disabled.
+        """
+
+        @property
+        def auto_mine(self) -> bool:
+            return False
+
+    provider = MyEthereumTestProvider(network=geth_provider.network)
+    provider._web3 = geth_provider.web3  # Borrow connection.
+
+    tx = geth_contract.setNumber.as_transaction(123)
+    tx = geth_account.prepare_transaction(tx)
+    tx = geth_account.sign_transaction(tx)
+    receipt = provider.send_transaction(tx)
+    assert not receipt.confirmed
 
 
 @geth_process_test


### PR DESCRIPTION
### What I did

same as https://github.com/ApeWorX/ape/pull/2443 but for providers like foundry/hardhat

sorry, test is a little weird because cant actual disable auto mine in geth --dev (i dont think anyway)

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
