### PR TITLE
fix: honor skip trace in proxy calls

### DIFF
--- a/src/ape_ethereum/provider.py
+++ b/src/ape_ethereum/provider.py
@@ -781,10 +781,10 @@ class Web3Provider(ProviderAPI, ABC):
 
             vm_err = self.get_virtual_machine_error(
                 err,
-                trace=lambda: _lazy_call_trace.trace,
+                trace=lambda: None if skip_trace else _lazy_call_trace.trace,
                 contract_address=contract_address,
-                source_traceback=lambda: _lazy_call_trace.source_traceback,
-                set_ape_traceback=raise_on_revert,
+                source_traceback=lambda: None if skip_trace else _lazy_call_trace.source_traceback,
+                set_ape_traceback=raise_on_revert and not skip_trace,
             )
             if raise_on_revert:
                 raise vm_err.with_ape_traceback() from err


### PR DESCRIPTION
### What I did

I noticed all the proxy traces still appeared which was annoying and causing confusion in the logs

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
