### PR TITLE
refactor: switch to instance method for after validator

### DIFF
--- a/src/ape_pm/dependency.py
+++ b/src/ape_pm/dependency.py
@@ -161,12 +161,11 @@ class GithubDependency(DependencyAPI):
         return model
 
     @model_validator(mode="after")
-    @classmethod
-    def ensure_ref_or_version(cls, dep):
-        if dep.ref is None and dep.version is None:
+    def ensure_ref_or_version(self):
+        if self.ref is None and self.version is None:
             raise ValueError("GitHub dependency must have either ref or version specified.")
 
-        return dep
+        return self
 
     @property
     def package_id(self) -> str:


### PR DESCRIPTION
### What I did

per deprecation warning in one of my tests 
```
site-packages/ape_pm/dependency.py:163: PydanticDeprecatedSince212: Using `@model_validator` with mode='after' on a classmethod is deprecated. Instead, use an instance method. See the documentation at https://docs.pydantic.dev/2.12/concepts/validators/#model-after-validator. Deprecated in Pydantic V2.12 to be removed in V3.0.
```
https://docs.pydantic.dev/2.12/concepts/validators/#model-validators

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
~~- [ ] Documentation is complete~~
