### PR TITLE
feat(query): add partial query solver engine

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
         "lazyasd>=0.1.4",
         "asttokens>=2.4.1,<3",  # Peer dependency; w/o pin container build fails.
         "cchecksum>=0.0.3,<1",
+        "more-itertools; python_version<'3.10'",  # backport for `itertools.pairwise`
         "narwhals>=1.29,<2",
         "packaging>=23.0,<24",
         "pluggy>=1.3,<2",

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ extras_require = {
         "pytest-timeout>=2.2.0,<3",  # For avoiding timing out during tests
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
         "hypothesis-jsonschema==0.19.0",  # JSON Schema fuzzer extension
+        "pandas",  # Needed to test w/ narwhals
     ],
     "lint": [
         "ruff>=0.10.0",  # Unified linter and formatter
@@ -92,10 +93,8 @@ setup(
         "lazyasd>=0.1.4",
         "asttokens>=2.4.1,<3",  # Peer dependency; w/o pin container build fails.
         "cchecksum>=0.0.3,<1",
-        # Pandas peer-dep: Numpy 2.0 causes issues for some users.
-        "numpy<2",
+        "narwhals>=1.29,<2",
         "packaging>=23.0,<24",
-        "pandas>=2.2.2,<3",
         "pluggy>=1.3,<2",
         "pydantic>=2.10.0,<3",
         "pydantic-settings>=2.5.2,<3",

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from collections.abc import Iterator, Sequence
 from functools import cache, cached_property
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, Optional, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Optional, TypeVar, Union
 
 from ethpm_types.abi import EventABI, MethodABI
 from pydantic import NonNegativeInt, PositiveInt, field_validator, model_validator
@@ -16,8 +16,8 @@ from .providers import BlockAPI
 from .transactions import ReceiptAPI, TransactionAPI
 
 if TYPE_CHECKING:
+    from narwhals import Implementation as DataframeImplementation
     from narwhals.typing import Frame
-    from narwhals.typing import Implementation as DataframeImplementation
 
     from ape.managers.query import QueryResult
 
@@ -104,7 +104,7 @@ ModelType = TypeVar("ModelType", bound=BaseInterfaceModel)
 
 
 class _BaseQuery(BaseModel, Generic[ModelType]):
-    Model: ClassVar[Optional[Type[BaseInterfaceModel]]] = None
+    Model: ClassVar[Optional[type[BaseInterfaceModel]]] = None
 
     columns: set[str]
 

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -16,6 +16,7 @@ from .transactions import ReceiptAPI, TransactionAPI
 
 if TYPE_CHECKING:
     from narwhals.typing import Frame
+    from narwhals.typing import Implementation as DataframeImplementation
 
     from ape.managers.query import QueryResult
 
@@ -376,7 +377,7 @@ class BaseCursorAPI(BaseInterfaceModel, Generic[QueryType, ModelType]):
 
     # Conversion out to fulfill user query requirements
     @abstractmethod
-    def as_dataframe(self, backend: str) -> "Frame":
+    def as_dataframe(self, backend: "DataframeImplementation") -> "Frame":
         """
         Execute and return this Cursor as a `~narwhals.v1.DataFrame` or `~narwhals.v1.LazyFrame`
         object. The use of `backend is exactly as it is mentioned in the `narwhals` documentation:
@@ -387,8 +388,8 @@ class BaseCursorAPI(BaseInterfaceModel, Generic[QueryType, ModelType]):
         https://narwhals-dev.github.io/narwhals/api-reference/narwhals/#narwhals.from_dict
 
         Args:
-            backend (str): A Narwhals-compatible backend specifier. See:
-                https://narwhals-dev.github.io/narwhals/api-reference/implementation/
+            backend (:object:`~narwhals.Implementation): A Narwhals-compatible backend specifier.
+                See: https://narwhals-dev.github.io/narwhals/api-reference/implementation/
 
         Returns:
             (`~narwhals.v1.DataFrame` | `~narwhals.v1.LazyFrame`): A narwhals dataframe.

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -333,8 +333,8 @@ class BaseCursorAPI(BaseInterfaceModel, Generic[QueryType, ModelType]):
     @abstractmethod
     def shrink(
         self,
-        start_index: int | None = None,
-        end_index: int | None = None,
+        start_index: Optional[int] = None,
+        end_index: Optional[int] = None,
     ) -> "Self":
         """
         Create a copy of this object with the query window shrunk inwards to `start_index` and/or

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from collections.abc import Iterator, Sequence
 from functools import cache, cached_property
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, Optional, Self, TypeVar, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Optional, TypeVar, Union
 
 from ethpm_types.abi import EventABI, MethodABI
 from pydantic import NonNegativeInt, PositiveInt, field_validator, model_validator
@@ -18,6 +18,12 @@ if TYPE_CHECKING:
     from narwhals.typing import Frame
 
     from ape.managers.query import QueryResult
+
+    try:
+        # Only on Python 3.11
+        from typing import Self  # type: ignore
+    except ImportError:
+        from typing_extensions import Self  # type: ignore
 
 
 @cache

--- a/src/ape/api/query.py
+++ b/src/ape/api/query.py
@@ -136,6 +136,7 @@ class BlockTransactionQuery(_BaseQuery):
     """
 
     block_id: Any
+    num_transactions: NonNegativeInt
 
 
 class AccountTransactionQuery(_BaseQuery):

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterator
 from functools import cached_property, singledispatchmethod
 from itertools import islice
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import click
 import narwhals.stable.v1 as nw
@@ -677,6 +677,12 @@ class ContractEvent(BaseInterfaceModel):
         for log in contract_events:
             for column in data:
                 data[column].append(getattr(log, column))
+
+        if backend is None:
+            backend = cast(nw.Implementation, self.config_manager.query.backend)
+
+        elif isinstance(backend, str):
+            backend = nw.Implementation.from_backend(backend)
 
         return nw.from_dict(data=data, backend=backend)
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -619,8 +619,7 @@ class ContractEvent(BaseInterfaceModel):
         stop_block: Optional[int] = None,
         step: int = 1,
         engine_to_use: Optional[str] = None,
-        # TODO: add support to source this from Config
-        backend: str = "pandas",
+        backend: Union[str, nw.Implementation, None] = None,
     ) -> "Frame":
         """
         Iterate through blocks for log events
@@ -636,6 +635,8 @@ class ContractEvent(BaseInterfaceModel):
               Defaults to ``1``.
             engine_to_use (Optional[str]): query engine to use, bypasses query
               engine selection algorithm.
+            backend (Union[:object:`~narwhals.Implementation, str None]): A Narwhals-compatible
+                backend. See: https://narwhals-dev.github.io/narwhals/api-reference/implementation
 
         Returns:
             :class:`~narwhals.typing.Frame`

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -119,8 +119,7 @@ class BlockContainer(BaseManager):
         stop_block: Optional[int] = None,
         step: int = 1,
         engine_to_use: Optional[str] = None,
-        # TODO: add support to source this from Config
-        backend: str = "pandas",
+        backend: Union[str, nw.Implementation, None] = None,
     ) -> "Frame":
         """
         A method for querying blocks and returning an Iterator. If you
@@ -142,6 +141,8 @@ class BlockContainer(BaseManager):
               Defaults to ``1``.
             engine_to_use (Optional[str]): query engine to use, bypasses query
               engine selection algorithm.
+            backend (Union[:object:`~narwhals.Implementation, str None]): A Narwhals-compatible
+                backend. See: https://narwhals-dev.github.io/narwhals/api-reference/implementation
 
         Returns:
             :class:`~narwhals.typing.Frame`
@@ -353,8 +354,7 @@ class AccountHistory(BaseInterfaceModel):
         start_nonce: int = 0,
         stop_nonce: Optional[int] = None,
         engine_to_use: Optional[str] = None,
-        # TODO: add support to source this from Config
-        backend: str = "pandas",
+        backend: Union[str, nw.Implementation, None] = None,
     ) -> "Frame":
         """
         A method for querying transactions made by an account and returning an Iterator.
@@ -374,6 +374,8 @@ class AccountHistory(BaseInterfaceModel):
               in the query. Defaults to the latest transaction.
             engine_to_use (Optional[str]): query engine to use, bypasses query
               engine selection algorithm.
+            backend (Union[:object:`~narwhals.Implementation, str None]): A Narwhals-compatible
+                backend. See: https://narwhals-dev.github.io/narwhals/api-reference/implementation
 
         Returns:
             :class:`~narwhals.typing.Frame`

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -179,6 +179,12 @@ class BlockContainer(BaseManager):
             for column in data:
                 data[column].append(getattr(block, column))
 
+        if backend is None:
+            backend = cast(nw.Implementation, self.config_manager.query.backend)
+
+        elif isinstance(backend, str):
+            backend = nw.Implementation.from_backend(backend)
+
         return nw.from_dict(data=data, backend=backend)
 
     def range(
@@ -409,6 +415,12 @@ class AccountHistory(BaseInterfaceModel):
         for txn in txns:
             for column in data:
                 data[column].append(getattr(txn, column))
+
+        if backend is None:
+            backend = cast(nw.Implementation, self.config_manager.query.backend)
+
+        elif isinstance(backend, str):
+            backend = nw.Implementation.from_backend(backend)
 
         return nw.from_dict(data=data, backend=backend)
 

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -287,14 +287,14 @@ class QueryResult(BaseCursorAPI[ModelType]):
                 cursor.total_time,
                 "seconds",
             )
-            assert (
-                cursor.query.start_index == current_pos
-            ), f"Cursor {i} starts at {cursor.query.start_index}, expected {current_pos}"
+            assert cursor.query.start_index == current_pos, (
+                f"Cursor {i} starts at {cursor.query.start_index}, expected {current_pos}"
+            )
             current_pos = cursor.query.end_index + 1
 
-        assert (
-            current_pos == self.query.end_index + 1
-        ), f"Coverage ended at {current_pos - 1}, expected {self.query.end_index}"
+        assert current_pos == self.query.end_index + 1, (
+            f"Coverage ended at {current_pos - 1}, expected {self.query.end_index}"
+        )
 
         return self
 
@@ -386,7 +386,6 @@ class QueryManager(ManagerAccessMixin):
         #       (resolves corner case when `query.start_index` == `query.end_index`)
         last_best_cursor = min(all_cursors, key=lambda c: (c.query, c.total_time))
         for start_index, end_index in pairwise(query_segments):
-
             lowest_unit_time = float("inf")
             best_cursor = None
             for cursor in all_cursors:

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -4,7 +4,7 @@ import time
 from collections.abc import Iterator
 from functools import cached_property, singledispatchmethod
 from itertools import pairwise, tee
-from typing import TYPE_CHECKING, Optional, Self
+from typing import TYPE_CHECKING, Optional
 
 import narwhals as nw
 from pydantic import model_validator
@@ -34,13 +34,19 @@ if TYPE_CHECKING:
 
     from ape.api.providers import BlockAPI
 
+    try:
+        # Only on Python 3.11
+        from typing import Self  # type: ignore
+    except ImportError:
+        from typing_extensions import Self  # type: ignore
+
 
 class _RpcCursor(BaseCursorAPI):
     def shrink(
         self,
         start_index: int | None = None,
         end_index: int | None = None,
-    ) -> Self:
+    ) -> "Self":
         copy = self.model_copy(deep=True)
 
         if start_index is not None:
@@ -90,7 +96,7 @@ class _RpcBlockTransactionCursor(_RpcCursor):
         self,
         start_index: int | None = None,
         end_index: int | None = None,
-    ) -> Self:
+    ) -> "Self":
         if (start_index and start_index != 0) or (
             end_index and end_index != self.query.num_transactions
         ):
@@ -130,7 +136,7 @@ class _RpcAccountTransactionCursor(_RpcCursor):
         self,
         start_index: int | None = None,
         end_index: int | None = None,
-    ) -> Self:
+    ) -> "Self":
         copy = self.model_copy(deep=True)
 
         if start_index is not None:
@@ -284,7 +290,7 @@ class QueryResult(BaseCursorAPI):
         return self
 
     # TODO: Move to `BaseCursorAPI` and don't have `@abstractmethod`?
-    def shrink(self, start_index: int | None = None, end_index: int | None = None) -> Self:
+    def shrink(self, start_index: int | None = None, end_index: int | None = None) -> "Self":
         raise NotImplementedError
 
     @property

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -52,8 +52,8 @@ if TYPE_CHECKING:
 class _RpcCursor(BaseCursorAPI):
     def shrink(
         self,
-        start_index: int | None = None,
-        end_index: int | None = None,
+        start_index: Optional[int] = None,
+        end_index: Optional[int] = None,
     ) -> "Self":
         copy = self.model_copy(deep=True)
 
@@ -102,8 +102,8 @@ class _RpcBlockTransactionCursor(_RpcCursor):
     # TODO: Move to default implementation in `BaseCursorAPI`? (remove `@abstractmethod`)
     def shrink(
         self,
-        start_index: int | None = None,
-        end_index: int | None = None,
+        start_index: Optional[int] = None,
+        end_index: Optional[int] = None,
     ) -> "Self":
         if (start_index and start_index != 0) or (
             end_index and end_index != self.query.num_transactions
@@ -142,8 +142,8 @@ class _RpcAccountTransactionCursor(_RpcCursor):
 
     def shrink(
         self,
-        start_index: int | None = None,
-        end_index: int | None = None,
+        start_index: Optional[int] = None,
+        end_index: Optional[int] = None,
     ) -> "Self":
         copy = self.model_copy(deep=True)
 
@@ -299,7 +299,11 @@ class QueryResult(BaseCursorAPI):
         return self
 
     # TODO: Move to `BaseCursorAPI` and don't have `@abstractmethod`?
-    def shrink(self, start_index: int | None = None, end_index: int | None = None) -> "Self":
+    def shrink(
+        self,
+        start_index: Optional[int] = None,
+        end_index: Optional[int] = None,
+    ) -> "Self":
         raise NotImplementedError
 
     @property

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -3,7 +3,7 @@ import os
 import time
 from collections.abc import Iterator
 from functools import cached_property, singledispatchmethod
-from itertools import pairwise, tee
+from itertools import tee
 from typing import TYPE_CHECKING, Optional, Union, cast
 
 import narwhals as nw
@@ -28,6 +28,14 @@ from ape.exceptions import QueryEngineError
 from ape.logging import logger
 from ape.plugins._utils import clean_plugin_name
 from ape.utils.basemodel import ManagerAccessMixin
+
+try:
+    from itertools import pairwise
+
+except ImportError:
+    # TODO: Remove when 3.9 dropped (`itertools.pairwise` introduced in 3.10)
+    from more_itertools import pairwise  # type: ignore[no-redef,assignment]
+
 
 if TYPE_CHECKING:
     from narwhals.typing import Frame

--- a/src/ape/managers/query.py
+++ b/src/ape/managers/query.py
@@ -1,17 +1,25 @@
 import difflib
+import os
 import time
 from collections.abc import Iterator
 from functools import cached_property, singledispatchmethod
-from itertools import tee
-from typing import Optional
+from itertools import pairwise, tee
+from typing import TYPE_CHECKING, Optional, Self
 
+import narwhals as nw
+from pydantic import model_validator
+
+# TODO: Switch to `import narwhals.v1 as nw` per narwhals documentation
 from ape.api.query import (
     AccountTransactionQuery,
+    BaseCursorAPI,
     BaseInterfaceModel,
     BlockQuery,
     BlockTransactionQuery,
     ContractEventQuery,
+    ModelType,
     QueryAPI,
+    QueryEngineAPI,
     QueryType,
 )
 from ape.api.transactions import ReceiptAPI, TransactionAPI
@@ -21,16 +29,163 @@ from ape.logging import logger
 from ape.plugins._utils import clean_plugin_name
 from ape.utils.basemodel import ManagerAccessMixin
 
+if TYPE_CHECKING:
+    from narwhals.typing import Frame
 
-class DefaultQueryProvider(QueryAPI):
+    from ape.api.providers import BlockAPI
+
+
+class _RpcCursor(BaseCursorAPI):
+    def shrink(
+        self,
+        start_index: int | None = None,
+        end_index: int | None = None,
+    ) -> Self:
+        copy = self.model_copy(deep=True)
+
+        if start_index is not None:
+            copy.query.start_block = start_index
+
+        if end_index is not None:
+            copy.query.stop_block = end_index
+
+        return copy
+
+    @property
+    def total_time(self) -> float:
+        return self.time_per_row * (1 + self.query.end_index - self.query.start_index)
+
+    @property
+    def time_per_row(self) -> float:
+        # NOTE: Very loose estimate of 100ms per item
+        return 0.1  # seconds
+
+    def as_dataframe(self, backend: str) -> "Frame":
+        data: dict[str, list] = {column: [] for column in self.query.columns}
+
+        for item in self.as_model_iter():
+            for column in data:
+                data[column] = getattr(item, column)
+
+        return nw.from_dict(data, backend=backend)
+
+
+class _RpcBlockCursor(_RpcCursor):
+    query: BlockQuery
+
+    def as_model_iter(self) -> Iterator["BlockAPI"]:
+        return map(
+            self.provider.get_block,
+            # NOTE: the range stop block is a non-inclusive stop.
+            #       Where the query method is an inclusive stop.
+            range(self.query.start_block, self.query.stop_block + 1, self.query.step),
+        )
+
+
+class _RpcBlockTransactionCursor(_RpcCursor):
+    query: BlockTransactionQuery
+
+    # TODO: Move to default implementation in `BaseCursorAPI`? (remove `@abstractmethod`)
+    def shrink(
+        self,
+        start_index: int | None = None,
+        end_index: int | None = None,
+    ) -> Self:
+        if (start_index and start_index != 0) or (
+            end_index and end_index != self.query.num_transactions
+        ):
+            # NOTE: Not possible to shrink this query (also, should never need to be shrunk unless
+            #       different Engines mismatch block on number of transactions in block)
+            raise NotImplementedError
+
+        return self
+
+    def as_model_iter(self) -> Iterator[TransactionAPI]:
+        if self.query.num_transactions > 0:
+            yield from self.provider.get_transactions_by_block(self.query.block_id)
+
+
+class _RpcContractEventCursor(_RpcCursor):
+    query: ContractEventQuery
+
+    def as_model_iter(self) -> Iterator[ContractLog]:
+        addresses = self.query.contract
+        if not isinstance(addresses, list):
+            addresses = [self.query.contract]  # type: ignore
+
+        log_filter = LogFilter.from_event(
+            event=self.query.event,
+            search_topics=self.query.search_topics,
+            addresses=addresses,
+            start_block=self.query.start_block,
+            stop_block=self.query.stop_block,
+        )
+        return self.provider.get_contract_logs(log_filter)
+
+
+class _RpcAccountTransactionCursor(_RpcCursor):
+    query: AccountTransactionQuery
+
+    def shrink(
+        self,
+        start_index: int | None = None,
+        end_index: int | None = None,
+    ) -> Self:
+        copy = self.model_copy(deep=True)
+
+        if start_index is not None:
+            copy.query.start_nonce = start_index
+
+        if end_index is not None:
+            copy.query.stop_nonce = end_index
+
+        return copy
+
+    @property
+    def time_per_row(self) -> float:
+        # NOTE: Extremely expensive query, involves binary search of all blocks in a chain
+        #       Very loose estimate of 5s per transaction for this query.
+        return 5.0
+
+    def as_model_iter(self) -> Iterator[TransactionAPI]:
+        yield from self.provider.get_transactions_by_account_nonce(
+            self.query.account, self.query.start_nonce, self.query.stop_nonce
+        )
+
+
+class DefaultQueryProvider(QueryEngineAPI):
     """
-    Default implementation of the :class:`~ape.api.query.QueryAPI`.
+    Default implementation of the :class:`~ape.api.query.QueryEngineAPI`.
     Allows for the query of blockchain data using connected provider.
     """
 
     def __init__(self):
+        # TODO: What is this for?
         self.supports_contract_creation = None
 
+    @QueryEngineAPI.exec.register
+    def exec_block_query(self, query: BlockQuery) -> Iterator[_RpcBlockCursor]:
+        yield _RpcBlockCursor(query=query)
+
+    @QueryEngineAPI.exec.register
+    def exec_block_transaction_query(
+        self, query: BlockTransactionQuery
+    ) -> Iterator[_RpcBlockTransactionCursor]:
+        yield _RpcBlockTransactionCursor(query=query)
+
+    @QueryEngineAPI.exec.register
+    def exec_contract_event_query(
+        self, query: ContractEventQuery
+    ) -> Iterator[_RpcContractEventCursor]:
+        yield _RpcContractEventCursor(query=query)
+
+    @QueryEngineAPI.exec.register
+    def exec_account_transaction_query(
+        self, query: AccountTransactionQuery
+    ) -> Iterator[_RpcAccountTransactionCursor]:
+        yield _RpcAccountTransactionCursor(query=query)
+
+    # TODO: Remove below in v0.9
     @singledispatchmethod
     def estimate_query(self, query: QueryType) -> Optional[int]:  # type: ignore
         return None  # can't handle this query
@@ -99,6 +254,57 @@ class DefaultQueryProvider(QueryAPI):
         )
 
 
+class QueryResult(BaseCursorAPI):
+    cursors: list[BaseCursorAPI]
+
+    @model_validator(mode="after")
+    def validate_coverage(self):
+        # NOTE: This is done to assert that we have full coverage of queries during testing
+        #       (both testing Core and in 2nd/3rd party plugins)
+        current_pos = self.query.start_index
+        for i, cursor in enumerate(self.cursors):
+            logger.debug(
+                "Start:",
+                cursor.query.start_index,
+                "End:",
+                cursor.query.end_index,
+                "Total:",
+                cursor.total_time,
+                "seconds",
+            )
+            assert (
+                cursor.query.start_index == current_pos
+            ), f"Cursor {i} starts at {cursor.query.start_index}, expected {current_pos}"
+            current_pos = cursor.query.end_index + 1
+
+        assert (
+            current_pos == self.query.end_index + 1
+        ), f"Coverage ended at {current_pos - 1}, expected {self.query.end_index}"
+
+        return self
+
+    # TODO: Move to `BaseCursorAPI` and don't have `@abstractmethod`?
+    def shrink(self, start_index: int | None = None, end_index: int | None = None) -> Self:
+        raise NotImplementedError
+
+    @property
+    def total_time(self) -> float:
+        return sum(c.total_time for c in self.cursors)
+
+    @property
+    def time_per_row(self) -> float:
+        return self.total_time / sum(len(c.query) for c in self.cursors)
+
+    # Conversion out to fulfill user query requirements
+    def as_dataframe(self, backend: str = "pandas") -> "Frame":
+        # TODO: Source `backend` from core `query:` config if defaulted to `None`
+        return nw.concat([c.as_dataframe(backend=backend) for c in self.cursors], how="vertical")
+
+    def as_model_iter(self) -> Iterator[ModelType]:
+        for result in self.cursors:
+            yield from result.as_model_iter()
+
+
 class QueryManager(ManagerAccessMixin):
     """
     A singleton that manages query engines and performs queries.
@@ -132,6 +338,109 @@ class QueryManager(ManagerAccessMixin):
     def _suggest_engines(self, engine_selection):
         return difflib.get_close_matches(engine_selection, list(self.engines), cutoff=0.6)
 
+    def _solve_optimal_coverage(
+        self,
+        query: QueryType,
+        all_cursors: list[BaseCursorAPI],
+    ) -> Iterator[BaseCursorAPI]:
+        # NOTE: Use this to reduce the amount of brute force iteration over query window
+        query_segments = sorted(
+            set(
+                [c.query.start_index for c in all_cursors]
+                + [c.query.end_index for c in all_cursors]
+            )
+        )
+
+        # Find the best cursor that fits each path segment in `cursor_to_use`
+        # NOTE: Prime these variables for every time "best cursor" gets yielded
+        last_start_index = query.start_index
+        # NOTE: Start with smallest cursor by coverage and total time
+        #       (resolves corner case when `query.start_index` == `query.end_index`)
+        last_best_cursor = min(all_cursors, key=lambda c: (c.query, c.total_time))
+        for start_index, end_index in pairwise(query_segments):
+
+            lowest_unit_time = float("inf")
+            best_cursor = None
+            for cursor in all_cursors:
+                # NOTE: Cursor window must at least contain path segment
+                if cursor.query.start_index <= start_index and cursor.query.end_index >= end_index:
+                    # NOTE: Allow cursor to use previous segment(s) if it was the last best
+                    #       since time should typically be better with larger coverage
+                    shrunk_cursor = cursor.shrink(
+                        start_index=(
+                            last_start_index
+                            if last_best_cursor and last_best_cursor is cursor
+                            else start_index
+                        )
+                    )
+                    if shrunk_cursor.time_per_row < lowest_unit_time:
+                        lowest_unit_time = shrunk_cursor.time_per_row
+                        # NOTE: Save original cursor to shrink later (not shrunk one)
+                        best_cursor = cursor
+
+            if best_cursor is None:
+                # NOTE: `AssertionError` because this should not be possible due to RPC engine
+                raise AssertionError(
+                    f"Could not solve, missing coverage in window [{start_index}:{end_index}]."
+                )
+            logger.debug(f"Best cursor for segment [{start_index}:{end_index}]: {best_cursor}")
+
+            if last_best_cursor is None:
+                # NOTE: Should only execute first time
+                last_best_cursor = best_cursor
+
+            elif last_best_cursor != best_cursor:
+                # NOTE: Yield whatever the last "best cursor" was,
+                #       shrunk up to just before current segment
+                yield last_best_cursor.shrink(
+                    start_index=last_start_index,
+                    end_index=start_index - 1,
+                )
+                # NOTE: Update our yield variables for next time
+                last_start_index = start_index
+                last_best_cursor = best_cursor
+
+            # else: last best is also current best, keep iterating until better one is found
+
+        # NOTE: Always yield last best after loop ends, which contain the final part of query
+        assert last_best_cursor, "This shouldn't happen best >2 endpoints exist"  # mypy happy
+        yield last_best_cursor.shrink(start_index=last_start_index)
+
+    def _experimental_query(
+        self, query: QueryType, engine_to_use: Optional[str] = None
+    ) -> QueryResult:
+        if not engine_to_use:
+            # Sort by earliest point in cursor window (then by longest coverage if same start)
+            # NOTE: We will iterate over this >1 times, so collect our iterator here
+            all_cursors = sorted(
+                (c for engine in self.engines.values() for c in engine.exec(query)),
+                key=lambda c: c.query,
+            )
+
+        elif selected_engine := self.engines.get(engine_to_use):
+            all_cursors = list(selected_engine.exec(query))
+
+        else:
+            raise QueryEngineError(
+                f"Query engine `{engine_to_use}` not found. "
+                f"Did you mean {' or '.join(self._suggest_engines(engine_to_use))}?"
+            )
+
+        logger.debug("Sorted cursors:\n  " + "\n  ".join(map(str, all_cursors)))
+        result = QueryResult(
+            query=query,
+            cursors=list(self._solve_optimal_coverage(query, all_cursors)),
+        )
+
+        # TODO: Execute in background thread when async support introduced
+        for engine_name, engine in self.engines.items():
+            logger.debug(f"Caching w/ '{engine_name}' ...")
+            engine.cache(result)
+            logger.debug(f"Caching done for '{engine_name}'")
+
+        return result
+
+    # TODO: Replace `.query` with `._experimental_query` and remove this in v0.9
     def query(
         self,
         query: QueryType,
@@ -150,6 +459,8 @@ class QueryManager(ManagerAccessMixin):
         Returns:
             Iterator[``BaseInterfaceModel``]
         """
+        if os.environ.get("APE_ENABLE_EXPERIMENTAL_QUERY_BACKEND", False):
+            return self._experimental_query(query, engine_to_use=engine_to_use).as_model_iter()
 
         if engine_to_use:
             if engine_to_use not in self.engines:

--- a/src/ape_cache/query.py
+++ b/src/ape_cache/query.py
@@ -1,30 +1,60 @@
 from collections.abc import Iterator
 from functools import singledispatchmethod
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import create_engine, func
-from sqlalchemy.engine import CursorResult
-from sqlalchemy.sql import column, insert, select
-from sqlalchemy.sql.expression import Insert, Select
+import narwhals as nw
 
 from ape.api.providers import BlockAPI
-from ape.api.query import (
-    BaseInterfaceModel,
-    BlockQuery,
-    BlockTransactionQuery,
-    ContractEventQuery,
-    QueryEngineAPI,
-    QueryType,
-)
-from ape.api.transactions import TransactionAPI
+from ape.api.query import BaseInterfaceModel, BlockQuery, CursorAPI, QueryEngineAPI, QueryType
 from ape.exceptions import QueryEngineError
-from ape.logging import logger
-from ape.types.events import ContractLog
-from ape.utils.misc import LOCAL_NETWORK_NAME
 
-from . import models
-from .models import Blocks, ContractEvents, Transactions
+if TYPE_CHECKING:
+    from narwhals.typing import Frame
+
+    try:
+        # Only on Python 3.11
+        from typing import Self  # type: ignore
+    except ImportError:
+        from typing_extensions import Self  # type: ignore
+
+
+class _BaseCursor(CursorAPI):
+    cache_folder: Path
+
+    @property
+    def total_time(self) -> float:
+        return (self.query.end_index - self.query.start_index) * (self.time_per_row)
+
+    @property
+    def time_per_row(self) -> float:
+        return 0.01  # 10ms per row to parse file w/ Pydantic
+
+
+class BlockCursor(_BaseCursor):
+    query: BlockQuery
+
+    def shrink(self, start_index: Optional[int] = None, end_index: Optional[int] = None) -> "Self":
+        copy = self.model_copy(deep=True)
+
+        if start_index is not None:
+            copy.query.start_block = start_index
+
+        if end_index is not None:
+            copy.query.stop_block = end_index
+
+        return copy
+
+    def as_dataframe(self, backend: nw.Implementation) -> "Frame":
+        return super().as_dataframe(backend)
+
+    def as_model_iter(self) -> Iterator[BlockAPI]:
+        block_index_folder = self.cache_folder / ".number"
+        for block_number in range(self.query.start_block, self.query.stop_block + 1):
+            yield from map(
+                self.provider.network.ecosystem.block_class.model_validate_json,
+                (block_index_folder / str(block_number)).read_text(),
+            )
 
 
 class CacheQueryProvider(QueryEngineAPI):
@@ -33,68 +63,50 @@ class CacheQueryProvider(QueryEngineAPI):
     Allows for the query of blockchain data using a connected provider.
     """
 
-    # Class var for tracking if we detect a scenario where the cache db isn't working
-    database_bypass = False
+    exec = singledispatchmethod(QueryEngineAPI.exec)
 
-    def _get_database_file(self, ecosystem_name: str, network_name: str) -> Path:
-        """
-        Allows us to figure out what the file *will be*, mostly used for database management.
-
-        Args:
-            ecosystem_name (str): Name of the ecosystem to store data for (ex: ethereum)
-            network_name (str): name of the network to store data for (ex: mainnet)
-
-        Raises:
-            :class:`~ape.exceptions.QueryEngineError`: If a local network is provided.
-        """
-
-        if network_name == LOCAL_NETWORK_NAME:
-            # NOTE: no need to cache local network, no use for data
-            raise QueryEngineError("Cannot cache local data")
-
-        if "-fork" in network_name:
-            # NOTE: send query to pull from upstream
-            network_name = network_name.replace("-fork", "")
-
-        return self.config_manager.DATA_FOLDER / ecosystem_name / network_name / "cache.db"
-
-    def _get_sqlite_uri(self, database_file: Path) -> str:
-        """
-        Gets a string for the sqlite db URI.
-
-        Args:
-            database_file (`pathlib.Path`): A path to the database file.
-
-        Returns:
-            str
-        """
-
-        return f"sqlite:///{database_file}"
-
-    def init_database(self, ecosystem_name: str, network_name: str):
-        """
-        Initialize the SQLite database for caching of provider data.
-
-        Args:
-            ecosystem_name (str): Name of the ecosystem to store data for (ex: ethereum)
-            network_name (str): name of the network to store data for (ex: mainnet)
-
-        Raises:
-            :class:`~ape.exceptions.QueryEngineError`: When the database has not been initialized
-        """
-
-        database_file = self._get_database_file(ecosystem_name, network_name)
-        if database_file.is_file():
-            raise QueryEngineError("Database has already been initialized")
-
-        # NOTE: Make sure database folder location has been created
-        database_file.parent.mkdir(exist_ok=True, parents=True)
-
-        models.Base.metadata.create_all(  # type: ignore
-            bind=create_engine(self._get_sqlite_uri(database_file), pool_pre_ping=True)
+    def cache_folder(self) -> Path:
+        return (
+            self.config_manager.DATA_FOLDER
+            / self.provider.network.ecosystem.name
+            / self.provider.network.name
         )
 
-    def purge_database(self, ecosystem_name: str, network_name: str):
+    def find_ranges(
+        self, index_folder: Path, start: int = 0, end: int = -1
+    ) -> Iterator[tuple[int, int]]:
+        all_indices = sorted(int(p.name) for p in index_folder.glob("*"))
+        last_index = max(start, min(all_indices))
+
+        for index in all_indices:
+            if index <= last_index:
+                continue  # NOTE: Skip past `last_index`
+
+            elif end != -1 and index >= end:
+                # NOTE: Yield last range in `[start, end]`
+                yield start, end
+                break
+
+            elif index - last_index > 1:
+                # NOTE: Gap identified
+                yield start, last_index
+                start = index
+
+            last_index = index
+
+    @exec.register
+    def exec_block_query(self, query: BlockQuery) -> Iterator[BlockCursor]:
+        if not (block_folder := self.cache_folder() / "blocks").exists():
+            return
+
+        for block_range in self.find_ranges(
+            block_folder / ".number",
+            start=query.start_block,
+            end=query.stop_block,
+        ):
+            yield BlockCursor(query=query, cache_folder=block_folder).shrink(*block_range)
+
+    def prune_database(self, ecosystem_name: str, network_name: str):
         """
         Removes the SQLite database file from disk.
 
@@ -106,373 +118,12 @@ class CacheQueryProvider(QueryEngineAPI):
             :class:`~ape.exceptions.QueryEngineError`: When the database has not been initialized
         """
 
-        database_file = self._get_database_file(ecosystem_name, network_name)
-        if not database_file.is_file():
-            raise QueryEngineError("Database must be initialized")
-
-        database_file.unlink()
-
-    @property
-    def database_connection(self):
-        """
-        Returns a connection for the currently active network.
-
-        **NOTE**: Creates a database if it doesn't exist.
-
-        Raises:
-            :class:`~ape.exceptions.QueryEngineError`: If you are not connected to a provider,
-                or if the database has not been initialized.
-
-        Returns:
-            Optional[`sqlalchemy.engine.Connection`]
-        """
-        if self.provider.network.is_local:
-            return None
-
-        if not self.network_manager.connected:
-            raise QueryEngineError("Not connected to a provider")
-
-        database_file = self._get_database_file(
-            self.provider.network.ecosystem.name, self.provider.network.name
-        )
-
-        if not database_file.is_file():
-            # NOTE: Raising `info` here hints user that they can initialize the cache db
-            logger.info("`ape-cache` database has not been initialized")
-            self.database_bypass = True
-            return None
-
-        try:
-            sqlite_uri = self._get_sqlite_uri(database_file)
-            return create_engine(sqlite_uri, pool_pre_ping=True).connect()
-
-        except QueryEngineError as e:
-            logger.debug(f"Exception when querying:\n{e}")
-            return None
-
-        except Exception as e:
-            logger.warning(f"Unhandled exception when querying:\n{e}")
-            self.database_bypass = True
-            return None
-
-    @singledispatchmethod
-    def _estimate_query_clause(self, query: QueryType) -> Select:
-        """
-        A singledispatchmethod that returns a select statement.
-
-        Args:
-            query (QueryType): Choice of query type to perform a
-                check of the number of rows that match the clause.
-
-        Raises:
-            :class:`~ape.exceptions.QueryEngineError`: When given an
-                incompatible QueryType.
-
-        Returns:
-            `sqlalchemy.sql.expression.Select`
-        """
-
-        raise QueryEngineError(
-            """
-            Not a compatible QueryType. For more details see our docs
-            https://docs.apeworx.io/ape/stable/methoddocs/exceptions.html#ape.exceptions.QueryEngineError
-            """
-        )
-
-    @_estimate_query_clause.register
-    def _block_estimate_query_clause(self, query: BlockQuery) -> Select:
-        return (
-            select(func.count())
-            .select_from(Blocks)
-            .where(Blocks.number >= query.start_block)
-            .where(Blocks.number <= query.stop_block)
-            .where(Blocks.number % query.step == 0)
-        )
-
-    @_estimate_query_clause.register
-    def _transaction_estimate_query_clause(self, query: BlockTransactionQuery) -> Select:
-        return (
-            select(func.count())
-            .select_from(Transactions)
-            .where(Transactions.block_hash == query.block_id)
-        )
-
-    @_estimate_query_clause.register
-    def _contract_events_estimate_query_clause(self, query: ContractEventQuery) -> Select:
-        return (
-            select(func.count())
-            .select_from(ContractEvents)
-            .where(ContractEvents.block_number >= query.start_block)
-            .where(ContractEvents.block_number <= query.stop_block)
-            .where(ContractEvents.block_number % query.step == 0)
-        )
-
-    @singledispatchmethod
-    def _compute_estimate(self, query: QueryType, result: CursorResult) -> Optional[int]:
-        """
-        A singledispatchemethod that computes the time a query
-        will take to perform from the caching database
-        """
-
-        return None  # can't handle this query
-
-    @_compute_estimate.register
-    def _compute_estimate_block_query(
-        self,
-        query: BlockQuery,
-        result: CursorResult,
-    ) -> Optional[int]:
-        if result.scalar() == (1 + query.stop_block - query.start_block) // query.step:
-            # NOTE: Assume 200 msec to get data from database
-            return 200
-
-        # Can't handle this query
-        # TODO: Allow partial queries
-        return None
-
-    @_compute_estimate.register
-    def _compute_estimate_block_transaction_query(
-        self,
-        query: BlockTransactionQuery,
-        result: CursorResult,
-    ) -> Optional[int]:
-        # TODO: Update `transactions` table schema so this query functions properly
-        # Uncomment below after https://github.com/ApeWorX/ape/issues/994
-        # if result.scalar() > 0:  # type: ignore
-        #    # NOTE: Assume 200 msec to get data from database
-        #    return 200
-
-        # Can't handle this query
-        return None
-
-    @_compute_estimate.register
-    def _compute_estimate_contract_events_query(
-        self,
-        query: ContractEventQuery,
-        result: CursorResult,
-    ) -> Optional[int]:
-        if result.scalar() == (query.stop_block - query.start_block) // query.step:
-            # NOTE: Assume 200 msec to get data from database
-            return 200
-
-        # Can't handle this query
-        # TODO: Allow partial queries
-        return None
-
+    # NOTE: Delete below after v0.9
     def estimate_query(self, query: QueryType) -> Optional[int]:
-        """
-        Method called by the client to return a query time estimate.
+        return None
 
-        Args:
-            query (QueryType): Choice of query type to perform a
-                check of the number of rows that match the clause.
-
-        Returns:
-            Optional[int]
-        """
-
-        # NOTE: Because of Python shortcircuiting, the first time `database_connection` is missing
-        #       this will lock the class var `database_bypass` in place for the rest of the session
-        if self.database_bypass or self.database_connection is None:
-            # No database, or some other issue
-            return None
-
-        try:
-            with self.database_connection as conn:
-                result = conn.execute(self._estimate_query_clause(query))
-                if not result:
-                    return None
-
-                return self._compute_estimate(query, result)
-
-        except QueryEngineError as err:
-            logger.debug(f"Bypassing cache database: {err}")
-            # Note: The reason we return None instead of failing is that we want
-            #       a failure of the query to bypass the query logic so that the
-            #       estimation phase does not fail in `QueryManager`.
-            return None
-
-    @singledispatchmethod
-    def perform_query(self, query: QueryType) -> Iterator:  # type: ignore
-        """
-        Performs the requested query from cache.
-
-        Args:
-            query (QueryType): Choice of query type to perform a
-                check of the number of rows that match the clause.
-
-        Raises:
-            :class:`~ape.exceptions.QueryEngineError`: When given an
-                incompatible QueryType, or encounters some sort of error
-                in the database or estimation logic.
-
-        Returns:
-            Iterator
-        """
-
-        raise QueryEngineError(
-            "Not a compatible QueryType. For more details see our docs "
-            "https://docs.apeworx.io/ape/stable/methoddocs/"
-            "exceptions.html#ape.exceptions.QueryEngineError"
-        )
-
-    @perform_query.register
-    def _perform_block_query(self, query: BlockQuery) -> Iterator[BlockAPI]:
-        with self.database_connection as conn:
-            result = conn.execute(
-                select([column(c) for c in query.columns])
-                .where(Blocks.number >= query.start_block)
-                .where(Blocks.number <= query.stop_block)
-                .where(Blocks.number % query.step == 0)
-            )
-
-            if not result:
-                # NOTE: Should be unreachable if estimated correctly
-                raise QueryEngineError(f"Could not perform query:\n{query}")
-
-            yield from map(
-                lambda row: self.provider.network.ecosystem.decode_block(dict(row.items())), result
-            )
-
-    @perform_query.register
-    def _perform_transaction_query(self, query: BlockTransactionQuery) -> Iterator[dict]:
-        with self.database_connection as conn:
-            result = conn.execute(
-                select([Transactions]).where(Transactions.block_hash == query.block_id)
-            )
-
-            if not result:
-                # NOTE: Should be unreachable if estimated correctly
-                raise QueryEngineError(f"Could not perform query:\n{query}")
-
-            yield from map(lambda row: dict(row.items()), result)
-
-    @perform_query.register
-    def _perform_contract_events_query(self, query: ContractEventQuery) -> Iterator[ContractLog]:
-        with self.database_connection as conn:
-            result = conn.execute(
-                select([column(c) for c in query.columns])
-                .where(ContractEvents.block_number >= query.start_block)
-                .where(ContractEvents.block_number <= query.stop_block)
-                .where(ContractEvents.block_number % query.step == 0)
-            )
-
-            if not result:
-                # NOTE: Should be unreachable if estimated correctly
-                raise QueryEngineError(f"Could not perform query:\n{query}")
-
-            yield from map(lambda row: ContractLog.model_validate(dict(row.items())), result)
-
-    @singledispatchmethod
-    def _cache_update_clause(self, query: QueryType) -> Insert:
-        """
-        Update cache database Insert statement.
-
-        Args:
-            query (QueryType): Choice of query type to perform a
-                check of the number of rows that match the clause.
-
-        Raises:
-            :class:`~ape.exceptions.QueryEngineError`: When given an
-                incompatible QueryType, or encounters some sort of error
-                in the database or estimation logic.
-
-        Returns:
-            `sqlalchemy.sql.Expression.Insert`
-        """
-        # Can't cache this query
-        raise QueryEngineError(
-            "Not a compatible QueryType. For more details see our docs "
-            "https://docs.apeworx.io/ape/stable/methoddocs/"
-            "exceptions.html#ape.exceptions.QueryEngineError"
-        )
-
-    @_cache_update_clause.register
-    def _cache_update_block_clause(self, query: BlockQuery) -> Insert:
-        return insert(Blocks)
-
-    # TODO: Update `transactions` table schema so we can use `EcosystemAPI.decode_receipt`
-    # Uncomment below after https://github.com/ApeWorX/ape/issues/994
-    # @_cache_update_clause.register
-    # def _cache_update_block_txns_clause(self, query: BlockTransactionQuery) -> Insert:
-    #    return insert(Transactions)  # type: ignore
-
-    @_cache_update_clause.register
-    def _cache_update_events_clause(self, query: ContractEventQuery) -> Insert:
-        return insert(ContractEvents)
-
-    @singledispatchmethod
-    def _get_cache_data(
-        self, query: QueryType, result: Iterator[BaseInterfaceModel]
-    ) -> Optional[list[dict[str, Any]]]:
-        raise QueryEngineError(
-            """
-            Not a compatible QueryType. For more details see our docs
-            https://docs.apeworx.io/ape/stable/methoddocs/exceptions.html#ape.exceptions.QueryEngineError
-            """
-        )
-
-    @_get_cache_data.register
-    def _get_block_cache_data(
-        self, query: BlockQuery, result: Iterator[BaseInterfaceModel]
-    ) -> Optional[list[dict[str, Any]]]:
-        return [m.model_dump(mode="json", by_alias=False) for m in result]
-
-    @_get_cache_data.register
-    def _get_block_txns_data(
-        self, query: BlockTransactionQuery, result: Iterator[BaseInterfaceModel]
-    ) -> Optional[list[dict[str, Any]]]:
-        new_result = []
-        table_columns = [c.key for c in Transactions.__table__.columns]  # type: ignore
-        txns: list[TransactionAPI] = cast(list[TransactionAPI], result)
-        for val in [m for m in txns]:
-            new_dict = {
-                k: v
-                for k, v in val.model_dump(mode="json", by_alias=False).items()
-                if k in table_columns
-            }
-            for col in table_columns:
-                if col == "txn_hash":
-                    new_dict["txn_hash"] = val.txn_hash
-                elif col == "sender":
-                    new_dict["sender"] = new_dict["sender"].encode()
-                elif col == "receiver" and "receiver" in new_dict:
-                    new_dict["receiver"] = new_dict["receiver"].encode()
-                elif col == "receiver" and "receiver" not in new_dict:
-                    new_dict["receiver"] = b""
-                elif col == "block_hash":
-                    new_dict["block_hash"] = query.block_id
-                elif col == "signature" and val.signature is not None:
-                    new_dict["signature"] = val.signature.encode_rsv()
-                elif col not in new_dict:
-                    new_dict[col] = None
-            new_result.append(new_dict)
-        return new_result
-
-    @_get_cache_data.register
-    def _get_cache_events_data(
-        self, query: ContractEventQuery, result: Iterator[BaseInterfaceModel]
-    ) -> Optional[list[dict[str, Any]]]:
-        return [m.model_dump(mode="json", by_alias=False) for m in result]
+    def perform_query(self, query: QueryType) -> Iterator:
+        raise QueryEngineError("Cannot use this engine in legacy mode")
 
     def update_cache(self, query: QueryType, result: Iterator[BaseInterfaceModel]):
-        try:
-            clause = self._cache_update_clause(query)
-        except QueryEngineError:
-            # Cannot handle query type
-            return
-
-        # NOTE: Because of Python shortcircuiting, the first time `database_connection` is missing
-        #       this will lock the class var `database_bypass` in place for the rest of the session
-        if not self.database_bypass and self.database_connection is not None:
-            logger.debug(f"Caching query: {query}")
-            with self.database_connection as conn:
-                try:
-                    conn.execute(
-                        clause.values(  # type: ignore
-                            self._get_cache_data(query, result)
-                        ).prefix_with("OR IGNORE")
-                    )
-
-                except QueryEngineError as err:
-                    logger.warning(f"Database corruption: {err}")
+        pass  # TODO: Add legacy cache support

--- a/src/ape_cache/query.py
+++ b/src/ape_cache/query.py
@@ -14,7 +14,7 @@ from ape.api.query import (
     BlockQuery,
     BlockTransactionQuery,
     ContractEventQuery,
-    QueryAPI,
+    QueryEngineAPI,
     QueryType,
 )
 from ape.api.transactions import TransactionAPI
@@ -27,7 +27,7 @@ from . import models
 from .models import Blocks, ContractEvents, Transactions
 
 
-class CacheQueryProvider(QueryAPI):
+class CacheQueryProvider(QueryEngineAPI):
     """
     Default implementation of the :class:`~ape.api.query.QueryAPI`.
     Allows for the query of blockchain data using a connected provider.

--- a/src/ape_ethereum/query.py
+++ b/src/ape_ethereum/query.py
@@ -2,12 +2,12 @@ from collections.abc import Iterator
 from functools import singledispatchmethod
 from typing import Optional
 
-from ape.api.query import ContractCreation, ContractCreationQuery, QueryAPI, QueryType
+from ape.api.query import ContractCreation, ContractCreationQuery, QueryEngineAPI, QueryType
 from ape.exceptions import APINotImplementedError, ProviderError, QueryEngineError
 from ape.types.address import AddressType
 
 
-class EthereumQueryProvider(QueryAPI):
+class EthereumQueryProvider(QueryEngineAPI):
     """
     Implements more advanced queries specific to Ethereum clients.
     """

--- a/src/ape_ethereum/query.py
+++ b/src/ape_ethereum/query.py
@@ -1,10 +1,151 @@
 from collections.abc import Iterator
 from functools import singledispatchmethod
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from ape.api.query import ContractCreation, ContractCreationQuery, QueryEngineAPI, QueryType
+import narwhals as nw
+
+from ape.api.query import (
+    ContractCreation,
+    ContractCreationQuery,
+    CursorAPI,
+    QueryEngineAPI,
+    QueryType,
+)
 from ape.exceptions import APINotImplementedError, ProviderError, QueryEngineError
-from ape.types.address import AddressType
+from ape.types import AddressType
+
+if TYPE_CHECKING:
+    from narwhals.typing import Frame
+
+    try:
+        # Only on Python 3.11
+        from typing import Self  # type: ignore
+    except ImportError:
+        from typing_extensions import Self  # type: ignore
+
+
+class ContractCreationCursor(CursorAPI[ContractCreation]):
+    query: ContractCreationQuery
+
+    use_debug_trace: bool
+
+    def shrink(
+        self,
+        start_index: Optional[int] = None,
+        end_index: Optional[int] = None,
+    ) -> "Self":
+        if (start_index is not None and start_index != self.query.start_index) or (
+            end_index is not None and end_index != self.query.end_index
+        ):
+            raise NotImplementedError
+
+        return self
+
+    @property
+    def total_time(self) -> float:
+        # NOTE: 1 row
+        return self.time_per_row
+
+    @property
+    def time_per_row(self) -> float:
+        # NOTE: Extremely expensive query, involves binary search of all blocks in a chain
+        #       Very loose estimate of 5s per call for this query.
+        return 5.0
+
+    def _find_creation_in_block_via_parity(self, block, contract_address):
+        # NOTE requires `trace_` namespace
+        traces = self.provider.make_request("trace_replayBlockTransactions", [block, ["trace"]])
+
+        for tx in traces:
+            for trace in tx["trace"]:
+                if (
+                    "error" not in trace
+                    and trace["type"] == "create"
+                    and trace["result"]["address"] == contract_address.lower()
+                ):
+                    receipt = self.chain_manager.get_receipt(tx["transactionHash"])
+                    creator = self.conversion_manager.convert(trace["action"]["from"], AddressType)
+                    yield ContractCreation(
+                        txn_hash=tx["transactionHash"],
+                        block=block,
+                        deployer=receipt.sender,
+                        factory=creator if creator != receipt.sender else None,
+                    )
+
+    def _find_creation_in_block_via_geth(self, block, contract_address):
+        # NOTE requires `debug_` namespace
+        traces = self.provider.make_request(
+            "debug_traceBlockByNumber", [hex(block), {"tracer": "callTracer"}]
+        )
+
+        def flatten(call):
+            if call["type"] in ["CREATE", "CREATE2"]:
+                yield call["from"], call["to"]
+
+            if "error" in call or "calls" not in call:
+                return
+
+            for sub in call["calls"]:
+                if sub["type"] in ["CREATE", "CREATE2"]:
+                    yield sub["from"], sub["to"]
+                else:
+                    yield from flatten(sub)
+
+        for tx in traces:
+            call = tx["result"]
+            sender = call["from"]
+            for factory, contract in flatten(call):
+                if contract == contract_address.lower():
+                    yield ContractCreation(
+                        txn_hash=tx["txHash"],
+                        block=block,
+                        deployer=self.conversion_manager.convert(sender, AddressType),
+                        factory=(
+                            self.conversion_manager.convert(factory, AddressType)
+                            if factory != sender
+                            else None
+                        ),
+                    )
+
+    def as_model_iter(self) -> Iterator[ContractCreation]:
+        # skip the search if there is still no code at address at head
+        if not self.chain_manager.get_code(self.query.contract):
+            return None
+
+        def find_creation_block(lo, hi):
+            # perform a binary search to find the block when the contract was deployed.
+            # takes log2(height), doesn't work with contracts that have been reinit.
+            while hi - lo > 1:
+                mid = (lo + hi) // 2
+                code = self.chain_manager.get_code(self.query.contract, block_id=mid)
+                if not code:
+                    lo = mid
+                else:
+                    hi = mid
+
+            if self.chain_manager.get_code(self.query.contract, block_id=hi):
+                return hi
+
+            return None
+
+        if not (block := find_creation_block(0, self.chain_manager.blocks.height)):
+            return
+
+        if self.use_debug_trace:
+            yield from self._find_creation_in_block_via_geth(block, self.query.contract)
+
+        else:
+            yield from self._find_creation_in_block_via_parity(block, self.query.contract)
+
+    def as_dataframe(self, backend: nw.Implementation) -> "Frame":
+        data: dict[str, list] = {column: [] for column in self.query.columns}
+
+        # NOTE: Only 1 item
+        item = next(self.as_model_iter())
+        for column in data:
+            data[column] = getattr(item, column)
+
+        return nw.from_dict(data, backend=backend)
 
 
 class EthereumQueryProvider(QueryEngineAPI):
@@ -12,6 +153,39 @@ class EthereumQueryProvider(QueryEngineAPI):
     Implements more advanced queries specific to Ethereum clients.
     """
 
+    def _has_method(self, rpc_method: str) -> bool:
+        try:
+            self.provider.make_request(rpc_method, [])
+            return True
+
+        except APINotImplementedError:
+            return False
+
+        except ProviderError as e:
+            return "Method not found" not in str(e)
+
+    @property
+    def use_debug_trace(self) -> bool:
+        return "geth" in self.provider.client_version.lower() and self._has_method(
+            "debug_traceBlockByNumber"
+        )
+
+    @property
+    def use_trace_replay(self) -> bool:
+        return self._has_method("trace_replayBlockTransactions")
+
+    @singledispatchmethod
+    def exec(self, query: QueryType) -> Iterator[CursorAPI]:  # type: ignore[override]
+        return super().exec(query)
+
+    @exec.register
+    def exec_contract_creation(
+        self, query: ContractCreationQuery
+    ) -> Iterator[ContractCreationCursor]:
+        if (use_debug_trace := self.use_debug_trace) or self.use_trace_replay:
+            yield ContractCreationCursor(query=query, use_debug_trace=use_debug_trace)
+
+    # TODO: Delete all of below in v0.9
     def __init__(self):
         self.supports_contract_creation = None  # will be set after we try for the first time
 

--- a/src/ape_node/query.py
+++ b/src/ape_node/query.py
@@ -2,13 +2,13 @@ from collections.abc import Iterator
 from functools import singledispatchmethod
 from typing import Optional
 
-from ape.api.query import ContractCreation, ContractCreationQuery, QueryAPI, QueryType
+from ape.api.query import ContractCreation, ContractCreationQuery, QueryEngineAPI, QueryType
 from ape.exceptions import QueryEngineError
 from ape.types.address import AddressType
 from ape_ethereum.provider import EthereumNodeProvider
 
 
-class OtterscanQueryEngine(QueryAPI):
+class OtterscanQueryEngine(QueryEngineAPI):
     @singledispatchmethod
     def estimate_query(self, query: QueryType) -> Optional[int]:  # type: ignore[override]
         return None

--- a/src/ape_node/query.py
+++ b/src/ape_node/query.py
@@ -1,14 +1,78 @@
 from collections.abc import Iterator
 from functools import singledispatchmethod
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from ape.api.query import ContractCreation, ContractCreationQuery, QueryEngineAPI, QueryType
+import narwhals as nw
+
+from ape.api.query import (
+    ContractCreation,
+    ContractCreationQuery,
+    CursorAPI,
+    QueryEngineAPI,
+    QueryType,
+)
 from ape.exceptions import QueryEngineError
-from ape.types.address import AddressType
+from ape.types import AddressType
 from ape_ethereum.provider import EthereumNodeProvider
+
+if TYPE_CHECKING:
+    from narwhals.typing import Frame
+
+
+class ContractCreationCursor(CursorAPI):
+    query: ContractCreationQuery
+
+    def shrink(
+        self,
+        start_index: Optional[int] = None,
+        end_index: Optional[int] = None,
+    ) -> "ContractCreationCursor":
+        if start_index or end_index:
+            raise NotImplementedError
+
+        return self
+
+    @property
+    def total_time(self) -> float:
+        return 0.25
+
+    @property
+    def time_per_row(self) -> float:
+        return 0.25
+
+    def _get_ots_contract_creation(self) -> ContractCreation:
+        result = self.provider.make_request("ots_getContractCreator", [self.query.contract])
+        creator = self.conversion_manager.convert(result["creator"], AddressType)
+        receipt = self.provider.get_receipt(result["hash"])
+        return ContractCreation(
+            txn_hash=result["hash"],
+            block=receipt.block_number,
+            deployer=receipt.sender,
+            factory=creator if creator != receipt.sender else None,
+        )
+
+    def as_dataframe(self, backend: nw.Implementation) -> "Frame":
+        return nw.from_dict(self._get_ots_contract_creation().model_dump(), backend=backend)
+
+    def as_model_iter(self) -> Iterator[ContractCreation]:
+        yield self._get_ots_contract_creation()
 
 
 class OtterscanQueryEngine(QueryEngineAPI):
+    @singledispatchmethod
+    def exec(self, query: QueryType) -> Iterator[CursorAPI]:  # type: ignore[override]
+        return super().exec(query)
+
+    @property
+    def supports_ots_namespace(self) -> bool:
+        return getattr(self.provider, "_ots_api_level", None) is not None
+
+    @exec.register
+    def exec_creation_query(self, query: ContractCreationQuery) -> Iterator[ContractCreationCursor]:
+        if self.supports_ots_namespace:
+            yield ContractCreationCursor(query=query)
+
+    # TODO: Delete below in v0.9
     @singledispatchmethod
     def estimate_query(self, query: QueryType) -> Optional[int]:  # type: ignore[override]
         return None

--- a/tests/functional/test_block.py
+++ b/tests/functional/test_block.py
@@ -128,14 +128,3 @@ def test_model_validate_web3_block():
     data = BlockData(number=123, timestamp=123, gasLimit=123, gasUsed=100)  # type: ignore
     actual = Block.model_validate(data)
     assert actual.number == 123
-
-
-def test_transactions(block):
-    actual = block.transactions
-    expected: list = []
-    assert actual == expected
-
-    # Ensure still works when hash is None (was a bug where this crashed).
-    block.hash = None
-    block.__dict__.pop("transactions", None)  # Ensure not cached.
-    assert block.transactions == []

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -1,6 +1,6 @@
 import time
 
-import pandas as pd
+import narwhals as nw
 import pytest
 
 from ape.api.query import validate_and_expand_columns
@@ -12,15 +12,15 @@ def test_basic_query(chain, eth_tester_provider):
     blocks_df0 = chain.blocks.query("*")
     blocks_df1 = chain.blocks.query("number", "timestamp")
 
-    assert list(blocks_df0["number"].values)[:4] == [0, 1, 2, 3]
+    assert blocks_df0["number"].to_list()[:4] == [0, 1, 2, 3]
     assert len(blocks_df1) == len(chain.blocks)
     assert (
-        blocks_df1.iloc[3]["timestamp"]
-        >= blocks_df1.iloc[2]["timestamp"]
-        >= blocks_df1.iloc[1]["timestamp"]
-        >= blocks_df1.iloc[0]["timestamp"]
+        blocks_df1["timestamp"][3]
+        >= blocks_df1["timestamp"][2]
+        >= blocks_df1["timestamp"][1]
+        >= blocks_df1["timestamp"][0]
     )
-    assert list(blocks_df0.columns) == [
+    assert blocks_df0.columns == [
         "base_fee",
         "difficulty",
         "gas_limit",
@@ -40,8 +40,8 @@ def test_relative_block_query(chain, eth_tester_provider):
     chain.mine(10)
     df = chain.blocks.query("*", start_block=-8, stop_block=-2)
     assert len(df) == 7
-    assert df.number.min() == chain.blocks[-8].number == start_block + 3
-    assert df.number.max() == chain.blocks[-2].number == start_block + 9
+    assert df["number"].min() == chain.blocks[-8].number == start_block + 3
+    assert df["number"].max() == chain.blocks[-2].number == start_block + 9
 
 
 def test_block_transaction_query(chain, eth_tester_provider, sender, receiver):
@@ -56,8 +56,8 @@ def test_transaction_contract_event_query(contract_instance, owner, eth_tester_p
     contract_instance.fooAndBar(sender=owner)
     time.sleep(0.1)
     df_events = contract_instance.FooHappened.query("*", start_block=-1)
-    assert isinstance(df_events, pd.DataFrame)
-    assert df_events.event_name[0] == "FooHappened"
+    assert isinstance(df_events, nw.DataFrame)
+    assert df_events["event_name"][0] == "FooHappened"
 
 
 def test_transaction_contract_event_query_starts_query_at_deploy_tx(
@@ -66,8 +66,8 @@ def test_transaction_contract_event_query_starts_query_at_deploy_tx(
     contract_instance.fooAndBar(sender=owner)
     time.sleep(0.1)
     df_events = contract_instance.FooHappened.query("*")
-    assert isinstance(df_events, pd.DataFrame)
-    assert df_events.event_name[0] == "FooHappened"
+    assert isinstance(df_events, nw.DataFrame)
+    assert df_events["event_name"][0] == "FooHappened"
 
 
 class Model(BaseInterfaceModel):


### PR DESCRIPTION
### What I did

This PR adds (provisional) support for "partial queries", e.g. breaking large user queries through the Query Management System into sub-queries according to the most efficient manner of provisioning them (based on installed plugins, plugin state, service access, environment, etc.)

Most of the time, when running some long-term query over a range of history, often certain providers are not enough to fully provision the entire query as some parts may be missing. Examples of this include disk cache with `cryo` (or the not-fully-functional `ape-cache` 1st party plugin), indexing services who might be a few minutes behind head w/ their API, or other such application-specific limitations (rate limits? free tier limits? etc.)

Thanks to this plugin, it is now possible to better support these types of queries efficiently, and also allow plugins to reduce overhead cost of conversion of their outputs, thanks to additions to the API to allow specifying different manners of providing raw Ape model access, or dataframes using `narwhals`'s dataframe-agnostic API

fixes: #702
fixes: #1079
fixes: #2013

### How I did it

First off, all built-in queries were modified using a new baseclass approach to add the concept of "query indexes" as an abstract API (and then implemented across relevant queries). Then the concept of a "cursor" was added to represent a provider-specific subset of the query **without** evaluating it. The cursors aided in the development of a new algorithm that finds the most efficient subset of all query engine's cursor objects that "cover" the original query. Lastly, this new algorithm and all machinery to make best use of it was implemented into query subsystem API objects as well as the query manager, gated behind an environment variable `APE_ENABLE_EXPERIMENTAL_QUERY_BACKEND`

### How to verify it

**NOTE**: To use the new solver, first enable it using `APE_ENABLE_EXPERIMENTAL_QUERY_BACKEND=1`

All regular functionality of the framework as well as any query-capable plugins should continue to function properly. Support for new query functionality needs to be added prior to v0.9 where the changes will be made breaking.

Also note that while it should function without **any** breaking changes to current v0.8, it is intended to replace the functionality of the query system when v0.9 rolls around, dropping support for the using the old method of querying from 2nd/3rd party plugins. The drop of support should be transparent to them however, as the old API methods will no longer be called, and the new ones have defaults which should not hinder proper operation.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
- [x] Documentation is complete
