### PR TITLE
fix: gas estimate multiple default value fix

### DIFF
--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -29,6 +29,7 @@ from ape.utils.basemodel import (
     ManagerAccessMixin,
 )
 from ape.utils.misc import (
+    DEFAULT_LIVE_NETWORK_BASE_FEE_MULTIPLIER,
     DEFAULT_TRANSACTION_ACCEPTANCE_TIMEOUT,
     LOCAL_NETWORK_NAME,
     log_instead_of_fail,
@@ -941,7 +942,7 @@ class NetworkAPI(BaseInterfaceModel):
         for opt in name_options:
             if cfg := self.ecosystem_config.get(opt):
                 if isinstance(cfg, dict):
-                    return cfg
+                    return PluginConfig.model_validate(cfg)
                 elif isinstance(cfg, PluginConfig):
                     return cfg
                 else:
@@ -951,7 +952,7 @@ class NetworkAPI(BaseInterfaceModel):
 
     @cached_property
     def gas_limit(self) -> GasLimit:
-        return self.config.get("gas_limit", "auto")
+        return self.config.get("gas_limit", AutoGasLimit())
 
     @cached_property
     def auto_gas_multiplier(self) -> float:
@@ -965,7 +966,7 @@ class NetworkAPI(BaseInterfaceModel):
         """
         A multiplier to apply to a transaction base fee.
         """
-        return self.config.get("base_fee_multiplier", 1.0)
+        return self.config.get("base_fee_multiplier", DEFAULT_LIVE_NETWORK_BASE_FEE_MULTIPLIER)
 
     @property
     def chain_id(self) -> int:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -136,7 +136,7 @@ class NetworkConfig(PluginConfig):
     from a transaction before failing.
     """
 
-    gas_limit: GasLimit = "auto"
+    gas_limit: GasLimit = AutoGasLimit()
     """
     The gas limit override to use for the network. If set to ``"auto"``, ape will
     estimate gas limits based on the transaction. If set to ``"max"`` the gas limit
@@ -163,8 +163,13 @@ class NetworkConfig(PluginConfig):
     @field_validator("gas_limit", mode="before")
     @classmethod
     def validate_gas_limit(cls, value):
-        if isinstance(value, dict) and "auto" in value:
-            return AutoGasLimit.model_validate(value["auto"])
+        if isinstance(value, dict):
+            value = value.get("auto", {})
+            return AutoGasLimit.model_validate(value)
+
+        elif isinstance(value, AutoGasLimit):
+            # Already validated AutoGasLimit.
+            return value
 
         elif value in ("auto", "max") or isinstance(value, AutoGasLimit):
             return value
@@ -175,10 +180,11 @@ class NetworkConfig(PluginConfig):
         elif isinstance(value, str) and value.isnumeric():
             return int(value)
 
-        elif isinstance(value, str) and is_hex(value) and is_0x_prefixed(value):
-            return int(value, 16)
+        elif isinstance(value, str) and is_hex(value):
+            if is_0x_prefixed(value):
+                return int(value, 16)
 
-        elif is_hex(value):
+            # Else, we don't know if it is base 10 or 16.
             raise ValueError("Gas limit hex str must include '0x' prefix.")
 
         raise ValueError(f"Invalid gas limit '{value}'")

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -167,9 +167,8 @@ class NetworkConfig(PluginConfig):
             value = value.get("auto", {})
             return AutoGasLimit.model_validate(value)
 
-        elif isinstance(value, AutoGasLimit):
-            # Already validated AutoGasLimit.
-            return value
+        elif value == "auto":
+            return AutoGasLimit()
 
         elif value in ("auto", "max") or isinstance(value, AutoGasLimit):
             return value

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -479,9 +479,9 @@ class Web3Provider(ProviderAPI, ABC):
 
         return self.settings.get("call_trace_approach")
 
-    def _get_fee_history(self, block_id: int | str = "latest") -> FeeHistory:
+    def _get_fee_history(self, block_id: "BlockID" = "latest") -> FeeHistory:
         try:
-            return self.web3.eth.fee_history(1, block_id, reward_percentiles=[])
+            return self.web3.eth.fee_history(1, block_id, reward_percentiles=[])  # type: ignore
         except (MethodUnavailable, AttributeError) as err:
             raise APINotImplementedError(str(err)) from err
 

--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
 import ijson  # type: ignore
 import requests
 from eth_pydantic_types import HexBytes
-from eth_typing import BlockNumber, HexStr
+from eth_typing import HexStr
 from eth_utils import add_0x_prefix, is_hex, to_hex
 from evmchains import PUBLIC_CHAIN_META, get_random_rpc
 from pydantic.dataclasses import dataclass
@@ -448,32 +448,23 @@ class Web3Provider(ProviderAPI, ABC):
 
     @property
     def base_fee(self) -> int:
-        latest_block_number = self._get_latest_block_rpc().get("number")
-        if latest_block_number is None:
-            # Possibly no blocks yet.
-            logger.debug("Latest block has no number. Using base fee of '0'.")
-            return 0
-
         try:
-            fee_history = self._get_fee_history(latest_block_number)
+            fee_history = self._get_fee_history()
         except Exception as exc:
-            # Use the less-accurate approach (OK for testing).
             logger.debug(
-                "Failed using `web3.eth.fee_history` for network "
-                f"'{self.network_choice}'. Error: {exc}"
+                f"Failed using `eth_feeHistory` for network '{self.network_choice}'. Error: {exc}"
             )
             return self._get_last_base_fee()
 
-        if "baseFeePerGas" not in fee_history or len(fee_history["baseFeePerGas"] or []) < 2:
-            logger.debug("Not enough fee_history. Defaulting less-accurate approach.")
-            return self._get_last_base_fee()
+        base_fees = fee_history.get("baseFeePerGas") or []
+        if base_fees:
+            latest_fee = base_fees[-1]
+            if latest_fee is not None:
+                return to_int(latest_fee)
 
-        pending_base_fee = fee_history["baseFeePerGas"][1]
-        if pending_base_fee is None:
-            # Non-EIP-1559 chains or we time-travelled pre-London fork.
-            return self._get_last_base_fee()
-
-        return to_int(pending_base_fee)
+        # Fallback for non-EIP-1559 chains or missing data
+        logger.debug("Insufficient or missing baseFeePerGas. Using fallback base fee.")
+        return self._get_last_base_fee()
 
     @property
     def call_trace_approach(self) -> Optional[TraceApproach]:
@@ -488,9 +479,9 @@ class Web3Provider(ProviderAPI, ABC):
 
         return self.settings.get("call_trace_approach")
 
-    def _get_fee_history(self, block_number: int) -> FeeHistory:
+    def _get_fee_history(self, block_id: int | str = "latest") -> FeeHistory:
         try:
-            return self.web3.eth.fee_history(1, BlockNumber(block_number), reward_percentiles=[])
+            return self.web3.eth.fee_history(1, block_id, reward_percentiles=[])
         except (MethodUnavailable, AttributeError) as err:
             raise APINotImplementedError(str(err)) from err
 

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -12,6 +12,7 @@ from evm_trace import CallTreeNode, CallType
 from ape.api.networks import ForkedNetworkAPI, NetworkAPI
 from ape.exceptions import CustomError, DecodingError, NetworkError, NetworkNotFoundError
 from ape.types.address import AddressType
+from ape.types.gas import AutoGasLimit
 from ape.types.units import CurrencyValueComparable
 from ape.utils.misc import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT, LOCAL_NETWORK_NAME
 from ape_ethereum.ecosystem import BLUEPRINT_HEADER, BaseEthereumConfig, Block, Ethereum
@@ -724,7 +725,7 @@ def test_gas_limit_local_networks(ethereum, network_name):
 
 def test_gas_limit_live_networks(ethereum):
     network = ethereum.get_network("sepolia")
-    assert network.gas_limit == "auto"
+    assert network.gas_limit == AutoGasLimit(multiplier=1.0)
 
 
 def test_encode_blueprint_contract(ethereum, project):

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -64,9 +64,7 @@ def event_abi(vyper_contract_instance):
 
 
 @pytest.fixture
-def configured_custom_ecosystem(
-    custom_networks_config_dict, project, networks, custom_network_name_0
-):
+def configured_custom_ecosystem(custom_networks_config_dict, project, custom_network_name_0):
     data = copy.deepcopy(custom_networks_config_dict)
     data["networks"]["custom"][0]["ecosystem"] = CUSTOM_ECOSYSTEM_NAME
 

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -222,7 +222,7 @@ def test_config_validates_dict():
 
     mock_ecosystem = MockEcosystem()
     network_type = create_network_type(0, 0, False)
-    network = network_type.model_construct(name=name, ecosystem=mock_ecosystem)
+    network = network_type.model_construct(name=name, ecosystem=mock_ecosystem)  # type: ignore
 
     assert isinstance(network.config, PluginConfig)
     assert network.config["fooprop"] == val

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -74,16 +74,30 @@ def test_gas_limit_defaults(ethereum, project, custom_networks_config_dict):
     (
         {"auto": {"multiplier": 1.1}},
         AutoGasLimit(multiplier=1.1),
-        # "auto",
-        # "max",
-        # 100,
-        # "0x100",
     ),
 )
