### PR TITLE
feat: `ape plugins list` section-header fix AND allowing `--format freeze` option

### DIFF
--- a/src/ape/plugins/_utils.py
+++ b/src/ape/plugins/_utils.py
@@ -223,7 +223,7 @@ class PluginMetadataList(BaseModel):
         cls,
         packages: Iterable[str],
         include_available: bool = True,
-        trusted_list: Optional[list] = None,
+        trusted_list: Optional[Iterable] = None,
     ) -> "PluginMetadataList":
         PluginMetadataList.model_rebuild()
         core = PluginGroup(plugin_type=PluginType.CORE)
@@ -473,7 +473,7 @@ class PluginMetadata(BaseInterfaceModel):
 
         return any(n == self.package_name for n in get_plugin_dists())
 
-    def check_trusted(self, use_web: bool = True, trusted_list: Optional[list] = None) -> bool:
+    def check_trusted(self, use_web: bool = True, trusted_list: Optional[Iterable] = None) -> bool:
         if use_web:
             return self.is_available
 

--- a/src/ape/plugins/_utils.py
+++ b/src/ape/plugins/_utils.py
@@ -71,7 +71,7 @@ TRUSTED_PLUGINS = [
     "notebook",
     "optimism",
     "polygon",
-    "polygon_zkevm",
+    "polygon-zkevm",
     "safe",
     "solidity",
     "template",
@@ -89,6 +89,12 @@ def clean_plugin_name(name: str) -> str:
 
 def get_plugin_dists():
     return _filter_plugins_from_dists(_get_distributions())
+
+
+class OutputFormat(str, Enum):
+    DEFAULT = "default"
+    PREFIXED = "prefixed"
+    FREEZE = "freeze"
 
 
 def _filter_plugins_from_dists(dists: Iterable) -> Iterator[str]:
@@ -232,14 +238,15 @@ class PluginMetadataList(BaseModel):
 
             # perf: only check these once.
             is_installed = plugin.is_installed
+            is_trusted = plugin.check_trusted(use_web=False)
             is_available = include_available and plugin.is_available
 
             if include_available and is_available and not is_installed:
                 available.plugins[name] = plugin
-            elif is_installed and not plugin.in_core and not is_available:
-                third_party.plugins[name] = plugin
-            elif is_installed:
+            elif is_installed and not plugin.in_core and is_trusted:
                 installed.plugins[name] = plugin
+            elif is_installed:
+                third_party.plugins[name] = plugin
             else:
                 logger.error(f"'{plugin.name}' is not a plugin.")
 
@@ -248,8 +255,14 @@ class PluginMetadataList(BaseModel):
     def __str__(self) -> str:
         return self.to_str()
 
-    def to_str(self, include: Optional[Sequence[PluginType]] = None) -> str:
-        return str(ApePluginsRepr(self, include=include))
+    def to_str(
+        self,
+        include: Optional[Sequence[PluginType]] = None,
+        include_version: bool = True,
+        output_format: OutputFormat = OutputFormat.DEFAULT,
+    ) -> str:
+        representation = ApePluginsRepr(self, include=include, output_format=output_format)
+        return str(representation)
 
     @property
     def all_plugins(self) -> Iterator["PluginMetadata"]:
@@ -461,10 +474,9 @@ class PluginMetadata(BaseInterfaceModel):
         if use_web:
             return self.is_available
 
-        else:
-            # Sometimes (such as for --help commands), it is better
-            # to not check GitHub to see if the plugin is trusted.
-            return self.name in TRUSTED_PLUGINS
+        # Sometimes (such as for --help commands), it is better
+        # to not check GitHub to see if the plugin is trusted.
+        return self.name in TRUSTED_PLUGINS
 
     def _prepare_install(
         self, upgrade: bool = False, skip_confirmation: bool = False
@@ -620,6 +632,9 @@ class PluginGroup(BaseModel):
     def __str__(self) -> str:
         return self.to_str()
 
+    def __iter__(self) -> Iterator[str]:  # type: ignore
+        yield from self.plugins
+
     @field_validator("plugin_type", mode="before")
     @classmethod
     def validate_plugin_type(cls, value):
@@ -637,7 +652,31 @@ class PluginGroup(BaseModel):
     def plugin_names(self) -> list[str]:
         return [x.name for x in self.plugins.values()]
 
-    def to_str(self, max_length: Optional[int] = None, include_version: bool = True) -> str:
+    def to_str(
+        self,
+        max_length: Optional[int] = None,
+        include_version: bool = True,
+        output_format: Optional[OutputFormat] = OutputFormat.DEFAULT,
+    ) -> str:
+        output_format = output_format or OutputFormat.DEFAULT
+        if output_format in (OutputFormat.DEFAULT, OutputFormat.PREFIXED):
+            return self._get_default_formatted_str(
+                max_length=max_length,
+                include_version=include_version,
+                include_prefix=f"{output_format}" == OutputFormat.PREFIXED,
+            )
+
+        # Freeze format.
+        return self._get_freeze_formatted_str(
+            max_length=max_length, include_version=include_version
+        )
+
+    def _get_default_formatted_str(
+        self,
+        max_length: Optional[int] = None,
+        include_version: bool = True,
+        include_prefix: bool = False,
+    ) -> str:
         title = f"{self.name} Plugins"
         if len(self.plugins) <= 0:
             return title
@@ -646,7 +685,7 @@ class PluginGroup(BaseModel):
         max_length = self.max_name_length if max_length is None else max_length
         plugins_sorted = sorted(self.plugins.values(), key=lambda p: p.name)
         for plugin in plugins_sorted:
-            line = plugin.name
+            line = plugin.package_name if include_prefix else plugin.name
             if include_version:
                 version = plugin.version or get_package_version(plugin.package_name)
                 if version:
@@ -654,6 +693,23 @@ class PluginGroup(BaseModel):
                     line = f"{line}{spacing * ' '}{version}"
 
             lines.append(f"  {line}")  # Indent.
+
+        return "\n".join(lines)
+
+    def _get_freeze_formatted_str(
+        self,
+        max_length: Optional[int] = None,
+        include_version: bool = True,
+        include_prefix: bool = False,
+    ) -> str:
+        lines = []
+        for plugin in sorted(self.plugins.values(), key=lambda p: p.name):
+            line = plugin.package_name
+            if include_version:
+                version = plugin.version or get_package_version(plugin.package_name)
+                line = f"{line}=={version}"
+
+            lines.append(line)
 
         return "\n".join(lines)
 
@@ -671,10 +727,16 @@ class ApePluginsRepr:
     """
 
     def __init__(
-        self, metadata: PluginMetadataList, include: Optional[Sequence[PluginType]] = None
+        self,
+        metadata: PluginMetadataList,
+        include: Optional[Sequence[PluginType]] = None,
+        include_version: bool = True,
+        output_format: Optional[OutputFormat] = None,
     ):
         self.include = include or (PluginType.INSTALLED, PluginType.THIRD_PARTY)
         self.metadata = metadata
+        self.include_version = include_version
+        self.output_format = output_format
 
     @log_instead_of_fail(default="<ApePluginsRepr>")
     def __repr__(self) -> str:
@@ -700,8 +762,16 @@ class ApePluginsRepr:
         max_length = max(x.max_name_length for x in sections)
 
         version_skips = (PluginType.CORE, PluginType.AVAILABLE)
+
+        def include_version(section):
+            return section.plugin_type not in version_skips if self.include_version else False
+
         formatted_sections = [
-            x.to_str(max_length=max_length, include_version=x.plugin_type not in version_skips)
+            x.to_str(
+                max_length=max_length,
+                include_version=include_version(x),
+                output_format=self.output_format,
+            )
             for x in sections
         ]
         return "\n\n".join(formatted_sections)

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -111,12 +111,21 @@ def _display_all_callback(ctx, param, value):
     callback=_display_all_callback,
     help="Display all plugins installed and available (including Core)",
 )
-def _list(cli_ctx, to_display):
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["default", "prefixed", "freeze"]),
+    default="default",
+)
+@click.option("--exclude-version", is_flag=True, help="Do not include plugin versions in output")
+def _list(cli_ctx, to_display, output_format, exclude_version):
     from ape.plugins._utils import PluginMetadataList, PluginType
 
     include_available = PluginType.AVAILABLE in to_display
     metadata = PluginMetadataList.load(cli_ctx.plugin_manager, include_available=include_available)
-    if output := metadata.to_str(include=to_display):
+    if output := metadata.to_str(
+        include=to_display, include_version=not exclude_version, output_format=output_format
+    ):
         click.echo(output)
         if not metadata.installed and not metadata.third_party:
             click.echo("No plugins installed (besides core plugins).")

--- a/src/ape_run/_cli.py
+++ b/src/ape_run/_cli.py
@@ -124,17 +124,18 @@ class ScriptCommand(click.MultiCommand):
 
             self._namespace[filepath.stem] = cli_ns
             cli_obj = cli_ns["cli"]
-            if isinstance(cli_obj, click.Command):
-                params = [getattr(x, "name", None) for x in cli_obj.params]
-                if "verbosity" not in params:
-                    option_kwargs = _create_verbosity_kwargs()
-                    option = click.Option(_VERBOSITY_VALUES, **option_kwargs)
-                    cli_obj.params.append(option)
+            if not isinstance(cli_obj, click.Command):
+                logger.warning("Found `cli()` method but it is not a click command.")
+                return None
 
-                cli_obj.name = filepath.stem if cli_obj.name in ("cli", "", None) else cli_obj.name
-                return cli_obj
+            params = [getattr(x, "name", None) for x in cli_obj.params]
+            if "verbosity" not in params:
+                option_kwargs = _create_verbosity_kwargs()
+                option = click.Option(_VERBOSITY_VALUES, **option_kwargs)
+                cli_obj.params.append(option)
 
-            return click.Command(name=cli_obj.__name__, callback=cli_obj)
+            cli_obj.name = filepath.stem if cli_obj.name in ("cli", "", None) else cli_obj.name
+            return cli_obj
 
         elif "main" in code.co_names:
             logger.debug(f"Found 'main' method in script: {relative_filepath}")

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -88,7 +88,7 @@ def plugin_metadata(package_names, plugin_test_env) -> PluginMetadataList:
     names.add(f"ape-installed==0.{ape_version.minor}.0")
     names.remove("ape-thirdparty")
     names.add(f"ape-thirdparty==0.{ape_version.minor}.0")
-    return PluginMetadataList.from_package_names(names)
+    return PluginMetadataList.from_package_names(names, trusted_list=("installed",))
 
 
 class TestPluginMetadataList:


### PR DESCRIPTION
### What I did

Two things on this PR:

1. fix: `ape plugins list` was including plugins in the wrong spot
2. feat: adds `--format` option to `ape plugins list` so that i can get it in freeze mode, similar to `pip list --fromat=freeze`


## To Verify

```
ape test tests/integration/cli/test_plugins.py --runxfail
```
