### PR TITLE
feat: allow `project.chdir()` to work in a context

### DIFF
--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -1065,9 +1065,16 @@ def test_chdir(project):
         project.chdir(new_path)
         assert project.path == new_path
 
-    # Undo.
-    project.chdir(original_path)
-    assert project.path == original_path
+        # Undo.
+        project.chdir(original_path)
+        assert project.path == original_path
+
+        # Show you can also use it in a context.
+        with project.chdir(new_path):
+            assert project.path == new_path
+
+        # It should have automatically undone.
+        assert project.path == original_path
 
 
 def test_within_project_path():


### PR DESCRIPTION
### What I did

we already had `project.chdir()`, but this makes it so you can also do:

```
with project.chdir():
   ...
```

this is useful for situations where we really just need `.local_project` to be something different, such as testing the framework itself.

### How I did it

made a `ChangeDirectory` context manager and used it

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
