### PR TITLE
fix: incorrect variable usage in ApeVersion method

### DIFF
--- a/src/ape/plugins/_utils.py
+++ b/src/ape/plugins/_utils.py
@@ -167,8 +167,8 @@ class ApeVersion:
         for spec in spec_set:
             spec_version = Version(spec.version)
             if spec.operator in ("==", "<", "<=") and (
-                (self.is_pre_one and spec_version.major < ape_version.major)
-                or (self.is_pre_one and spec_version.minor < ape_version.minor)
+                (self.is_pre_one and spec_version.major < self.major)
+                or (self.is_pre_one and spec_version.minor < self.minor)
             ):
                 return True
 


### PR DESCRIPTION
### What I did
Fixed an issue in the `ApeVersion` class method where it incorrectly compared with the global `ape_version` instead of using the object's current version (`self.major` and `self.minor`).

### How I did it
Replaced `ape_version.major` and `ape_version.minor` with `self.major` and `self.minor` to ensure the method compares the object's version correctly.

### How to verify it
Ensure that the method now properly compares the instance version with the given values when called on an `ApeVersion` object. Run the associated tests to confirm the fix.

### Checklist

- [x] All changes are completed
- [x] Change is covered in tests
- [x] Documentation is complete