### PR TITLE
fix(Contracts): only update contract cache with proper merge of ABI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
         "web3[tester]>=6.20.1,<8",
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.2.10,<0.3",
-        "ethpm-types>=0.6.23,<0.7",
+        "ethpm-types>=0.6.25,<0.7",
         "eth_pydantic_types>=0.1.3,<0.2",
         "evmchains>=0.1.0,<0.2",
         "evm-trace>=0.2.3,<0.3",

--- a/src/ape/managers/_contractscache.py
+++ b/src/ape/managers/_contractscache.py
@@ -955,5 +955,9 @@ def _merge_abis(base_contract: ContractType, extra_abis: list[ABI]) -> ContractT
 def _merge_contract_types(
     base_contract_type: ContractType, additive_contract_type: ContractType
 ) -> ContractType:
+    existing_methods = set(_get_relevant_additive_abis(base_contract_type))
     relevant_abis = _get_relevant_additive_abis(additive_contract_type)
-    return _merge_abis(base_contract_type, relevant_abis)
+    return _merge_abis(
+        base_contract_type,
+        [abi for abi in relevant_abis if abi not in existing_methods],
+    )

--- a/tests/functional/test_contracts_cache.py
+++ b/tests/functional/test_contracts_cache.py
@@ -5,6 +5,7 @@ from ape import Contract
 from ape.contracts import ContractInstance
 from ape.exceptions import ContractNotFoundError, ConversionError
 from ape.logging import LogLevel, logger
+from ape.managers._contractscache import _merge_contract_types
 from ape_ethereum.proxies import ProxyInfo, ProxyType, _make_minimal_proxy
 from tests.conftest import explorer_test, skip_if_plugin_installed
 
@@ -17,6 +18,15 @@ def contract_0(vyper_contract_container):
 @pytest.fixture
 def contract_1(solidity_contract_container):
     return solidity_contract_container
+
+
+def test_merge_contract_types(contract_instance):
+    ct = contract_instance.contract_type
+    modified_ct = ct.model_copy(deep=True)
+    modified_ct.view_methods[0].name = "foo"
+    new_ct = _merge_contract_types(ct, modified_ct)
+    assert len(new_ct.abi) == len(ct.abi) + 1 == len(modified_ct.abi) + 1
+    assert len(new_ct.abi) == len(_merge_contract_types(new_ct, modified_ct).abi)
 
 
 def test_instance_at(chain, contract_instance):


### PR DESCRIPTION
### What I did

Noticed that when a contract type was "merged" (by combining ABIs of 2 different types) that it was duplicating the shared ABI between the two. This change instead makes sure that only those ABIs that were missing from the underlying contract type will get merged with the base, ensuring that problems with duplicate methods do not appear.

fixes: #2566

### How I did it

Check relevant ABIs against the set of existing ABIs of the base contract type before merging. Do no merge those that are shared between the existing base contract type and the type to merge it with

### How to verify it

see: #2566

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
~~- [ ] Documentation is complete~~
