### PR TITLE
chore: wrong package license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Operating System :: MacOS",
         "Operating System :: POSIX",


### PR DESCRIPTION
## Description

Switch package classifier from “MIT” to “Apache Software License” to match the repository’s actual license:
- Root LICENSE file is Apache-2.0.
- setup.py previously advertised “MIT”, which is inconsistent metadata for PyPI.
- Correcting the classifier ensures downstream users and automation (e.g., compliance scanners, SBOM generators) receive accurate licensing information.