### PR TITLE
fix: correct pip install syntax for dev and doc extras

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ python3 -m venv venv
 source venv/bin/activate
 
 # install the developer dependencies (-e is editable mode)
-pip install -e . [dev]
+pip install -e .[dev]
 ```
 
 ```{note}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ python3 -m venv venv
 source venv/bin/activate
 
 # install the developer dependencies (-e is editable mode)
-pip install -e .'[dev]'
+pip install -e . [dev]
 ```
 
 ```{note}
@@ -52,7 +52,7 @@ export GITHUB_ACCESS_TOKEN=<your-token>
 First, make sure you have the docs-related tooling installed:
 
 ```bash
-pip install -e .'[doc]'
+pip install -e . [doc]
 ```
 
 Then, run the following from the root project directory:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ export GITHUB_ACCESS_TOKEN=<your-token>
 First, make sure you have the docs-related tooling installed:
 
 ```bash
-pip install -e . [doc]
+pip install -e .[doc]
 ```
 
 Then, run the following from the root project directory:


### PR DESCRIPTION
###  1. Developer Dependencies Installation:
**-pip install -e .'[dev]'
   +pip install -e .[dev]**

### 2.Documentation Tools Installation:

**-pip install -e .'[doc]'
  +pip install -e .[doc]**

> Reasons for changes:
The old version with quotes and dot (.'[dev]' or .'[doc]') could lead to installation errors as pip would incorrectly interpret the package path
The new version (.[ ]) is the standard pip syntax for specifying additional dependencies (extras)
This format is the widely accepted and documented way to install packages with extra dependencies
These changes make the installation commands correct and ensure their proper execution.