### PR TITLE
fix: improve error message when URI missing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         additional_dependencies: [flake8-breakpoint, flake8-print, flake8-pydantic, flake8-type-checking]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.14.1
     hooks:
     -   id: mypy
         additional_dependencies: [

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
     ],
     "lint": [
         "black>=24.10.0,<25",  # Auto-formatter and linter
-        "mypy>=1.13.0,<2",  # Static type analyzer
+        "mypy>=1.14.1,<1.15.0",  # Static type analyzer
         "types-PyYAML",  # Needed due to mypy typeshed
         "types-requests",  # Needed due to mypy typeshed
         "types-setuptools",  # Needed due to mypy typeshed

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -336,7 +336,9 @@ class Web3Provider(ProviderAPI, ABC):
         # NOTE: Don't use default IPC path here. IPC must be
         #   configured if it is the only RPC.
 
-        raise ProviderError("Missing URI.")
+        raise ProviderError(
+            f"Missing URI for network '{self.network.name}' on '{self.network.ecosystem.name}'."
+        )
 
     @property
     def network_choice(self) -> str:


### PR DESCRIPTION
### What I did

I tried using `mode` network but ran into an issue because it was not on the evm-chains package so I just needed to configure it (can also add it to that package if i get a chance), but anyway this error message would have been helpful as I was looping through a bunch of networks when I hit this.

### How I did it

Include network names in the error message.

### How to verify it

I added a test, trust me bro

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
