### PR TITLE
fix: unnecessarily was using explorer when providing proxy info manually

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.1.2
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-breakpoint, flake8-print, flake8-pydantic, flake8-type-checking]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ force_grid_wrap = 0
 include_trailing_comma = true
 multi_line_output = 3
 use_parentheses = true
+skip = ["version.py"]
 
 [tool.mdformat]
 number = true

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ extras_require = {
         "types-toml",  # Needed due to mypy typeshed
         "types-SQLAlchemy>=1.4.49",  # Needed due to mypy typeshed
         "types-python-dateutil",  # Needed due to mypy typeshed
-        "flake8>=7.1.1,<8",  # Style linter
+        "flake8>=7.1.2,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
         "flake8-print>=4.0.1,<5",  # Detect print statements left in code
         "flake8-pydantic",  # For detecting issues with Pydantic models

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -472,6 +472,13 @@ def dummy_live_network(chain):
     chain.provider.network.name = original_network
 
 
+@pytest.fixture
+def dummy_live_network_with_explorer(dummy_live_network, mock_explorer):
+    dummy_live_network.__dict__["explorer"] = mock_explorer
+    yield dummy_live_network
+    dummy_live_network.__dict__.pop("explorer", None)
+
+
 @pytest.fixture(scope="session")
 def proxy_contract_container(get_contract_type):
     return ContractContainer(get_contract_type("proxy"))

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -314,19 +314,19 @@ def test_deploy_and_publish_live_network_no_explorer(owner, contract_container, 
 
 
 @explorer_test
-def test_deploy_and_publish(owner, contract_container, dummy_live_network, mock_explorer):
-    dummy_live_network.__dict__["explorer"] = mock_explorer
+def test_deploy_and_publish(
+    owner, contract_container, dummy_live_network_with_explorer, mock_explorer
+):
     contract = owner.deploy(contract_container, 0, publish=True, required_confirmations=0)
     mock_explorer.publish_contract.assert_called_once_with(contract.address)
-    dummy_live_network.__dict__["explorer"] = None
 
 
 @explorer_test
-def test_deploy_and_not_publish(owner, contract_container, dummy_live_network, mock_explorer):
-    dummy_live_network.__dict__["explorer"] = mock_explorer
+def test_deploy_and_not_publish(
+    owner, contract_container, dummy_live_network_with_explorer, mock_explorer
+):
     owner.deploy(contract_container, 0, publish=True, required_confirmations=0)
     assert not mock_explorer.call_count
-    dummy_live_network.__dict__["explorer"] = None
 
 
 def test_deploy_proxy(owner, vyper_contract_instance, proxy_contract_container, chain):

--- a/tests/functional/test_contract.py
+++ b/tests/functional/test_contract.py
@@ -85,12 +85,13 @@ def test_Contract_at_unknown_address(networks_connected_to_tester, address):
 
 
 def test_Contract_specify_contract_type(
-    solidity_contract_instance, vyper_contract_type, owner, networks_connected_to_tester
+    vyper_contract_instance, solidity_contract_type, owner, networks_connected_to_tester
 ):
-    # Vyper contract type is very close to solidity's.
+    # Solidity's contract type is very close to Vyper's.
     # This test purposely uses the other just to show we are able to specify it externally.
-    contract = Contract(solidity_contract_instance.address, contract_type=vyper_contract_type)
-    assert contract.address == solidity_contract_instance.address
-    assert contract.contract_type == vyper_contract_type
-    assert contract.setNumber(2, sender=owner)
-    assert contract.myNumber() == 2
+    contract = Contract(vyper_contract_instance.address, contract_type=solidity_contract_type)
+    assert contract.address == vyper_contract_instance.address
+
+    abis = [abi.name for abi in contract.contract_type.abi if hasattr(abi, "name")]
+    assert "setNumber" in abis  # Shared ABI.
+    assert "ACustomError" in abis  # SolidityContract-defined ABI.

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -55,18 +55,18 @@ def test_deploy_and_publish_live_network_no_explorer(owner, contract_container, 
         contract_container.deploy(0, sender=owner, publish=True, required_confirmations=0)
 
 
-def test_deploy_and_publish(owner, contract_container, dummy_live_network, mock_explorer):
-    dummy_live_network.__dict__["explorer"] = mock_explorer
+def test_deploy_and_publish(
+    owner, contract_container, dummy_live_network_with_explorer, mock_explorer
+):
     contract = contract_container.deploy(0, sender=owner, publish=True, required_confirmations=0)
     mock_explorer.publish_contract.assert_called_once_with(contract.address)
-    dummy_live_network.__dict__["explorer"] = None
 
 
-def test_deploy_and_not_publish(owner, contract_container, dummy_live_network, mock_explorer):
-    dummy_live_network.__dict__["explorer"] = mock_explorer
+def test_deploy_and_not_publish(
+    owner, contract_container, dummy_live_network_with_explorer, mock_explorer
+):
     contract_container.deploy(0, sender=owner, publish=False, required_confirmations=0)
     assert not mock_explorer.call_count
-    dummy_live_network.__dict__["explorer"] = None
 
 
 def test_deploy_privately(owner, contract_container):

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -10,6 +10,7 @@ from ape.exceptions import (
     ProjectError,
 )
 from ape_ethereum.ecosystem import ProxyType
+from tests.conftest import explorer_test
 
 
 def test_deploy(
@@ -55,6 +56,7 @@ def test_deploy_and_publish_live_network_no_explorer(owner, contract_container, 
         contract_container.deploy(0, sender=owner, publish=True, required_confirmations=0)
 
 
+@explorer_test
 def test_deploy_and_publish(
     owner, contract_container, dummy_live_network_with_explorer, mock_explorer
 ):
@@ -62,6 +64,7 @@ def test_deploy_and_publish(
     mock_explorer.publish_contract.assert_called_once_with(contract.address)
 
 
+@explorer_test
 def test_deploy_and_not_publish(
     owner, contract_container, dummy_live_network_with_explorer, mock_explorer
 ):

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -880,9 +880,9 @@ def test_value_to_non_payable_fallback_and_no_receive(
             break
 
     new_contract_type = ContractType.model_validate(contract_type_data)
-    contract = owner.chain_manager.contracts.instance_at(
-        vyper_fallback_contract.address, contract_type=new_contract_type
-    )
+    contract = owner.chain_manager.contracts.instance_at(vyper_fallback_contract.address)
+    contract.contract_type = new_contract_type  # Setting to completely override instead of merge.
+
     expected = (
         r"Contract's fallback is non-payable and there is no receive ABI\. Unable to send value\."
     )

--- a/tests/functional/test_contracts_cache.py
+++ b/tests/functional/test_contracts_cache.py
@@ -167,7 +167,7 @@ def test_cache_deployment_live_network(
     vyper_contract_container,
 ):
     # Arrange - Ensure the contract is not cached anywhere
-    address = vyper_contract_instance.addresstest_Contract_specify_contract_type
+    address = vyper_contract_instance.address
     contract_name = vyper_contract_instance.contract_type.name
     contract_types = chain.contracts.contract_types.memory
     chain.contracts.contract_types.memory = {

--- a/tests/functional/test_contracts_cache.py
+++ b/tests/functional/test_contracts_cache.py
@@ -167,7 +167,7 @@ def test_cache_deployment_live_network(
     vyper_contract_container,
 ):
     # Arrange - Ensure the contract is not cached anywhere
-    address = vyper_contract_instance.address
+    address = vyper_contract_instance.addresstest_Contract_specify_contract_type
     contract_name = vyper_contract_instance.contract_type.name
     contract_types = chain.contracts.contract_types.memory
     chain.contracts.contract_types.memory = {

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -716,6 +716,7 @@ def test_default_transaction_type_changed_at_class_level(ethereum):
 @pytest.mark.parametrize("network_name", (LOCAL_NETWORK_NAME, "mainnet-fork", "mainnet_fork"))
 def test_gas_limit_local_networks(ethereum, network_name):
     network = ethereum.get_network(network_name)
+    network.__dict__.pop("gas_limit", None)  # Refresh in case was changed in another test.
     assert network.gas_limit == "max"
 
 


### PR DESCRIPTION
### What I did

It seems to unnecessarily use the explorer when you provider the proxy manually and the contract type is already cached.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
