### PR TITLE
fix(node): try up to 10 public nodes before failing random RPC method

### DIFF
--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -424,7 +424,7 @@ class Web3Provider(ProviderAPI, ABC):
         except KeyError:
             return None
 
-        def rpc_available(rpc_uri: str):
+        def rpc_available(rpc_uri: str) -> bool:
             try:
                 return Web3(HTTPProvider(rpc_uri)).is_connected()
 

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -420,9 +420,27 @@ class Web3Provider(ProviderAPI, ABC):
 
         # Use public RPC if available
         try:
-            return get_random_rpc(ecosystem, network)
+            rpc = get_random_rpc(ecosystem, network)
         except KeyError:
             return None
+
+        def rpc_available(rpc_uri: str):
+            try:
+                return Web3(HTTPProvider(rpc_uri)).is_connected()
+
+            except Exception:
+                return False
+
+        retries = 10
+        while retries > 0:
+            if rpc_available(rpc):
+                return rpc
+
+            rpc = get_random_rpc(ecosystem, network)
+            logger.warning(f"RPC at '{rpc}' not available, retrying {retries} more times")
+            retries -= 1
+
+        return None
 
     @property
     def client_version(self) -> str:

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -118,7 +118,7 @@ def test_uri_non_dev_and_not_configured(mocker, ethereum):
         _ = provider.uri
 
     # Show that if an evm-chains _does_ exist, it will use that.
-    patch = mocker.patch("ape_ethereum.provider.get_random_rpc")
+    patch = mocker.patch("ape_ethereum.provider.Web3Provider._get_random_rpc")
 
     # The following URL is made up (please keep example.com).
     expected = "https://gorillas.example.com/v1/rpc"


### PR DESCRIPTION
### What I did

Ape will now retry up to 10 times before failing to find an RPC using the random public RPC feature

fixes: #2533 

### How I did it

Connect and make sure it is available before giving up

### How to verify it

```sh
$ ape console --network :mainnet:node
WARNING:  RPC at 'https://rpc.mevblocker.io/noreverts' not available, retrying 10 more times
INFO:     Connecting to a 'mevblocker' node.
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
~~- [ ] Documentation is complete~~
