### PR TITLE
fix: respect local ethereum provider config

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -285,10 +285,25 @@ class BaseEthereumConfig(PluginConfig):
     @computed_field  # type: ignore[misc]
     @cached_property
     def local(self) -> NetworkConfig:
-        return create_local_network_config(
+        default_config = create_local_network_config(
             default_provider="test",
             default_transaction_type=self.DEFAULT_TRANSACTION_TYPE,
             gas_limit=self.DEFAULT_LOCAL_GAS_LIMIT,
+        )
+        configured_local: dict[str, Any] | NetworkConfig | None = PluginConfig.get(
+            self, LOCAL_NETWORK_NAME
+        )
+        if configured_local is None:
+            return default_config
+
+        if isinstance(configured_local, NetworkConfig):
+            configured_local = configured_local.model_dump(by_alias=True)
+
+        if not isinstance(configured_local, dict):
+            return default_config
+
+        return NetworkConfig.model_validate(
+            merge_configs(default_config.model_dump(by_alias=True), configured_local)
         )
 
     @only_raise_attribute_error

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -362,6 +362,17 @@ def test_ethereum_network_configs(config, project):
         assert actual.sepolia.block_time == 15
 
 
+def test_ethereum_local_network_config(config, project):
+    eth_config = {"ethereum": {"local": {"default_provider": "node"}}}
+    with project.temp_config(**eth_config):
+        actual = config.get_config("ethereum")
+        assert actual.local.default_provider == "node"
+
+        # Ensure that local-network defaults remain unaffected.
+        assert actual.local.gas_limit == "max"
+        assert actual.local.required_confirmations == 0
+
+
 def test_network_gas_limit_default(config):
     eth_config = config.get_config("ethereum")
 


### PR DESCRIPTION
## What I changed
- Updated `BaseEthereumConfig.local` to merge configured `ethereum.local` values into the existing local-network defaults instead of always returning the hard-coded default provider.
- Added a regression test covering `ethereum.local.default_provider` while preserving local defaults such as `gas_limit="max"` and `required_confirmations=0`.

## Why
`networks.ethereum.local.default_provider` can resolve from config, but `project.config.ethereum.local.default_provider` was still reporting the computed default (`test`) because the computed `local` config ignored the raw configured `local` section.

## Validation
- `uv run pytest tests/functional/test_config.py -k "ethereum_local_network_config or ethereum_network_configs or network_gas_limit_default"`
- `uv run ruff check src/ape_ethereum/ecosystem.py tests/functional/test_config.py`
- Manual sanity check: `EthereumConfig.model_validate({'local': {'default_provider': 'node'}}).local.default_provider == 'node'` and `EthereumConfig().local.default_provider == 'test'`

Closes #2490
