### PR TITLE
fix: `ape pm install` didn't show error in some cases

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -1248,12 +1248,12 @@ class DependencyManager(BaseManager):
             if allow_install:
                 try:
                     dependency.install(use_cache=use_cache, config_override=config_override)
-                except ProjectError:
+                except ProjectError as err:
                     # This dependency has issues. Let's wait to until the user
                     # actually requests something before failing, and
                     # yield an uninstalled version of the specified dependency for
                     # them to fix.
-                    pass
+                    logger.error(str(err))
 
             yield dependency
 

--- a/src/ape/utils/_github.py
+++ b/src/ape/utils/_github.py
@@ -150,11 +150,16 @@ class _GithubClient:
             except Exception as err:
                 raise ProjectError(f"Unknown repository '{repo_path}'") from err
 
-        else:
-            return self._repo_cache[repo_path]
+        return self._repo_cache[repo_path]
 
     def _get_repo(self, org_name: str, repo_name: str) -> dict:
-        return self._get(f"repos/{org_name}/{repo_name}")
+        try:
+            return self._get(f"repos/{org_name}/{repo_name}")
+        except HTTPError as err:
+            if err.response.status_code == 404:
+                raise ProjectError(f"Unknown repository '{org_name}/{repo_name}'")
+
+            raise  # The original HTTPError
 
     def get_latest_release(self, org_name: str, repo_name: str) -> dict:
         return self._get(f"repos/{org_name}/{repo_name}/releases/latest")
@@ -249,9 +254,9 @@ class _GithubClient:
                     )
                     return response.json()
 
-        else:
-            # Successful response status code!
-            return response.json()
+            raise  # Raise the error.
+
+        return response.json()
 
 
 github_client = _GithubClient()

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -217,7 +217,7 @@ def test_add_dependency_with_dependencies(project, with_dependencies_project_pat
     assert actual.version == "local"
 
 
-def test_get_project_dependencies(project, with_dependencies_project_path):
+def test_get_project_dependencies(project, ape_caplog):
     installed_package = {"name": "web3", "site_package": "web3"}
     not_installed_package = {
         "name": "apethisisnotarealpackageape",
@@ -226,11 +226,13 @@ def test_get_project_dependencies(project, with_dependencies_project_path):
     with project.temp_config(dependencies=[installed_package, not_installed_package]):
         dm = project.dependencies
         actual = list(dm.get_project_dependencies())
+        logs = ape_caplog.head
         assert len(actual) == 2
         assert actual[0].name == "web3"
         assert actual[0].installed
         assert actual[1].name == "apethisisnotarealpackageape"
         assert not actual[1].installed
+        assert "Dependency 'apethisisnotarealpackageape' not installed." in logs
 
 
 def test_install(project, mocker):


### PR DESCRIPTION
### What I did

if the HTTP returned 404 it was not showing anywhere for a few reasons

this is how i stupidly was configuring it:

```
dependencies:
  - name: aragon
    ref: 1.3.0
    github: git@github.com:aragon/osx.git
```

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
