### PR TITLE
fix: ability to set transaction `.gas` (alias for `.gas_limit`)

### DIFF
--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -105,6 +105,10 @@ class TransactionAPI(BaseInterfaceModel):
         """
         return self.gas_limit
 
+    @gas.setter
+    def gas(self, value):
+        self.gas_limit = self.validate_gas_limit(value)
+
     @property
     def raise_on_revert(self) -> bool:
         """

--- a/tests/functional/test_transaction.py
+++ b/tests/functional/test_transaction.py
@@ -479,8 +479,18 @@ def test_override_annotated_fields():
     assert my_tx.type == tx_type
 
 
-def test_gas(ethereum):
-    tx = ethereum.create_transaction(gas_limit=123)
+@pytest.mark.parametrize("key", ("gas_limit", "gas"))
+def test_gas(ethereum, key):
+    kwargs = {key: 123}
+    tx = ethereum.create_transaction(**kwargs)
     assert tx.gas_limit == 123
     # Show the `gas` alias works.
     assert tx.gas == 123
+
+
+@pytest.mark.parametrize("val", (2, "0x2"))
+def test_gas_setter(ethereum, val):
+    tx = ethereum.create_transaction()
+    tx.gas = val
+    assert tx.gas_limit == 2
+    assert tx.gas == 2


### PR DESCRIPTION
### What I did

`.gas` was already an alias, it just didn't have a setter, which was confusing for a second.

fixes: #2681

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
