### PR TITLE
chore: fix typos

### DIFF
--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -913,9 +913,9 @@ class TestNetworkChoice:
 
     def test_bad_network(self, network_choice):
         # NOTE: "local" is spelled wrong.
-        expected = r"No network in 'ethereum' named 'lokal'\. Did you mean 'local'\?"
+        expected = r"No network in 'ethereum' named 'local'\. Did you mean 'local'\?"
         with pytest.raises(BadParameter, match=expected):
-            network_choice.convert("ethereum:lokal:test", None, None)
+            network_choice.convert("ethereum:local:test", None, None)
 
     def test_bad_provider(self, network_choice):
         # NOTE: "test" is spelled wrong.


### PR DESCRIPTION
### What I did

Fixed a spelling error in test error messages, changing "lokal" to "local" in the test_cli.py file.

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

### How I did it

Updated the misspelled word in both the expected error message string and the network choice parameter in the test_bad_network function. This ensures consistency between the test expectations and actual error messages.

### How to verify it

Run the affected test to confirm it passes with the corrected spelling:
```python
pytest tests/functional/test_cli.py::test_bad_network
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
- [x] Documentation is complete