### PR TITLE
feat: ability to skip proxy detection

### DIFF
--- a/tests/functional/test_contracts_cache.py
+++ b/tests/functional/test_contracts_cache.py
@@ -120,7 +120,7 @@ def test_instance_at_use_abi(chain, solidity_fallback_contract, owner):
     assert instance2.contract_type.abi == instance.contract_type.abi
 
 
-def test_instance_at_skip_proxy_check(mocker, chain, vyper_contract_instance, owner):
+def test_instance_at_provide_proxy(mocker, chain, vyper_contract_instance, owner):
     address = vyper_contract_instance.address
     container = _make_minimal_proxy(address=address.lower())
     proxy = container.deploy(sender=owner)
@@ -135,11 +135,28 @@ def test_instance_at_skip_proxy_check(mocker, chain, vyper_contract_instance, ow
         # longer knows what the contract type is. That is fine for this test!
         chain.contracts.instance_at(proxy.address, proxy_info=proxy_info)
 
-    # The real test: we check the spy to ensure we never attempted to look-up
+    # The real test: we check the spy to ensure we never attempted to look up
     # the proxy info for the given address to `instance_at()`.
     for call in proxy_detection_spy.call_args_list:
         for arg in call[0]:
             assert proxy.address != arg
+
+
+def test_instance_at_skip_proxy(mocker, chain, vyper_contract_instance, owner):
+    address = vyper_contract_instance.address
+    del chain.contracts[address]
+    proxy_detection_spy = mocker.spy(chain.contracts.proxy_infos, "get_type")
+
+    with pytest.raises(ContractNotFoundError):
+        # This just fails because we deleted it from the cache so Ape no
+        # longer knows what the contract type is. That is fine for this test!
+        chain.contracts.instance_at(address, detect_proxy=False)
+
+    # The real test: we check the spy to ensure we never attempted to look up
+    # the proxy info for the given address to `instance_at()`.
+    for call in proxy_detection_spy.call_args_list:
+        for arg in call[0]:
+            assert address != arg
 
 
 def test_cache_deployment_live_network(


### PR DESCRIPTION
### What I did

inspired by https://github.com/ApeWorX/ape/issues/2465
added a kwarg to skip or provide proxy info to Contract("0x..."

### How I did it

new kwarg to `chain.contracts.instance_at()`

### How to verify it

`Contract("0x123...", proxy_info=proxy)`

or

`Contract("0x123...", detect_proxy=False)`

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
