### PR TITLE
feat: `accounts.resolve_address()` method for resolving input into address types

### DIFF
--- a/src/ape/managers/accounts.py
+++ b/src/ape/managers/accounts.py
@@ -469,7 +469,7 @@ class AccountManager(BaseManager):
     ) -> "TestAccountAPI":
         return self.test_accounts.init_test_account(index, address, private_key)
 
-    def resolve(
+    def resolve_address(
         self, account_id: Union["BaseAddress", AddressType, str, int, bytes]
     ) -> Optional[AddressType]:
         """

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -22,7 +22,6 @@ from ape.exceptions import (
     APINotImplementedError,
     BlockNotFoundError,
     ChainError,
-    ConversionError,
     ProviderNotConnectedError,
     QueryEngineError,
     TransactionNotFoundError,
@@ -955,11 +954,8 @@ class ChainManager(BaseManager):
         if (isinstance(address, str) and not address.startswith("0x")) or not isinstance(
             address, str
         ):
-            try:
-                address = self.conversion_manager.convert(address, AddressType)
-            except ConversionError:
-                # Try to get the balance anyway; maybe the provider can handle it.
-                address = address
+            # Handles accounts, ENS, integers, aliases, everything.
+            address = self.account_manager.resolve_address(address)
 
         return self.provider.get_balance(address, block_id=block_id)
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -1004,3 +1004,33 @@ def test_call_sign_false(owner, vyper_contract_instance):
     tx = vyper_contract_instance.setNumber.as_transaction(5991)
     with pytest.raises(SignatureError):
         owner.call(tx, sign=False)
+
+
+def test_resolve(owner, keyfile_account, account_manager, vyper_contract_instance):
+    # Test test-account alias input.
+    actual = account_manager.resolve(owner.alias)
+    assert actual == owner.address
+
+    # Test keyfile-account alias input.
+    actual = account_manager.resolve(keyfile_account.alias)
+    assert actual == keyfile_account.address
+
+    # Test address input.
+    actual = account_manager.resolve(owner.address)
+    assert actual == owner.address
+
+    # Test account input.
+    actual = account_manager.resolve(owner)
+    assert actual == owner.address
+
+    # Test contract input.
+    actual = account_manager.resolve(vyper_contract_instance)
+    assert actual == vyper_contract_instance.address
+
+    # Test int input.
+    actual = account_manager.resolve(int(owner.address, 16))
+    assert actual == owner.address
+
+    # Test int input.
+    actual = account_manager.resolve(HexBytes(owner.address))
+    assert actual == owner.address

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -1006,31 +1006,31 @@ def test_call_sign_false(owner, vyper_contract_instance):
         owner.call(tx, sign=False)
 
 
-def test_resolve(owner, keyfile_account, account_manager, vyper_contract_instance):
+def test_resolve_address(owner, keyfile_account, account_manager, vyper_contract_instance):
     # Test test-account alias input.
-    actual = account_manager.resolve(owner.alias)
+    actual = account_manager.resolve_address(owner.alias)
     assert actual == owner.address
 
     # Test keyfile-account alias input.
-    actual = account_manager.resolve(keyfile_account.alias)
+    actual = account_manager.resolve_address(keyfile_account.alias)
     assert actual == keyfile_account.address
 
     # Test address input.
-    actual = account_manager.resolve(owner.address)
+    actual = account_manager.resolve_address(owner.address)
     assert actual == owner.address
 
     # Test account input.
-    actual = account_manager.resolve(owner)
+    actual = account_manager.resolve_address(owner)
     assert actual == owner.address
 
     # Test contract input.
-    actual = account_manager.resolve(vyper_contract_instance)
+    actual = account_manager.resolve_address(vyper_contract_instance)
     assert actual == vyper_contract_instance.address
 
     # Test int input.
-    actual = account_manager.resolve(int(owner.address, 16))
+    actual = account_manager.resolve_address(int(owner.address, 16))
     assert actual == owner.address
 
     # Test int input.
-    actual = account_manager.resolve(HexBytes(owner.address))
+    actual = account_manager.resolve_address(HexBytes(owner.address))
     assert actual == owner.address


### PR DESCRIPTION
### What I did

It is much easier to resolve ENS names from an active Ape console now:

```
(apedev13) ➜  ape git:(feat/resolve-account) ✗ ape console                           

In [1]: accounts.resolve("vitalik.eth")
Out[1]: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
```

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
