### PR TITLE
feat(contracts): easily get signed serialized transactions bytes from contract handlers

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -83,6 +83,11 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         """
         return None
 
+    def prepare_transaction(self, txn: "TransactionAPI", **kwargs) -> "TransactionAPI":
+        sign = kwargs.pop("sign", False)
+        prepared_tx = super().prepare_transaction(txn, **kwargs)
+        return self.sign_transaction(prepared_tx) if sign else prepared_tx
+
     def sign_raw_msghash(self, msghash: "HexBytes") -> Optional[MessageSignature]:
         """
         Sign a raw message hash.

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -86,7 +86,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
     def prepare_transaction(self, txn: "TransactionAPI", **kwargs) -> "TransactionAPI":
         sign = kwargs.pop("sign", False)
         prepared_tx = super().prepare_transaction(txn, **kwargs)
-        return self.sign_transaction(prepared_tx) if sign else prepared_tx
+        return (self.sign_transaction(prepared_tx) or prepared_tx) if sign else prepared_tx
 
     def sign_raw_msghash(self, msghash: "HexBytes") -> Optional[MessageSignature]:
         """

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -197,7 +197,7 @@ class BaseAddress(BaseInterface):
         if sender := kwargs.get("sender"):
             if hasattr(sender, "prepare_transaction"):
                 prepared = sender.prepare_transaction(tx)
-                return sender.sign(prepared) if sign else prepared
+                return (sender.sign_transaction(prepared) or prepared) if sign else prepared
 
         return tx
 

--- a/src/ape/api/address.py
+++ b/src/ape/api/address.py
@@ -198,7 +198,7 @@ class BaseAddress(BaseInterface):
         txn = self.as_transaction(**kwargs)
         return self.provider.estimate_gas_cost(txn)
 
-    def prepare_transaction(self, txn: "TransactionAPI") -> "TransactionAPI":
+    def prepare_transaction(self, txn: "TransactionAPI", **kwargs) -> "TransactionAPI":
         """
         Set default values on a transaction.
 
@@ -209,6 +209,7 @@ class BaseAddress(BaseInterface):
 
         Args:
             txn (:class:`~ape.api.transactions.TransactionAPI`): The transaction to prepare.
+            **kwargs: Sub-classes, such as :class:`~ape.api.accounts.AccountAPI`, use additional kwargs.
 
         Returns:
             :class:`~ape.api.transactions.TransactionAPI`
@@ -234,6 +235,7 @@ class BaseAddress(BaseInterface):
                 f"(transfer_value={txn.total_transfer_value}, balance={self.balance})."
             )
 
+        txn.sender = txn.sender or self.address
         return txn
 
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -298,12 +298,20 @@ class ContractCallHandler(ContractMethodHandler):
         """
         return self.transact.as_transaction(*args, **kwargs)
 
+    def as_transaction_bytes(self, *args, **txn_kwargs) -> HexBytes:
+        """
+        Get a signed serialized transaction.
+
+        Returns:
+            HexBytes: The serialized transaction
+        """
+        return self.transact.as_transaction_bytes(**txn_kwargs)
+
     @property
     def transact(self) -> "ContractTransactionHandler":
         """
         Send the call as a transaction.
         """
-
         return ContractTransactionHandler(self.contract, self.abis)
 
     def estimate_gas_cost(self, *args, **kwargs) -> int:
@@ -403,6 +411,17 @@ class ContractTransactionHandler(ContractMethodHandler):
                 return sender.sign_transaction(prepped_tx) if sign else prepped_tx
 
         return transaction
+
+    def as_transaction_bytes(self, *args, **txn_kwargs) -> HexBytes:
+        """
+        Get a signed serialized transaction.
+
+        Returns:
+            HexBytes: The serialized transaction
+        """
+        txn_kwargs["sign"] = True
+        tx = self.as_transaction(*args, **txn_kwargs)
+        return tx.serialize_transaction()
 
     def estimate_gas_cost(self, *args, **kwargs) -> int:
         """

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -11,6 +11,7 @@ from eth_pydantic_types import HexBytes
 from eth_utils import to_hex
 from ethpm_types.abi import EventABI
 
