### PR TITLE
docs: Fix typos in display configuration and version callback function names

### DIFF
--- a/src/ape/api/config.py
+++ b/src/ape/api/config.py
@@ -283,7 +283,7 @@ def _get_problem_with_config(errors: list, path: Path) -> Optional[str]:
 
 class DisplayConfig(PluginConfig):
     """
-    Configure dispaly settings in Ape.
+    Configure display settings in Ape.
     """
 
     calldata: CalldataRepr = CalldataRepr.abridged
@@ -333,7 +333,7 @@ class ApeConfig(ExtraAttributesMixin, BaseSettings, ManagerAccessMixin):
 
     display: DisplayConfig = DisplayConfig()
     """
-    Configure dispaly settings in Ape.
+    Configure display settings in Ape.
     """
 
     interfaces_folder: str = "interfaces"

--- a/src/ape_plugins/_cli.py
+++ b/src/ape_plugins/_cli.py
@@ -263,14 +263,14 @@ def update():
     _change_version(ape_version.next_version_range)
 
 
-def _version_callack(ctx, param, value):
+def _version_callback(ctx, param, value):
     obj = Version(value)
     version_str = f"0.{obj.minor}.0" if obj.major == 0 else f"{obj.major}.0.0"
     return f"=={version_str}"
 
 
 @cli.command()
-@click.argument("version", callback=_version_callack)
+@click.argument("version", callback=_version_callback)
 def change_version(version):
     """
     Change ape and all plugins version


### PR DESCRIPTION
### What I did

1. Corrects "dispaly" to "display" in docstring comments in src/ape/api/config.py
2. Fixes the version callback function name from "_version_callack" to "_version_callback" in src/ape_plugins/_cli.py

These changes improve code consistency and readability without affecting functionality.
