### PR TITLE
fix: interface compiler would compile the wrong interfaces when source ID matched local project

### DIFF
--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -45,13 +45,16 @@ class InterfaceCompiler(CompilerAPI):
         }
         logger.info(f"Compiling {', '.join(source_ids.values())}.")
         for path in contract_filepaths:
-            if not path.is_file() and (project.path / path).is_file():
-                # Was given a relative path.
+            if (not path.is_absolute() and (project.path / path).is_file()):
+                # Was given a relative path to the project.
                 src_path = project.path / path
-            elif not path.is_file():
-                raise CompilerError(f"'{path}' is not a file.")
-            else:
+
+            elif path.is_file():
+                # Absolute existing path.
                 src_path = path
+
+            else:
+                raise CompilerError(f"'{path}' is not a file.")
 
             code = src_path.read_text()
             source_id = source_ids[path]

--- a/src/ape_pm/compiler.py
+++ b/src/ape_pm/compiler.py
@@ -45,7 +45,7 @@ class InterfaceCompiler(CompilerAPI):
         }
         logger.info(f"Compiling {', '.join(source_ids.values())}.")
         for path in contract_filepaths:
-            if (not path.is_absolute() and (project.path / path).is_file()):
+            if not path.is_absolute() and (project.path / path).is_file():
                 # Was given a relative path to the project.
                 src_path = project.path / path
 

--- a/tests/functional/test_compilers.py
+++ b/tests/functional/test_compilers.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from re import Pattern
 from typing import cast
@@ -200,6 +201,45 @@ def test_compile_source(compilers):
     code = '[{"name":"foo","type":"fallback", "stateMutability":"nonpayable"}]'
     actual = compilers.compile_source("ethpm", code)
     assert isinstance(actual, ContractContainer)
+
+
+def test_compile_in_project_where_source_id_matches_local_project(project, compilers):
+    """
+    Tests against a bug where if you had two projects with the same source IDs but
+    different content, it always compiled the local project's source.
+    """
+    new_abi = {
+        "inputs": [],
+        "name": "retrieve",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    }
+    content = json.dumps([new_abi])
+    with project.isolate_in_tempdir() as temp_project:
+        assert compilers.local_project.path != temp_project.path, (
+            "Cannot be same as local for this test"
+        )
+        contract = temp_project.load_contracts()["Interface"]
+        path = temp_project.sources.lookup(contract.source_id)
+        path.unlink(missing_ok=True)
+        path.write_text(content, encoding="utf8")
+
+        # NOTE: Another condition for this bug is that the given path
+        #   must be in source-ID form, meaning it relative to the project
+        #   (but not _necessarily_ a relative path, e.g. no `./` prefix).
+        argument = Path(contract.source_id)
+
+        # Compile the file with the same name but different content.
+        result = [
+            x
+            for x in compilers.compile([argument], project=temp_project)
+            if x.name == contract.name
+        ][0]
+
+        # It should reflect the new content and not the one with the same
+        # source ID from the local project.
+        assert "retrieve" in result.methods
 
 
 def test_enrich_error_custom_error(chain, compilers):

--- a/tests/integration/cli/test_compile.py
+++ b/tests/integration/cli/test_compile.py
@@ -39,7 +39,8 @@ def test_compile_missing_contracts_dir(ape_cli, runner, project):
 
 @skip_non_compilable_projects
 def test_compile(ape_cli, runner, integ_project, clean_cache):
-    assert not integ_project.manifest.contract_types, "Setup failed - expecting clean start"
+    integ_project.clean()
+
     cmd = ("compile", "--project", f"{integ_project.path}")
     result = runner.invoke(ape_cli, cmd, catch_exceptions=False)
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
### What I did

kinda a weird bug but it threw me for a loop, I tried to clean up the logic a bit and fix it.

### How I did it

Check `.is_absolute()` instead of `.is_file()` in the case of checking if path is relative to the given project.

### How to verify it


See my test, requires a very oddly specific setup.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
