### PR TITLE
feat: Add python loc option for installing plugins

### DIFF
--- a/src/ape/plugins/_utils.py
+++ b/src/ape/plugins/_utils.py
@@ -1,8 +1,12 @@
+import json
+import os
 import re
+import subprocess
 import sys
 from collections.abc import Iterable, Iterator, Sequence
 from enum import Enum
 from functools import cached_property
+from pathlib import Path
 from shutil import which
 from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urlparse
@@ -482,6 +486,53 @@ class PluginMetadata(BaseInterfaceModel):
         trusted_list = trusted_list or TRUSTED_PLUGINS
         return self.name in trusted_list
 
+    def is_venv(self):
+        """
+        Check if the current Python environment is a virtual environment.
+        Returns True for venv, virtualenv, and conda environments.
+        """
+        standard_venv = hasattr(sys, "real_prefix") or (
+            hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix
+        )
+        conda_env = os.environ.get("CONDA_PREFIX") is not None
+
+        return standard_venv or conda_env
+
+    def infer_pipx_venv_location(self, package_name: str) -> Optional[str]:
+        """
+        Get the virtual environment location for a specific package using `pipx list --json`.
+
+        Args:
+            package_name (str): The name of the package to look up.
+
+        Returns:
+            str: The path to the virtual environment for the specified package if found else None
+        """
+        logger.info("Trying to infer virtual environment location using pipx")
+        try:
+            result = subprocess.run(
+                ["pipx", "list", "--json"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            pipx_data = json.loads(result.stdout)
+
+            if package_name not in pipx_data.get("venvs", {}):
+                return None
+
+            bin_path = pipx_data["venvs"][package_name]["metadata"]["main_package"]["app_paths"][0][
+                "__Path__"
+            ]
+            venv_path = str(
+                Path(bin_path).parent.parent
+            )  # Go up two levels to get the venv directory
+
+            return venv_path
+        except Exception as e:
+            logger.warning("Exception while trying to infer virtual environment location: %s", e)
+            return None
+
     def _prepare_install(
         self, upgrade: bool = False, skip_confirmation: bool = False
     ) -> Optional[dict[str, Any]]:
@@ -502,6 +553,11 @@ class PluginMetadata(BaseInterfaceModel):
 
         result_handler = ModifyPluginResultHandler(self)
         pip_arguments = [*self.pip_command, "install"]
+
+        if not self.is_venv() and self.pip_command[0] == "uv":
+            virtual_env = self.infer_pipx_venv_location("eth-ape")
+            if virtual_env:
+                pip_arguments.extend(("--python", virtual_env))
 
         if upgrade:
             logger.info(f"Upgrading '{self.name}' plugin ...")

--- a/src/ape/plugins/_utils.py
+++ b/src/ape/plugins/_utils.py
@@ -486,7 +486,7 @@ class PluginMetadata(BaseInterfaceModel):
         self,
         verb: str,
         python_location: Optional[str] = None,
-        extra_args: Optional[list[str]] = None,
+        extra_args: Optional[Iterable[str]] = None,
     ) -> list[str]:
         """
         Build command arguments for pip or uv package managers.
@@ -494,19 +494,21 @@ class PluginMetadata(BaseInterfaceModel):
         Usage:
             args = prepare_package_manager_args("install", "/path/to/python", ["--user"])
         """
-        extra_args = extra_args or []
+        extra_args = list(extra_args) if extra_args else []
         command = list(self.pip_command)
 
         if command[0] == "uv":
-            if python_location:
-                return command + [verb, "--python", python_location] + extra_args
-            else:
-                return command + [verb] + extra_args
-        else:
-            if python_location:
-                return command + ["--python", python_location, verb] + extra_args
-            else:
-                return command + [verb] + extra_args
+            return (
+                [*command, verb, "--python", python_location] + extra_args
+                if python_location
+                else [*command, verb, *extra_args]
+            )
+
+        return (
+            [*command, "--python", python_location, verb] + extra_args
+            if python_location
+            else [*command, verb, *extra_args]
+        )
 
     def _prepare_install(
         self,

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -97,7 +97,8 @@ def validate_python_path(ctx, param, value):
     path = Path(value).expanduser().resolve()
     if not path.exists():
         ctx.fail(f"Python path does not exist: {value}")
-    return str(path)
+
+    return f"{path}"
 
 
 def python_location_option(help: str = "", **kwargs):
@@ -240,7 +241,7 @@ def uninstall(cli_ctx, plugins, skip_confirmation, python: str):
             skip_confirmation or click.confirm(f"Remove plugin '{plugin}'?")
         ):
             cli_ctx.logger.info(f"Uninstalling '{plugin.name}'...")
-            arguments = plugin._get_uninstall_args(python)
+            arguments = plugin._get_uninstall_args(python_location=python)
 
             # NOTE: Be *extremely careful* with this command, as it modifies the user's
             #       installed packages, to potentially catastrophic results

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -240,7 +240,7 @@ def uninstall(cli_ctx, plugins, skip_confirmation, python: str):
             skip_confirmation or click.confirm(f"Remove plugin '{plugin}'?")
         ):
             cli_ctx.logger.info(f"Uninstalling '{plugin.name}'...")
