### PR TITLE
feat: `--no-recurse` flag on  `ape pm install` command

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -1657,15 +1657,17 @@ class DependencyManager(BaseManager):
         Args:
             **dependency: Dependency data, same to what you put in `dependencies:` config.
               When excluded, installs all project-specified dependencies. Also, use
-              ``use_cache=False`` to force re-installing.
+              ``use_cache=False`` to force re-installing and ``recurse=False`` to avoid
+              installing dependencies of dependencies.
 
         Returns:
             :class:`~ape.managers.project.Dependency` when given data else a list
             of them, one for each specified.
         """
         use_cache: bool = dependency.pop("use_cache", True)
+        recurse: bool = dependency.pop("recurse", True)
         if dependency:
-            return self.install_dependency(dependency, use_cache=use_cache)
+            return self.install_dependency(dependency, use_cache=use_cache, recurse=recurse)
 
         # Install all project's.
         result: list[Dependency] = []
@@ -1681,9 +1683,10 @@ class DependencyManager(BaseManager):
         dependency_data: Union[dict, DependencyAPI],
         use_cache: bool = True,
         config_override: Optional[dict] = None,
+        recurse: bool = True,
     ) -> Dependency:
         dependency = self.add(dependency_data)
-        dependency.install(use_cache=use_cache, config_override=config_override)
+        dependency.install(use_cache=use_cache, config_override=config_override, recurse=recurse)
         return dependency
 
     def unpack(self, base_path: Path, cache_name: str = ".cache"):

--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -760,7 +760,9 @@ class Dependency(BaseManager, ExtraAttributesMixin):
             if use_cache and self.manifest_path.is_file():
                 # Attempt using sources from manifest. This may happen
                 # if having deleted dependencies but not their manifests.
-                man = PackageManifest.model_validate_json(self.manifest_path.read_text(encoding="utf8"))
+                man = PackageManifest.model_validate_json(
+                    self.manifest_path.read_text(encoding="utf8")
+                )
                 if man.sources:
                     self.project_path.mkdir(parents=True, exist_ok=True)
                     man.unpack_sources(self.project_path)
@@ -800,7 +802,9 @@ class Dependency(BaseManager, ExtraAttributesMixin):
                 if suffix == ".json":
                     path = paths[0]
                     try:
-                        manifest = PackageManifest.model_validate_json(path.read_text(encoding="utf8"))
+                        manifest = PackageManifest.model_validate_json(
+                            path.read_text(encoding="utf8")
+                        )
                     except Exception:
                         # False alarm.
                         pass
@@ -1316,7 +1320,9 @@ class DependencyManager(BaseManager):
 
             if allow_install:
                 try:
-                    dependency.install(use_cache=use_cache, config_override=config_override, recurse=recurse)
+                    dependency.install(
+                        use_cache=use_cache, config_override=config_override, recurse=recurse
+                    )
                 except ProjectError as err:
                     if strict:
                         raise  # This error.
@@ -1686,7 +1692,9 @@ class DependencyManager(BaseManager):
         # Install all project's.
         result: list[Dependency] = []
 
-        for dep in self.get_project_dependencies(use_cache=use_cache, allow_install=True, recurse=recurse):
+        for dep in self.get_project_dependencies(
+            use_cache=use_cache, allow_install=True, recurse=recurse
+        ):
             result.append(dep)
 
         return result

--- a/src/ape_pm/_cli.py
+++ b/src/ape_pm/_cli.py
@@ -199,20 +199,11 @@ def install(cli_ctx, package, name, version, ref, force, config_override, no_rec
         if version:
             cli_ctx.abort("Cannot specify version when installing from config.")
 
-        # Print out all the dependencies being installed.
-        if deps_to_install := [d for d in pm.dependencies.specified if force or not d.installed]:
-            click.echo(
-                "\n".join(
-                    f"Installing {d.package_id.replace(f'{Path.home()}', '$HOME')}"
-                    for d in deps_to_install
-                )
-            )
-
         pm.dependencies.install(use_cache=not force, recurse=not no_recurse)
         message = "All project packages installed."
 
         # In the case the user didn't realize --force is required to re-install.
-        if not deps_to_install and not force:
+        if not force:
             message = f"{message} Use `--force` to re-install."
 
         cli_ctx.logger.success(message)

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -282,9 +282,9 @@ def test_install(project, mocker):
         assert isinstance(project, ProjectManager)
         assert dependency.project_path.is_dir()  # Was re-created from manifest sources.
 
-        # Force install and prove it actually does the re-install.
+        # Force install and prove it actually does the re-installation.
         tmp_project.dependencies.install(use_cache=False)
-        get_spec_spy.assert_called_once_with(use_cache=False)
+        get_spec_spy.assert_called_once_with(use_cache=False, allow_install=True, recurse=True)
 
 
 def test_install_dependencies_of_dependencies(project, with_dependencies_project_path):

--- a/tests/integration/cli/test_pm.py
+++ b/tests/integration/cli/test_pm.py
@@ -150,6 +150,14 @@ def test_install_name_with_version_flag(pm_runner, integ_project):
     assert f"Package '{dependency.name}@{dependency.version}' installed." in result.output
 
 
+@skip_projects_except("with-dependencies")
+def test_install_no_recurse(pm_runner, integ_project):
+    pm_runner.project = integ_project
+    result = pm_runner.invoke("install", "--no-recurse")
+    assert result.exit_code == 0, result.output
+    assert "containing_sub_dependencies/sub_dependency" not in result.output
+
+
 @run_once
 def test_compile_package_not_exists(pm_runner, integ_project):
     pm_runner.project = integ_project


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #2604 

This can be quite the time saver when you only want to force reinstall the main dependency and not all of its dependencies... like i dont need to install `forge-std` over and over again, but my own projects that are also dependencies, yes i typically need to force reinstall those to get new changes and stuff

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
