### PR TITLE
feat: `@ape.logging.silenced` decorator for ensuring an entire method does not log

### DIFF
--- a/src/ape/logging.py
+++ b/src/ape/logging.py
@@ -379,4 +379,19 @@ def get_rich_console(file: Optional[IO[str]] = None, **kwargs) -> "RichConsole":
     return _factory.get_console(file, **kwargs)
 
 
-__all__ = ["DEFAULT_LOG_LEVEL", "logger", "LogLevel", "ApeLogger", "get_rich_console"]
+def silenced(func: Callable):
+    """
+    A decorator for ensuring a function does not output any logs.
+
+    Args:
+        func (Callable): The function to call silently.
+    """
+
+    def wrapper(*args, **kwargs):
+        with logger.disabled():
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+__all__ = ["DEFAULT_LOG_LEVEL", "logger", "LogLevel", "ApeLogger", "get_rich_console", "silenced"]

--- a/tests/functional/test_logging.py
+++ b/tests/functional/test_logging.py
@@ -3,7 +3,7 @@ import pytest
 from click.testing import CliRunner
 
 from ape.cli import ape_cli_context
-from ape.logging import LogLevel, logger, sanitize_url
+from ape.logging import LogLevel, logger, sanitize_url, silenced
 
 
 @pytest.fixture
@@ -147,3 +147,14 @@ def test_disabled(ape_caplog):
     # Show it is back.
     logger.error(message)
     assert message in ape_caplog.head
+
+
+def test_silenced(ape_caplog):
+    @silenced
+    def method_to_silence(x: int, y: str):
+        logger.error(f"{x} {y}")
+
+    magic = [156236, "Asd#g"]
+    unexpected = f"{magic[0]} {magic[1]}"
+    method_to_silence(*magic)
+    assert unexpected not in ape_caplog.head


### PR DESCRIPTION
### What I did

useful for CLIs where output is important.
part of the 0.9 goals as well

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
