### PR TITLE
feat: test accounts public key

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,15 +91,14 @@ jobs:
             pip uninstall eth-ape --yes
             pip install .[test]
 
-#        - name: Run Functional Tests
-#          run: ape test tests/functional -m "not fuzzing" -s --cov=src --cov-append -n auto --dist loadgroup
+        - name: Run Functional Tests
+          run: ape test tests/functional -m "not fuzzing" -s --cov=src --cov-append -n auto --dist loadgroup
 
-        # TODO: Undo - debugging
         - name: Run Integration Tests
           run: ape test tests/integration/cli/test_test.py -m "not fuzzing" -s --cov=src --cov-append -n auto --dist loadgroup
 
-#        - name: Run Performance Tests
-#          run: ape test tests/performance -s
+        - name: Run Performance Tests
+          run: ape test tests/performance -s
 
     fuzzing:
         runs-on: ubuntu-latest

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -73,7 +73,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         return None
 
     @property
-    def public_key(self) -> Optional[HexBytes]:
+    def public_key(self) -> Optional["HexBytes"]:
         """
         The public key for the account.
         """

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -72,6 +72,14 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         """
         return None
 
+    # TODO: In 0.9, make this an @abstactmetod
+    @property
+    @raises_not_implemented
+    def public_key(self):
+        """
+        The public key for the account.
+        """
+
     def sign_raw_msghash(self, msghash: "HexBytes") -> Optional[MessageSignature]:
         """
         Sign a raw message hash.

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -76,6 +76,10 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
     def public_key(self) -> Optional["HexBytes"]:
         """
         The public key for the account.
+
+        ```{notice}
+        Account might not have this property if feature is unsupported or inaccessible.
+        ```
         """
         return None
 

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -72,13 +72,12 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         """
         return None
 
-    # TODO: In 0.9, make this an @abstactmetod
     @property
-    @raises_not_implemented
-    def public_key(self):
+    def public_key(self) -> Optional[HexBytes]:
         """
         The public key for the account.
         """
+        return None
 
     def sign_raw_msghash(self, msghash: "HexBytes") -> Optional[MessageSignature]:
         """

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -1537,6 +1537,9 @@ class ContractContainer(ContractTypeWrapper, ExtraAttributesMixin):
             txn_hash (Union[str, HexBytes]): The hash of the transaction that deployed the
               contract, if available. Defaults to ``None``.
             fetch_from_explorer (bool): Set to ``False`` to avoid fetching from an explorer.
+            proxy_info (:class:`~ape.api.networks.ProxyInfoAPI` | None): Proxy info object to set
+              to avoid detection; defaults to ``None`` which will detect it if ``detect_proxy=True``.
+            detect_proxy (bool): Set to ``False`` to avoid detecting missing proxy info.
 
         Returns:
             :class:`~ape.contracts.ContractInstance`

--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -768,7 +768,6 @@ class ChainManager(BaseManager):
         """
         The price for what it costs to transact.
         """
-
         return self.provider.gas_price
 
     @property
