### PR TITLE
refactor(Accounts): retry unlock prompt if failed interactively

### DIFF
--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -266,27 +266,33 @@ class KeyfileAccount(AccountAPI):
         return public_key
 
     def unlock(self, passphrase: str | None = None):
-        if not passphrase:
-            # Check if environment variable is available
-            env_variable = f"APE_ACCOUNTS_{self.alias}_PASSPHRASE"
-            passphrase = environ.get(env_variable, None)
+        private_key: bytes = b""
+        if passphrase:
+            # NOTE: Try only once, if it fails it was given incorrectly and we should not prompt
+            private_key = self.__decrypt_keyfile(passphrase)
 
-            if passphrase:
-                # Passphrase found in environment variable
-                logger.info(
-                    f"Using passphrase for account '{self.alias}' from environment variable"
-                )
-            else:
-                # Passphrase not found, prompt for it
-                passphrase = self._prompt_for_passphrase(
-                    f"Enter passphrase to permanently unlock '{self.alias}'"
-                )
+        elif passphrase := environ.get(f"APE_ACCOUNTS_{self.alias}_PASSPHRASE"):
+            logger.info(f"Using passphrase for account '{self.alias}' from environment variable")
+            # NOTE: Try only once, if it fails then we are non-interactive, so we can't prompt
+            private_key = self.__decrypt_keyfile(passphrase)
 
-        if passphrase is None:
-            raise AccountsError("Passphrase can't be 'None'")
+        attempts = 1
+        while not private_key:
+            # Passphrase not found, prompt for it up to 3 times.
+            passphrase = self._prompt_for_passphrase(
+                f"Enter passphrase to permanently unlock '{self.alias}'"
+            )
+            try:
+                private_key = self.__decrypt_keyfile(passphrase)
 
-        # Rest of the code to unlock the account using the passphrase
-        self.__cached_signer = ApeSigner(private_key=self.__decrypt_keyfile(passphrase))
+            except InvalidPasswordError:
+                if attempts < 3:
+                    logger.error("Invalid password")
+                    attempts += 1
+                else:
+                    raise
+
+        self.__cached_signer = ApeSigner(private_key=private_key)
         self.locked = False
 
     def lock(self):

--- a/src/ape_accounts/accounts.py
+++ b/src/ape_accounts/accounts.py
@@ -285,12 +285,12 @@ class KeyfileAccount(AccountAPI):
             try:
                 private_key = self.__decrypt_keyfile(passphrase)
 
-            except InvalidPasswordError:
+            except InvalidPasswordError as err:
                 if attempts < 3:
                     logger.error("Invalid password")
                     attempts += 1
                 else:
-                    raise
+                    raise AccountsError(f"Failed to unlock after {attempts} attempts.") from err
 
         self.__cached_signer = ApeSigner(private_key=private_key)
         self.locked = False

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -613,8 +613,11 @@ def test_unlock_from_prompt_retries_and_succeeds(runner, keyfile_account):
 
 
 def test_unlock_from_prompt_fails_after_three_attempts(runner, keyfile_account):
-    with pytest.raises(AccountsError, match="Invalid password"):
-        keyfile_account.unlock()
+    with runner.isolation(
+        input=f"{INVALID_PASSPHRASE}\n{INVALID_PASSPHRASE}\n{INVALID_PASSPHRASE}\n"
+    ):
+        with pytest.raises(AccountsError, match="Failed to unlock after 3 attempts."):
+            keyfile_account.unlock()
 
     assert keyfile_account.locked
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -605,6 +605,20 @@ def test_unlock_from_prompt_and_sign_message(runner, keyfile_account, message):
         assert keyfile_account.check_signature(message, signature)
 
 
+def test_unlock_from_prompt_retries_and_succeeds(runner, keyfile_account):
+    with runner.isolation(input=f"{INVALID_PASSPHRASE}\n{INVALID_PASSPHRASE}\n{PASSPHRASE}\n"):
+        keyfile_account.unlock()
+
+    assert not keyfile_account.locked
+
+
+def test_unlock_from_prompt_fails_after_three_attempts(runner, keyfile_account):
+    with pytest.raises(AccountsError, match="Invalid password"):
+        keyfile_account.unlock()
+
+    assert keyfile_account.locked
+
+
 def test_unlock_with_passphrase_and_sign_transaction(runner, keyfile_account, receiver):
     keyfile_account.unlock(passphrase=PASSPHRASE)
     # y: yes, sign (note: unlocking makes the key available but is not the same as autosign).


### PR DESCRIPTION
### Motivation

- Improve the UX and robustness of `KeyfileAccount.unlock` by retrying interactive prompts when the passphrase is entered incorrectly.

### Description

- prompt up to three times and catch `InvalidPasswordError`, logging an error on each bad attempt and re-raising on the third failure. 
- Add two functional tests `test_unlock_from_prompt_retries_and_succeeds` and `test_unlock_from_prompt_fails_after_three_attempts` to cover retry and failure behavior.

### Testing
- `test_unlock_with_passphrase_and_sign_message` and `test_unlock_from_prompt_and_sign_message`, and both newly added tests; all tests passed.
- Verified `unlock` behavior when `APE_ACCOUNTS_{alias}_PASSPHRASE` is set and when prompting interactively; tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc7c545ca083339a18a75049224782)