### PR TITLE
fix: wrong chainId in cache when using multiple local nets of same network

### DIFF
--- a/src/ape/managers/chain.py
+++ b/src/ape/managers/chain.py
@@ -39,6 +39,7 @@ from ape.utils.misc import ZERO_ADDRESS, is_evm_precompile, is_zero_hex, log_ins
 if TYPE_CHECKING:
     from rich.console import Console as RichConsole
 
+    from ape.api.providers import ProviderAPI
     from ape.types import BlockID, ContractCode, GasReport, SnapshotID, SourceTraceback
 
 
@@ -698,6 +699,33 @@ class ReportManager(BaseManager):
         return get_rich_console(*args, **kwargs)
 
 
+class ChainIdCache(dict):
+    """
+    A cache of ``chain_id`` keyed by the active network (and, for local
+    networks, also by the provider name).
+    """
+
+    @staticmethod
+    def key_for(provider: "ProviderAPI") -> str:
+        """Return the cache key for ``provider``.
+
+        Named networks key by ``network.name`` (chain_id is a network
+        invariant). Local networks additionally disambiguate by provider name
+        so ape-test (``local:test`` → 1337) and ape-foundry
+        (``local:foundry`` → 31337) don't overwrite each other.
+        """
+        network = provider.network
+        return f"{network.name}:{provider.name}" if network.is_local else network.name
+
+    def get_for_provider(self, provider: "ProviderAPI") -> int:
+        """Return the chain id for ``provider``, querying and caching if unseen."""
+        key = self.key_for(provider)
+        if key not in self:
+            self[key] = provider.chain_id
+
+        return self[key]
+
+
 class ChainManager(BaseManager):
     """
     A class for managing the state of the active blockchain.
@@ -710,7 +738,7 @@ class ChainManager(BaseManager):
     """
 
     _snapshots: defaultdict = defaultdict(list)  # chain_id -> snapshots
-    _chain_id_map: dict[str, int] = {}
+    _chain_id_cache: ChainIdCache = ChainIdCache()
     _block_container_map: dict[int, BlockContainer] = {}
     _transaction_history_map: dict[int, TransactionHistory] = {}
     _reports: ReportManager = ReportManager()
@@ -756,11 +784,7 @@ class ChainManager(BaseManager):
         The blockchain ID.
         See `ChainList <https://chainlist.org/>`__ for a comprehensive list of IDs.
         """
-        network_name = self.provider.network.name
-        if network_name not in self._chain_id_map:
-            self._chain_id_map[network_name] = self.provider.chain_id
-
-        return self._chain_id_map[network_name]
+        return self._chain_id_cache.get_for_provider(self.provider)
 
     @property
     def gas_price(self) -> int:

--- a/tests/functional/test_chain.py
+++ b/tests/functional/test_chain.py
@@ -4,8 +4,78 @@ from datetime import datetime, timedelta
 import pytest
 
 from ape.exceptions import APINotImplementedError, ChainError, UnknownSnapshotError
-from ape.managers.chain import AccountHistory
+from ape.managers.chain import AccountHistory, ChainIdCache
 from ape.types.address import AddressType
+
+
+class TestChainIdCache:
+    @staticmethod
+    def _make_provider(mocker, network_name, provider_name, chain_id, is_local):
+        network = mocker.MagicMock()
+        network.name = network_name
+        network.is_local = is_local
+        provider = mocker.MagicMock()
+        provider.network = network
+        provider.name = provider_name
+        chain_id_prop = mocker.PropertyMock(return_value=chain_id)
+        type(provider).chain_id = chain_id_prop
+        provider.chain_id_prop = chain_id_prop
+        return provider
+
+    def test_local_networks_namespaced_by_provider(self, mocker):
+        test_provider = self._make_provider(mocker, "local", "test", 1337, is_local=True)
+        foundry_provider = self._make_provider(mocker, "local", "foundry", 31337, is_local=True)
+        cache = ChainIdCache()
+
+        assert cache.get_for_provider(test_provider) == 1337
+        assert cache.get_for_provider(foundry_provider) == 31337
+        assert cache.get_for_provider(test_provider) == 1337
+
+    def test_named_networks_keyed_by_network_name(self, mocker):
+        infura = self._make_provider(mocker, "mainnet", "infura", 1, is_local=False)
+        alchemy = self._make_provider(mocker, "mainnet", "alchemy", 1, is_local=False)
+        cache = ChainIdCache()
+
+        assert cache.get_for_provider(infura) == 1
+        assert cache.get_for_provider(alchemy) == 1
+        assert alchemy.chain_id_prop.call_count == 0
+
+    def test_clear_forces_reread(self, mocker):
+        provider = self._make_provider(mocker, "local", "foundry", 31337, is_local=True)
+        cache = ChainIdCache()
+
+        cache.get_for_provider(provider)
+        assert provider.chain_id_prop.call_count == 1
+        cache.get_for_provider(provider)
+        assert provider.chain_id_prop.call_count == 1  # cached
+
+        cache.clear()
+        cache.get_for_provider(provider)
+        assert provider.chain_id_prop.call_count == 2  # re-queried after clear
+
+    def test_behaves_like_a_dict(self, mocker):
+        cache = ChainIdCache()
+        cache["local:test"] = 1337
+        cache["local:foundry"] = 31337
+
+        assert cache["local:test"] == 1337
+        assert cache["local:foundry"] == 31337
+        assert "local:test" in cache
+        assert dict(cache) == {"local:test": 1337, "local:foundry": 31337}
+
+        assert cache.pop("local:test") == 1337
+        assert "local:test" not in cache
+
+        cache.clear()
+        assert cache == {}
+
+    def test_get_for_provider_honours_preseeded_entries(self, mocker):
+        provider = self._make_provider(mocker, "local", "foundry", 31337, is_local=True)
+        cache = ChainIdCache()
+        cache[ChainIdCache.key_for(provider)] = 99999
+
+        assert cache.get_for_provider(provider) == 99999
+        assert provider.chain_id_prop.call_count == 0
 
 
 def test_snapshot_and_restore(chain, owner, receiver, vyper_contract_instance):


### PR DESCRIPTION
### What I did

Had an ape-test going with an ape-foundry and their chain Ids differed and caused problems

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
