### PR TITLE
feat: config can load project name from `pyproject.toml` project setting

### DIFF
--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -170,6 +170,28 @@ contract = project.MyContract.deployments[0]
 Ape does not add or edit deployments in your `ape-config.yaml` file.
 ```
 
+## Name
+
+Configure the name of the project:
+
+```toml
+[tool.ape]
+name = "ape-project"
+```
+
+If the name is not specified in `tool.ape` but is in `project`, Ape will use that as the project name:
+
+```toml
+[project]
+name = "ape-project"
+```
+
+To configure this name using an `ape-config.yaml` file, do:
+
+```yaml
+name: ape-project
+```
+
 ## Networks
 
 Set default network and network providers:

--- a/docs/userguides/config.md
+++ b/docs/userguides/config.md
@@ -170,33 +170,6 @@ contract = project.MyContract.deployments[0]
 Ape does not add or edit deployments in your `ape-config.yaml` file.
 ```
 
-## Node
-
-When using the `node` provider, you can customize its settings.
-For example, to change the URI for an Ethereum network, do:
-
-```toml
-[tool.ape.node.ethereum.mainnet]
-uri = "http://localhost:5030"
-```
-
-Or the equivalent YAML:
-
-```yaml
-node:
-  ethereum:
-    mainnet:
-      uri: http://localhost:5030
-```
-
-Now, the `ape-node` core plugin will use the URL `http://localhost:5030` to connect and make requests.
-
-```{warning}
-Instead of using `ape-node` to connect to an Infura or Alchemy node, use the [ape-infura](https://github.com/ApeWorX/ape-infura) or [ape-alchemy](https://github.com/ApeWorX/ape-alchemy) provider plugins instead, which have their own way of managing API keys via environment variables.
-```
-
-For more information on networking as a whole, see [this guide](./networks.html).
-
 ## Networks
 
 Set default network and network providers:
@@ -245,6 +218,33 @@ ethereum:
 ```
 
 For the local network configuration, the default is `"max"`. Otherwise, it is `"auto"`.
+
+## Node
+
+When using the `node` provider, you can customize its settings.
+For example, to change the URI for an Ethereum network, do:
+
+```toml
+[tool.ape.node.ethereum.mainnet]
+uri = "http://localhost:5030"
+```
+
+Or the equivalent YAML:
+
+```yaml
+node:
+  ethereum:
+    mainnet:
+      uri: http://localhost:5030
+```
+
+Now, the `ape-node` core plugin will use the URL `http://localhost:5030` to connect and make requests.
+
+```{warning}
+Instead of using `ape-node` to connect to an Infura or Alchemy node, use the [ape-infura](https://github.com/ApeWorX/ape-infura) or [ape-alchemy](https://github.com/ApeWorX/ape-alchemy) provider plugins instead, which have their own way of managing API keys via environment variables.
+```
+
+For more information on networking as a whole, see [this guide](./networks.html).
 
 ## Plugins
 

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -218,7 +218,14 @@ def load_config(path: Path, expand_envars=True, must_exist=False) -> dict:
             contents = expand_environment_variables(contents)
 
         if path.name == "pyproject.toml":
-            config = tomllib.loads(contents).get("tool", {}).get("ape", {})
+            pyproject_toml = tomllib.loads(contents)
+            config = pyproject_toml.get("tool", {}).get("ape", {})
+
+            # Utilize [project] for some settings.
+            if project_settings := pyproject_toml.get("project"):
+                if "name" not in config and "name" in project_settings:
+                    config["name"] = project_settings["name"]
+
         elif path.suffix in (".json",):
             config = json.loads(contents)
         elif path.suffix in (".yml", ".yaml"):

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -196,6 +196,16 @@ def test_validate_file_shows_linenos_handles_lists():
         assert "-->4" in str(err.value)
 
 
+def test_validate_file_uses_project_name():
+    name = "apexampledapp"
+    with create_tempdir() as temp_dir:
+        file = temp_dir / "pyproject.toml"
+        content = f'[project]\nname = "{name}"\n'
+        file.write_text(content)
+        cfg = ApeConfig.validate_file(file)
+        assert cfg.name == name
+
+
 def test_deployments(networks_connected_to_tester, owner, vyper_contract_container, project):
     _ = networks_connected_to_tester  # Connection needs to lookup config.
 


### PR DESCRIPTION
### What I did

allow ape-config to use:

```
[project]
name = "myproject"
```

and use that as the project name so you don't necessarily have to do both configs (tool.ape as well)

### How I did it

during config load from file, grab it.

### How to verify it

make a project with pyproject.toml like

```
[project]
name = "myproject"
```

```sh
ape console -c "print(project.name)"
myproject
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
