### PR TITLE
feat: `ape pm install` command supports package ID

### DIFF
--- a/docs/userguides/dependencies.md
+++ b/docs/userguides/dependencies.md
@@ -165,6 +165,12 @@ If the dependencies are already cached and you want to re-install them, use the 
 ape pm install --force
 ```
 
+To install a specific dependency by ID that is listed in a config file, use the ID or name as the package argument:
+
+```shell
+ape pm install OpenZeppelin/openzeppelin-contracts
+```
+
 To install a dependency that is not in your config, you can specify it directly along with `--name` and `--version`:
 
 ```shell

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -1438,7 +1438,7 @@ class DependencyManager(BaseManager):
         version_options = _version_to_options(version)
 
         # Also try the lower of the name
-        # so ``OpenZeppelin`` would give you ``openzeppelin``.
+        # so `OpenZeppelin` would give you `openzeppelin`.
         id_options = [dependency_id]
         if dependency_id.lower() != dependency_id:
             # Ensure we try dependency_id without lower first.

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -1359,19 +1359,20 @@ class DependencyManager(BaseManager):
 
         return None
 
-    def get_versions(self, name: str) -> Iterator[Dependency]:
+    def get_versions(self, name: str, allow_install: bool = True) -> Iterator[Dependency]:
         """
         Get all installed versions of a dependency.
 
         Args:
             name (str): The name of the dependency.
+            allow_install (bool): Set to ``False`` to not allow installing.
 
         Returns:
             Iterator[:class:`~ape.managers.project.Dependency`]
         """
-        # First, check specified. Note: installs if needed.
+        # First, check specified.
         versions_yielded = set()
-        for dependency in self.get_project_dependencies(name=name):
+        for dependency in self.get_project_dependencies(name=name, allow_install=allow_install):
             if dependency.version in versions_yielded:
                 continue
 

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -1565,7 +1565,7 @@ class DependencyManager(BaseManager):
             base_path (Path): The target path.
             cache_name (str): The cache folder name to create
               at the target path. Defaults to ``.cache`` because
