### PR TITLE
feat: adds `.abi` property to `ContractLog`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,12 @@ repos:
     -   id: check-yaml
 
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
         name: black
@@ -22,7 +22,7 @@ repos:
         additional_dependencies: [flake8-breakpoint, flake8-print, flake8-pydantic, flake8-type-checking]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.15.0
     hooks:
     -   id: mypy
         additional_dependencies: [
@@ -37,7 +37,7 @@ repos:
         ]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.19
+    rev: 0.7.22
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter, mdformat-pyproject]

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ extras_require = {
         "hypothesis-jsonschema==0.19.0",  # JSON Schema fuzzer extension
     ],
     "lint": [
-        "black>=24.10.0,<25",  # Auto-formatter and linter
-        "mypy>=1.14.1,<1.15.0",  # Static type analyzer
+        "black>=25.1.0,<26",  # Auto-formatter and linter
+        "mypy>=1.15.0,<1.16.0",  # Static type analyzer
         "types-PyYAML",  # Needed due to mypy typeshed
         "types-requests",  # Needed due to mypy typeshed
         "types-setuptools",  # Needed due to mypy typeshed
@@ -36,8 +36,8 @@ extras_require = {
         "flake8-print>=4.0.1,<5",  # Detect print statements left in code
         "flake8-pydantic",  # For detecting issues with Pydantic models
         "flake8-type-checking",  # Detect imports to move in/out of type-checking blocks
-        "isort>=5.13.2,<6",  # Import sorting linter
-        "mdformat>=0.7.19",  # Auto-formatter for markdown
+        "isort>=6.0.0,<7",  # Import sorting linter
+        "mdformat>=0.7.22",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
         "mdformat-pyproject>=0.0.2",  # Allows configuring in pyproject.toml

--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -24,7 +24,7 @@ _DEFAULT_SENDERS: list[AccountAPI] = []
 
 @contextlib.contextmanager
 def _use_sender(
-    account: Union[AccountAPI, TestAccountAPI]
+    account: Union[AccountAPI, TestAccountAPI],
 ) -> "Generator[AccountAPI, TestAccountAPI, None]":
     try:
         _DEFAULT_SENDERS.append(account)

--- a/src/ape/plugins/network.py
+++ b/src/ape/plugins/network.py
@@ -16,8 +16,8 @@ class EcosystemPlugin(PluginType):
     what is required to implement an ecosystem plugin.
     """
 
-    @hookspec  # type: ignore[empty-body]
-    def ecosystems(self) -> Iterator[type["EcosystemAPI"]]:
+    @hookspec
+    def ecosystems(self) -> Iterator[type["EcosystemAPI"]]:  # type: ignore[empty-body]
         """
         A hook that must return an iterator of :class:`ape.api.networks.EcosystemAPI`
         subclasses.
@@ -40,8 +40,8 @@ class NetworkPlugin(PluginType):
     networks.
     """
 
-    @hookspec  # type: ignore[empty-body]
-    def networks(self) -> Iterator[tuple[str, str, type["NetworkAPI"]]]:
+    @hookspec
+    def networks(self) -> Iterator[tuple[str, str, type["NetworkAPI"]]]:  # type: ignore[empty-body]
         """
         A hook that must return an iterator of tuples of:
 

--- a/src/ape/plugins/project.py
+++ b/src/ape/plugins/project.py
@@ -16,8 +16,8 @@ class ProjectPlugin(PluginType):
     via ``.gitmodules``.
     """
 
-    @hookspec  # type: ignore[empty-body]
-    def projects(self) -> Iterator[type["ProjectAPI"]]:
+    @hookspec
+    def projects(self) -> Iterator[type["ProjectAPI"]]:  # type: ignore[empty-body]
         """
         A hook that returns a :class:`~ape.api.projects.ProjectAPI` subclass type.
 

--- a/src/ape/plugins/query.py
+++ b/src/ape/plugins/query.py
@@ -12,8 +12,8 @@ class QueryPlugin(PluginType):
     A plugin for querying chains.
     """
 
-    @hookspec  # type: ignore[empty-body]
-    def query_engines(self) -> Iterator[type["QueryAPI"]]:
+    @hookspec
+    def query_engines(self) -> Iterator[type["QueryAPI"]]:  # type: ignore[empty-body]
         """
         A hook that returns an iterator of types of a ``QueryAPI`` subclasses
 

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -1027,6 +1027,7 @@ class Ethereum(EcosystemAPI):
                     converted_arguments[key] = value
 
             yield ContractLog(
+                _abi=abi,
                 block_hash=log.get("blockHash") or log.get("block_hash") or "",
                 block_number=log.get("blockNumber") or log.get("block_number") or 0,
                 contract_address=self.decode_address(log["address"]),

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -119,7 +119,7 @@ def test_sign_message_with_prompts(runner, keyfile_account, message):
 
 def test_sign_raw_hash(runner, keyfile_account):
     # NOTE: `message` is a 32 byte raw hash, which is treated specially
-    message = b"\xAB" * 32
+    message = b"\xab" * 32
 
     # "y\na\ny": yes sign raw hash, password, yes keep unlocked
     with runner.isolation(input=f"y\n{PASSPHRASE}\ny"):

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -242,6 +242,11 @@ def test_get_contract_logs_single_log(chain, contract_instance, owner, eth_teste
     logs = [log for log in eth_tester_provider.get_contract_logs(log_filter)]
     assert len(logs) == 1
     assert logs[0]["foo"] == 0
+    assert logs[0].abi == contract_instance.FooHappened.abi
+
+    # Show it looks up the ABI when not cached not anymore.
+    logs[0]._abi = None
+    assert logs[0].abi == contract_instance.FooHappened.abi
 
 
 def test_get_contract_logs_single_log_query_multiple_values(

--- a/tests/functional/test_types.py
+++ b/tests/functional/test_types.py
@@ -100,6 +100,11 @@ def test_contract_log_access(log):
     assert log.bar == log["bar"] == log.get("bar") == 1
 
 
+def test_contract_log_abi(log):
+    # The log fixture is very basic class usage.
+    assert log.abi.name == "MyEvent"
+
+
 def test_topic_filter_encoding():
     event_abi = EventABI.model_validate_json(RAW_EVENT_ABI)
     log_filter = LogFilter.from_event(


### PR DESCRIPTION
### What I did

I was frustrated this wasn't available, so this makes it available.

### How I did it

1. When getting logs from the provider, use a private property
2. Do a lookup from the address => contract type to find the abi and cache it.
3. craft a default one, last case scenario, this needs works but is very rare and doesnt probably show up

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
