### PR TITLE
fix(deps): upgrade packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         "cchecksum>=0.0.3,<1",
         # Pandas peer-dep: Numpy 2.0 causes issues for some users.
         "numpy<2",
-        "packaging>=23.0,<24",
+        "packaging>=24.2,<25",
         "pandas>=2.2.2,<3",
         "pluggy>=1.3,<2",
         "pydantic>=2.10.0,<3",

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -1038,6 +1038,7 @@ class PackagesCache(ManagerAccessMixin):
                 shutil.rmtree(self.root)
                 if packages_cache.is_dir():
                     # Restore.
+                    self.root.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copytree(packages_cache, self.root)
 
 
@@ -2511,11 +2512,13 @@ class LocalProject(Project):
 
     def unpack(self, destination: Path, config_override: Optional[dict] = None) -> "LocalProject":
         config_override = {**self._config_override, **(config_override or {})}
+        destination.mkdir(parents=True, exist_ok=True)
 
         # Unpack contracts.
         if self.contracts_folder.is_dir():
             contracts_path = get_relative_path(self.contracts_folder, self.path)
             contracts_destination = destination / contracts_path
+            contracts_destination.parent.mkdir(parents=True, exist_ok=True)
             shutil.copytree(self.contracts_folder, contracts_destination, dirs_exist_ok=True)
 
         # Unpack config file.


### PR DESCRIPTION
### What I did

I guess `setuptools` upgraded there pin and it screwed us:
https://github.com/ApeWorX/ape/actions/runs/13958350355/job/39075553268

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
- [x] Documentation is complete
