### PR TITLE
fix: issue where `project.sources.lookup()` returned wrong path in certain conditions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = ["setuptools>=75.0.0", "wheel", "setuptools_scm[toml]>=5.0"]
 
+[tool.ape]
+contracts_folder = "tests/functional/data/contracts/ethereum/local"
+
 [tool.ape.test]
 show_internal = true
 

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -259,7 +259,7 @@ class SourceManager(BaseManager):
             Path: The full path to the source file.
         """
         input_path = Path(path_id)
-        if input_path.is_file():
+        if input_path.is_file() and input_path.is_relative_to(self.root_path):
             # Already given an existing file.
             return input_path.absolute()
 

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -876,12 +876,14 @@ class TestSourceManager:
         path = project.sources.lookup(source_id)
         assert path.is_file(), "Test path does not exist."
 
-        with Project.create_temporary_project() as other_tmp_project:
+        cfg = {"contracts_folder": project.config.contracts_folder}
+        with Project.create_temporary_project(config_override=cfg) as other_tmp_project:
             new_source = other_tmp_project.path / source_id
             new_source.parent.mkdir(parents=True, exist_ok=True)
             new_source.write_text(path.read_text(encoding="utf8"), encoding="utf8")
 
             actual = other_tmp_project.sources.lookup(source_id)
+            assert actual is not None
             expected = other_tmp_project.path / source_id
             assert actual == expected
 

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -866,6 +866,25 @@ class TestSourceManager:
         path = tmp_project.sources.lookup(source_id)
         assert path == tmp_project.path / source_id
 
+    def test_lookup_same_source_id_as_local_project(self, project, tmp_project):
+        """
+        Tests against a bug where if the source ID of the project matched
+        a file in the local project, it would mistakenly return the path
+        to the local file instead of the project's file.
+        """
+        source_id = project.contracts["ContractA"].source_id
+        path = project.sources.lookup(source_id)
+        assert path.is_file(), "Test path does not exist."
+
+        with Project.create_temporary_project() as other_tmp_project:
+            new_source = other_tmp_project.path / source_id
+            new_source.parent.mkdir(parents=True, exist_ok=True)
+            new_source.write_text(path.read_text(encoding="utf8"), encoding="utf8")
+
+            actual = other_tmp_project.sources.lookup(source_id)
+            expected = other_tmp_project.path / source_id
+            assert actual == expected
+
     def test_lookup_missing_extension(self, tmp_project):
         source_id = tmp_project.Other.contract_type.source_id
         source_id_wo_ext = ".".join(source_id.split(".")[:-1])


### PR DESCRIPTION
### What I did

If you are using a non-local project with a source ID that happened to exist in the local project, it would mistakenly return you the wrong paths, which was kinda bad and caused bugs.

### How I did it

Require the source ID also to have the right base path before early returning

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
