### PR TITLE
feat: add three converters to ape-ethereum plugin

### DIFF
--- a/src/ape_ethereum/__init__.py
+++ b/src/ape_ethereum/__init__.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from ape import plugins
 
 
@@ -10,9 +12,17 @@ def config_class():
 
 @plugins.register(plugins.ConversionPlugin)
 def converters():
-    from ape_ethereum._converters import WeiConversions
+    from ape_ethereum._converters import (
+        EthDecimalStrConversions,
+        WeiConversions,
+        WeiIntEthDecimalConversions,
+        WeiIntStrConversions,
+    )
 
     yield int, WeiConversions
+    yield str, WeiIntStrConversions
+    yield str, EthDecimalStrConversions
+    yield Decimal, WeiIntEthDecimalConversions
 
 
 @plugins.register(plugins.EcosystemPlugin)

--- a/src/ape_ethereum/_converters.py
+++ b/src/ape_ethereum/_converters.py
@@ -41,3 +41,45 @@ class WeiConversions(ConverterAPI):
             Decimal(value.replace("_", "").replace(",", "")) * ETHER_UNITS[unit.lower()]
         )
         return CurrencyValue(converted_value)
+
+
+class WeiIntStrConversions(ConverterAPI):
+    """Converts a int to a string units like 1e18 to '1 ether'."""
+
+    def is_convertible(self, value: str) -> bool:
+        return isinstance(value, int)
+
+    def convert(self, value: int) -> str:
+        from ape import convert
+
+        decimal_value = convert(value, Decimal)
+
+        return convert(decimal_value, str)
+
+
+class EthDecimalStrConversions(ConverterAPI):
+    """Converts a decimal to a string units like 1.0 to '1 ether'."""
+
+    def is_convertible(self, value: str) -> bool:
+        return isinstance(value, Decimal)
+
+    def convert(self, value: Decimal) -> str:
+        ETH_THRESHOLD = 1 / Decimal(1e3)
+        GWEI_THRESHOLD = 1 / Decimal(1e12)
+
+        if value < GWEI_THRESHOLD:
+            return f"{value * Decimal(1e18).normalize():,f} wei"
+        elif GWEI_THRESHOLD <= value < ETH_THRESHOLD:
+            return f"{value * Decimal(1e9).normalize():,f} gwei"
+        # value >= ETH_THRESHOLD
+        return f"{value.normalize():,f} ether"
+
+
+class WeiIntEthDecimalConversions(ConverterAPI):
+    """Converts a int to a decimal units like 1e18 to Decimal('1.0')"""
+
+    def is_convertible(self, value: int) -> bool:
+        return isinstance(value, int)
+
+    def convert(self, value: int) -> Decimal:
+        return Decimal(value) / Decimal(1e18)

--- a/tests/functional/conversion/test_ether.py
+++ b/tests/functional/conversion/test_ether.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pytest
 from eth_typing import ChecksumAddress
 from hypothesis import given
@@ -54,4 +56,46 @@ def test_separaters(convert, sep):
     currency_str = f"10{sep}000 ETHER"
     actual = convert(currency_str, int)
     expected = TEN_THOUSAND_ETHER_IN_WEI
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "val,expected",
+    [
+        (int(1e18), "1 ether"),
+        (int(1e9), "1 gwei"),
+        (1, "1 wei"),
+        (int(1e6), "0.001 gwei"),
+        (int(1e17), "0.1 ether"),
+        (int(1e20), "100 ether"),
+        (int(1e7), "0.01 gwei"),
+        (int(1e14), "100,000 gwei"),
+    ],
+)
+def test_convert_int_str(val, expected, convert):
+    """
+    Show that converting a Decimal to a currency string works.
+    """
+    actual = convert(val, str)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "val,expected",
+    [
+        (Decimal(1), "1 ether"),
+        (Decimal(1) / Decimal(1e9), "1 gwei"),
+        (Decimal(1) / Decimal(1e18), "1 wei"),
+        (Decimal(1000000), "1,000,000 ether"),
+        (Decimal(1) / Decimal(1000), "0.001 ether"),
+        (Decimal(1) / Decimal(1e10), "0.1 gwei"),
+        (Decimal(1) / Decimal(1e7), "100 gwei"),
+        (Decimal(1) / Decimal(10000), "100,000 gwei"),
+    ],
+)
+def test_convert_dec_str(val, expected, convert):
+    """
+    Show that converting a Decimal to a currency string works.
+    """
+    actual = convert(val, str)
     assert actual == expected


### PR DESCRIPTION
### What I did

This PR adds three new converters to handle ethereum units:

1. ` WeiIntStrConversions` : Converts an integer value (in wei) to a string representation (e.g. 1e18 to "1 ether"). 
2. `EthDecimalStrConversions` : Converts a Decimal value ( in ether ) to a string representation.
3. `WeiIntEthDecimalConversions`: Converts an integer value (in wei) to a Decimal representation in ether.

String conversions select the most appropriate Ethereum unit ( "ether", "gwei", or "wei") based on the value.


<!-- All PRs must complete the following checklist before being merged -->

- [ x] All changes are completed
- [x ] Change is covered in tests
- [ ] Documentation is complete