-            arguments = plugin._get_uninstall_args(python)
+            arguments = plugin._get_uninstall_args(python_location)
 
             # NOTE: Be *extremely careful* with this command, as it modifies the user's
             #       installed packages, to potentially catastrophic results

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -240,7 +240,7 @@ def uninstall(cli_ctx, plugins, skip_confirmation, python: str):
             skip_confirmation or click.confirm(f"Remove plugin '{plugin}'?")
         ):
             cli_ctx.logger.info(f"Uninstalling '{plugin.name}'...")
-            arguments = plugin._get_uninstall_args(python_location)
+            arguments = plugin._get_uninstall_args(python)
 
             # NOTE: Be *extremely careful* with this command, as it modifies the user's
             #       installed packages, to potentially catastrophic results

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -17,7 +17,6 @@ from ape.plugins._utils import (
     _filter_plugins_from_dists,
     ape_version,
 )
-from ape_plugins._cli import validate_python_path
 
 CORE_PLUGINS = ("run",)
 AVAILABLE_PLUGINS = ("available", "installed")
@@ -269,7 +268,7 @@ class TestPluginMetadata:
     @parametrize_pip_cmd
     def test_get_uninstall_args(self, pip_command):
         metadata = PluginMetadata(name="dontmatter", pip_command=pip_command)
-        arguments = metadata._get_uninstall_args()
+        arguments = metadata._get_uninstall_args(python_location=None)
         pip_cmd_len = len(metadata.pip_command)
 
         for idx, pip_pt in enumerate(pip_command):
@@ -423,14 +422,6 @@ def test_core_plugins():
     non_core_plugins = ("ape_arbitrum", "ape_vyper", "ape_solidity", "ape_ens")
     assert not any(p in CORE_PLUGINS_LIST for p in non_core_plugins)
     assert "ape_ethereum" in CORE_PLUGINS_LIST
-
-
-@pytest.fixture
-def mock_python_path(tmp_path):
-    """Create a temporary path to simulate a Python interpreter location."""
-    python_path = tmp_path / "python"
-    python_path.touch()
-    return str(python_path)
 
 
 class TestBuildPipArgs:

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -96,7 +96,7 @@ def mock_python_path(tmp_path):
     """Create a temporary path to simulate a Python interpreter location."""
     python_path = tmp_path / "python"
     python_path.touch()
-    return str(python_path)
+    return f"{python_path}"
 
 
 @pytest.fixture
@@ -431,11 +431,11 @@ class TestBuildPipArgs:
 
         args = metadata.prepare_package_manager_args("install", python_location=mock_python_path)
 
-        if pip_command[0] == "uv":
-            expected = pip_command + ["install", "--python", mock_python_path]
-        else:
-            expected = pip_command + ["--python", mock_python_path, "install"]
-
+        expected = (
+            [*pip_command, "install", "--python", mock_python_path]
+            if pip_command[0] == "uv"
+            else [*pip_command, "--python", mock_python_path, "install"]
+        )
         assert args == expected
 
     @parametrize_pip_cmd
@@ -457,11 +457,11 @@ class TestBuildPipArgs:
             "install", python_location=mock_python_path, extra_args=extra
         )
 
-        if pip_command[0] == "uv":
-            expected = pip_command + ["install", "--python", mock_python_path] + extra
-        else:
-            expected = pip_command + ["--python", mock_python_path, "install"] + extra
-
+        expected = (
+            [*pip_command, "install", "--python", mock_python_path] + extra
+            if pip_command[0] == "uv"
+            else [*pip_command, "--python", mock_python_path, "install"] + extra
+        )
         assert args == expected
 
     @parametrize_pip_cmd
@@ -470,9 +470,9 @@ class TestBuildPipArgs:
 
         args = metadata.prepare_package_manager_args("uninstall", python_location=mock_python_path)
 
-        if pip_command[0] == "uv":
-            expected = pip_command + ["uninstall", "--python", mock_python_path]
-        else:
-            expected = pip_command + ["--python", mock_python_path, "uninstall"]
-
+        expected = (
+            [*pip_command, "uninstall", "--python", mock_python_path]
+            if pip_command[0] == "uv"
+            else [*pip_command, "--python", mock_python_path, "uninstall"]
+        )
         assert args == expected


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

Related to issue #2350 

### How I did it

I installed eth-ape using pipx and noticed that `ape plugins install arbitrum` fails since it can't find the virtual environment
Added an optional python venv location so that user can specify the location incase the install fails.

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
- [ ] Documentation is complete
