### PR TITLE
fix: remove unimplemented _repr_mimebundle_

### DIFF
--- a/src/ape/managers/base.py
+++ b/src/ape/managers/base.py
@@ -8,11 +8,6 @@ class BaseManager(ManagerAccessMixin):
     """
 
     @raises_not_implemented
-    def _repr_mimebundle_(self, include=None, exclude=None):
-        # This works better than AttributeError for Ape.
-        pass
-
-    @raises_not_implemented
     def _ipython_display_(self, include=None, exclude=None):
         # This works better than AttributeError for Ape.
         pass

--- a/src/ape/utils/basemodel.py
+++ b/src/ape/utils/basemodel.py
@@ -425,11 +425,6 @@ class BaseModel(EthpmTypesBaseModel):
         return result
 
     @raises_not_implemented
-    def _repr_mimebundle_(self, include=None, exclude=None):
-        # This works better than AttributeError for Ape.
-        pass
-
-    @raises_not_implemented
     def _ipython_display_(self, include=None, exclude=None):
         # This works better than AttributeError for Ape.
         pass

--- a/tests/functional/test_base_manager.py
+++ b/tests/functional/test_base_manager.py
@@ -12,7 +12,7 @@ def manager():
     return MyManager()
 
 
-@pytest.mark.parametrize("fn_name", ("_repr_mimebundle_", "_ipython_display_"))
+@pytest.mark.parametrize("fn_name", ["_ipython_display_"])
 def test_ipython_integration_defaults(manager, fn_name):
     """
     Test default behavior for IPython integration methods.

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -266,7 +266,7 @@ def test_getattr_same_name_as_source_file(project_with_source_files_contract):
         _ = project_with_source_files_contract.ContractA
 
 
-@pytest.mark.parametrize("iypthon_attr_name", ("_repr_mimebundle_", "_ipython_display_"))
+@pytest.mark.parametrize("iypthon_attr_name", ["_ipython_display_"])
 def test_getattr_ipython(tmp_project, iypthon_attr_name):
     # Remove contract types, if there for some reason is any.
     tmp_project.manifest.contract_types = {}


### PR DESCRIPTION
### Background

In [marimo](https://marimo.io/) I get this error when trying to render any Ape object.

```python
# smallest replication:
from ape import accounts
accounts
```

```python
Traceback (most recent call last):
  File ".venv/lib/python3.12/site-packages/marimo/_output/formatting.py", line 201, in try_format
    mimetype, data = formatter(obj)
                     ^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/marimo/_output/formatters/repr_formatters.py", line 50, in f_repr
    contents = method(include=[], exclude=[])
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/ape/utils/misc.py", line 332, in inner
    raise _create_raises_not_implemented_error(fn)
ape.exceptions.APINotImplementedError: Attempted to call method 'BaseManager._repr_mimebundle_', method not supported.
```

The cause of this is unlike `_ipython_display_`, the `_repr_mimebundle_` method doesn't catch `NotImplementedError`. This is supported by both [IPython](https://ipython.readthedocs.io/en/7.x/config/integrating.html#MyObject._repr_mimebundle_) and [marimo](https://docs.marimo.io/guides/integrating_with_marimo/displaying_objects/) docs.

> **Should return a dictionary of multiple formats**, keyed by mimetype, or a tuple of two dictionaries: data, metadata. If this returns something, other `_repr_*_` methods are ignored. The method should take keyword arguments include and exclude, though it is not required to respect them.

This regression was added as a part of this fix https://github.com/ApeWorX/ape/pull/1925

### What I did

Removed `_repr_mimebundle_` from `BaseManager` and `BaseModel`.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

The example works in both marimo and IPython now.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
