### PR TITLE
chore: bump py-geth

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
         "eth-typing>=3.5.2,<6",
         "eth-utils>=2.1.0,<6",
         "hexbytes>=0.3.1,<2",
-        "py-geth>=3.14.0,<6",
+        "py-geth>=5.1.0,<6",
         "trie>=3.0.1,<4",  # Peer: stricter pin needed for uv support.
         "web3[tester]>=6.20.1,<8",
         # ** Dependencies maintained by ApeWorX **


### PR DESCRIPTION
### What I did
Bumped py-geth because it was giving a `ModuleNotFoundError: No module named 'pkg_resources'` Error when connecting to networks. 

Py-geth has been tested on both web3[tester] 6.20.3 and 7.6.1 to ensure that it works on both versions of web3. 
<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
