### PR TITLE
fix: default call transactions would not get prepared when sender is a contract

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -401,44 +401,6 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         else:
             raise AccountsError(f"Unsupported message type: {type(data)}.")
 
-    def prepare_transaction(self, txn: TransactionAPI) -> TransactionAPI:
-        """
-        Set default values on a transaction.
-
-        Raises:
-            :class:`~ape.exceptions.AccountsError`: When the account cannot afford the transaction
-              or the nonce is invalid.
-            :class:`~ape.exceptions.TransactionError`: When given negative required confirmations.
-
-        Args:
-            txn (:class:`~ape.api.transactions.TransactionAPI`): The transaction to prepare.
-
-        Returns:
-            :class:`~ape.api.transactions.TransactionAPI`
-        """
-
-        # NOTE: Allow overriding nonce, assume user understands what this does
-        if txn.nonce is None:
-            txn.nonce = self.nonce
-        elif txn.nonce < self.nonce:
-            raise AccountsError("Invalid nonce, will not publish.")
-
-        txn = self.provider.prepare_transaction(txn)
-
-        if (
-            txn.sender not in self.account_manager.test_accounts._impersonated_accounts
-            and txn.total_transfer_value > self.balance
-        ):
-            raise AccountsError(
-                f"Transfer value meets or exceeds account balance "
-                f"for account '{self.address}' on chain '{self.provider.chain_id}' "
-                f"using provider '{self.provider.name}'.\n"
-                "Are you using the correct account / chain / provider combination?\n"
-                f"(transfer_value={txn.total_transfer_value}, balance={self.balance})."
-            )
-
-        return txn
-
     def get_deployment_address(self, nonce: Optional[int] = None) -> AddressType:
         """
         Get a contract address before it is deployed. This is useful

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -188,7 +188,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         if sign:
             prepared_txn = self.sign_transaction(txn, **signer_options)
             if not prepared_txn:
-                raise SignatureError("The transaction was not signed.")
+                raise SignatureError("The transaction was not signed.", transaction=txn)
 
         else:
             prepared_txn = txn

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from eth_pydantic_types import HexBytes
 
-from ape.exceptions import ConversionError
+from ape.exceptions import ConversionError, AccountsError
 from ape.types.address import AddressType
 from ape.types.units import CurrencyValue
 from ape.utils.basemodel import BaseInterface
@@ -103,9 +103,17 @@ class BaseAddress(BaseInterface):
         """
 
         txn = self.as_transaction(**kwargs)
-        if "sender" in kwargs and hasattr(kwargs["sender"], "call"):
-            sender = kwargs["sender"]
-            return sender.call(txn, **kwargs)
+        if "sender" in kwargs:
+            if hasattr(kwargs["sender"], "call"):
+                # AccountAPI
+                sender = kwargs["sender"]
+                return sender.call(txn, **kwargs)
+
+            elif hasattr(kwargs["sender"], "prepare_transaction"):
+                # BaseAddress (likely, a ContractInstance)
+                prepare_transaction = kwargs["sender"].prepare_transaction(txn)
+                return self.provider.send_transaction(prepare_transaction)
+
         elif "sender" not in kwargs and self.account_manager.default_sender is not None:
             return self.account_manager.default_sender.call(txn, **kwargs)
 
@@ -185,6 +193,44 @@ class BaseAddress(BaseInterface):
     def estimate_gas_cost(self, **kwargs) -> int:
         txn = self.as_transaction(**kwargs)
         return self.provider.estimate_gas_cost(txn)
+
+    def prepare_transaction(self, txn: "TransactionAPI") -> "TransactionAPI":
+        """
+        Set default values on a transaction.
+
+        Raises:
+            :class:`~ape.exceptions.AccountsError`: When the account cannot afford the transaction
+              or the nonce is invalid.
+            :class:`~ape.exceptions.TransactionError`: When given negative required confirmations.
+
+        Args:
+            txn (:class:`~ape.api.transactions.TransactionAPI`): The transaction to prepare.
+
+        Returns:
+            :class:`~ape.api.transactions.TransactionAPI`
+        """
+
+        # NOTE: Allow overriding nonce, assume user understands what this does
+        if txn.nonce is None:
+            txn.nonce = self.nonce
+        elif txn.nonce < self.nonce:
+            raise AccountsError("Invalid nonce, will not publish.")
+
+        txn = self.provider.prepare_transaction(txn)
+
+        if (
+            txn.sender not in self.account_manager.test_accounts._impersonated_accounts
+            and txn.total_transfer_value > self.balance
+        ):
+            raise AccountsError(
+                f"Transfer value meets or exceeds account balance "
+                f"for account '{self.address}' on chain '{self.provider.chain_id}' "
+                f"using provider '{self.provider.name}'.\n"
+                "Are you using the correct account / chain / provider combination?\n"
+                f"(transfer_value={txn.total_transfer_value}, balance={self.balance})."
+            )
+
+        return txn
 
 
 class Address(BaseAddress):

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from eth_pydantic_types import HexBytes
 
