### PR TITLE
fix(config): respect ethereum.local default_provider overrides

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -283,11 +283,22 @@ class BaseEthereumConfig(PluginConfig):
     @computed_field  # type: ignore[misc]
     @cached_property
     def local(self) -> NetworkConfig:
-        return create_local_network_config(
+        default_local = create_local_network_config(
             default_provider="test",
             default_transaction_type=self.DEFAULT_TRANSACTION_TYPE,
             gas_limit=self.DEFAULT_LOCAL_GAS_LIMIT,
         )
+        if not (override := (self.__pydantic_extra__ or {}).get("local")):
+            return default_local
+
+        if isinstance(override, NetworkConfig):
+            return override
+
+        if isinstance(override, dict):
+            data = merge_configs(default_local.model_dump(by_alias=True), override)
+            return NetworkConfig.model_validate(data)
+
+        return default_local
 
     @only_raise_attribute_error
     def __getattr__(self, key: str) -> Any:

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -362,6 +362,14 @@ def test_ethereum_network_configs(config, project):
         assert actual.sepolia.block_time == 15
 
 
+def test_ethereum_local_network_config_override(project, config, ethereum):
+    eth_config = {"ethereum": {"local": {"default_provider": "node"}}}
+    with project.temp_config(**eth_config):
+        actual = config.get_config("ethereum")
+        assert actual.local.default_provider == "node"
+        assert ethereum.local.config.default_provider == "node"
+
+
 def test_network_gas_limit_default(config):
     eth_config = config.get_config("ethereum")
 


### PR DESCRIPTION
### What I did

Updated the config model so project/global overrides for `ethereum.local.default_provider` are reflected in `EthereumConfig.local`.

fixes: #2490

### How I did it

- read the raw `local` override from the plugin extras instead of always constructing a hard-coded local config
- merged the configured `local` values with the existing local defaults before validating as `NetworkConfig`
- added regression coverage for `ethereum.local.default_provider` override behavior

### How to verify it

```bash
pytest tests/functional/test_config.py -k ethereum_local_network_config_override -q
pytest tests/functional/test_network_api.py -k "gas_limit_defaults or gas_limit_configured_max or base_fee_multiplier or config_custom_networks_default or config_custom_networks" -q
```

### Checklist

- [x] All changes are completed
- [x] Change is covered in tests
- [x] Documentation is complete; no user-facing docs update was needed for this internal config-model fix
