### PR TITLE
fix(API): corruption of abridged calldata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "click>=8.1.6,<9",
+        "click>=8.1.6,<8.2",
         "ijson>=3.1.4,<4",
         "ipython>=8.18.1,<9",
         "lazyasd>=0.1.4",

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -205,7 +205,7 @@ class TransactionAPI(BaseInterfaceModel):
 
         # Ellide the transaction calldata for abridged representations if the length exceeds 8
         # (4 bytes for function selector and trailing 4 bytes).
-        calldata = HexBytes(data['data'])
+        calldata = HexBytes(data["data"])
         data["data"] = (
             calldata[:4].to_0x_hex() + "..." + calldata[-4:].hex()
             if calldata_repr == "abridged" and len(calldata) > 8

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -207,8 +207,8 @@ class TransactionAPI(BaseInterfaceModel):
         # (4 bytes for function selector and trailing 4 bytes).
         calldata = HexBytes(data['data'])
         data["data"] = (
-            calldata[:4].to_0x_hex() + "..." + calldata[-4:].hex() 
-            if calldata_repr == "abridged" and len(calldata) > 8 
+            calldata[:4].to_0x_hex() + "..." + calldata[-4:].hex()
+            if calldata_repr == "abridged" and len(calldata) > 8
             else calldata.to_0x_hex()
         )
 

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -315,7 +315,7 @@ def test_str_when_data_is_long_shows_first_4_bytes(vyper_contract_instance):
     txn = vyper_contract_instance.setNumber.as_transaction(123)
     actual = str(txn)
     assert isinstance(actual, str)
-    assert "data: 0x30783366..." in actual
+    assert "data: 0x3fb5c1cb..." in actual
 
 
 def test_str_when_data_is_long_and_configured_full_calldata(project, vyper_contract_instance):
@@ -324,8 +324,7 @@ def test_str_when_data_is_long_and_configured_full_calldata(project, vyper_contr
         actual = str(txn)
 
     expected = (
-        "data: 0x3078336662356331636230303030303030303030303030303030303030303030303030"
-        "303030303030303030303030303030303030303030303030303030303030303030303030303762"
+        "data: 0x3fb5c1cb000000000000000000000000000000000000000000000000000000000000007b"
     )
     assert isinstance(actual, str)
     assert expected in actual

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -323,9 +323,7 @@ def test_str_when_data_is_long_and_configured_full_calldata(project, vyper_contr
     with project.temp_config(display={"calldata": "full"}):
         actual = str(txn)
 
-    expected = (
-        "data: 0x3fb5c1cb000000000000000000000000000000000000000000000000000000000000007b"
-    )
+    expected = "data: 0x3fb5c1cb000000000000000000000000000000000000000000000000000000000000007b"
     assert isinstance(actual, str)
     assert expected in actual
 


### PR DESCRIPTION
### What I did

Extended the fix for corrupted calldata strings proposed by @fubuloubu in #2616 to work with full and abridged calldata.

### How I did it

Transform calldata to a bytes representation using `HexBytes` before performing string conversions.

### How to verify it
Compare result to functional transaction tests (`test_str_when_data_is_long_shows_first_4_bytes`, `test_str_when_data_is_long_and_configured_full_calldata`). 

Encoded inputs:
```
>>> HexBytes(HexBytes(web3.Web3.keccak(text='setNumber(uint256)'))[:4] + HexBytes(eth_abi.encode(['uint256'],[123]))).to_0x_hex()
'0x3fb5c1cb000000000000000000000000000000000000000000000000000000000000007b'

>>> HexBytes(web3.Web3.keccak(text='setNumber(uint256)'))[:4])
HexBytes('0x3fb5c1cb')
```

### Checklist

- [x] All changes are completed
- [x] Change is covered in tests
