### PR TITLE
Added `via_ir` Detection for Foundry Projects in Ape

### DIFF
--- a/src/ape_pm/project.py
+++ b/src/ape_pm/project.py
@@ -266,6 +266,9 @@ class FoundryProject(ProjectAPI):
         if evm_version := data.get("evm_version"):
             sol_cfg["evm_version"] = evm_version
 
+        if via_ir := data.get("via_ir"):
+            sol_cfg["viaIR"] = via_ir
+
         foundry_remappings = [*data.get("remappings", []), *self._parse_remappings_file()]
         if remappings := self._parse_remappings(
             foundry_remappings, dependencies, lib_paths, contracts_folder=contracts_folder

--- a/src/ape_pm/project.py
+++ b/src/ape_pm/project.py
@@ -267,7 +267,7 @@ class FoundryProject(ProjectAPI):
             sol_cfg["evm_version"] = evm_version
 
         if via_ir := data.get("via_ir"):
-            sol_cfg["viaIR"] = via_ir
+            sol_cfg["via_ir"] = via_ir
 
         foundry_remappings = [*data.get("remappings", []), *self._parse_remappings_file()]
         if remappings := self._parse_remappings(

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -59,6 +59,7 @@ out = 'out'
 libs = ['lib']
 solc = "0.8.18"
 evm_version = 'cancun'
+via_ir = true
 
 remappings = [
     'forge-std/=lib/forge-std/src/',
@@ -877,6 +878,7 @@ class TestFoundryProject:
             ]
             assert actual_sol["version"] == "0.8.18"
             assert actual_sol["evm_version"] == "cancun"
+            assert actual_sol["via_ir"] is True
 
             # Ensure dependencies migrated from .gitmodules.
             assert "dependencies" in actual, "Dependencies failed to migrate"


### PR DESCRIPTION
## Description

This PR fixes issue #2564  , where Ape’s `FoundryProject` class does not detect the `via_ir` setting from Foundry’s `foundry.toml` configuration file. 

The change updates the `_parse_solidity_config` method in `src/ape_pm/project.py` to read the `via_ir` key and include it in the Solidity compiler configuration as `viaIR`. This ensures Ape respects Foundry’s `via_ir` setting during compilation, aligning with Foundry’s behavior.

### Changes Made
- Modified `FoundryProject._parse_solidity_config` in `src/ape_pm/project.py` to check for `via_ir` in the parsed `foundry.toml` data.
- Added `via_ir` to the `sol_cfg` dictionary as `"viaIR": via_ir` when present, preserving existing logic for other settings (`version`, `evm_version`, `remappings`).
- While ensuring safe handling of missing `via_ir` keys using `data.get("via_ir")`.

---

### Testing

- Created a test Foundry project with:

  ```toml
  [profile.default]
  via_ir = true
  ```
  in `foundry.toml`.

- Ran `ape compile` to verify that the compiler applies the `viaIR` pipeline (confirmed via compiler output).
- Tested with `via_ir` absent to ensure no unintended side effects.
- [Optional] Added a unit test in `tests/test_foundry_project.py` to validate `via_ir` detection.

---

Thank you for considering this contribution! 🚀