@@ -782,7 +781,6 @@ class ChainManager(BaseManager):
             NotImplementedError: When this provider does not implement
               `EIP-1559 <https://eips.ethereum.org/EIPS/eip-1559>`__.
         """
-
         return self.provider.base_fee
 
     @property

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -19,9 +19,9 @@ from importlib.metadata import PackageNotFoundError, distributions
 from importlib.metadata import version as version_metadata
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
-from eth_keys import keys  # type: ignore
 
 import yaml
+from eth_keys import keys  # type: ignore
 from eth_pydantic_types import HexBytes
 from eth_utils import is_0x_prefixed
 from packaging.specifiers import SpecifierSet

--- a/src/ape/utils/misc.py
+++ b/src/ape/utils/misc.py
@@ -19,6 +19,7 @@ from importlib.metadata import PackageNotFoundError, distributions
 from importlib.metadata import version as version_metadata
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
+from eth_keys import keys  # type: ignore
 
 import yaml
 from eth_pydantic_types import HexBytes
@@ -526,6 +527,21 @@ def as_our_module(cls_or_def: _MOD_T, doc_str: Optional[str] = None) -> _MOD_T:
         cls_or_def.__module__ = module.__name__
 
     return cls_or_def
+
+
+def derive_public_key(private_key: bytes) -> HexBytes:
+    """
+    Derive the public key for the given private key.
+
+    Args:
+        private_key (bytes): The private key.
+
+    Returns:
+        HexBytes: The public key.
+    """
+    pk = keys.PrivateKey(private_key)
+    public_key = f"{pk.public_key}"[2:]
+    return HexBytes(bytes.fromhex(public_key))
 
 
 __all__ = [

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -139,7 +139,10 @@ class KeyfileAccount(AccountAPI):
                 passphrase = self._prompt_for_passphrase(
                     f"Enter passphrase to permanently unlock '{self.alias}'"
                 )
-        assert passphrase is not None, "Passphrase can't be 'None'"
+
+        if passphrase is None:
+            raise AccountsError("Passphrase can't be 'None'")
+
         # Rest of the code to unlock the account using the passphrase
         self.__cached_key = self.__decrypt_keyfile(passphrase)
         self.locked = False

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -108,7 +108,7 @@ class KeyfileAccount(AccountAPI):
         return key
 
     @property
-    def public_key(self) -> HexBytes:
+    def public_key(self) -> Optional[HexBytes]:
         keyfile_data = self.keyfile
         if "public_key" in keyfile_data:
             return HexBytes(bytes.fromhex(keyfile_data["public_key"]))

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -111,19 +111,17 @@ class KeyfileAccount(AccountAPI):
     def public_key(self) -> HexBytes:
         if "public_key" in self.keyfile:
             return HexBytes(bytes.fromhex(self.keyfile["public_key"]))
-        key = self.__key
 
         # Derive the public key from the private key
-        pk = keys.PrivateKey(key)
-        # convert from eth_keys.datatypes.PublicKey to str to make it HexBytes
-        publicKey = str(pk.public_key)
-
+        pk = keys.PrivateKey(self.__key)
+        public_key = f"{pk.public_key}"[2:]
         key_file_data = self.keyfile
-        key_file_data["public_key"] = publicKey[2:]
+        key_file_data["public_key"] = public_key
 
+        # Store the public key so we don't have to derive it again.
         self.keyfile_path.write_text(json.dumps(key_file_data), encoding="utf8")
 
-        return HexBytes(bytes.fromhex(publicKey[2:]))
+        return HexBytes(bytes.fromhex(public_key))
 
     def unlock(self, passphrase: Optional[str] = None):
         if not passphrase:

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -10,9 +10,8 @@ from eip712.messages import EIP712Message, EIP712Type
 from eth_account import Account as EthAccount
 from eth_account.hdaccount import ETHEREUM_DEFAULT_PATH
 from eth_account.messages import encode_defunct
-from eth_keys import keys  # type: ignore
 from eth_pydantic_types import HexBytes
-from eth_utils import to_bytes, to_hex, remove_0x_prefix
+from eth_utils import remove_0x_prefix, to_bytes, to_hex
 
 from ape.api.accounts import AccountAPI, AccountContainerAPI
 from ape.exceptions import AccountsError
@@ -20,7 +19,7 @@ from ape.logging import logger
 from ape.types.signatures import MessageSignature, SignableMessage, TransactionSignature
 from ape.utils._web3_compat import sign_hash
 from ape.utils.basemodel import ManagerAccessMixin
-from ape.utils.misc import log_instead_of_fail, derive_public_key
+from ape.utils.misc import derive_public_key, log_instead_of_fail
 from ape.utils.validators import _validate_account_alias, _validate_account_passphrase
 
 if TYPE_CHECKING:

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -11,6 +11,7 @@ from eth_account import Account as EthAccount
 from eth_account.hdaccount import ETHEREUM_DEFAULT_PATH
 from eth_account.messages import encode_defunct
 from eth_pydantic_types import HexBytes
+from eth_typing import HexStr
 from eth_utils import remove_0x_prefix, to_bytes, to_hex
 
 from ape.api.accounts import AccountAPI, AccountContainerAPI
@@ -114,7 +115,7 @@ class KeyfileAccount(AccountAPI):
 
         # Derive the public key from the private key
         public_key = derive_public_key(self.__key)
-        keyfile_data["public_key"] = remove_0x_prefix(public_key.hex())
+        keyfile_data["public_key"] = remove_0x_prefix(HexStr(public_key.hex()))
 
         # Store the public key so we don't have to derive it again.
         self.keyfile_path.write_text(json.dumps(keyfile_data), encoding="utf8")

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -447,7 +447,7 @@ class Ethereum(EcosystemAPI):
         bytes_obj = contract_type.deployment_bytecode
         contract_bytes = (bytes_obj.to_bytes() or b"") if bytes_obj else b""
         header = kwargs.pop("header", BLUEPRINT_HEADER)
-        blueprint_bytecode = header + HexBytes(0) + contract_bytes
+        blueprint_bytecode = header + b"\x00" + contract_bytes
         len_bytes = len(blueprint_bytecode).to_bytes(2, "big")
         return_data_size = kwargs.pop("return_data_size", HexBytes("0x61"))
         return_instructions = kwargs.pop("return_instructions", HexBytes("0x3d81600a3d39f3"))

--- a/src/ape_pm/dependency.py
+++ b/src/ape_pm/dependency.py
@@ -101,7 +101,7 @@ class LocalDependency(DependencyAPI):
 
 class GithubDependency(DependencyAPI):
     """
