### PR TITLE
fix: making it easier to install dependencies

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -1435,12 +1435,25 @@ class DependencyManager(BaseManager):
         self, package_id: str, version: Optional[str] = None, attr: str = "package_id"
     ) -> Optional[DependencyAPI]:
         matching = []
+
+        # First, only look at local configured packages (to give priority).
         for dependency in self.config_apis:
             if getattr(dependency, attr) != package_id:
                 continue
 
             if (version and dependency.version_id == version) or not version:
                 matching.append(dependency)
+
+        if not matching:
+            # Nothing found: search in 'all'.
+            for dependency in self.all:
+                if getattr(dependency, attr) != package_id:
+                    continue
+
+                if (version and dependency.api.version_id == version) or not version:
+                    matching.append(dependency.api)
+
+        # else: prioritize the local dependencies, as that is most-likely what the user wants.
 
         return sorted(matching, key=lambda d: d.version_id)[-1] if matching else None
 

--- a/src/ape_pm/_cli.py
+++ b/src/ape_pm/_cli.py
@@ -173,7 +173,9 @@ def _package_callback(ctx, param, value):
         else:
             return dependency
 
-    raise click.BadArgumentUsage(f"Unknown package '{value}'.")
+    raise click.BadArgumentUsage(
+        f"Unknown package '{value}'. Did you mean to prefix with `gh:`, `npm:` etc.?"
+    )
 
 
 @cli.command()


### PR DESCRIPTION
### What I did

I tried doing

```
ape pm install <package-id> --force
```

for a dependency that i already had installed, but for some reason it wasn't working - was expecting the `gh:` prefix and i was like "huh that doesn't seem necessary"... but I see why it was that way but i made it still work here for me.
### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
