### PR TITLE
fix: PluginManager to handle single items and iterables

### DIFF
--- a/src/ape/managers/plugins.py
+++ b/src/ape/managers/plugins.py
@@ -104,16 +104,15 @@ class PluginManager:
 
         for plugin_name, results in map(get_plugin_name_and_hookfn, hookimpls):
             # NOTE: Some plugins return a tuple and some return iterators
-            if not isinstance(results, Generator):
-                validated_plugin = self._validate_plugin(plugin_name, results)
-                if validated_plugin:
-                    yield validated_plugin
-            else:
-                # Only if it's an iterator, provide results as a series
+            if isinstance(results, Iterable) and not isinstance(results, (str, bytes)):
                 for result in results:
                     validated_plugin = self._validate_plugin(plugin_name, result)
                     if validated_plugin:
                         yield validated_plugin
+            else:
+                validated_plugin = self._validate_plugin(plugin_name, results)
+                if validated_plugin:
+                    yield validated_plugin
 
     @cached_property
     def registered_plugins(self) -> set[str]:


### PR DESCRIPTION
### What I did

updated `__getattr__` in `PluginManager` so it handles both single objects and collections (lists, tuples, generators) correctly.

### How I did it

replaced the `Generator` check with an `Iterable` check (excluding strings and bytes). Iterates over collections when needed, validates single objects directly.

### How to verify it

call hooks that return either a single object or a collection and ensure they are processed correctly without errors.

### Checklist

* [x] All changes are completed
* [ ] Change is covered in tests
* [ ] Documentation is complete