-              that is what is what ``ape-solidity`` uses.
+              that is what ``ape-solidity`` uses.
         """
         cache_folder = base_path / cache_name
         for dependency in self.specified:

--- a/src/ape_pm/_cli.py
+++ b/src/ape_pm/_cli.py
@@ -151,7 +151,7 @@ def _package_callback(ctx, param, value):
     except Exception:
         pass
     else:
-        if path.is_file():
+        if path.exists():
             return _handle_package_path(path, original_value=value)
 
     if isinstance(value, str) and ":" in value:

--- a/src/ape_pm/_cli.py
+++ b/src/ape_pm/_cli.py
@@ -166,8 +166,11 @@ def _package_callback(ctx, param, value):
         if not version and "@" in value:
             name, version = value.split("@")
 
-        if dependency := project.dependencies.get_dependency_api(name, version=version):
-            return dependency
+        try:
+            dependency = project.dependencies.get_dependency_api(name, version=version)
+        except ProjectError:
+            pass
+        else:
             return dependency
 
     raise click.BadArgumentUsage(f"Unknown package '{value}'.")

--- a/src/ape_pm/_cli.py
+++ b/src/ape_pm/_cli.py
@@ -167,21 +167,9 @@ def _package_callback(ctx, param, value):
         if not version and "@" in value:
             name, version = value.split("@")
 
-        # Check my package ID.
-        for dependency in project.dependencies.config_apis:
-            if dependency.package_id != name:
-                continue
-
-            if (version and dependency.version_id == version) or not version:
-                return dependency
-
-        # Check by name.
-        for dependency in project.dependencies.config_apis:
-            if dependency.name != name:
-                continue
-
-            if (version and dependency.version_id == version) or not version:
-                return dependency
+        if dependency := project.dependencies.get_dependency_api(name, version=version):
+            return dependency
+            return dependency
 
     raise click.BadArgumentUsage(f"Unknown package '{value}'.")
 

--- a/src/ape_pm/_cli.py
+++ b/src/ape_pm/_cli.py
@@ -130,7 +130,6 @@ def _package_callback(ctx, param, value):
         # Install all packages from local project.
         return None
 
-    # Check if it is a dependency not listed anywhere.
     elif isinstance(value, Path):
         return _handle_package_path(value)
 

--- a/tests/integration/cli/test_pm.py
+++ b/tests/integration/cli/test_pm.py
@@ -118,6 +118,7 @@ def test_install_config_override(pm_runner, integ_project):
 
 @skip_projects_except("with-contracts")
 def test_install_package_id(pm_runner, integ_project):
+    pm_runner.project = integ_project
     package_id = [x for x in integ_project.dependencies][0].package_id
     result = pm_runner.invoke("install", package_id)
     assert result.exit_code == 0, result.output
@@ -125,6 +126,7 @@ def test_install_package_id(pm_runner, integ_project):
 
 @skip_projects_except("with-contracts")
 def test_install_name(pm_runner, integ_project):
+    pm_runner.project = integ_project
     name = [x for x in integ_project.dependencies][0].name
     result = pm_runner.invoke("install", name)
     assert result.exit_code == 0, result.output
@@ -132,6 +134,7 @@ def test_install_name(pm_runner, integ_project):
 
 @skip_projects_except("with-contracts")
 def test_install_name_with_version_in_id(pm_runner, integ_project):
+    pm_runner.project = integ_project
     dependency = [x for x in integ_project.dependencies][0]
     result = pm_runner.invoke("install", f"{dependency.name}@{dependency.version}")
     assert result.exit_code == 0, result.output
@@ -140,6 +143,7 @@ def test_install_name_with_version_in_id(pm_runner, integ_project):
 
 @skip_projects_except("with-contracts")
 def test_install_name_with_version_flag(pm_runner, integ_project):
+    pm_runner.project = integ_project
     dependency = [x for x in integ_project.dependencies][0]
     result = pm_runner.invoke("install", f"{dependency.name}", "--version", dependency.version)
     assert result.exit_code == 0, result.output

--- a/tests/integration/cli/test_pm.py
+++ b/tests/integration/cli/test_pm.py
@@ -19,7 +19,7 @@ def pm_runner(config):
 
 
 @run_once
-def test_install_path_not_exists(pm_runner):
+def test_install_unknown_package(pm_runner):
     path = "path/to/nowhere"
     result = pm_runner.invoke("install", path)
     assert result.exit_code != 0, result.output

--- a/tests/integration/cli/test_pm.py
+++ b/tests/integration/cli/test_pm.py
@@ -116,6 +116,36 @@ def test_install_config_override(pm_runner, integ_project):
     assert actual == "src"
 
 
+@skip_projects_except("with-contracts")
+def test_install_package_id(pm_runner, integ_project):
+    package_id = [x for x in integ_project.dependencies][0].package_id
+    result = pm_runner.invoke("install", package_id)
+    assert result.exit_code == 0, result.output
+
+
+@skip_projects_except("with-contracts")
+def test_install_name(pm_runner, integ_project):
+    name = [x for x in integ_project.dependencies][0].name
+    result = pm_runner.invoke("install", name)
+    assert result.exit_code == 0, result.output
+
+
+@skip_projects_except("with-contracts")
+def test_install_name_with_version_in_id(pm_runner, integ_project):
+    dependency = [x for x in integ_project.dependencies][0]
+    result = pm_runner.invoke("install", f"{dependency.name}@{dependency.version}")
+    assert result.exit_code == 0, result.output
+    assert f"Package '{dependency.name}@{dependency.version}' installed." in result.output
+
+
+@skip_projects_except("with-contracts")
+def test_install_name_with_version_flag(pm_runner, integ_project):
+    dependency = [x for x in integ_project.dependencies][0]
+    result = pm_runner.invoke("install", f"{dependency.name}", "--version", dependency.version)
+    assert result.exit_code == 0, result.output
+    assert f"Package '{dependency.name}@{dependency.version}' installed." in result.output
+
+
 @run_once
 def test_compile_package_not_exists(pm_runner, integ_project):
     pm_runner.project = integ_project


### PR DESCRIPTION
### What I did

Allow existing package ID / name for package argument in `ape pm install` command.
Before, it only expected new dependencies here, but since we introduced the concept of "uninstalled" dependencies (not installing unless asked in a project config), this feature was missing.

So do stuff like

```
ape pm install OpenZeppelin/openzeppelin-contracts --version "5.0.0"
```

when it is already in your config like:

```
[[tool.ape.dependencies]]
name = "openzeppelin"
github = "OpenZeppelin/openzeppelin-contracts"
version = "5.0.0"
```

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
