### PR TITLE
feat: local network process MGMT CLI

### DIFF
--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -550,7 +550,7 @@ Once you are done with your node, you can simply exit the process to tear it dow
 Or, if you used `--background` or lost the process some other way, you can stop the node using the `kill` command:
 
 ```shell
-ape networks kill
+ape networks kill --all
 ```
 
 To list all running networks, use the `list --running` command:

--- a/docs/userguides/networks.md
+++ b/docs/userguides/networks.md
@@ -525,6 +525,14 @@ To run a network with a process, use the `ape networks run` command:
 ape networks run
 ```
 
+This launches a development node in the current working terminal session.
+To continue developing, you will have to launch a new terminal session.
+Alternatively, you can use the `--background` flag to background the process:
+
+```shell
+ape networks run --background
+```
+
 By default, `ape networks run` runs a development Node (geth) process.
 To use a different network, such as `hardhat` or Anvil nodes, use the `--network` flag:
 
@@ -533,6 +541,23 @@ ape networks run --network ethereum:local:foundry
 ```
 
 To configure the network's block time, use the `--block-time` option.
+
+```shell
+ape networks run --network ethereum:local:foundry --block-time 10
+```
+
+Once you are done with your node, you can simply exit the process to tear it down.
+Or, if you used `--background` or lost the process some other way, you can stop the node using the `kill` command:
+
+```shell
+ape networks kill
+```
+
+To list all running networks, use the `list --running` command:
+
+```shell
+ape networks list --running
+```
 
 ## Provider Interaction
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras_require = {
         "hypothesis-jsonschema==0.19.0",  # JSON Schema fuzzer extension
     ],
     "lint": [
-        "ruff>=0.9.10",  # Unified linter and formatter
+        "ruff>=0.9.10,<0.10",  # Unified linter and formatter
         "mypy>=1.15.0,<1.16.0",  # Static type analyzer
         "types-PyYAML",  # Needed due to mypy typeshed
         "types-requests",  # Needed due to mypy typeshed

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -256,7 +256,7 @@ class ProviderAPI(BaseInterfaceModel):
     @property
     def ipc_path(self) -> Optional[Path]:
         """
-        Return the IPC path for the provider, is supported.
+        Return the IPC path for the provider, if supported.
         """
         return None
 

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -1115,7 +1115,7 @@ class SubprocessProvider(ProviderAPI):
                 out_file = PIPE
 
             cmd = self.build_command()
-            process = Popen(cmd, preexec_fn=pre_exec_fn, stdout=out_file, stderr=out_file)
+            process = popen(cmd, preexec_fn=pre_exec_fn, stdout=out_file, stderr=out_file)
             self.process = process
             spawn(self.produce_stdout_queue)
             spawn(self.produce_stderr_queue)
@@ -1132,6 +1132,9 @@ class SubprocessProvider(ProviderAPI):
 
                     time.sleep(0.1)
                     _timeout.check()
+
+        else:
+            raise ProviderError("Process not started and cannot connect to existing process.")
 
     def produce_stdout_queue(self):
         process = self.process
@@ -1278,3 +1281,8 @@ def _linux_set_death_signal():
     # the second argument is what signal to send to child subprocesses
     libc = ctypes.CDLL("libc.so.6")
     return libc.prctl(1, SIGTERM)
+
+
+def popen(cmd: list[str], **kwargs):
+    # Abstracted for testing purporses.
+    return Popen(cmd, **kwargs)

--- a/src/ape/api/providers.py
+++ b/src/ape/api/providers.py
@@ -254,6 +254,13 @@ class ProviderAPI(BaseInterfaceModel):
         """
 
     @property
+    def ipc_path(self) -> Optional[Path]:
+        """
+        Return the IPC path for the provider, is supported.
+        """
+        return None
+
+    @property
     def http_uri(self) -> Optional[str]:
         """
         Return the raw HTTP/HTTPS URI to connect to this provider, if supported.
@@ -984,7 +991,9 @@ class SubprocessProvider(ProviderAPI):
     """
 
     PROCESS_WAIT_TIMEOUT: int = 15
+    background: bool = False
     process: Optional[Popen] = None
+    allow_start: bool = True
     is_stopping: bool = False
 
     stdout_queue: Optional[JoinableQueue] = None
@@ -1059,7 +1068,7 @@ class SubprocessProvider(ProviderAPI):
             or self.config_manager.get_config("test").disconnect_providers_after
         )
         if disconnect_after:
-            atexit.register(self.disconnect)
+            atexit.register(self._disconnect_atexit)
 
         # Register handlers to ensure atexit handlers are called when Python dies.
         def _signal_handler(signum, frame):
@@ -1068,6 +1077,12 @@ class SubprocessProvider(ProviderAPI):
 
         signal(SIGINT, _signal_handler)
         signal(SIGTERM, _signal_handler)
+
+    def _disconnect_atexit(self):
+        if self.background:
+            return
+
+        self.disconnect()
 
     def disconnect(self):
         """
@@ -1078,24 +1093,37 @@ class SubprocessProvider(ProviderAPI):
         if self.process:
             self.stop()
 
+        # Delete entry from managed list of running nodes.
+        self.network_manager.running_nodes.remove_provider(self)
+
     def start(self, timeout: int = 20):
         """Start the process and wait for its RPC to be ready."""
 
         if self.is_connected:
             logger.info(f"Connecting to existing '{self.process_name}' process.")
             self.process = None  # Not managing the process.
-        else:
+
+        elif self.allow_start:
             logger.info(f"Starting '{self.process_name}' process.")
             pre_exec_fn = _linux_set_death_signal if platform.uname().system == "Linux" else None
             self.stderr_queue = JoinableQueue()
             self.stdout_queue = JoinableQueue()
-            out_file = PIPE if logger.level <= LogLevel.DEBUG else DEVNULL
+
+            if self.background or logger.level > LogLevel.DEBUG:
+                out_file = DEVNULL
+            else:
+                out_file = PIPE
+
             cmd = self.build_command()
-            self.process = Popen(cmd, preexec_fn=pre_exec_fn, stdout=out_file, stderr=out_file)
+            process = Popen(cmd, preexec_fn=pre_exec_fn, stdout=out_file, stderr=out_file)
+            self.process = process
             spawn(self.produce_stdout_queue)
             spawn(self.produce_stderr_queue)
             spawn(self.consume_stdout_queue)
             spawn(self.consume_stderr_queue)
+
+            # Cache the process so we can manage it even if lost.
+            self.network_manager.running_nodes.cache_provider(self)
 
             with RPCTimeoutError(self, seconds=timeout) as _timeout:
                 while True:

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -309,10 +309,6 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         if not self.running_nodes:
             return {}
 
-        if not process_ids:
-            # Defaults to all managed processes.
-            process_ids = self.running_nodes.process_ids
-
         pids_killed = {}
         for pid in process_ids:
             if not (data := self.running_nodes.nodes.get(pid)):

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -101,6 +101,9 @@ class NodeProcessMap(DiskCacheableModel):
         """
         return bool(self.nodes)
 
+    def __contains__(self, pid: int) -> bool:
+        return pid in self.nodes
+
     def get(self, pid: int) -> Optional[NodeProcessData]:
         return self.nodes.get(int(pid))
 

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -107,8 +107,11 @@ class NodeProcessMap(DiskCacheableModel):
 
         return False
 
-    def get(self, pid: int) -> Optional[NodeProcessData]:
-        return self.nodes.get(int(pid))
+    def get(self, pid_or_provider: Union[int, str]) -> Optional[NodeProcessData]:
+        return self.nodes.get(int(pid_or_provider))
+
+    def lookup_processes(self, provider: "SubprocessProvider") -> dict[int, NodeProcessData]:
+        return {pid: data for pid, data in self.nodes.items() if data.matches_provider(provider)}
 
     def cache_provider(self, provider: "SubprocessProvider"):
         # Don't use `provider.network_choice` here because we want to ensure the provider

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -107,8 +107,8 @@ class NodeProcessMap(DiskCacheableModel):
 
         return False
 
-    def get(self, pid_or_provider: Union[int, str]) -> Optional[NodeProcessData]:
-        return self.nodes.get(int(pid_or_provider))
+    def get(self, pid: Union[int, str]) -> Optional[NodeProcessData]:
+        return self.nodes.get(int(pid))
 
     def lookup_processes(self, provider: "SubprocessProvider") -> dict[int, NodeProcessData]:
         return {pid: data for pid, data in self.nodes.items() if data.matches_provider(provider)}

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -262,7 +262,7 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         if not (data := self.running_nodes.get(pid)):
             raise NetworkError(f"No running node for pid '{pid}'.")
 
-        uri = None
+        uri: Optional[Union[str, Path]] = None
         if ipc := data.ipc_path:
             if ipc.exists():
                 uri = ipc

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -70,11 +70,7 @@ class NodeProcessData(BaseModel):
 
         # Skip if any of the connection paths (IPC, HTTP, WS) differ
         for attr in ("ipc_path", "http_uri", "ws_uri"):
-            if (
-                getattr(provider, attr)
-                and getattr(self, attr)
-                and getattr(provider, attr) != getattr(self, attr)
-            ):
+            if getattr(provider, attr, None) != getattr(self, attr, None):
                 return False
 
         return True
@@ -129,7 +125,9 @@ class NodeProcessMap(DiskCacheableModel):
             self.model_dump_file()
 
         else:
-            raise NetworkError("Unable to cache subprocess-provider information: not connected.")
+            raise NetworkError(
+                "Unable to cache subprocess-provider information: not connected."
+            )
 
     def _delete_all_matching(self, node: NodeProcessData):
         pids_to_remove = set()
@@ -145,7 +143,9 @@ class NodeProcessMap(DiskCacheableModel):
         pids_to_remove = {
             pid for pid, data in self.nodes.items() if data.matches_provider(provider)
         }
-        self.nodes = {pid: node for pid, node in self.nodes.items() if pid not in pids_to_remove}
+        self.nodes = {
+            pid: node for pid, node in self.nodes.items() if pid not in pids_to_remove
+        }
         self.model_dump_file()
 
     def remove_processes(self, *pids: int):
@@ -182,7 +182,9 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
     def __repr__(self) -> str:
         provider = self.active_provider
         class_name = NetworkManager.__name__
-        content = f"{class_name} active_provider={provider!r}" if provider else class_name
+        content = (
+            f"{class_name} active_provider={provider!r}" if provider else class_name
+        )
         return f"<{content}>"
 
     @property
@@ -263,7 +265,9 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
             "http_uri": data.http_uri,
             "ws_uri": data.ws_uri,
         }
-        provider_settings = {k: v for k, v in provider_settings.items() if v is not None}
+        provider_settings = {
+            k: v for k, v in provider_settings.items() if v is not None
+        }
 
         provider = self.get_provider_from_choice(
             network_choice=network_choice, provider_settings=provider_settings or None
@@ -353,7 +357,9 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         """
         network_name = self.network.name
         is_fork_already = network_name.endswith("-fork")
-        forked_network_name = network_name if is_fork_already else f"{network_name}-fork"
+        forked_network_name = (
+            network_name if is_fork_already else f"{network_name}-fork"
+        )
         try:
             forked_network = self.ecosystem.get_network(forked_network_name)
         except NetworkNotFoundError as err:
@@ -386,7 +392,10 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
             {"fork": {self.ecosystem.name: {self.network.name: fork_settings}}},
         )
 
