### PR TITLE
fix(pm): sourceless dependencies of dependencies are always re-downloaded on compile

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -663,10 +663,7 @@ class Dependency(BaseManager, ExtraAttributesMixin):
         return self._cache.get_project_path(self.package_id, self.version)
 
     @property
-    def _project_cache_exists(self) -> bool:
-        if self._installation is None:
-            return False
-
+    def _project_disk_cache_exists(self) -> bool:
         path = self._cache.get_project_path(self.package_id, self.version)
         if not path.is_dir():
             return False
@@ -754,7 +751,7 @@ class Dependency(BaseManager, ExtraAttributesMixin):
 
             return self._installation
 
-        elif not self._project_cache_exists or not use_cache:
+        elif not self._project_disk_cache_exists or not use_cache:
             # Project does not yet exist in the cache. We have to fetch the sources.
             unpacked = False
             if use_cache and self.manifest_path.is_file():

--- a/src/ape_pm/dependency.py
+++ b/src/ape_pm/dependency.py
@@ -73,7 +73,7 @@ class LocalDependency(DependencyAPI):
 
     def __repr__(self) -> str:
         path = clean_path(self.local)
-        return f"<LocalDependency local={path}, version={self.version}>"
+        return f"<LocalDependency local={path}, version={self.version_id}>"
 
     @property
     def package_id(self) -> str:

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -291,8 +291,11 @@ def test_install_dependencies_of_dependencies(project, with_dependencies_project
     dm = project.dependencies
     actual = dm.install(local=with_dependencies_project_path, name="wdep")
     assert actual.name == "wdep"
-    # TODO: Check deps of deps also installed
-    # deps_of_deps = [x for x in actual.project.dependencies.specified]
+
+    # Ensure dependencies of dependencies also installed.
+    dep_with_deps = actual.project.dependencies["containing-sub-dependencies"]["local"]
+    dep_of_dep = dep_with_deps.dependencies.get_dependency("sub-dependency", "local")
+    assert dep_of_dep.installed
 
 
 @pytest.mark.parametrize("name", ("openzeppelin", "OpenZeppelin/openzeppelin-contracts"))

--- a/tests/functional/test_dependencies.py
+++ b/tests/functional/test_dependencies.py
@@ -277,8 +277,10 @@ def test_install(project, mocker):
 
         # Delete project path (but not manifest) and install again.
         shutil.rmtree(dependency.project_path)
+        installation = dependency._installation
         dependency._installation = None
         project = dependency.install()
+        dependency._installation = installation
         assert isinstance(project, ProjectManager)
         assert dependency.project_path.is_dir()  # Was re-created from manifest sources.
 
@@ -307,6 +309,7 @@ def test_install_already_installed(mocker, project, with_dependencies_project_pa
     dep = dm.install(local=with_dependencies_project_path, name="wdep")
 
     # Set up a spy on the fetch API, which can be costly and require internet.
+    real_api = dep.api
     mock_api = mocker.MagicMock()
     dep.api = mock_api
 
@@ -316,6 +319,8 @@ def test_install_already_installed(mocker, project, with_dependencies_project_pa
     # Install again.
     with pytest.raises(ProjectError):
         dep.install()
+
+    dep.api = real_api
 
     # Ensure it doesn't need to re-fetch
     assert mock_api.call_count == 0


### PR DESCRIPTION
### What I did

Ape is constantly re-fetching dependencies without sources. This fixes it.

### How I did it

Ape was doing this because it thought it was failing to produce a project.
However, you can use `--force` to re-download if something bad happens during fetch. Also, some dependencies may never actually produce a project because they only have `.test.sol` contracts (TBD on that)

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
