### PR TITLE
feat: Include additional flags to ape networks run

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -996,6 +996,10 @@ class NetworkAPI(BaseInterfaceModel):
         """
         return self.config.get("base_fee_multiplier", 1.0)
 
+    @base_fee_multiplier.setter
+    def base_fee_multiplier(self, value: float):
+        self.config["base_fee_multiplier"] = value
+
     @property
     def chain_id(self) -> int:
         """
@@ -1038,8 +1042,11 @@ class NetworkAPI(BaseInterfaceModel):
               mainnet:
                 block_time: 15
         """
-
         return self.config.get("block_time", 0)
+
+    @block_time.setter
+    def block_time(self, value: int):
+        self.config["block_time"] = value
 
     @property
     def transaction_acceptance_timeout(self) -> int:
@@ -1051,6 +1058,10 @@ class NetworkAPI(BaseInterfaceModel):
         return self.config.get(
             "transaction_acceptance_timeout", DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT
         )
+
+    @transaction_acceptance_timeout.setter
+    def transaction_acceptance_timeout(self, value: int):
+        self.config["transaction_acceptance_timeout"] = value
 
     @cached_property
     def explorer(self) -> Optional["ExplorerAPI"]:


### PR DESCRIPTION
### What I did

Allows passing additional flags to the command `ape networks run', such as: `--block-time`,`--base-fee-multiplier`, `--transaction-timeout`

fixes: #1672

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
