### PR TITLE
fix: eth-tester was failing with too-low base fee errors

### DIFF
--- a/src/ape_test/provider.py
+++ b/src/ape_test/provider.py
@@ -498,7 +498,7 @@ class LocalProvider(TestProviderAPI, Web3Provider):
         self.evm_backend.add_account(private_key)
 
     def _get_last_base_fee(self) -> int:
-        base_fee = self._get_latest_block_rpc().get("base_fee_per_gas", None)
+        base_fee = self.evm_backend.get_block_by_number("pending").get("base_fee_per_gas", None)
         if base_fee is not None:
             return base_fee
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -170,7 +170,7 @@ def test_transfer_without_value_send_everything_true_with_low_gas(sender, receiv
 
     # Clear balance of sender.
     # Use small gas so for sure runs out of money.
-    receipt = sender.transfer(receiver, send_everything=True, gas=21000)
+    receipt = sender.transfer(receiver, send_everything=True, gas=22000)
 
     value_given = receipt.value
     total_spent = value_given + receipt.total_fees_paid

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -534,7 +534,7 @@ def test_make_request_rate_limiting(mocker, ethereum, mock_web3):
 
 def test_base_fee(eth_tester_provider):
     actual = eth_tester_provider.base_fee
-    assert actual > 0
+    assert actual >= eth_tester_provider.get_block("pending").base_fee
 
     # NOTE: Mostly doing this to ensure we are calling the fee history
     #   RPC correctly. There was a bug where we were not.


### PR DESCRIPTION
### What I did

I was trying to demo something and was not able to do even the most basic transactions with eth-tester for some reason because of a base fee issue... Not sure why this hasnt come up in the test, but whatever here we are.

### How I did it

use pending block base instead of latest.

### How to verify it

my demo works now

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
