### PR TITLE
feat: ability to show contract-type in stdout when compiling

### DIFF
--- a/docs/userguides/compile.md
+++ b/docs/userguides/compile.md
@@ -162,3 +162,13 @@ Then, after compiling, you should notice minified ABI json files in your `.build
 This is useful if hosting these files on a web-server.
 
 To see the full list of supported output-extra, see [the OutputExtras enum documentation](../methoddocs/ape_compile.html#ape_compile.config.OutputExtras).
+
+## Show Output
+
+To also display the contract type in the CLI terminal, use the `--show-output` flag when compiling:
+
+```shell
+ape compile --show-output
+```
+
+Now, your ABIs and bytecode (and all other artifacts) will appear stdout as well as Ape's disk cache.

--- a/src/ape_compile/_cli.py
+++ b/src/ape_compile/_cli.py
@@ -42,6 +42,7 @@ def _include_dependencies_callback(ctx, param, value):
     help="Also compile dependencies",
     callback=_include_dependencies_callback,
 )
+@click.option("--show-output", is_flag=True, help="Show contract-types in stdout")
 @config_override_option()
 def cli(
     cli_ctx,
@@ -51,6 +52,7 @@ def cli(
     display_size: bool,
     include_dependencies,
     config_override,
+    show_output,
 ):
     """
     Compiles the manifest for this project and saves the results
@@ -70,6 +72,11 @@ def cli(
             k: v.contract_type
             for k, v in project.load_contracts(*file_paths, use_cache=use_cache).items()
         }
+
+        if show_output:
+            for contract in contracts.values():
+                click.echo(contract.model_dump_json())
+
         cli_ctx.logger.success("'local project' compiled.")
         compiled = True
         if display_size:
@@ -79,7 +86,7 @@ def cli(
         project.dependencies
     ) > 0:
         for dependency in project.dependencies:
-            # Even if compiling we failed, we at least tried
+            # Even if compiling we failed, we at least tried,
             # and so we don't need to warn "Nothing to compile".
             compiled = True
 

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -377,20 +377,34 @@ def test_raw_compiler_output_bytecode(integ_project):
 
 
 @skip_projects_except("with-contracts")
-def test_compile_exclude(ape_cli, runner):
-    result = runner.invoke(ape_cli, ("compile", "--force"), catch_exceptions=False)
+def test_compile_exclude(ape_cli, runner, integ_project):
+    result = runner.invoke(
+        ape_cli,
+        ("compile", "--force", "--project", f"{integ_project.path}"),
+        catch_exceptions=False,
+    )
     assert "Compiling 'contracts/Exclude.json'" not in result.output
     assert "Compiling 'contracts/IgnoreUsingRegex.json'" not in result.output
     assert "Compiling 'contracts/exclude_dir/UnwantedContract.json'" not in result.output
 
 
 @skip_projects_except("with-contracts")
-def test_compile_config_override(ape_cli, runner):
+def test_compile_config_override(ape_cli, runner, integ_project):
     arguments = (
         "compile",
         "--force",
         "--config-override",
         '{"compile": {"exclude": ["*ContractA*"]}}',
+        "--project",
+        f"{integ_project.path}",
     )
     result = runner.invoke(ape_cli, arguments, catch_exceptions=False)
     assert "Compiling 'contracts/ContractA.json'" not in result.output
+
+
+@skip_projects_except("with-contracts")
+def test_compile_show_output(ape_cli, runner, integ_project):
+    arguments = ("compile", "--force", "--show-output", "--project", f"{integ_project.path}")
+    result = runner.invoke(ape_cli, arguments, catch_exceptions=False)
+    assert "Compiling 'contracts/ContractA.json'" not in result.output
+    assert '{"bytecode":"0x34611' in result.output


### PR DESCRIPTION
### What I did

new flag

```
ape compile --show-output
```

which also displays the contract types in stdout.
This is mostly useful in ape-vyper when switching up `-f` to be non-traditional.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
