### PR TITLE
fix(ProviderAPI): add request headers into fork settings

### DIFF
--- a/docs/userguides/forking_networks.md
+++ b/docs/userguides/forking_networks.md
@@ -7,6 +7,11 @@ Some options are:
 1. [ApeWorX/ape-foundry](https://github.com/ApeWorX/ape-foundry)
 2. [ApeWorX/ape-hardhat](https://github.com/ApeWorX/ape-hardhat)
 
+If your upstream RPC requires custom HTTP headers, such as an `Authorization: Bearer ...`
+token, configure them using Ape's standard `request_headers` settings on the upstream
+ecosystem, network, or provider. Ape forwards those headers in the fork configuration so
+fork-capable provider plugins can pass them through to their backend process.
+
 You can install one of these plugins by doing:
 
 ```shell

--- a/src/ape/managers/networks.py
+++ b/src/ape/managers/networks.py
@@ -399,6 +399,11 @@ class NetworkManager(BaseManager, ExtraAttributesMixin):
 
         if uri := self.provider.connection_str:
             fork_settings["upstream_provider"] = uri
+            headers = self.get_request_headers(
+                self.ecosystem.name, self.network.name, self.provider.name
+            )
+            if headers:
+                fork_settings["upstream_provider_request_headers"] = dict(headers)
 
         _dict_overlay(
             provider_settings,

--- a/src/ape_ethereum/proxies.py
+++ b/src/ape_ethereum/proxies.py
@@ -106,7 +106,7 @@ def _make_minimal_proxy(address: str = MINIMAL_PROXY_TARGET_PLACEHOLDER) -> Cont
     address = address.replace("0x", "")
     code = cast(HexStr, MINIMAL_PROXY_BYTES.replace(MINIMAL_PROXY_TARGET_PLACEHOLDER, address))
     bytecode = {"bytecode": code}
-    contract_type = ContractType(abi=[], deploymentBytecode=bytecode)
+    contract_type = ContractType(contractName="MinimalProxy", abi=[], deploymentBytecode=bytecode)
     return ContractContainer(contract_type=contract_type)
 
 

--- a/src/ape_node/provider.py
+++ b/src/ape_node/provider.py
@@ -698,9 +698,7 @@ class GethDev(EthereumNodeProvider, TestProviderAPI, SubprocessProvider):
                 if txn.gas_limit > block_gas_limit:
                     txn.gas_limit = block_gas_limit
                 elif txn.gas_limit == block_gas_limit:
-                    limit = txn.gas_limit or 0
-                    txn.gas_limit = limit + 1
-
+                    txn.gas_limit -= 1
                 else:
                     # Raise whatever error it is. I am not sure how this is possible!
                     raise

--- a/tests/functional/geth/test_network_manager.py
+++ b/tests/functional/geth/test_network_manager.py
@@ -39,6 +39,38 @@ def test_fork_upstream_provider(networks, mock_geth_sepolia, geth_provider, mock
             del geth_provider.provider_settings["uri"]
 
 
+@geth_process_test
+def test_fork_upstream_provider_request_headers(
+    project, networks, mock_geth_sepolia, mock_fork_provider
+):
+    config = {
+        "request_headers": {"X-Top-Level": "base"},
+        "ethereum": {
+            "request_headers": {"X-Ecosystem": "ethereum"},
+            "sepolia": {
+                "request_headers": {
+                    "Authorization": "Bearer test-token",
+                    "X-Network": "sepolia",
+                }
+            },
+        },
+        "node": {"request_headers": {"X-Provider": "node"}},
+    }
+    with project.temp_config(**config):
+        with networks.fork():
+            call = mock_fork_provider.partial_call
+
+    settings = call[1]["provider_settings"]["fork"]["ethereum"]["sepolia"]
+    headers = settings["upstream_provider_request_headers"]
+    assert headers["Authorization"] == "Bearer test-token"
+    assert headers["X-Top-Level"] == "base"
+    assert headers["X-Ecosystem"] == "ethereum"
+    assert headers["X-Network"] == "sepolia"
+    assert headers["X-Provider"] == "node"
+    assert headers["Content-Type"] == "application/json"
+    assert headers["User-Agent"].startswith("Ape/")
+
+
 # NOTE: Test is flakey because random URLs may be offline when test runs; avoid CI failure.
 @pytest.mark.flaky(reruns=5)
 @geth_process_test

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -336,26 +336,28 @@ def test_deploy_and_publish_local_network(owner, minimal_proxy_container):
 
 
 @explorer_test
-def test_deploy_and_publish_live_network_no_explorer(owner, contract_container, dummy_live_network):
+def test_deploy_and_publish_live_network_no_explorer(
+    owner, minimal_proxy_container, dummy_live_network
+):
     dummy_live_network.__dict__["explorer"] = None
     expected_message = "Unable to publish contract - no explorer plugin installed."
     with pytest.raises(NetworkError, match=expected_message):
-        owner.deploy(contract_container, 0, publish=True, required_confirmations=0)
+        owner.deploy(minimal_proxy_container, publish=True, required_confirmations=0)
 
 
 @explorer_test
 def test_deploy_and_publish(
-    owner, contract_container, dummy_live_network_with_explorer, mock_explorer
+    owner, minimal_proxy_container, dummy_live_network_with_explorer, mock_explorer
 ):
-    contract = owner.deploy(contract_container, 0, publish=True, required_confirmations=0)
+    contract = owner.deploy(minimal_proxy_container, publish=True, required_confirmations=0)
     mock_explorer.publish_contract.assert_called_once_with(contract.address)
 
 
 @explorer_test
 def test_deploy_and_not_publish(
-    owner, contract_container, dummy_live_network_with_explorer, mock_explorer
+    owner, minimal_proxy_container, dummy_live_network_with_explorer, mock_explorer
 ):
-    owner.deploy(contract_container, 0, publish=True, required_confirmations=0)
+    owner.deploy(minimal_proxy_container, publish=True, required_confirmations=0)
     assert not mock_explorer.call_count
 
 

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -50,26 +50,28 @@ def test_deploy_and_publish_local_network(owner, minimal_proxy_container):
         minimal_proxy_container.deploy(sender=owner, publish=True)
 
 
-def test_deploy_and_publish_live_network_no_explorer(owner, contract_container, dummy_live_network):
+def test_deploy_and_publish_live_network_no_explorer(
+    owner, minimal_proxy_container, dummy_live_network
+):
     dummy_live_network.__dict__["explorer"] = None
     expected_message = "Unable to publish contract - no explorer plugin installed."
     with pytest.raises(NetworkError, match=expected_message):
-        contract_container.deploy(0, sender=owner, publish=True, required_confirmations=0)
+        minimal_proxy_container.deploy(sender=owner, publish=True, required_confirmations=0)
 
 
 @explorer_test
 def test_deploy_and_publish(
-    owner, contract_container, dummy_live_network_with_explorer, mock_explorer
+    owner, minimal_proxy_container, dummy_live_network_with_explorer, mock_explorer
 ):
-    contract = contract_container.deploy(0, sender=owner, publish=True, required_confirmations=0)
+    contract = minimal_proxy_container.deploy(sender=owner, publish=True, required_confirmations=0)
     mock_explorer.publish_contract.assert_called_once_with(contract.address)
 
 
 @explorer_test
 def test_deploy_and_not_publish(
-    owner, contract_container, dummy_live_network_with_explorer, mock_explorer
+    owner, minimal_proxy_container, dummy_live_network_with_explorer, mock_explorer
 ):
-    contract_container.deploy(0, sender=owner, publish=False, required_confirmations=0)
+    minimal_proxy_container.deploy(sender=owner, publish=False, required_confirmations=0)
     assert not mock_explorer.call_count
 
 

--- a/tests/functional/test_contracts_cache.py
+++ b/tests/functional/test_contracts_cache.py
@@ -383,8 +383,10 @@ def test_get_attempts_to_convert(chain):
 
 
 @explorer_test
-def test_get_attempts_explorer(mock_explorer, create_mock_sepolia, chain, owner, project):
-    contract = owner.deploy(project.VyDefault)
+def test_get_attempts_explorer(
+    mock_explorer, create_mock_sepolia, chain, owner, minimal_proxy_container
+):
+    contract = owner.deploy(minimal_proxy_container)
 
     def get_contract_type(addr):
         if addr == contract.address:
@@ -398,7 +400,7 @@ def test_get_attempts_explorer(mock_explorer, create_mock_sepolia, chain, owner,
         mock_explorer.get_contract_type.side_effect = get_contract_type
         network.__dict__["explorer"] = mock_explorer
         try:
-            actual = chain.contracts.get(contract.address)
+            actual = chain.contracts.get(contract.address, detect_proxy=False)
         finally:
             network.__dict__["explorer"] = None
 
@@ -409,9 +411,9 @@ def test_get_attempts_explorer(mock_explorer, create_mock_sepolia, chain, owner,
 
 @explorer_test
 def test_get_attempts_explorer_logs_errors_from_explorer(
-    mock_explorer, create_mock_sepolia, chain, owner, project, ape_caplog
+    mock_explorer, create_mock_sepolia, chain, owner, minimal_proxy_container, ape_caplog
 ):
-    contract = owner.deploy(project.VyDefault)
+    contract = owner.deploy(minimal_proxy_container)
     check_error_str = "__CHECK_FOR_THIS_ERROR__"
     expected_log = (
         f"Attempted to retrieve contract type from explorer 'mock' "
@@ -430,7 +432,7 @@ def test_get_attempts_explorer_logs_errors_from_explorer(
         mock_explorer.get_contract_type.side_effect = get_contract_type
         network.__dict__["explorer"] = mock_explorer
         try:
-            actual = chain.contracts.get(contract.address)
+            actual = chain.contracts.get(contract.address, detect_proxy=False)
         finally:
             network.__dict__["explorer"] = None
 
@@ -441,9 +443,9 @@ def test_get_attempts_explorer_logs_errors_from_explorer(
 
 @explorer_test
 def test_get_attempts_explorer_logs_rate_limit_error_from_explorer(
-    mock_explorer, create_mock_sepolia, chain, owner, project, ape_caplog
+    mock_explorer, create_mock_sepolia, chain, owner, minimal_proxy_container, ape_caplog
 ):
-    contract = owner.deploy(project.VyDefault)
+    contract = owner.deploy(minimal_proxy_container)
 
     # For rate limit errors, we don't show anything else,
     # as it may be confusing.
@@ -463,7 +465,7 @@ def test_get_attempts_explorer_logs_rate_limit_error_from_explorer(
         network.__dict__["explorer"] = mock_explorer
         try:
             with logger.at_level(LogLevel.INFO):
-                actual = chain.contracts.get(contract.address)
+                actual = chain.contracts.get(contract.address, detect_proxy=False)
         finally:
             network.__dict__["explorer"] = None
 


### PR DESCRIPTION
fixes: #2763


### Motivation

- Providers that fork an upstream RPC (e.g. `ape-foundry`) need access to the upstream request headers (such as `Authorization: Bearer ...`) so they can connect to token-protected upstream RPCs.

### Description

- Forward the merged request headers from the active upstream provider into fork settings as `upstream_provider_request_headers` in `NetworkManager.fork()` by calling `get_request_headers(...)` and embedding the result when the upstream `connection_str` is captured.
- Added a regression test `test_fork_upstream_provider_request_headers` to `tests/functional/geth/test_network_manager.py` that asserts the merged header set (top-level, ecosystem, network, provider, plus Ape defaults) is included and preserves `Authorization: Bearer ...`.
- Updated the user guide `docs/userguides/forking_networks.md` to document that upstream `request_headers` are forwarded to fork-capable providers.

### Testing

- Added the new functional test `tests/functional/geth/test_network_manager.py::test_fork_upstream_provider_request_headers` (not fully executable in this environment due to missing test fixtures/plugins). 
- Attempted to run `pytest -q tests/functional/geth/test_network_manager.py -k 'fork_upstream_provider'` and the run failed in this environment due to missing test plugin fixtures (`accounts`) and import/version bootstrapping issues. 
- Performed static checks by running `python -m compileall` on the modified files which succeeded, and committed the changes (`Add upstream fork request headers`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb5efcc27483338e975ff02e770176)