### PR TITLE
feat: allow specifying topic filters w/ `ContractEvent.poll_logs` 

### DIFF
--- a/docs/userguides/contracts.md
+++ b/docs/userguides/contracts.md
@@ -385,6 +385,26 @@ receipt = contract.set_number(sender=dev, private=True)
 
 The `private=True` is available on all contract interactions.
 
+## Events
+
+Smart Contracts on many blockchains support a feature called Events,
+which are user-defined hooks created in smart contract code that can trigger off-chain callbacks to clients configured to receive them.
+This feature can be extremely useful for purposes such as triggering real-time responses to smart contract transactons in client-side scripts.
+
+Ape provides many features for working with contract event logs.
+If your contract instance has an Event called `MyEvent` in it's ABI, you can access these features by calling `contract_instance.MyEvent`.
+For example, if you want to create a script that listens to new event logs from your contract where the indexed argument `arg` is a specific value,
+you can do:
+
+```python
+for log in contract_instance.MyEvent.poll_logs(argname=1):
+    assert log.argname == 1  # NOTE: we only filter on logs where `log.argname=1`
+    print("New log received:", log)
+```
+
+Ape also provides features for collecting historical event logs through it's data system.
+To learn more about Ape's data query capabilities with events, visit [Querying Data](./data#getting-contract-event-data).
+
 ## Decoding and Encoding Inputs
 
 If you want to separately decode and encode inputs without sending a transaction or making a call, you can achieve this with Ape.
@@ -475,7 +495,7 @@ def main():
     for pool in POOLS:
         # By default allowFailure=True, so the multicall continues even if one call fails
         call.add(pool.getReserves)
-        
+
         # To require a call to succeed (revert entire multicall if this call fails)
         call.add(pool.anotherMethod, allowFailure=False)
 
@@ -486,7 +506,7 @@ def main():
     for pool in POOLS:
         # Same allowFailure option for transactions
         tx.add(pool.ApplyDiscount, 123, allowFailure=True)
-        
+
         # For payable functions, you can also specify value
         tx.add(pool.deposit, value=1000)
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -615,7 +615,10 @@ class ContractEvent(BaseInterfaceModel):
             else:
                 converted_args[key] = self.conversion_manager.convert(value, py_type)
 
-        properties: dict = {"event_arguments": converted_args, "event_name": self.abi.name}
+        properties: dict = {
+            "event_arguments": converted_args,
+            "event_name": self.abi.name,
+        }
         if hasattr(self.contract, "address"):
             # Only address if this is off an instance.
             properties["contract_address"] = self.contract.address
@@ -666,7 +669,7 @@ class ContractEvent(BaseInterfaceModel):
                 f"'stop={stop_block}' cannot be greater than the chain length ({HEAD})."
             )
         query: dict = {
-            "columns": list(ContractLog.__pydantic_fields__) if columns[0] == "*" else columns,
+            "columns": (list(ContractLog.__pydantic_fields__) if columns[0] == "*" else columns),
             "event": self.abi,
             "start_block": start_block,
             "stop_block": stop_block,

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1140,7 +1140,7 @@ class Web3Provider(ProviderAPI, ABC):
             if address is not None:
                 log_params["addresses"] = [address]
             if topics is not None:
-                log_params["topics"] = topics
+                log_params["topic_filter"] = topics
 
             log_filter = LogFilter(**log_params)
             yield from self.get_contract_logs(log_filter)

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -303,7 +303,7 @@ def test_poll_logs_with_topics(
 ):
     size = 1
     logs: Queue = Queue(maxsize=size)
-    poller = vyper_contract_instance.NumberChange.poll_logs(start_block=0, topics={"newNum": 33})
+    poller = vyper_contract_instance.NumberChange.poll_logs(start_block=0, newNum=33)
     start_block = chain.blocks.height
 
     with PollDaemon("logs", poller, logs.put, logs.full):

--- a/tests/functional/test_contract_event.py
+++ b/tests/functional/test_contract_event.py
@@ -138,7 +138,13 @@ def test_range(chain, contract_instance, owner, assert_log_values):
 
 
 def test_range_by_address(
-    mocker, chain, eth_tester_provider, accounts, contract_instance, owner, assert_log_values
+    mocker,
+    chain,
+    eth_tester_provider,
+    accounts,
+    contract_instance,
+    owner,
+    assert_log_values,
 ):
     get_logs_spy = mocker.spy(eth_tester_provider.tester.ethereum_tester, "get_logs")
     contract_instance.setAddress(accounts[1], sender=owner)
@@ -292,7 +298,9 @@ def test_poll_logs(chain, vyper_contract_instance, eth_tester_provider, owner, P
     assert actual[2].block_number == actual[2].block.number == actual[1].block_number + 1
 
 
-def test_poll_logs_with_topics(chain, vyper_contract_instance, eth_tester_provider, owner, PollDaemon):
+def test_poll_logs_with_topics(
+    chain, vyper_contract_instance, eth_tester_provider, owner, PollDaemon
+):
     size = 1
     logs: Queue = Queue(maxsize=size)
     poller = vyper_contract_instance.NumberChange.poll_logs(start_block=0, topics={"newNum": 33})


### PR DESCRIPTION
### What I did

Added the capability to use topic filters w/ `ContractEvent.poll_logs` in a nice way

Also noticed that the field in `LogFilter` is `topic_filter` not just `topics`
https://github.com/ApeWorX/ape/blob/55a71681e6ad05d5cc44661ab4d6d86be33e4e16/src/ape/types/events.py#L29

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
- [x] Documentation is complete
