### PR TITLE
Chore/drop py39

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,7 +64,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
-                python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+                python-version: ["3.10", "3.11", "3.12", "3.13"]
 
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -166,6 +166,5 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: 3.14",
     ],
 )


### PR DESCRIPTION
### What I did

<!-- Create a summary of the changes -->

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

Related #2723

- Removed Python 3.9 from the GitHub Actions test matrix.
- Removed the `Programming Language :: Python :: 3.9` classifier to keep metadata consistent with `python_requires >=3.10`.

### How I did it

<!-- Discuss the thought process behind the change -->
- Updated `.github/workflows/test.yaml` to drop 3.9 from `matrix.python-version`.
- Updated `setup.py` classifiers to reflect supported versions.

### How to verify it

<!-- Discuss methods to verify the change -->

1) Confirm the CI matrix no longer includes 3.9.
2) Run locally (optional):

```
python -m ruff check .
python -m compileall -q src
```
### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
- [ ] Documentation is complete