-from ape.exceptions import ConversionError, AccountsError
+from ape.exceptions import AccountsError, ConversionError
 from ape.types.address import AddressType
 from ape.types.units import CurrencyValue
 from ape.utils.basemodel import BaseInterface

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -226,7 +226,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
             bytes
         """
         if not self.signature:
-            raise SignatureError("The transaction is not signed.")
+            raise SignatureError("The transaction is not signed.", transaction=self)
 
         txn_data = self.model_dump(exclude={"sender"})
         unsigned_txn = serializable_unsigned_transaction_from_dict(txn_data)
@@ -239,7 +239,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
         signed_txn = encode_transaction(unsigned_txn, signature)
 
         if self.sender and EthAccount.recover_transaction(signed_txn) != self.sender:
-            raise SignatureError("Recovered signer doesn't match sender!")
+            raise SignatureError("Recovered signer doesn't match sender!", transaction=signed_txn)
 
         return signed_txn
 

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -226,7 +226,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
             bytes
         """
         if not self.signature:
-            raise SignatureError("The transaction is not signed.", transaction=self)
+            raise SignatureError("The transaction is not signed.")
 
         txn_data = self.model_dump(exclude={"sender"})
         unsigned_txn = serializable_unsigned_transaction_from_dict(txn_data)
@@ -239,7 +239,7 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
         signed_txn = encode_transaction(unsigned_txn, signature)
 
         if self.sender and EthAccount.recover_transaction(signed_txn) != self.sender:
-            raise SignatureError("Recovered signer doesn't match sender!", transaction=signed_txn)
+            raise SignatureError("Recovered signer doesn't match sender!")
 
         return signed_txn
 

--- a/src/ape/exceptions.py
+++ b/src/ape/exceptions.py
@@ -74,6 +74,10 @@ class SignatureError(AccountsError):
     Raised when there are issues with signing.
     """
 
+    def __init__(self, message: str, transaction: Optional["TransactionAPI"] = None):
+        self.transaction = transaction
+        super().__init__(message)
+
 
 class ContractDataError(ApeException):
     """

--- a/src/ape_ethereum/transactions.py
+++ b/src/ape_ethereum/transactions.py
@@ -72,7 +72,7 @@ class BaseTransaction(TransactionAPI):
                     "Did you forget to add the `sender=` kwarg to the transaction function call?"
                 )
 
-            raise SignatureError(message)
+            raise SignatureError(message, transaction=self)
 
         txn_data = self.model_dump(by_alias=True, exclude={"sender", "type"})
 
@@ -107,7 +107,8 @@ class BaseTransaction(TransactionAPI):
             recovered_signer = EthAccount.recover_transaction(signed_txn)
             if recovered_signer != self.sender:
                 raise SignatureError(
-                    f"Recovered signer '{recovered_signer}' doesn't match sender {self.sender}!"
+                    f"Recovered signer '{recovered_signer}' doesn't match sender {self.sender}!",
+                    transaction=self,
                 )
 
         return signed_txn

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -161,7 +161,7 @@ class TestAccount(TestAccountAPI):
             ) = sign_transaction_dict(private_key, tx_data)
         except TypeError as err:
             # Occurs when missing properties on the txn that are needed to sign.
-            raise SignatureError(str(err)) from err
+            raise SignatureError(str(err), transaction=txn) from err
 
         # NOTE: Using `to_bytes(hexstr=to_hex(sig_r))` instead of `to_bytes(sig_r)` as
         #   a performance optimization.

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -1043,4 +1043,5 @@ def test_call_contract_as_sender(fallback_contract, owner, vyper_contract_instan
         fallback_contract(sender=fallback_contract, value="1 wei")
 
     transaction = info.value.transaction
+    assert transaction is not None
     assert transaction.nonce is not None  # Proves it was prepared.

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -1027,3 +1027,20 @@ def test_calldata_arg(calldata, expected, contract_instance, owner):
     tx = contract_instance.functionWithCalldata(calldata, sender=owner)
     assert not tx.failed
     assert HexBytes(expected) in tx.data
+
+
+def test_call(fallback_contract, owner):
+    """
+    Fallback contract call test.
+    """
+    tx = fallback_contract(sender=owner, value="1 wei")
+    assert not tx.failed
+
+
+def test_call_contract_as_sender(fallback_contract, owner, vyper_contract_instance):
+    owner.transfer(fallback_contract, "1 ETH")
+    with pytest.raises(SignatureError) as info:
+        fallback_contract(sender=fallback_contract, value="1 wei")
+
+    transaction = info.value.transaction
+    assert transaction.nonce is not None  # Proves it was prepared.


### PR DESCRIPTION
### What I did

it is difficult to test this without a provider that can handle impersonated accounts (can't wait for boa to be part of ape core).
but if your account is a contract and you call a fallback method on another contract, the transaction would never get prepared causing you to have to manually specify `nonce=` and everything else you neeed.

### How I did it

* move `prepare_transaction()` to `BaseAddress` class.
* if the given sender isnt an account but is base-address, still do the `prepare_transaction()` part.

### How to verify it

I had to add exception kwarg to `SignatureError` so i can at least verify the txn data is now populated.
I also confirmed with breakpoint and it unblocks me someplace else too. added a test.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
