### PR TITLE
perf: utilize chain ID cache on re-connect in Ethereum node provider

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -1005,7 +1005,6 @@ class NetworkAPI(BaseInterfaceModel):
         **NOTE**: Unless overridden, returns same as
         :py:attr:`ape.api.providers.ProviderAPI.chain_id`.
         """
-
         return self.provider.chain_id
 
     @property

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -757,7 +757,6 @@ class ChainManager(BaseManager):
         The blockchain ID.
         See `ChainList <https://chainlist.org/>`__ for a comprehensive list of IDs.
         """
-
         network_name = self.provider.network.name
         if network_name not in self._chain_id_map:
             self._chain_id_map[network_name] = self.provider.chain_id

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -586,6 +586,15 @@ class Web3Provider(ProviderAPI, ABC):
 
             raise  # Original error
 
+        except ValueError as err:
+            # Possible syncing error.
+            raise ProviderError(
+                err.args[0].get("message")
+                if all((hasattr(err, "args"), err.args, isinstance(err.args[0], dict)))
+                else "Error getting chain id."
+            )
+
+
         if default_chain_id is not None:
             return default_chain_id
 
@@ -1603,15 +1612,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
         if not self.network.is_dev:
             self.web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
 
-        # Check for chain errors, including syncing
-        try:
-            chain_id = self.web3.eth.chain_id
-        except ValueError as err:
-            raise ProviderError(
-                err.args[0].get("message")
-                if all((hasattr(err, "args"), err.args, isinstance(err.args[0], dict)))
-                else "Error getting chain id."
-            )
+        chain_id = self.chain_id
 
         # NOTE: We have to check both earliest and latest
         #   because if the chain was _ever_ PoA, we need

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -578,7 +578,7 @@ class Web3Provider(ProviderAPI, ABC):
 
         try:
             if hasattr(self.web3, "eth"):
-                return self.make_request("eth_chainId", [])
+                return self._get_chain_id()
 
         except ProviderNotConnectedError:
             if default_chain_id is not None:
@@ -613,6 +613,13 @@ class Web3Provider(ProviderAPI, ABC):
             raise APINotImplementedError(
                 "eth_maxPriorityFeePerGas not supported in this RPC. Please specify manually."
             ) from err
+
+    def _get_chain_id(self) -> int:
+        result = self.make_request("eth_chainId", [])
+        if isinstance(result, int):
+            return result
+
+        return int(result, 16)
 
     def get_block(self, block_id: "BlockID") -> BlockAPI:
         if isinstance(block_id, str) and block_id.isnumeric():

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -578,7 +578,7 @@ class Web3Provider(ProviderAPI, ABC):
 
         try:
             if hasattr(self.web3, "eth"):
-                return self.web3.eth.chain_id
+                return self.make_request("eth_chainId", [])
 
         except ProviderNotConnectedError:
             if default_chain_id is not None:
@@ -591,9 +591,8 @@ class Web3Provider(ProviderAPI, ABC):
             raise ProviderError(
                 err.args[0].get("message")
                 if all((hasattr(err, "args"), err.args, isinstance(err.args[0], dict)))
-                else "Error getting chain id."
+                else "Error getting chain ID."
             )
-
 
         if default_chain_id is not None:
             return default_chain_id

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -572,8 +572,8 @@ class Web3Provider(ProviderAPI, ABC):
     @cached_property
     def chain_id(self) -> int:
         default_chain_id = None
-        if self.network.name != "custom" and not self.network.is_dev:
-            # If using a live network, the chain ID is hardcoded.
+        if self.network.name not in ("adhoc", "custom") and not self.network.is_dev:
+            # If using a live plugin-based network, the chain ID is hardcoded.
             default_chain_id = self.network.chain_id
 
         try:

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -616,10 +616,7 @@ class Web3Provider(ProviderAPI, ABC):
 
     def _get_chain_id(self) -> int:
         result = self.make_request("eth_chainId", [])
-        if isinstance(result, int):
-            return result
-
-        return int(result, 16)
+        return result if isinstance(result, int) else int(result, 16)
 
     def get_block(self, block_id: "BlockID") -> BlockAPI:
         if isinstance(block_id, str) and block_id.isnumeric():

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -240,7 +240,14 @@ def test_connect_to_chain_that_started_poa(mock_web3, web3_factory, ethereum):
     to fetch blocks during the PoA portion of the chain.
     """
     mock_web3.eth.get_block.side_effect = ExtraDataLengthError
-    mock_web3.eth.chain_id = ethereum.sepolia.chain_id
+
+    def make_request(rpc, arguments):
+        if rpc == "eth_chainId":
+            return {"result": ethereum.sepolia.chain_id}
+
+        return None
+
+    mock_web3.provider.make_request.side_effect = make_request
     web3_factory.return_value = mock_web3
     provider = ethereum.sepolia.get_provider("node")
     provider.provider_settings = {"uri": "http://node.example.com"}  # fake

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -702,7 +702,7 @@ def test_connect_uses_cached_chain_id(mocker, mock_web3, ethereum, eth_tester_pr
         def make_request(self, rpc, args):
             if rpc == "eth_chainId":
                 self.call_count += 1
-                return {"result": 11155111}  # Sepolia
+                return {"result": "0xaa36a7"}  # Sepolia
 
             return eth_tester_provider.make_request(rpc, args)
 

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -105,6 +105,28 @@ def test_chain_id_is_cached(eth_tester_provider):
     eth_tester_provider._web3 = web3  # Undo
 
 
+def test_chain_id_from_ethereum_base_provider_is_cached(mock_web3, ethereum):
+    """
+    Simulated chain ID from a plugin (using base-ethereum class) to ensure is
+    also cached.
+    """
+    mock_web3.eth.chain_id = 11155111  # Sepolia
+
+    class PluginProvider(Web3Provider):
+        def connect(self):
+            return
+
+        def disconnect(self):
+            return
+
+    provider = PluginProvider(name="sim", network=ethereum.sepolia)
+    provider._web3 = mock_web3
+    assert provider.chain_id == 11155111
+    # Unset to web3 to prove it does not check it again (else it would fail).
+    provider._web3 = None
+    assert provider.chain_id == 11155111
+
+
 def test_chain_id_when_disconnected(eth_tester_provider):
     eth_tester_provider.disconnect()
     try:


### PR DESCRIPTION
### What I did

this part was not utilizing the chain ID cache, so this could save a request (or many)

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
