### PR TITLE
refactor(Ethereum): improve efficiency of SafeProxy detection heuristic

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -36,7 +36,6 @@ from ape.exceptions import (
     CustomError,
     DecodingError,
     SignatureError,
-    TransactionError,
 )
 from ape.logging import logger
 from ape.managers.config import merge_configs
@@ -561,19 +560,18 @@ class Ethereum(EcosystemAPI):
                         pass
 
         # safe >=1.1.0 provides `masterCopy()` (0xa619486e), which is also stored in slot 0
-        if re.match(r".*a619486e.*", code):  # NOTE: Such a short sequence can have false positives
+        if "a619486e" in code:
             slot_0 = self.provider.get_storage(address, 0)
-            # Slot value is "address-like" heuristic (all contract addresses have >12 nonzero bytes)
-            # NOTE: Farming an address with 8 leading zeros is pretty improbable
+            # "Address-like" heuristic: 12 leading zero bytes, and the trailing 20 bytes
+            # contain >=12 non-zero bytes. Vanity addresses with that many zeros are rare.
             if all(b == 0 for b in slot_0[:-20]) and sum(1 for b in slot_0[-20:] if b > 0) >= 12:
-                # Slot is "address-like", so convert it
                 target = self.conversion_manager.convert(slot_0[-20:], AddressType)
 
                 try:
                     # call `masterCopy()` and check that target matches return value
                     singleton = ContractCall(MASTER_COPY_ABI, address)(skip_trace=True)
 
-                except TransactionError:
+                except Exception:
                     pass
 
                 else:

--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -36,6 +36,7 @@ from ape.exceptions import (
     CustomError,
     DecodingError,
     SignatureError,
+    TransactionError,
 )
 from ape.logging import logger
 from ape.managers.config import merge_configs
@@ -559,18 +560,28 @@ class Ethereum(EcosystemAPI):
                     except ApeException:
                         pass
 
-        # safe >=1.1.0 provides `masterCopy()`, which is also stored in slot 0
-        # call it and check that target matches
-        try:
-            singleton = ContractCall(MASTER_COPY_ABI, address)(skip_trace=True)
+        # safe >=1.1.0 provides `masterCopy()` (0xa619486e), which is also stored in slot 0
+        if re.match(r".*a619486e.*", code):  # NOTE: Such a short sequence can have false positives
             slot_0 = self.provider.get_storage(address, 0)
-            target = self.conversion_manager.convert(slot_0[-20:], AddressType)
-            # NOTE: `target` is set in initialized proxies
-            if target != ZERO_ADDRESS and target == singleton:
-                return ProxyInfo(type=ProxyType.GnosisSafe, target=target, abi=MASTER_COPY_ABI)
+            # Slot value is "address-like" heuristic (all contract addresses have >12 nonzero bytes)
+            # NOTE: Farming an address with 8 leading zeros is pretty improbable
+            if all(b == 0 for b in slot_0[:-20]) and sum(1 for b in slot_0[-20:] if b > 0) >= 12:
+                # Slot is "address-like", so convert it
+                target = self.conversion_manager.convert(slot_0[-20:], AddressType)
 
-        except ApeException:
-            pass
+                try:
+                    # call `masterCopy()` and check that target matches return value
+                    singleton = ContractCall(MASTER_COPY_ABI, address)(skip_trace=True)
+
+                except TransactionError:
+                    pass
+
+                else:
+                    # NOTE: `target` is set in initialized proxies like GnosisSafe
+                    if target == singleton:
+                        return ProxyInfo(
+                            type=ProxyType.GnosisSafe, target=target, abi=MASTER_COPY_ABI
+                        )
 
         # eip-897 delegate proxy, read `proxyType()` and `implementation()`
         # perf: only make a call when a proxyType() selector is mentioned in the code


### PR DESCRIPTION
### What I did

Narrow the heuristic which triggers the `masterCopy()` call to a contract to determine if it is a SafeProxy type. This should reduce/eliminate most of the instances where Ape tries the call and it fails and creates a log like so:

```
reverted without message
0xC8C8...6793.0xa619486e()
```

### How I did it

We can add a couple extra ~free checks on code and slot_0 value before triggering `masterCopy()`:
1. check that the method ID for `masterCopy()` (0xa619486e) is actually in the proxy code (should always be true, but has potential for false positives)
2. check that slot_0 is "address-like" (has 12 leading empty bytes, and at least 12/32 non-empty bytes)

### How to verify it

Anything weird happens

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
~~- [ ] Documentation is complete~~
