### PR TITLE
feat: allow setting `sign=False` on transactions (good for titanoboa)

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -258,7 +258,8 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
             if txn.value < 0:
                 raise AccountsError("Value cannot be negative.")
 
-        return self.call(txn, private=private, **kwargs)
+        sign = kwargs.pop("sign", True)
+        return self.call(txn, private=private, sign=sign, **kwargs)
 
     def deploy(
         self, contract: "ContractContainer", *args, publish: bool = False, **kwargs

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -258,8 +258,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
             if txn.value < 0:
                 raise AccountsError("Value cannot be negative.")
 
-        sign = kwargs.pop("sign", True)
-        return self.call(txn, private=private, sign=sign, **kwargs)
+        return self.call(txn, private=private, **kwargs)
 
     def deploy(
         self, contract: "ContractContainer", *args, publish: bool = False, **kwargs

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -144,9 +144,9 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
               Defaults to ``False``.
             private (bool): ``True`` will use the
               :meth:`~ape.api.providers.ProviderAPI.send_private_transaction` method.
-            **signer_options: Additional kwargs given to the signer to modify the signing operation.
             sign (bool): ``False`` to not sign the transaction (useful for providers like Titanoboa
               which still use a sender but don't need to sign).
+            **signer_options: Additional kwargs given to the signer to modify the signing operation.
 
         Returns:
             :class:`~ape.api.transactions.ReceiptAPI`

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -90,7 +90,8 @@ class ContractConstructor(ManagerAccessMixin):
 
         if "sender" in kwargs and hasattr(kwargs["sender"], "call"):
             sender = kwargs["sender"]
-            return sender.call(txn, **kwargs)
+            sign = kwargs.pop("sign", True)
+            return sender.call(txn, sign=sign, **kwargs)
         elif "sender" not in kwargs and self.account_manager.default_sender is not None:
             return self.account_manager.default_sender.call(txn, **kwargs)
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -90,8 +90,7 @@ class ContractConstructor(ManagerAccessMixin):
 
         if "sender" in kwargs and hasattr(kwargs["sender"], "call"):
             sender = kwargs["sender"]
-            sign = kwargs.pop("sign", True)
-            return sender.call(txn, sign=sign, **kwargs)
+            return sender.call(txn, **kwargs)
         elif "sender" not in kwargs and self.account_manager.default_sender is not None:
             return self.account_manager.default_sender.call(txn, **kwargs)
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -261,6 +261,11 @@ def test_transfer_mixed_up_sender_and_value(sender, receiver):
         sender.transfer("123 wei", receiver)
 
 
+def test_transfer_sign_is_false(sender, receiver):
+    with pytest.raises(SignatureError):
+        sender.transfer(receiver, "1 gwei", sign=False)
+
+
 def test_deploy(owner, contract_container, clean_contract_caches):
     contract = owner.deploy(contract_container, 0)
     assert contract.address

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -978,3 +978,15 @@ def test_repr(account_manager):
     """
     actual = repr(account_manager)
     assert actual == "<AccountManager>"
+
+
+def test_call(owner, vyper_contract_instance):
+    tx = vyper_contract_instance.setNumber.as_transaction(5991)
+    receipt = owner.call(tx)
+    assert not receipt.failed
+
+
+def test_call_sign_false(owner, vyper_contract_instance):
+    tx = vyper_contract_instance.setNumber.as_transaction(5991)
+    with pytest.raises(SignatureError):
+        owner.call(tx, sign=False)

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -17,6 +17,7 @@ from ape.exceptions import (
     ContractLogicError,
     CustomError,
     MethodNonPayableError,
+    SignatureError,
 )
 from ape.types.address import AddressType
 from ape_ethereum.transactions import TransactionStatusEnum, TransactionType
@@ -72,6 +73,11 @@ def test_eq(vyper_contract_instance, chain):
 def test_contract_transactions(owner, contract_instance):
     contract_instance.setNumber(2, sender=owner)
     assert contract_instance.myNumber() == 2
+
+
+def test_contract_transaction_when_sign_false(owner, contract_instance):
+    with pytest.raises(SignatureError):
+        contract_instance.setNumber(2, sender=owner, sign=False)
 
 
 def test_wrong_number_of_arguments(owner, contract_instance):


### PR DESCRIPTION
### What I did

allows setting `sign=False` when making transactions.
I am thinking this is the first step to getting a faster titanoboa integration, helps us avoid signing the transactions

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
