### PR TITLE
fix: bump web3 to v7.12.1; undo MockBatchingContext hack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
         "hexbytes>=1.2.0,<2",
         "py-geth>=5.4.0,<6",
         "trie>=3.0.1,<4",  # Peer: stricter pin needed for uv support.
-        "web3[tester]>=6.20.1,<8",
+        "web3[tester]>=7.12.1,<8",
         # ** Dependencies maintained by ApeWorX **
         "eip712>=0.2.10,<0.3",
         "ethpm-types>=0.6.27,<0.7",

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -1794,13 +1794,6 @@ def _create_web3(
 
     provider = AutoProvider(potential_providers=providers)
 
-    # TODO: Getting attribute error without this. Figure out why and do proper fix.
-    class MockBatchingContext:
-        def get(self, *args, **kwargs):
-            return None
-
-    provider._batching_context = MockBatchingContext()  # type: ignore
-
     return Web3(provider, middleware=[])
 
 


### PR DESCRIPTION
### What I did

bumped the version of web3 dependency to v7.12.1.

removed MockBatchingContext swap out hack in ape_ethereum/provider.py

Fixes #2677 

### How to verify it

Honestly, I am quite new to blockchain and python dev - please let me know if there are better ways to verify.

I just built locally successfully using docker build . <image> following the ape README.md. After a reviewer approves, I was hoping ape project's github CI actions will run tests against it without breakage.

### Checklist

- [x] All changes are completed
- [x] Change is covered in tests
- [x] Documentation is complete