-def test_gas_limit_configured_auto(gas_limit_cfg, ethereum, project, custom_networks_config_dict):
-    custom_networks_config_dict["networks"]["custom"][0]["gas_limit"] = gas_limit_cfg
-    with project.temp_config(**custom_networks_config_dict):
-        assert ethereum.apenet.gas_limit == AutoGasLimit(multiplier=1.1)
+def test_gas_limit_configured_auto_with_multiplier(gas_limit_cfg):
+    cfg = NetworkConfig(gas_limit=gas_limit_cfg)
+    assert cfg.gas_limit == AutoGasLimit(multiplier=1.1)
+
+
+def test_gas_limit_configured_auto(ethereum, project):
+    network = NetworkConfig(gas_limit="auto")
+    assert network.gas_limit == AutoGasLimit(multiplier=1.0)
+
+
+def test_gas_limit_configured_max(ethereum, project):
+    with project.temp_config(ethereum={"local": {"gas_limit": "max"}}):
+        assert ethereum.local.gas_limit == "max"
+
+
+@pytest.mark.parametrize(
+    "gas_limit_cfg",
+    (100, "0x64"),
+)
+def test_gas_limit_configured_numerically(gas_limit_cfg):
+    network = NetworkConfig(gas_limit=gas_limit_cfg)
+    assert network.gas_limit == 100
 
 
 def test_base_fee_multiplier(ethereum):


### PR DESCRIPTION
### What I did

base fee multiplier was 1.0 on other default live networks.
also, was having some pydantic validation issues when trying to configure, fixed that
also uses AutoGasLimit default instead of string "auto"
also a perf where we use "latest" instead of fetching latest block number, better for faster chains i think

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
