### PR TITLE
fix: adhoc network connection fix

### DIFF
--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -572,7 +572,7 @@ class Web3Provider(ProviderAPI, ABC):
     @cached_property
     def chain_id(self) -> int:
         default_chain_id = None
-        if (not self.network.is_adhoc and self.network.is_custom) and not self.network.is_dev:
+        if (not self.network.is_adhoc and self.network.is_custom) or not self.network.is_dev:
             # If using a live network, the chain ID is hardcoded.
             default_chain_id = self.network.chain_id
 

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -572,8 +572,7 @@ class Web3Provider(ProviderAPI, ABC):
     @cached_property
     def chain_id(self) -> int:
         default_chain_id = None
-
-        if self.network.is_custom or not self.network.is_dev:
+        if (not self.network.is_adhoc and self.network.is_custom) and not self.network.is_dev:
             # If using a live network, the chain ID is hardcoded.
             default_chain_id = self.network.chain_id
 

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -146,7 +146,7 @@ def test_chain_id_when_disconnected(eth_tester_provider):
 
 
 def test_chain_id_adhoc(networks):
-    with networks.parse_network_choice("'https://www.shibrpc.com") as bor:
+    with networks.parse_network_choice("https://www.shibrpc.com") as bor:
         assert bor.chain_id == 109
 
 

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -145,6 +145,11 @@ def test_chain_id_when_disconnected(eth_tester_provider):
         eth_tester_provider.connect()
 
 
+def test_chain_id_adhoc(networks):
+    with networks.parse_network_choice("'https://www.shibrpc.com") as bor:
+        assert bor.chain_id == 109
+
+
 def test_get_receipt_not_exists_with_timeout(eth_tester_provider):
     unknown_txn = "0x053cba5c12172654d894f66d5670bab6215517a94189a9ffc09bc40a589ec04d"
     expected = (


### PR DESCRIPTION
### What I did

last night's PR https://github.com/ApeWorX/ape/pull/2466/files broke the use-case on accident when you do `--network https:///`, this fixes it

### How I did it

really had to discen adhoc from custom here. custom uses hardcoded chain id whereas adhoc does not

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
