### PR TITLE
feat(AccountAPI): show deployment address before broadcast

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -339,7 +339,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         possible_address = self.get_deployment_address()
         styled_address = click.style(possible_address, bold=True)
         logger.info(f"Contract will be deployed at: {styled_address}")
-        
+
         from ape.contracts import ContractContainer
 
         if isinstance(contract, ContractType):

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -339,6 +339,7 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         possible_address = self.get_deployment_address()
         styled_address = click.style(possible_address, bold=True)
         logger.info(f"Contract will be deployed at: {styled_address}")
+        
         from ape.contracts import ContractContainer
 
         if isinstance(contract, ContractType):

--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -336,6 +336,9 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
         Returns:
             :class:`~ape.contracts.ContractInstance`: An instance of the deployed contract.
         """
+        possible_address = self.get_deployment_address()
+        styled_address = click.style(possible_address, bold=True)
+        logger.info(f"Contract will be deployed at: {styled_address}")
         from ape.contracts import ContractContainer
 
         if isinstance(contract, ContractType):

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -1628,6 +1628,12 @@ class ContractContainer(ContractTypeWrapper, ExtraAttributesMixin):
         Returns:
             :class:`~ape.contracts.base.ContractInstance`
         """
+        # TODO: Not possible method not available
+        
+        if "sender" in kwargs:
+            possible_address = kwargs["sender"].get_deployment_address()
+            styled_address = click.style(possible_address, bold=True)
+            logger.info(f"Contract will be deployed at: {styled_address}")
 
         bytecode = self.contract_type.deployment_bytecode
         if not bytecode or bytecode.bytecode in (None, "", "0x"):

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -1628,10 +1628,8 @@ class ContractContainer(ContractTypeWrapper, ExtraAttributesMixin):
         Returns:
             :class:`~ape.contracts.base.ContractInstance`
         """
-        # TODO: Not possible method not available
-
-        if "sender" in kwargs:
-            possible_address = kwargs["sender"].get_deployment_address()
+        if isinstance(sender := kwargs.get("sender"), AccountAPI):
+            possible_address = sender.get_deployment_address()
             styled_address = click.style(possible_address, bold=True)
             logger.info(f"Contract will be deployed at: {styled_address}")
 

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -1629,7 +1629,7 @@ class ContractContainer(ContractTypeWrapper, ExtraAttributesMixin):
             :class:`~ape.contracts.base.ContractInstance`
         """
         # TODO: Not possible method not available
-        
+
         if "sender" in kwargs:
             possible_address = kwargs["sender"].get_deployment_address()
             styled_address = click.style(possible_address, bold=True)


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #2596 

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

Put the following contract into the `contracts` folder

```js
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.28;

contract SimpleContract {
    address public owner;
    constructor() {
        owner = msg.sender;
    }

    function get_value(uint256 value) external view returns(uint){
        return value;
    }
}
```



Put the following test script in the `scripts` folder

```py
from ape import project, accounts
from rich.console import Console

cs = Console()

def main():
    deployer = accounts.load("test")
    #deployer.unlock(passphrase="a")
    deployer.set_autosign(True)
    cs.print("-" * 100)
    cs.print("Deploying by contract.deploy")
    cs.print("-" * 100)
    contract1 = project.SimpleContract.deploy(sender=deployer)
    
    cs.print("-" * 100)
    cs.print("Deploying by account.deploy")
    cs.print("-" * 100)
    contract2 = deployer.deploy(project.SimpleContract)
    cs.print("-" * 100)
    #print(contract1.address)

if __name__ == "__main__":
    main()
```

The output

![image](https://github.com/user-attachments/assets/b1799748-2438-44c7-b653-5535336ef88d)




<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
