### PR TITLE
feat: adds error handler to change file permissions if delete fails

### DIFF
--- a/src/ape/utils/__init__.py
+++ b/src/ape/utils/__init__.py
@@ -72,6 +72,7 @@ def __getattr__(name: str):
         "get_relative_path",
         "in_tempdir",
         "path_match",
+        "remove_readonly",
         "run_in_tempdir",
         "use_temp_sys_path",
     ):
@@ -171,6 +172,7 @@ __all__ = [
     "parse_gas_table",
     "path_match",
     "raises_not_implemented",
+    "remove_readonly",
     "returns_array",
     "request_with_retry",
     "RPCHeaders",

--- a/src/ape/utils/os.py
+++ b/src/ape/utils/os.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import stat
 import sys
 import tarfile
 import zipfile
@@ -370,6 +371,14 @@ def extract_archive(archive_file: Path, destination: Optional[Path] = None):
 
     else:
         raise ValueError(f"Unsupported zip format: '{archive_file.suffix}'.")
+
+
+def remove_readonly(func, path, excinfo):
+    """
+    Error handler for shutil.rmtree that handles removing read-only files.
+    """
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
 
 
 class CacheDirectory:

--- a/src/ape_pm/dependency.py
+++ b/src/ape_pm/dependency.py
@@ -16,7 +16,7 @@ from ape.logging import logger
 from ape.managers.project import _version_to_options
 from ape.utils._github import _GithubClient, github_client
 from ape.utils.basemodel import ManagerAccessMixin
-from ape.utils.os import clean_path, extract_archive, get_package_path, in_tempdir
+from ape.utils.os import clean_path, extract_archive, get_package_path, in_tempdir, remove_readonly
 
 
 def _fetch_local(src: Path, destination: Path, config_override: Optional[dict] = None):
@@ -204,8 +204,11 @@ class GithubDependency(DependencyAPI):
     def fetch(self, destination: Path):
         destination.parent.mkdir(exist_ok=True, parents=True)
         if ref := self.ref:
+            # NOTE: destination path should not exist at this point,
+            #   so delete it in case it's left over from a failure.
+            shutil.rmtree(destination, onerror=remove_readonly)
+            
             # Fetch using git-clone approach (by git-reference).
-            # NOTE: destination path does not exist at this point.
             self._fetch_ref(ref, destination)
         else:
             # Fetch using Version API from GitHub.
@@ -222,7 +225,7 @@ class GithubDependency(DependencyAPI):
                 # NOTE: When using ref-from-a-version, ensure
                 #   it didn't create the destination along the way;
                 #   else, the ref is cloned in the wrong spot.
-                shutil.rmtree(destination, ignore_errors=True)
+                shutil.rmtree(destination, onerror=remove_readonly)
                 try:
                     self._fetch_ref(version, destination)
                 except Exception:


### PR DESCRIPTION
### What I did

On windows, `shutil.rmtree()` can fail to delete directories when they contain a read-only file, which git can place.

### How I did it

Adds an error handler that will change the file permissions to not be read-only

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
- [x] Documentation is complete
