### PR TITLE
fix: unable to connect to adhoc local network when using IPC

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -974,7 +974,10 @@ class NetworkAPI(BaseInterfaceModel):
         **NOTE**: Unless overridden, returns same as
         :py:attr:`ape.api.providers.ProviderAPI.chain_id`.
         """
-        if self.provider.network == self:
+        if (
+            self.provider.network.name == self.name
+            and self.provider.network.ecosystem.name == self.ecosystem.name
+        ):
             # Ensure 'active_provider' is actually (seemingly) connected
             # to this network.
             return self.provider.chain_id

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -974,7 +974,15 @@ class NetworkAPI(BaseInterfaceModel):
         **NOTE**: Unless overridden, returns same as
         :py:attr:`ape.api.providers.ProviderAPI.chain_id`.
         """
-        return self.provider.chain_id
+        if self.provider.network == self:
+            # Ensure 'active_provider' is actually (seemingly) connected
+            # to this network.
+            return self.provider.chain_id
+
+        raise NetworkError(
+            "Unable to reference provider to get `chain_id`: "
+            f"Network '{self.name}' is detached and information is missing."
+        )
 
     @property
     def network_id(self) -> int:

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -594,7 +594,9 @@ class Web3Provider(ProviderAPI, ABC):
     @cached_property
     def chain_id(self) -> int:
         default_chain_id = None
-        if (not self.network.is_adhoc and self.network.is_custom) or not self.network.is_dev:
+        if (not self.network.is_adhoc and self.network.is_custom) or (
+            not self.network.is_dev and not self.network.is_adhoc
+        ):
             # If using a live network, the chain ID is hardcoded.
             default_chain_id = self.network.chain_id
 

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -594,10 +594,12 @@ class Web3Provider(ProviderAPI, ABC):
     @cached_property
     def chain_id(self) -> int:
         default_chain_id = None
-        if (not self.network.is_adhoc and self.network.is_custom) or (
-            not self.network.is_dev and not self.network.is_adhoc
-        ):
-            # If using a live network, the chain ID is hardcoded.
+        if not self.network.is_adhoc and self.network.is_custom:
+            # If using a configured, custom network, the chain ID is hardcoded.
+            default_chain_id = self.network.chain_id
+
+        elif not self.network.is_dev and not self.network.is_adhoc:
+            # If using a configured public network, the chain ID is hardcoded.
             default_chain_id = self.network.chain_id
 
         try:

--- a/tests/functional/geth/test_provider.py
+++ b/tests/functional/geth/test_provider.py
@@ -21,6 +21,7 @@ from ape.exceptions import (
     ContractLogicError,
     NetworkMismatchError,
     ProviderError,
+    ProviderNotConnectedError,
     TransactionError,
     TransactionNotFoundError,
     VirtualMachineError,
@@ -39,7 +40,6 @@ from ape_ethereum.transactions import (
     TransactionType,
 )
 from ape_node.provider import GethDevProcess, Node, NodeSoftwareNotInstalledError
-from build.lib.ape.exceptions import ProviderNotConnectedError
 from tests.conftest import GETH_URI, geth_process_test
 
 

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -145,7 +145,7 @@ def test_chain_id_when_disconnected(eth_tester_provider):
         eth_tester_provider.connect()
 
 
-def test_chain_id_adhoc(networks):
+def test_chain_id_adhoc_http(networks):
     with networks.parse_network_choice("https://www.shibrpc.com") as bor:
         assert bor.chain_id == 109
 


### PR DESCRIPTION
### What I did

In one terminal do:

```
geth --dev
```

**Notice the IPC path it spits out.**

In another do,

```
ape console --network <path/to/gethdev/ipc>
```

It was failing before, thinking the network was hardcoded. But now, it should realize it isn't.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
