### PR TITLE
fix: custom network would sometimes use the wrong provider class

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -153,7 +153,6 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
         A :class:`~ape.api.networks.NetworkAPI` for custom networks where the
         network is either not known, unspecified, or does not have an Ape plugin.
         """
-
         ethereum_class = None
         for plugin_name, ecosystem_class in self.plugin_manager.ecosystems:
             if plugin_name == "ethereum":
@@ -1130,6 +1129,13 @@ class NetworkAPI(BaseInterfaceModel):
         """
         return self.name == "custom" and not self._is_custom
 
+    @property
+    def is_custom(self) -> bool:
+        """
+        True when this network is a configured custom network.
+        """
+        return self._is_custom
+
     @cached_property
     def providers(self):  # -> dict[str, Partial[ProviderAPI]]
         """
@@ -1161,6 +1167,8 @@ class NetworkAPI(BaseInterfaceModel):
                         (self.is_fork and "Fork" in provider_class.__name__)
                         or (not self.is_fork and "Fork" not in provider_class.__name__)
                     )
+                    and provider_class.__name__
+                    == "Node"  # Ensure uses Node class instead of GethDev
                 )
             ):
                 # NOTE: Lazily load provider config

--- a/src/ape/managers/compilers.py
+++ b/src/ape/managers/compilers.py
@@ -300,7 +300,7 @@ class CompilerManager(BaseManager, ExtraAttributesMixin):
         """
         Get a custom error for the given contract logic error using the contract-type
         found from address-data in the error. Returns ``None`` if the given error is
-        not a custom-error or it is not able to find the associated contract type or
+        not a custom-error, or it is not able to find the associated contract type or
         address.
 
         Args:

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -557,7 +557,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
             default_network = self.default_ecosystem.default_network
             return default_network.get_provider(provider_settings=provider_settings)
 
-        elif _is_custom_network(network_choice):
+        elif _is_adhoc_url(network_choice):
             # Custom network w/o ecosystem & network spec.
             return self.create_custom_provider(network_choice)
 
@@ -568,7 +568,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
             provider_value = ":".join(selections[2:])
             selections[2] = provider_value
             selections = selections[:3]
-            if _is_custom_network(provider_value):
+            if _is_adhoc_url(provider_value):
                 selections[1] = selections[1] or "custom"
 
         if selections == network_choice or len(selections) == 1:
@@ -754,7 +754,7 @@ def _validate_filter(arg: Optional[Union[list[str], str]], options: set[str]):
     return filters
 
 
-def _is_custom_network(value: str) -> bool:
+def _is_adhoc_url(value: str) -> bool:
     return (
         value.startswith("http://")
         or value.startswith("https://")

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -572,8 +572,9 @@ class Web3Provider(ProviderAPI, ABC):
     @cached_property
     def chain_id(self) -> int:
         default_chain_id = None
-        if self.network.name not in ("adhoc", "custom") and not self.network.is_dev:
-            # If using a live plugin-based network, the chain ID is hardcoded.
+
+        if self.network.is_custom or not self.network.is_dev:
+            # If using a live network, the chain ID is hardcoded.
             default_chain_id = self.network.chain_id
 
         try:
@@ -1631,7 +1632,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
 
             except Exception:
                 # Some chains are "light" and we may not be able to detect
-                # if it need PoA middleware.
+                # if it needs PoA middleware.
                 continue
 
             else:

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -237,6 +237,11 @@ def test_providers_custom_network(project, custom_networks_config_dict, ethereum
         network = ethereum.apenet
         actual = network.providers
         assert "node" in actual
+        node = actual["node"]
+        # NOTE: There was a bug where sometimes it would use the GethDev class
+        #   and sometimes it would use the Node class. Node is what we want.
+        assert "Node" in repr(node.func)
+        assert "GethDev" not in repr(node.func)
 
 
 def test_providers_custom_non_fork_network_does_not_use_fork_provider(


### PR DESCRIPTION
### What I did

This bug did not reveal itself until functionality was required on it, meaning it always was doing this but never mattered until now.

It is supposed to use the generic Node class, not GethDev, but they both come from the same provider and the order is not deterministic so sometimes it would be one or the other. However, the chain ID caching mechanism fails if it is does not use the Node class (as of https://github.com/ApeWorX/ape/pull/2464), so it became a bug at that point, thankfully not released yet.

fixes: https://github.com/ApeWorX/ape/pull/2449#issuecomment-2585322375

### How I did it

adjust if statement to ensure right class

### How to verify it

you can consistently use custom networks again

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