-        shared_kwargs: dict = {"provider_settings": provider_settings, "disconnect_after": True}
+        shared_kwargs: dict = {
+            "provider_settings": provider_settings,
+            "disconnect_after": True,
+        }
         return (
             forked_network.use_provider(provider_name, **shared_kwargs)
             if provider_name
@@ -470,7 +479,8 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
                 continue
 
             base_ecosystem_name = (
-                custom_network.get("base_ecosystem_plugin") or self.default_ecosystem_name
+                custom_network.get("base_ecosystem_plugin")
+                or self.default_ecosystem_name
             )
 
             if base_ecosystem_name not in plugin_ecosystems:
@@ -560,7 +570,9 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
             name = provider_name
 
         provider_settings: dict = {}
-        if connection_str.startswith("https://") or connection_str.startswith("http://"):
+        if connection_str.startswith("https://") or connection_str.startswith(
+            "http://"
+        ):
             provider_settings["uri"] = connection_str
         elif connection_str.endswith(".ipc"):
             provider_settings["ipc_path"] = connection_str
@@ -643,12 +655,16 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
 
         ecosystem_items = self.ecosystems
         if ecosystem_filter:
-            ecosystem_items = {n: e for n, e in ecosystem_items.items() if n in ecosystem_filter}
+            ecosystem_items = {
+                n: e for n, e in ecosystem_items.items() if n in ecosystem_filter
+            }
 
         for ecosystem_name, ecosystem in ecosystem_items.items():
             network_items = ecosystem.networks
             if network_filter:
-                network_items = {n: net for n, net in network_items.items() if n in network_filter}
+                network_items = {
+                    n: net for n, net in network_items.items() if n in network_filter
+                }
 
             if not network_items:
                 continue
@@ -724,7 +740,9 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
 
         raise EcosystemNotFoundError(ecosystem_name, options=self.ecosystem_names)
 
-    def _get_ecosystem_from_evmchains(self, ecosystem_name: str) -> Optional["EcosystemAPI"]:
+    def _get_ecosystem_from_evmchains(
+        self, ecosystem_name: str
+    ) -> Optional["EcosystemAPI"]:
         if ecosystem_name not in PUBLIC_CHAIN_META:
             return None
 
@@ -800,17 +818,25 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
         elif len(selections) == 2:
             # Only ecosystem and network were specified, not provider
             ecosystem_name, network_name = selections
-            ecosystem = self.get_ecosystem(ecosystem_name or self.default_ecosystem.name)
-            network = ecosystem.get_network(network_name or ecosystem.default_network_name)
+            ecosystem = self.get_ecosystem(
+                ecosystem_name or self.default_ecosystem.name
+            )
+            network = ecosystem.get_network(
+                network_name or ecosystem.default_network_name
+            )
             return network.get_provider(provider_settings=provider_settings)
 
         elif len(selections) == 3:
             # Everything is specified, use specified provider for ecosystem and network
             ecosystem_name, network_name, provider_name = selections
             ecosystem = (
-                self.get_ecosystem(ecosystem_name) if ecosystem_name else self.default_ecosystem
+                self.get_ecosystem(ecosystem_name)
+                if ecosystem_name
+                else self.default_ecosystem
             )
-            network = ecosystem.get_network(network_name or ecosystem.default_network_name)
+            network = ecosystem.get_network(
+                network_name or ecosystem.default_network_name
+            )
             return network.get_provider(
                 provider_name=provider_name, provider_settings=provider_settings
             )
@@ -920,7 +946,9 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
                 continue
 
             ecosystem_data = self._get_ecosystem_data(
-                ecosystem_name, network_filter=network_filter, provider_filter=provider_filter
+                ecosystem_name,
+                network_filter=network_filter,
+                provider_filter=provider_filter,
             )
             data["ecosystems"].append(ecosystem_data)
 
@@ -946,7 +974,9 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
             if network_filter and network_name not in network_filter:
                 continue
 
-            network_data = ecosystem.get_network_data(network_name, provider_filter=provider_filter)
+            network_data = ecosystem.get_network_data(
+                network_name, provider_filter=provider_filter
+            )
             ecosystem_data["networks"].append(network_data)
 
         return ecosystem_data

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -780,6 +780,14 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
             default_network = self.default_ecosystem.default_network
             return default_network.get_provider(provider_settings=provider_settings)
 
+        elif network_choice.startswith("pid://"):
+            # Was given a process ID (already running node on local machine).
+            pid_str = network_choice[len("pid://") :]
+            if not pid_str.isdigit():
+                raise ValueError(f"Invalid PID: {pid_str}")
+
+            return self.get_running_node(int(pid_str))
+
         elif _is_adhoc_url(network_choice):
             # Custom network w/o ecosystem & network spec.
             return self.create_custom_provider(network_choice)

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -214,7 +214,7 @@ class Web3Provider(ProviderAPI, ABC):
 
     @property
     def _network_config(self) -> dict:
-        config: dict = self.config.get(self.network.ecosystem.name, None)
+        config: dict = self.settings.get(self.network.ecosystem.name, None)
         if config is None:
             return {}
 
@@ -226,13 +226,13 @@ class Web3Provider(ProviderAPI, ABC):
         result = None
         rpc: str
         if rpc := settings.get(key):
-            result = rpc
+            result = f"{rpc}"
 
         else:
             # See if it was configured for the network directly.
             config = self._network_config
             if rpc := config.get(key):
-                result = rpc
+                result = f"{rpc}"
 
         if result:
             if validator(result):
@@ -257,7 +257,7 @@ class Web3Provider(ProviderAPI, ABC):
 
     @property
     def _configured_uri(self) -> Optional[str]:
-        for key in ("uri", "url"):
+        for key in ("uri", "url", "ipc_path", "http_uri", "ws_uri"):
             if rpc := self._get_configured_rpc(key, _is_uri):
                 return rpc
 
@@ -1573,7 +1573,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
 
     @property
     def _clean_uri(self) -> str:
-        uri = self.uri
+        uri = f"{self.uri}"
         return sanitize_url(uri) if _is_http_url(uri) or _is_ws_url(uri) else uri
 
     @property

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1584,7 +1584,7 @@ class EthereumNodeProvider(Web3Provider, ABC):
         return _get_default_data_dir()
 
     @property
-    def ipc_path(self) -> Path:
+    def ipc_path(self) -> Optional[Path]:
         if path := super().ipc_path:
             return path
 
@@ -1692,9 +1692,10 @@ class EthereumNodeProvider(Web3Provider, ABC):
 
     def _log_connection(self, client_name: str):
         msg = f"Connecting to existing {client_name.strip()} node at"
+
         suffix = (
             self.ipc_path.as_posix().replace(Path.home().as_posix(), "$HOME")
-            if self.ipc_path.exists()
+            if self.ipc_path is not None and self.ipc_path.exists()
             else self._clean_uri
         )
         logger.info(f"{msg} {suffix}.")

--- a/src/ape_networks/_cli.py
+++ b/src/ape_networks/_cli.py
@@ -207,7 +207,7 @@ def _run(cli_ctx, provider: "SubprocessProvider", background: bool = False):
 
 @cli.command(short_help="Stop node processes")
 @ape_cli_context()
-@click.argument("process_ids", nargs=-1, type=int)
+@click.argument("process_ids", rnargs=-1, type=int)
 @click.option("--all", "kill_all", is_flag=True, help="Kill all running processes")
 @network_option(default=None)
 def kill(cli_ctx, process_ids, kill_all):

--- a/src/ape_networks/_cli.py
+++ b/src/ape_networks/_cli.py
@@ -207,9 +207,7 @@ def _run(cli_ctx, provider: "SubprocessProvider", background: bool = False):
 
 @cli.command(short_help="Stop node processes")
 @ape_cli_context()
-@click.option(
-    "--pid", "process_ids", help="The PID of the process(es) to kill", multiple=True, type=int
-)
+@click.argument("process_ids", nargs=-1, type=int)
 @click.option("--all", "kill_all", is_flag=True, help="Kill all running processes")
 @network_option(default=None)
 def kill(cli_ctx, process_ids, kill_all):

--- a/src/ape_networks/_cli.py
+++ b/src/ape_networks/_cli.py
@@ -209,7 +209,7 @@ def _run(cli_ctx, provider: "SubprocessProvider", background: bool = False):
 @ape_cli_context()
 @click.option("--pid", "process_ids", help="The PID of the process(es) to kill", multiple=True)
 @network_option(default=None)
-def kill(cli_ctx, process_ids, provider):
+def kill(cli_ctx, process_ids):
     """
     Stop node processes
     """

--- a/src/ape_networks/_cli.py
+++ b/src/ape_networks/_cli.py
@@ -207,7 +207,7 @@ def _run(cli_ctx, provider: "SubprocessProvider", background: bool = False):
 
 @cli.command(short_help="Stop node processes")
 @ape_cli_context()
-@click.argument("process_ids", rnargs=-1, type=int)
+@click.argument("process_ids", nargs=-1, type=int)
 @click.option("--all", "kill_all", is_flag=True, help="Kill all running processes")
 @network_option(default=None)
 def kill(cli_ctx, process_ids, kill_all):

--- a/src/ape_networks/_cli.py
+++ b/src/ape_networks/_cli.py
@@ -113,7 +113,8 @@ def _list(cli_ctx, output_format, ecosystem_filter, network_filter, provider_fil
 @ape_cli_context()
 @network_option(default="ethereum:local:node")
 @click.option("--block-time", default=None, type=int, help="Block time in seconds")
-def run(cli_ctx, provider, block_time):
+@click.option("--background", is_flag=True, help="Run in the background")
+def run(cli_ctx, provider, block_time, background):
     """
     Start a subprocess node as if running independently
     and stream stdout and stderr.
@@ -142,17 +143,18 @@ def run(cli_ctx, provider, block_time):
     cli_ctx.logger.format(fmt="%(message)s")
 
     try:
-        _run(cli_ctx, provider)
+        _run(cli_ctx, provider, background=background)
     finally:
         cli_ctx.logger.set_level(original_level)
         cli_ctx.logger.format(fmt=original_format)
 
 
-def _run(cli_ctx, provider: "SubprocessProvider"):
+def _run(cli_ctx, provider: "SubprocessProvider", background: bool = False):
     provider.connect()
     if process := provider.process:
         try:
-            process.wait()
+            if not background:
+                process.wait()
         finally:
             try:
                 provider.disconnect()

--- a/src/ape_networks/_cli.py
+++ b/src/ape_networks/_cli.py
@@ -207,7 +207,9 @@ def _run(cli_ctx, provider: "SubprocessProvider", background: bool = False):
 
 @cli.command(short_help="Stop node processes")
 @ape_cli_context()
-@click.option("--pid", "process_ids", help="The PID of the process(es) to kill", multiple=True, type=int)
+@click.option(
+    "--pid", "process_ids", help="The PID of the process(es) to kill", multiple=True, type=int
+)
 @click.option("--all", "kill_all", is_flag=True, help="Kill all running processes")
 @network_option(default=None)
 def kill(cli_ctx, process_ids, kill_all):

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -186,6 +186,7 @@ class GethDevProcess(BaseGethProcess):
 
         process_kwargs = {
             "auto_disconnect": kwargs.get("auto_disconnect", True),
+            "background": kwargs.get("background", False),
             "block_time": block_time,
             "executable": kwargs.get("executable"),
             "extra_funded_accounts": extra_accounts,

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -113,6 +113,7 @@ class GethDevProcess(BaseGethProcess):
         block_time: Optional[int] = None,
         generate_accounts: bool = True,
         initialize_chain: bool = True,
+        background: bool = False,
     ):
         executable = executable or "geth"
         if not shutil.which(executable):
@@ -121,6 +122,7 @@ class GethDevProcess(BaseGethProcess):
         self._data_dir = data_dir
         self.is_running = False
         self._auto_disconnect = auto_disconnect
+        self.background = background
 
         kwargs_ctor: dict = {
             "data_dir": self.data_dir,
@@ -276,7 +278,12 @@ class GethDevProcess(BaseGethProcess):
             return
 
         self.is_running = True
-        out_file = PIPE if logger.level <= LogLevel.DEBUG else DEVNULL
+
+        if self.background or logger.level > LogLevel.DEBUG:
+            out_file = DEVNULL
+        else:
+            out_file = PIPE
+
         self.proc = Popen(
             self.command,
             stdin=PIPE,
@@ -447,9 +454,11 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
         self._set_web3()
         if self.is_connected:
             self._complete_connect()
-        else:
+
+        elif self.allow_start:
             # Starting the process.
             self.start()
+            atexit.register(self._disconnect_atexit)
 
     def start(self, timeout: int = 20):
         geth_dev = self._create_process()
@@ -475,6 +484,8 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
             spawn(self.consume_stdout_queue)
             spawn(self.consume_stderr_queue)
 
+            self.network_manager.running_nodes.cache_provider(self)
+
     def _create_process(self) -> GethDevProcess:
         # NOTE: Using JSON mode to ensure types can be passed as CLI args.
         test_config = self.config_manager.get_config("test").model_dump(mode="json")
@@ -484,9 +495,11 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
             test_config["executable"] = self.settings.executable
 
         test_config["ipc_path"] = self.ipc_path
-        test_config["auto_disconnect"] = self._test_runner is None or test_config.get(
-            "disconnect_providers_after", True
-        )
+
+        # Let the provider handle disconnecting the process.
+        # This avoids multiple atexit handlers from being unnecessarily
+        # registered that do some of the same thing.
+        test_config["auto_disconnect"] = False
 
         # Include extra accounts to allocated funds to at genesis.
         extra_accounts = self.settings.ethereum.local.get("extra_funded_accounts", [])
@@ -494,9 +507,14 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
         extra_accounts = list({a.lower() for a in extra_accounts})
         test_config["extra_funded_accounts"] = extra_accounts
         test_config["initial_balance"] = self.test_config.balance
+        test_config["background"] = self.background
         uri = self.ws_uri or self.uri
+
         return GethDevProcess.from_uri(
-            uri, self.data_dir, block_time=self.block_time, **test_config
+            uri,
+            self.data_dir,
+            block_time=self.block_time,
+            **test_config,
         )
 
     def disconnect(self):
@@ -504,6 +522,9 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
         if self._process is not None:
             self._process.disconnect()
             self._process = None
+
+            # Remove self from managed-processes list.
+            self.network_manager.running_nodes.remove_provider(self)
 
         # Also unset the subprocess-provider reference.
         # NOTE: Type ignore is wrong; TODO: figure out why.

--- a/tests/functional/geth/test_network_manager.py
+++ b/tests/functional/geth/test_network_manager.py
@@ -64,3 +64,15 @@ def test_parse_network_choice_evmchains(networks, connection_str):
             else f"{connection_str}:node"
         )
         assert moon_provider.network_choice == expected_network_choice
+
+
+@geth_process_test
+def test_parse_network_choice_pid(geth_provider, networks):
+    if proc := geth_provider.process:
+        pid = proc.pid
+    else:
+        pid = next(networks.running_nodes.lookup_processes(geth_provider))
+
+    # Show we are able to connect to providers via PID URL.
+    with networks.parse_network_choice(f"pid://{pid}") as provider:
+        assert provider.is_connected

--- a/tests/functional/geth/test_network_manager.py
+++ b/tests/functional/geth/test_network_manager.py
@@ -76,3 +76,4 @@ def test_parse_network_choice_pid(geth_provider, networks):
     # Show we are able to connect to providers via PID URL.
     with networks.parse_network_choice(f"pid://{pid}") as provider:
         assert provider.is_connected
+        assert provider.network_choice == f"ethereum:local:{geth_provider.ipc_path}"

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -6,6 +6,7 @@ import pytest
 import ape
 from ape.api.networks import EcosystemAPI
 from ape.exceptions import NetworkError, ProviderNotFoundError
+from ape.managers.networks import NodeProcessData
 from ape.utils.misc import LOCAL_NETWORK_NAME
 from ape.utils.testing import DEFAULT_TEST_CHAIN_ID
 
@@ -134,7 +135,9 @@ def test_get_provider_when_no_default(network_with_no_providers):
 
 def test_repr_connected_to_local(networks_connected_to_tester):
     actual = repr(networks_connected_to_tester)
-    expected = f"<NetworkManager active_provider=<Test chain_id={DEFAULT_TEST_CHAIN_ID}>>"
+    expected = (
+        f"<NetworkManager active_provider=<Test chain_id={DEFAULT_TEST_CHAIN_ID}>>"
+    )
     assert actual == expected
 
     # Check individual network
@@ -147,12 +150,17 @@ def test_repr_disconnected(networks_disconnected):
     assert repr(networks_disconnected) == "<NetworkManager>"
     assert repr(networks_disconnected.ethereum) == "<ethereum>"
     assert repr(networks_disconnected.ethereum.local) == "<ethereum:local>"
-    assert repr(networks_disconnected.ethereum.sepolia) == "<ethereum:sepolia chain_id=11155111>"
+    assert (
+        repr(networks_disconnected.ethereum.sepolia)
+        == "<ethereum:sepolia chain_id=11155111>"
+    )
 
 
 def test_get_provider_from_choice_custom_provider(networks_connected_to_tester):
     uri = "https://geth:1234567890abcdef@geth.foo.bar/"
-    provider = networks_connected_to_tester.get_provider_from_choice(f"ethereum:local:{uri}")
+    provider = networks_connected_to_tester.get_provider_from_choice(
+        f"ethereum:local:{uri}"
+    )
     assert uri in provider.connection_id
     assert provider.name == "node"
     assert provider.uri == uri
@@ -169,7 +177,9 @@ def test_get_provider_from_choice_custom_adhoc_ecosystem(networks_connected_to_t
     assert provider.network.ecosystem.name == "ethereum"
 
 
-def test_parse_network_choice_same_provider(chain, networks_connected_to_tester, get_context):
+def test_parse_network_choice_same_provider(
+    chain, networks_connected_to_tester, get_context
+):
     context = get_context()
     start_count = len(context.connected_providers)
     original_block_number = chain.blocks.height
@@ -191,7 +201,9 @@ def test_parse_network_choice_same_provider(chain, networks_connected_to_tester,
 
 
 @pytest.mark.xdist_group(name="multiple-eth-testers")
-def test_parse_network_choice_new_chain_id(get_provider_with_unused_chain_id, get_context):
+def test_parse_network_choice_new_chain_id(
+    get_provider_with_unused_chain_id, get_context
+):
     start_count = len(get_context().connected_providers)
     context = get_provider_with_unused_chain_id()
     with context:
@@ -221,9 +233,9 @@ def test_parse_network_choice_multiple_contexts(
     eth_tester_provider, get_provider_with_unused_chain_id
 ):
     first_context = get_provider_with_unused_chain_id()
-    assert eth_tester_provider.chain_id == DEFAULT_TEST_CHAIN_ID, (
-        "Test setup failed - expecting to start on default chain ID"
-    )
+    assert (
+        eth_tester_provider.chain_id == DEFAULT_TEST_CHAIN_ID
+    ), "Test setup failed - expecting to start on default chain ID"
     assert eth_tester_provider.make_request("eth_chainId") == DEFAULT_TEST_CHAIN_ID
 
     with first_context:
@@ -435,7 +447,9 @@ def test_fork_with_negative_block_number(
     assert actual == expected
 
 
-def test_fork_past_genesis(networks, mock_sepolia, mock_fork_provider, eth_tester_provider):
+def test_fork_past_genesis(
+    networks, mock_sepolia, mock_fork_provider, eth_tester_provider
+):
     block_id = -10_000_000_000
     with pytest.raises(NetworkError, match="Unable to fork past genesis block."):
         with networks.fork(block_number=block_id):
@@ -471,7 +485,9 @@ def test_custom_networks_defined_in_non_local_project(custom_networks_config_dic
     custom_networks["networks"]["custom"][0]["name"] = net_name
     custom_networks["networks"]["custom"][0]["ecosystem"] = eco_name
 
-    with ape.Project.create_temporary_project(config_override=custom_networks) as temp_project:
+    with ape.Project.create_temporary_project(
+        config_override=custom_networks
+    ) as temp_project:
         nm = temp_project.network_manager
 
         # Tests `.get_ecosystem()` for custom networks.
@@ -496,3 +512,14 @@ def test_get_ecosystem_from_evmchains(networks):
     moonbeam = networks.get_ecosystem("moonbeam")
     assert isinstance(moonbeam, EcosystemAPI)
     assert moonbeam.name == "moonbeam"
+
+
+class TestNodeProcessData:
+    def test_matches_provider(self, eth_tester_provider):
+        data = NodeProcessData(
+            network_choice=f"{eth_tester_provider.network.choice}:{eth_tester_provider.name}",
+            ipc_path="test.ipc",
+        )
+        assert not data.matches_provider(eth_tester_provider)
+        data.ipc_path = None
+        assert data.matches_provider(eth_tester_provider)

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -523,8 +523,8 @@ class TestNodeProcessMap:
                 return True
 
         # Hack to allow abstract methods.
-        MyFakeProvider.__abstractmethods__ = set()
-        provider = MyFakeProvider(name="fake", network=eth_tester_provider.network)
+        MyFakeProvider.__abstractmethods__ = set()  # type: ignore
+        provider = MyFakeProvider(name="fake", network=eth_tester_provider.network)  # type: ignore
         provider.process = mock_process
 
         with create_tempdir() as tmp:

--- a/tests/functional/test_network_manager.py
+++ b/tests/functional/test_network_manager.py
@@ -304,7 +304,7 @@ def test_create_custom_provider_ws(networks, scheme):
 def test_create_custom_provider_ipc(networks):
     provider = networks.create_custom_provider("path/to/geth.ipc")
     assert provider.ipc_path == Path("path/to/geth.ipc")
-    assert provider.uri == provider.ipc_path
+    assert provider.uri == f"{provider.ipc_path}"
 
 
 def test_ecosystems(networks):

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -802,9 +802,9 @@ class TestSubprocessProvider:
                 return ["apemockprocess"]
 
         # Hack to allow abstract methods anyway.
-        MockSubprocessProvider.__abstractmethods__ = set()
+        MockSubprocessProvider.__abstractmethods__ = set()  # type: ignore
 
-        return MockSubprocessProvider(name="apemockprocess", network=eth_tester_provider.network)
+        return MockSubprocessProvider(name="apemockprocess", network=eth_tester_provider.network)  # type: ignore
 
     def test_start(self, subprocess_provider):
         assert not subprocess_provider.is_connected

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -12,6 +12,7 @@ from requests import HTTPError
 from web3.exceptions import ContractPanicError, TimeExhausted
 
 from ape import convert
+from ape.api.providers import SubprocessProvider
 from ape.exceptions import (
     APINotImplementedError,
     BlockNotFoundError,
@@ -367,7 +368,9 @@ def test_set_timestamp_handle_same_time_race_condition(mocker, eth_tester_provid
     eth_tester_provider.set_timestamp(123)
 
 
-def test_get_virtual_machine_error_when_txn_failed_includes_base_error(eth_tester_provider):
+def test_get_virtual_machine_error_when_txn_failed_includes_base_error(
+    eth_tester_provider,
+):
     txn_failed = TransactionFailed()
     actual = eth_tester_provider.get_virtual_machine_error(txn_failed)
     assert actual.base_err == txn_failed
@@ -416,7 +419,12 @@ def test_no_comma_in_rpc_url():
 
 
 def test_send_transaction_when_no_error_and_receipt_fails(
-    mocker, mock_web3, mock_transaction, eth_tester_provider, owner, vyper_contract_instance
+    mocker,
+    mock_web3,
+    mock_transaction,
+    eth_tester_provider,
+    owner,
+    vyper_contract_instance,
 ):
     start_web3 = eth_tester_provider._web3
     eth_tester_provider._web3 = mock_web3
@@ -661,7 +669,11 @@ def test_account_balance_state(project, eth_tester_provider, owner):
 
 @pytest.mark.parametrize(
     "uri,key",
-    [("ws://example.com", "ws_uri"), ("wss://example.com", "ws_uri"), ("wss://example.com", "uri")],
+    [
+        ("ws://example.com", "ws_uri"),
+        ("wss://example.com", "ws_uri"),
+        ("wss://example.com", "uri"),
+    ],
 )
 def test_node_ws_uri(project, uri, key):
     node = project.network_manager.ethereum.sepolia.get_provider("node")
@@ -755,3 +767,55 @@ def test_connect_uses_cached_chain_id(mocker, mock_web3, ethereum, eth_tester_pr
     provider.connect()
     # It is still cached from the previous connection.
     assert chain_id_tracker.call_count == 1
+
+
+class TestSubprocessProvider:
+    FAKE_PID = 12345678901234567890
+
+    @pytest.fixture(autouse=True)
+    def mock_process(self, mocker):
+        mock_process = mocker.MagicMock()
+        mock_process.pid = self.FAKE_PID
+        return mock_process
+
+    @pytest.fixture(autouse=True)
+    def popen_patch(self, mocker, mock_process):
+        # Prevent actually creating new processes.
+        patch = mocker.patch("ape.api.providers.popen")
+        patch.return_value = mock_process
+        return patch
+
+    @pytest.fixture(autouse=True)
+    def spawn_patch(self, mocker):
+        # Prevent spawning process monitoring threads.
+        return mocker.patch("ape.api.providers.spawn")
+
+    @pytest.fixture
+    def subprocess_provider(self, popen_patch, eth_tester_provider):
+        class MockSubprocessProvider(SubprocessProvider):
+            @property
+            def is_connected(self):
+                # Once Popen is called once, we are "connected"
+                return popen_patch.call_count > 0
+
+            def build_command(self) -> list[str]:
+                return ["apemockprocess"]
+
+        # Hack to allow abstract methods anyway.
+        MockSubprocessProvider.__abstractmethods__ = set()
+
+        return MockSubprocessProvider(name="apemockprocess", network=eth_tester_provider.network)
+
+    def test_start(self, subprocess_provider):
+        assert not subprocess_provider.is_connected
+        subprocess_provider.start()
+        assert subprocess_provider.is_connected
+
+        # Show it gets tracked in network manager's managed nodes.
+        assert self.FAKE_PID in subprocess_provider.network_manager.running_nodes
+
+    def test_start_allow_start_false(self, subprocess_provider):
+        subprocess_provider.allow_start = False
+        expected = r"Process not started and cannot connect to existing process\."
+        with pytest.raises(ProviderError, match=expected):
+            subprocess_provider.start()

--- a/tests/integration/cli/test_networks.py
+++ b/tests/integration/cli/test_networks.py
@@ -158,7 +158,7 @@ def test_list_running(ape_cli, runner, geth_provider):
     assert result.exit_code == 0
     assert geth_provider.ipc_path is not None, "any uri is needed for test"
     actual = "".join(result.output.split("\n"))
-    assert f"{geth_provider.ipc_path}" in actual
+    assert f"{geth_provider.ipc_path}" in actual or "Local node(s) not running." in actual
 
 
 @run_once

--- a/tests/integration/cli/test_networks.py
+++ b/tests/integration/cli/test_networks.py
@@ -152,6 +152,15 @@ def test_list_geth(ape_cli, runner, networks, project):
     assert actual_uri.startswith("http")
 
 
+@skip_projects_except("geth")
+def test_list_running(ape_cli, runner, geth_provider):
+    result = runner.invoke(ape_cli, ("networks", "list", "--running"))
+    assert result.exit_code == 0
+    assert geth_provider.ipc_path is not None, "any uri is needed for test"
+    actual = "".join(result.output.split("\n"))
+    assert f"{geth_provider.ipc_path}" in actual
+
+
 @run_once
 def test_list_filter_networks(ape_cli, runner):
     result = runner.invoke(ape_cli, ("networks", "list", "--network", "sepolia"))


### PR DESCRIPTION
### What I did

Allows flows like this:

```
ape networks run --network ::node --background
ape networks list --running
ape networks ping --network ::node
ape networks kill --all
```

basically Ape now tracks the processes it has started and you can easily kill them all from the command line as well more easily background the processes in the same terminal session and w/o losing the PID

fixes: #2528 

Also allows 

```python
with networks.parse_network_choice("pid://12345") as running_node":
    ...
```

For connecting to local nodes processes via PID.
**Note**: this process must have been started by Ape for this to work currently though.

### How I did it

copied this from the `dfx` tool: https://github.com/dfinity/sdk

### How to verify it

tbd

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
- [x] Documentation is complete