-    A dependency from Github. Use the ``github`` key in your ``dependencies:``
+    A dependency from GitHub. Use the ``github`` key in your ``dependencies:``
     section of your ``ape-config.yaml`` file to declare a dependency from GitHub.
 
     Config example::

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -14,7 +14,7 @@ from ape.api.accounts import TestAccountAPI, TestAccountContainerAPI
 from ape.exceptions import ProviderNotConnectedError, SignatureError
 from ape.types.signatures import MessageSignature, TransactionSignature
 from ape.utils._web3_compat import sign_hash
-from ape.utils.misc import log_instead_of_fail, derive_public_key
+from ape.utils.misc import derive_public_key, log_instead_of_fail
 from ape.utils.testing import generate_dev_accounts
 
 if TYPE_CHECKING:

--- a/src/ape_test/accounts.py
+++ b/src/ape_test/accounts.py
@@ -14,7 +14,7 @@ from ape.api.accounts import TestAccountAPI, TestAccountContainerAPI
 from ape.exceptions import ProviderNotConnectedError, SignatureError
 from ape.types.signatures import MessageSignature, TransactionSignature
 from ape.utils._web3_compat import sign_hash
-from ape.utils.misc import log_instead_of_fail
+from ape.utils.misc import log_instead_of_fail, derive_public_key
 from ape.utils.testing import generate_dev_accounts
 
 if TYPE_CHECKING:
@@ -117,6 +117,10 @@ class TestAccount(TestAccountAPI):
     @property
     def address(self) -> "AddressType":
         return self.network_manager.ethereum.decode_address(self.address_str)
+
+    @property
+    def public_key(self) -> "HexBytes":
+        return derive_public_key(HexBytes(self.private_key))
 
     @log_instead_of_fail(default="<TestAccount>")
     def __repr__(self) -> str:

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -842,9 +842,12 @@ def test_prepare_transaction_and_call_using_max_gas(tx_type, ethereum, sender, e
     assert not actual.failed
 
 
-def test_public_key(runner, keyfile_account):
+def test_public_key(runner, keyfile_account, owner):
     with runner.isolation(input=f"{PASSPHRASE}\ny\n"):
         assert isinstance(keyfile_account.public_key, HexBytes)
+
+    # Also, show the test accounts have access to their public key.
+    assert owner.public_key is not None
 
 
 def test_load_public_key_from_keyfile(runner, keyfile_account):


### PR DESCRIPTION
i need to be able to easily access public keys in tests

* makes public_key more of an official api and gives test accounts access to their publi
* adds a couple missing arg docs
* fixes a casing from camelCase to snake_case
* replaces a production assert statement with an actual error
* other small stylistic improvements