### PR TITLE
docs: typo fix Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ cd ape
 python3 -m venv venv
 source venv/bin/activate
 
-# install the developer dependencies (-e is interactive mode)
+# install the developer dependencies (-e is editable mode)
 pip install -e .'[dev]'
 ```
 


### PR DESCRIPTION
### What I did

While reviewing the code, I noticed a misleading comment describing the `-e` flag in pip as "interactive mode."
This is incorrect; `-e` actually refers to "**editable mode**."  

I've updated the comment to accurately reflect its purpose, ensuring clarity for anyone reading or maintaining the code in the future.

- [x] All changes are completed
- [x] Change is covered in tests
- [x] Documentation is complete
