### PR TITLE
feat: ability to get conversion classes by name

### DIFF
--- a/src/ape/api/convert.py
+++ b/src/ape/api/convert.py
@@ -45,3 +45,14 @@ class ConverterAPI(BaseInterfaceModel, Generic[ConvertedType]):
             # '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
 
         """
+
+    @property
+    def name(self) -> str:
+        """
+        The calculated name of the converter class.
+        Typically, it is the lowered prefix of the class without
+        the "Converter" or "Conversions" suffix.
+        """
+        class_name = self.__class__.__name__
+        name = class_name.replace("Converter", "").replace("Conversions", "")
+        return name.lower()

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -394,6 +394,18 @@ class ConversionManager(BaseManager):
 
         raise ConversionError(f"No conversion registered to handle '{value}'.")
 
+    def get_converters_by_type(self, converter_type: type) -> list[ConverterAPI]:
+        """
+        Get all the converters for the given type.
+
+        Args:
+            converter_type (type): The type to get converters for.
+
+        Returns:
+            list[ConverterAPI]: All registered converters for the given type.
+        """
+        return self._converters.get(converter_type, [])
+
     def get_converter(self, name: str) -> ConverterAPI:
         """
         Get a converter plugin by name.

--- a/src/ape/managers/converters.py
+++ b/src/ape/managers/converters.py
@@ -394,6 +394,23 @@ class ConversionManager(BaseManager):
 
         raise ConversionError(f"No conversion registered to handle '{value}'.")
 
+    def get_converter(self, name: str) -> ConverterAPI:
+        """
+        Get a converter plugin by name.
+
+        Args:
+            name (str): The name of the converter.
+
+        Returns:
+            :class:`~ape.api.converters.ConverterAPI`: The converter.
+        """
+        for converter_ls in self._converters.values():
+            for converter in converter_ls:
+                if converter.name == name.lower():
+                    return converter
+
+        raise ConversionError("No converters with name '{name}'.'")
+
     def convert_method_args(
         self,
         abi: Union["MethodABI", "ConstructorABI", "EventABI"],

--- a/src/ape_ethereum/_converters.py
+++ b/src/ape_ethereum/_converters.py
@@ -23,13 +23,13 @@ NUMBER_PATTERN = re.compile(r"^-?\d{1,3}(?:[,_]?\d{3})*(?:\.\d+)?(?:[eE][+-]?\d+
 
 
 class WeiConversions(ConverterAPI):
-    """Converts units like `1 ether` to 1e18 wei"""
+    """Converts units like `1 ether` to 1e18 wei."""
 
     def is_convertible(self, value: str) -> bool:
         if not isinstance(value, str):
             return False
 
-        if " " not in value or len(value.split(" ")) > 2:
+        elif " " not in value or len(value.split(" ")) > 2:
             return False
 
         val, unit = value.split(" ")

--- a/tests/functional/test_converters.py
+++ b/tests/functional/test_converters.py
@@ -1,0 +1,36 @@
+import pytest
+
+from ape.managers.converters import (
+    AddressAPIConverter,
+    BytesAddressConverter,
+    HexConverter,
+    HexIntConverter,
+    IntAddressConverter,
+    StringDecimalConverter,
+    StringIntConverter,
+)
+from ape.utils.basemodel import ManagerAccessMixin
+from ape_ethereum._converters import WeiConversions
+
+NAME_TO_CONVERTER = {
+    "AddressAPI": AddressAPIConverter,
+    "BytesAddress": BytesAddressConverter,
+    "hex": HexConverter,
+    "HexInt": HexIntConverter,
+    "IntAddress": IntAddressConverter,
+    "StringDecimal": StringDecimalConverter,
+    "StringInt": StringIntConverter,
+    "wei": WeiConversions,
+}
+
+
+@pytest.fixture
+def conversion_manager():
+    return ManagerAccessMixin.conversion_manager
+
+
+@pytest.mark.parametrize("name", NAME_TO_CONVERTER)
+def test_get_converter(name, conversion_manager):
+    actual = conversion_manager.get_converter(name)
+    expected = NAME_TO_CONVERTER[name]
+    assert isinstance(actual, expected)

--- a/tests/functional/test_converters.py
+++ b/tests/functional/test_converters.py
@@ -9,6 +9,7 @@ from ape.managers.converters import (
     StringDecimalConverter,
     StringIntConverter,
 )
+from ape.types.address import AddressType
 from ape.utils.basemodel import ManagerAccessMixin
 from ape_ethereum._converters import WeiConversions
 
@@ -34,3 +35,9 @@ def test_get_converter(name, conversion_manager):
     actual = conversion_manager.get_converter(name)
     expected = NAME_TO_CONVERTER[name]
     assert isinstance(actual, expected)
+
+
+def test_get_converters_by_type(conversion_manager):
+    converters = conversion_manager.get_converters_by_type(AddressType)
+    for expected in (AddressAPIConverter, IntAddressConverter, BytesAddressConverter):
+        assert any(isinstance(c, expected) for c in converters)


### PR DESCRIPTION
### What I did

This helps me access the ENS conversion class, which makes more sense than any of these, but is still helpful.

This is what I have to do in the meantime to get access to ENS in the ape-ens tests:

```

@pytest.fixture(scope="session")
def converter(chain):
    # TODO: Replace with https://github.com/ApeWorX/ape/pull/2497
    #   (requires ape 0.8.26).
    converters = chain.conversion_manager._converters[AddressType]
    for converter in converters:
        if isinstance(converter, ENSConversions):
            return converter

    pytest.fail("Failed to find ENS converter registered in Ape.")
```

Ape should be good about testing stuff like `ape-ens`

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
