### PR TITLE
feat: `provider.batch_requests()` low-level implementation

### DIFF
--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -385,6 +385,17 @@ class ProviderAPI(BaseInterfaceModel):
             An iterator of items.
         """
 
+    @raises_not_implemented
+    def batch_requests(self, requests: list[dict]) -> Any:
+        """
+        Send batched requests (multiple requests at once) to the RPC provider.
+
+        Args:
+            requests (list[dict]): The requests to send.
+
+        Returns: The results of each request.
+        """
+
     # TODO: In 0.9, delete this method.
     def get_storage_at(self, *args, **kwargs) -> "HexBytes":
         warnings.warn(

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -656,6 +656,25 @@ def test_make_request_not_exists(geth_provider):
 
 
 @geth_process_test
+def test_batch_requests(geth_account, geth_contract, geth_provider):
+    call = geth_contract.myNumber.as_transaction().model_dump()
+    results = geth_provider.batch_requests(
+        [
+            {
+                "method": "eth_call",
+                "params": [{"data": call["data"], "to": geth_contract.address}],
+            },
+            {
+                "method": "eth_getBalance",
+                "params": [geth_account.address, "latest"],
+            },
+        ]
+    )
+    for result in results:
+        assert result.startswith("0x")
+
+
+@geth_process_test
 @pytest.mark.parametrize(
     "message",
     (


### PR DESCRIPTION
### What I did

implements batch requets at the provider level, not sure about a more top level API yet (maybe something like multicall?)

fixes: #2472

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
