### PR TITLE
feat: allow setting block time in `geth --dev` provider

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
         "eth-typing>=3.5.2,<6",
         "eth-utils>=2.1.0,<6",
         "hexbytes>=0.3.1,<2",
-        "py-geth>=5.1.0,<6",
+        "py-geth>=5.2.1,<6",
         "trie>=3.0.1,<4",  # Peer: stricter pin needed for uv support.
         "web3[tester]>=6.20.1,<8",
         # ** Dependencies maintained by ApeWorX **

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -399,6 +399,10 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
         return self.settings.ethereum.local.get("chain_id", DEFAULT_TEST_CHAIN_ID)
 
     @property
+    def block_time(self) -> Optional[int]:
+        return self.settings.ethereum.local.get("block_time")
+
+    @property
     def data_dir(self) -> Path:
         # Overridden from base class for placing debug logs in ape data folder.
         return self.settings.data_dir or self.config_manager.DATA_FOLDER / self.name
@@ -478,7 +482,7 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
         test_config["initial_balance"] = self.test_config.balance
         uri = self.ws_uri or self.uri
         return GethDevProcess.from_uri(
-            uri, self.data_dir, block_time=self.settings.block_time, **test_config
+            uri, self.data_dir, block_time=self.block_time, **test_config
         )
 
     def disconnect(self):

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -713,7 +713,7 @@ def test_make_request_not_exists_different_messages(message, mock_web3, geth_pro
 def test_geth_bin_not_found():
     bin_name = "__NOT_A_REAL_EXECUTABLE_HOPEFULLY__"
     with pytest.raises(NodeSoftwareNotInstalledError):
-        _ = GethDevProcess(Path.cwd(), executable=bin_name)
+        _ = GethDevProcess(Path.cwd() / "notexists", executable=bin_name)
 
 
 @geth_process_test
@@ -935,3 +935,15 @@ def test_geth_dev_from_uri_ipc(data_folder):
     assert kwargs.get("ws_api") is None
     assert kwargs.get("ws_addr") is None
     assert kwargs.get("rpc_addr") is None
+
+
+@geth_process_test
+def test_geth_dev_block_period(data_folder):
+    geth_dev = GethDevProcess.from_uri(
+        "path/to/geth.ipc",
+        data_folder,
+        block_time=1,
+        generate_accounts=False,
+        initialize_chain=False,
+    )
+    assert geth_dev.geth_kwargs["dev_period"] == "1"


### PR DESCRIPTION
### What I did

This allows changing the block time (dev-period) in the geth dev provider in Ape.
It requires this PR for py-geth: https://github.com/ethereum/py-geth/pull/248

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
