### PR TITLE
fix(API): stringified TransactionAPI re-encoded hex data

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -205,7 +205,7 @@ class TransactionAPI(BaseInterfaceModel):
 
         if calldata_repr == "full" or len(data["data"]) <= 9:
             data["data"] = (
-                to_hex(bytes(data["data"], encoding="utf8"))
+                (data["data"] if is_hex(data["data"]) else to_hex(bytes(data["data"], encoding="utf8")))
                 if isinstance(data["data"], str)
                 else to_hex(bytes(data["data"]))
             )


### PR DESCRIPTION
### What I did

s/o to @BowTiedDevil for finding this, basically the `TransactionAPI.to_string` function was re-encoding the `.data` field into hex

### How I did it

Visual inspection

### How to verify it

Sign a txn

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] Change is covered in tests
~~- [ ] Documentation is complete~~
