### PR TITLE
fix: show first 4 bytes of transaction data in signing string (instead of 3)

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -190,13 +190,13 @@ class TransactionAPI(BaseInterfaceModel):
             if isinstance(data["data"], str):
                 data["data"] = (
                     "0x"
-                    + bytes(data["data"][:3], encoding="utf8").hex()
+                    + bytes(data["data"][:4], encoding="utf8").hex()
                     + "..."
-                    + bytes(data["data"][-3:], encoding="utf8").hex()
+                    + bytes(data["data"][-4:], encoding="utf8").hex()
                 )
             else:
                 data["data"] = (
-                    to_hex(bytes(data["data"][:3])) + "..." + to_hex(bytes(data["data"][-3:]))
+                    to_hex(bytes(data["data"][:4])) + "..." + to_hex(bytes(data["data"][-4:]))
                 )
         else:
             if isinstance(data["data"], str):

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -71,6 +71,23 @@ def test_sign_message(signer, message):
     assert signer.check_signature(message, signature)
 
 
+def test_sign_transaction(signer, message, ethereum):
+    transaction = ethereum.create_transaction(nonce=0, max_fee=0, max_priority_fee=0)
+    signed_transaction = signer.sign_transaction(transaction)
+    assert signed_transaction.signature is not None
+
+
+def test_sign_transaction_using_keyfile_account(keyfile_account, message, ethereum, runner):
+    transaction = ethereum.create_transaction(
+        nonce=0, max_fee=0, max_priority_fee=0, data="0x21314135413451"
+    )
+
+    with runner.isolation(f"y\n{PASSPHRASE}\ny"):
+        signed_transaction = keyfile_account.sign_transaction(transaction)
+
+    assert signed_transaction.signature is not None
+
+
 def test_sign_string(signer):
     message = "Hello Apes!"
     signature = signer.sign_message(message)

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -307,6 +307,17 @@ def test_str_when_data_is_bytes(ethereum):
     assert isinstance(actual, str)
 
 
+def test_str_when_data_is_long_shows_first_4_bytes(vyper_contract_instance):
+    """
+    Tests against a condition that would cause transactions to
+    fail with string-encoding errors.
+    """
+    txn = vyper_contract_instance.setNumber.as_transaction(123)
+    actual = str(txn)
+    assert isinstance(actual, str)
+    assert "data: 0x30783366..." in actual
+
+
 def test_receipt_when_none(ethereum):
     txn = ethereum.create_transaction(data=HexBytes("0x123"))
     assert txn.receipt is None


### PR DESCRIPTION
### What I did

Transaction showed data like (3 bytes)

```
data: 0x307833...303762
```

but is now (4 bytes):

```
data: 0x30783334...30303762
```

fixes: #2519 

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