+from ape.api.accounts import AccountAPI
 from ape.api.address import Address, BaseAddress
 from ape.api.query import (
     ContractCreation,
@@ -391,10 +392,16 @@ class ContractTransactionHandler(ContractMethodHandler):
         Returns:
             :class:`~ape.api.transactions.TransactionAPI`
         """
-
+        sign = kwargs.pop("sign", False)
         contract_transaction = self._as_transaction(*args)
         transaction = contract_transaction.serialize_transaction(*args, **kwargs)
         self.provider.prepare_transaction(transaction)
+
+        if sender := kwargs.get("sender"):
+            if isinstance(sender, AccountAPI):
+                prepped_tx = sender.prepare_transaction(transaction)
+                return sender.sign_transaction(prepped_tx) if sign else prepped_tx
+
         return transaction
 
     def estimate_gas_cost(self, *args, **kwargs) -> int:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -408,7 +408,7 @@ class ContractTransactionHandler(ContractMethodHandler):
         if sender := kwargs.get("sender"):
             if isinstance(sender, AccountAPI):
                 prepped_tx = sender.prepare_transaction(transaction)
-                return sender.sign_transaction(prepped_tx) if sign else prepped_tx
+                return (sender.sign_transaction(prepped_tx) or prepped_tx) if sign else prepped_tx
 
         return transaction
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -774,6 +774,20 @@ def test_declare(contract_container, sender):
     assert not receipt.failed
 
 
+def test_prepare_transaction(ethereum, sender):
+    tx = ethereum.create_transaction()
+    prepared_tx = sender.prepare_transaction(tx)
+    assert prepared_tx.sender == sender.address
+    assert prepared_tx.signature is None
+
+
+def test_prepare_transaction_sign(sender, ethereum):
+    tx = ethereum.create_transaction()
+    prepared_tx = sender.prepare_transaction(tx, sign=True)
+    assert prepared_tx.sender == sender.address
+    assert prepared_tx.signature is not None
+
+
 @pytest.mark.parametrize("tx_type", (TransactionType.STATIC, TransactionType.DYNAMIC))
 def test_prepare_transaction_using_auto_gas(sender, ethereum, tx_type):
     params = (

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -1057,6 +1057,14 @@ def test_sending_funds_to_non_payable_constructor_by_accountDeploy(
 def test_as_transaction(tx_type, vyper_contract_instance, owner, eth_tester_provider):
     tx = vyper_contract_instance.setNumber.as_transaction(987, sender=owner, type=tx_type.value)
     assert tx.gas_limit == eth_tester_provider.max_gas
+    assert tx.sender == owner.address
+    assert tx.signature is None
+
+
+def test_as_transaction_sign(vyper_contract_instance, owner, eth_tester_provider):
+    tx = vyper_contract_instance.setNumber.as_transaction(987, sender=owner, sign=True)
+    assert tx.gas_limit == eth_tester_provider.max_gas
+    assert tx.signature is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_contract_instance.py
+++ b/tests/functional/test_contract_instance.py
@@ -1067,6 +1067,11 @@ def test_as_transaction_sign(vyper_contract_instance, owner, eth_tester_provider
     assert tx.signature is not None
 
 
+def test_as_transaction_bytes(vyper_contract_instance, owner, eth_tester_provider):
+    signed_tx = vyper_contract_instance.setNumber.as_transaction_bytes(987, sender=owner, sign=True)
+    assert isinstance(signed_tx, bytes)
+
+
 @pytest.mark.parametrize(
     "calldata,expected",
     (


### PR DESCRIPTION
### What I did

This helps me turn 4 lines of code into 1

```python
tx = contract.MyMethod.as_transaction(sender=me)
prepped_tx = me.prepare_transaction(tx)
signed_tx = me.sign_transaction(prepped_tx)
tx_bytes  = signed_tx.serialize_transaction()
```

to

```python
tx_bytes = contract.MyMethod.as_transaction_bytes(sender=me)
```

fixes: #2631 

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
