### PR TITLE
fix: cache `.get_code()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ norecursedirs = "projects"
 #    And 'pytest_ethereum' is not used and causes issues in some environments.
 addopts = """
 -p no:pytest_ethereum
+-p no:boa_test
 """
 
 python_files = "test_*.py"

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -20,6 +20,7 @@ class BaseAddress(BaseInterface):
     """
     A base address API class. All account-types subclass this type.
     """
+    _code: dict[str, dict[str, "ContractCode"]] = {}
 
     @property
     def _base_dir_values(self) -> list[str]:
@@ -150,9 +151,7 @@ class BaseAddress(BaseInterface):
         """
         The raw bytes of the smart-contract code at the address.
         """
-
-        # TODO: Explore caching this (based on `self.provider.network` and examining code)
-        return self.provider.get_code(self.address)
+        return self.chain_manager.get_code(self.address)
 
     @property
     def codesize(self) -> int:

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -150,6 +150,7 @@ class BaseAddress(BaseInterface):
         """
         The raw bytes of the smart-contract code at the address.
         """
+        # NOTE: Chain manager handles code caching.
         return self.chain_manager.get_code(self.address)
 
     @property

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -20,7 +20,6 @@ class BaseAddress(BaseInterface):
     """
     A base address API class. All account-types subclass this type.
     """
-    _code: dict[str, dict[str, "ContractCode"]] = {}
 
     @property
     def _base_dir_values(self) -> list[str]:

--- a/src/ape/managers/_contractscache.py
+++ b/src/ape/managers/_contractscache.py
@@ -587,12 +587,6 @@ class ContractCache(BaseManager):
                 self.contract_types[address_key] = contract_type_to_cache
                 return contract_type_to_cache
 
-            if not self.provider.get_code(address_key):
-                if default:
-                    self.contract_types[address_key] = default
-
-                return default
-
             # Also gets cached to disk for faster lookup next time.
             if fetch_from_explorer:
                 contract_type = self._get_contract_type_from_explorer(address_key)

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -37,8 +37,7 @@ from ape.utils.misc import ZERO_ADDRESS, is_evm_precompile, is_zero_hex, log_ins
 if TYPE_CHECKING:
     from rich.console import Console as RichConsole
 
-    from ape.types.trace import GasReport, SourceTraceback
-    from ape.types.vm import ContractCode, SnapshotID
+    from ape.types import BlockID, ContractCode, GasReport, SnapshotID, SourceTraceback
 
 
 class BlockContainer(BaseManager):
@@ -716,7 +715,7 @@ class ChainManager(BaseManager):
     _block_container_map: dict[int, BlockContainer] = {}
     _transaction_history_map: dict[int, TransactionHistory] = {}
     _reports: ReportManager = ReportManager()
-    _code: dict[str, dict[str, dict["AddressType", "ContractCode"]]] = {}
+    _code: dict[str, dict[str, dict[AddressType, "ContractCode"]]] = {}
 
     @cached_property
     def contracts(self) -> ContractCache:
@@ -967,12 +966,14 @@ class ChainManager(BaseManager):
 
         return receipt
 
-    def get_code(self, address: "AddressType") -> "ContractCode":
+    def get_code(
+        self, address: AddressType, block_id: Optional["BlockID"] = None
+    ) -> "ContractCode":
         network = self.provider.network
         if network.is_dev:
             # Avoid caching when dev, as you can manipulate the chain more
             # (and there is isolation).
-            return self.provider.get_code(address)
+            return self.provider.get_code(address, block_id=block_id)
 
         self._code.setdefault(network.ecosystem.name, {})
         self._code[network.ecosystem.name].setdefault(network.name, {})

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -969,11 +969,15 @@ class ChainManager(BaseManager):
 
     def get_code(self, address: "AddressType") -> "ContractCode":
         network = self.provider.network
-        if not network.is_local:
-            self._code.setdefault(network.ecosystem.name, {})
-            self._code[network.ecosystem.name].setdefault(network.name, {})
-            if address in self._code[network.ecosystem.name][network.name]:
-                return self._code[network.ecosystem.name][network.name][address]
+        if network.is_dev:
+            # Avoid caching when dev, as you can manipulate the chain more
+            # (and there is isolation).
+            return self.provider.get_code(address)
+
+        self._code.setdefault(network.ecosystem.name, {})
+        self._code[network.ecosystem.name].setdefault(network.name, {})
+        if address in self._code[network.ecosystem.name][network.name]:
+            return self._code[network.ecosystem.name][network.name][address]
 
         # Get from RPC for the first time.
         code = self.provider.get_code(address)

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -969,10 +969,11 @@ class ChainManager(BaseManager):
 
     def get_code(self, address: "AddressType") -> "ContractCode":
         network = self.provider.network
-        self._code.setdefault(network.ecosystem.name, {})
-        self._code[network.ecosystem.name].setdefault(network.name, {})
-        if address in self._code[network.ecosystem.name][network.name]:
-            return self._code[network.ecosystem.name][network.name][address]
+        if not network.is_local:
+            self._code.setdefault(network.ecosystem.name, {})
+            self._code[network.ecosystem.name].setdefault(network.name, {})
+            if address in self._code[network.ecosystem.name][network.name]:
+                return self._code[network.ecosystem.name][network.name][address]
 
         # Get from RPC for the first time.
         code = self.provider.get_code(address)

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from rich.console import Console as RichConsole
 
     from ape.types.trace import GasReport, SourceTraceback
-    from ape.types.vm import SnapshotID, ContractCode
+    from ape.types.vm import ContractCode, SnapshotID
 
 
 class BlockContainer(BaseManager):

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -1150,12 +1150,13 @@ class Ethereum(EcosystemAPI):
             except KeyError:
                 name = call["method_id"]
             else:
-                assert isinstance(method_abi, MethodABI)  # For mypy
-
-                # Check if method name duplicated. If that is the case, use selector.
-                times = len([x for x in contract_type.methods if x.name == method_abi.name])
-                name = (method_abi.name if times == 1 else method_abi.selector) or call["method_id"]
-                call = self._enrich_calldata(call, method_abi, **kwargs)
+                if isinstance(method_abi, MethodABI):
+                    # Check if method name duplicated. If that is the case, use selector.
+                    times = len([x for x in contract_type.methods if x.name == method_abi.name])
+                    name = (method_abi.name if times == 1 else method_abi.selector) or call["method_id"]
+                    call = self._enrich_calldata(call, method_abi, **kwargs)
+                else:
+                    name = call.get("method_id") or "0x"
         else:
             name = call.get("method_id") or "0x"
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -1153,7 +1153,9 @@ class Ethereum(EcosystemAPI):
                 if isinstance(method_abi, MethodABI):
                     # Check if method name duplicated. If that is the case, use selector.
                     times = len([x for x in contract_type.methods if x.name == method_abi.name])
-                    name = (method_abi.name if times == 1 else method_abi.selector) or call["method_id"]
+                    name = (method_abi.name if times == 1 else method_abi.selector) or call[
+                        "method_id"
+                    ]
                     call = self._enrich_calldata(call, method_abi, **kwargs)
                 else:
                     name = call.get("method_id") or "0x"

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -458,7 +458,7 @@ class Ethereum(EcosystemAPI):
         )
 
     def get_proxy_info(self, address: AddressType) -> Optional[ProxyInfo]:
-        contract_code = self.provider.get_code(address)
+        contract_code = self.chain_manager.get_code(address)
         if isinstance(contract_code, bytes):
             contract_code = to_hex(contract_code)
 

--- a/src/ape_ethereum/query.py
+++ b/src/ape_ethereum/query.py
@@ -39,7 +39,7 @@ class EthereumQueryProvider(QueryAPI):
         Find when a contract was deployed using binary search and block tracing.
         """
         # skip the search if there is still no code at address at head
-        if not self.provider.get_code(query.contract):
+        if not self.chain_manager.get_code(query.contract):
             return None
 
         def find_creation_block(lo, hi):
@@ -47,13 +47,13 @@ class EthereumQueryProvider(QueryAPI):
             # takes log2(height), doesn't work with contracts that have been reinit.
             while hi - lo > 1:
                 mid = (lo + hi) // 2
-                code = self.provider.get_code(query.contract, block_id=mid)
+                code = self.chain_manager.get_code(query.contract, block_id=mid)
                 if not code:
                     lo = mid
                 else:
                     hi = mid
 
-            if self.provider.get_code(query.contract, block_id=hi):
+            if self.chain_manager.get_code(query.contract, block_id=hi):
                 return hi
 
             return None

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -82,7 +82,12 @@ class TestAccountContainer(TestAccountContainerAPI):
         account = self.init_test_account(
             new_index, generated_account.address, generated_account.private_key
         )
-        self.generated_accounts.append(account)
+
+        # Only cache if being created outside the expected number of accounts.
+        # Else, ends up cached twice and caused logic problems elsewhere.
+        if new_index >= self.number_of_accounts:
+            self.generated_accounts.append(account)
+
         return account
 
     @classmethod

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -691,7 +691,7 @@ def create_mock_sepolia(ethereum, eth_tester_provider, vyper_contract_instance):
     @contextmanager
     def fn():
         # Ensuring contract exists before hack.
-        # This allow the network to be past genesis which is more realistic.
+        # This allows the network to be past genesis which is more realistic.
         _ = vyper_contract_instance
         eth_tester_provider.network.name = "sepolia"
         yield eth_tester_provider.network

--- a/tests/functional/geth/test_chain.py
+++ b/tests/functional/geth/test_chain.py
@@ -1,0 +1,18 @@
+from tests.conftest import geth_process_test
+
+
+@geth_process_test
+def test_get_code(mocker, chain, geth_contract, mock_sepolia):
+    # NOTE: Using mock_sepolia because code doesn't get cached in local networks.
+    actual = chain.get_code(geth_contract.address)
+    expected = chain.provider.get_code(geth_contract.address)
+    assert actual == expected
+
+    # Ensure uses cache (via not using provider).
+    provider_spy = mocker.spy(chain.provider.web3.eth, "get_code")
+    _ = chain.get_code(geth_contract.address)
+    assert provider_spy.call_count == 0
+
+    # block_id test, cache should interfere.
+    actual_2 = chain.get_code(geth_contract.address, block_id=0)
+    assert not actual_2  # Doesn't exist at block 0.

--- a/tests/functional/geth/test_contracts_cache.py
+++ b/tests/functional/geth/test_contracts_cache.py
@@ -39,7 +39,7 @@ def test_get_proxy_from_explorer(
         raise ValueError("Fake explorer only knows about proxy and target contracts.")
 
     with create_mock_sepolia() as network:
-        # Setup our network to use our fake explorer.
+        # Set up our network to use our fake explorer.
         mock_explorer.get_contract_type.side_effect = get_contract_type
         network.__dict__["explorer"] = mock_explorer
 

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -181,6 +181,7 @@ def test_isolate_in_tempdir_does_not_alter_sources(project):
     # First, create a bad source.
     with project.temp_config(contracts_folder="build"):
         new_src = project.contracts_folder / "newsource.json"
+        new_src.parent.mkdir(exist_ok=True, parents=True)
         new_src.write_text("this is not json, oops")
         project.sources.refresh()  # Only need to be called when run with other tests.
 

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -6,6 +6,9 @@ NOTE: Most proxy tests are in `geth/test_proxy.py`.
 
 
 def test_minimal_proxy(ethereum, minimal_proxy, chain):
+    chain.provider.network.__dict__["explorer"] = (
+        None  # Ensure no explorer, messes up test.
+    )
     actual = ethereum.get_proxy_info(minimal_proxy.address)
     assert actual is not None
     assert actual.type == ProxyType.Minimal

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -6,9 +6,7 @@ NOTE: Most proxy tests are in `geth/test_proxy.py`.
 
 
 def test_minimal_proxy(ethereum, minimal_proxy, chain):
-    chain.provider.network.__dict__["explorer"] = (
-        None  # Ensure no explorer, messes up test.
-    )
+    chain.provider.network.__dict__["explorer"] = None  # Ensure no explorer, messes up test.
     actual = ethereum.get_proxy_info(minimal_proxy.address)
     assert actual is not None
     assert actual.type == ProxyType.Minimal


### PR DESCRIPTION
### What I did

Caches code, which is easier to do now that selfdestructs don't matter.
So there are a couples times when not to cache however such as during dev because of chain isolation and also when specifying `block_id=` because you likely are checking for contract creation at a certain time.

caching happens at the chain manager level, which is a familiar pattern.
The provider always checks the RPC, as should be its job.

fixes: #482

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
