### PR TITLE
fix: bugs where interfaces would unpack in the wrong spot

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -2533,10 +2533,10 @@ class LocalProject(Project):
             shutil.copytree(self.tests_folder, tests_destination, dirs_exist_ok=True)
 
         # Unpack interfaces folder. Avoid double unpacking if already covered in contracts folder.
-        if self.interfaces_folder.is_dir() and self.interfaces_folder.is_relative_to(
+        if self.interfaces_folder.is_dir() and not self.interfaces_folder.is_relative_to(
             self.contracts_folder
         ):
-            prefix = get_relative_path(self.interfaces_folder, self.path)
+            prefix = get_relative_path(self.interfaces_folder.parent, self.path)
             interfaces_destination = destination / prefix / self.config.interfaces_folder
             interfaces_destination.parent.mkdir(parents=True, exist_ok=True)
             shutil.copytree(self.interfaces_folder, interfaces_destination, dirs_exist_ok=True)

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -546,6 +546,36 @@ def test_unpack_includes_build_file(project_with_contracts):
         assert expected.is_file()
 
 
+def test_unpack_includes_interfaces():
+    iname = "unp_interface"
+    with create_tempdir() as path:
+        interfaces = path / "interfaces"
+        interfaces.mkdir(parents=True, exist_ok=True)
+        interface = interfaces / f"{iname}.json"
+        interface.write_text("{}", encoding="utf8")
+
+        project = Project(path)
+        with create_tempdir() as new_path:
+            project.unpack(new_path)
+            expected_interface = new_path / "interfaces" / f"{iname}.json"
+            assert expected_interface.is_file()
+
+
+def test_unpack_includes_interfaces_when_part_of_contracts():
+    iname = "unp_interface"
+    with create_tempdir() as path:
+        interfaces = path / "contracts" / "interfaces"
+        interfaces.mkdir(parents=True, exist_ok=True)
+        interface = interfaces / f"{iname}.json"
+        interface.write_text("{}", encoding="utf8")
+
+        project = Project(path)
+        with create_tempdir() as new_path:
+            project.unpack(new_path)
+            expected_interface = new_path / "contracts" / "interfaces" / f"{iname}.json"
+            assert expected_interface.is_file()
+
+
 def test_add_compiler_data(project_with_dependency_config):
     # NOTE: Using different project than default to lessen
     #   chance of race-conditions from multiprocess test runners.


### PR DESCRIPTION
### What I did

`project.unpack()` was not properly handling interfaces... The condition was flipped mistakenly so it would double unpack them... That is fine, but it still would unpack them in the wrong spot anyway, with an extra nested `"interfaces"` keyword.

### How I did it

get the relative path from the parent of the project's path instead of the project's path

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
