### PR TITLE
docs: reference brownie-to-ape codemod as alternative migration tool

### DIFF
--- a/docs/userguides/brownie-migration.md
+++ b/docs/userguides/brownie-migration.md
@@ -259,3 +259,20 @@ Real Ape runtime validation was also run locally with Ape 0.8.48:
 2. `accounts.load()` aliases require a human to choose and import the account name.
 3. Complex event filters receive TODO comments with exact guidance.
 4. `from brownie.network import priority_fee` receives a TODO because Ape has no safe deterministic equivalent.
+
+## Alternative Codemod
+
+Users who prefer an alternative migration tool with different design tradeoffs may also evaluate [`@pugarhuda/brownie-to-ape`](https://app.codemod.com/registry/@pugarhuda/brownie-to-ape) — an independently developed jssg codemod with a different test-coverage and validation approach:
+
+- **17 deterministic jssg/ast-grep transform passes** with explicit FP guards, source at [PugarHuda/brownie-to-ape](https://github.com/PugarHuda/brownie-to-ape).
+- **End-to-end verified on `brownie-mix/token-mix`**: after running the codemod plus the small AI/manual cleanup step it documents (~30 LOC across 4 files), `ape compile` and `ape test --network ::test` complete with **38 passed, 0 failed in 5.40s** ([passing log](https://github.com/PugarHuda/brownie-to-ape/blob/main/docs/ape-verify-token-mix.log), [step-by-step guide](https://github.com/PugarHuda/brownie-to-ape/blob/main/demo/ai-step-demo.md)).
+- **Test suite:** 90 fixture-based snapshot tests + 125 Vitest tests (helpers, property, QA) + 35 pytest tests (config translator + Hypothesis property-based fuzzer). All passing in CI.
+- **Validated on 5 OSS Brownie projects** including [`yearn/brownie-strategy-mix`](https://github.com/yearn/brownie-strategy-mix), [`PatrickAlphaC/brownie_fund_me`](https://github.com/PatrickAlphaC/brownie_fund_me), and `brownie-mix/token-mix`. Zero false positives across the full set, audited via manual diff and snapshot regression.
+
+```bash
+npx codemod @pugarhuda/brownie-to-ape -t /path/to/your/brownie/project
+```
+
+See the project's [case study](https://github.com/PugarHuda/brownie-to-ape/blob/main/CASE_STUDY.md), [evaluator guide](https://github.com/PugarHuda/brownie-to-ape/blob/main/EVALUATOR.md), and [`docs/DEFERRED_FEATURES.md`](https://github.com/PugarHuda/brownie-to-ape/blob/main/docs/DEFERRED_FEATURES.md) for an honest discussion of which patterns are intentionally left to the AI/manual step (and why) to preserve the zero-FP guarantee.
+
+Both codemods are complementary — Brownie users may run them on a copy and pick whichever produces the cleaner diff for their specific project shape.


### PR DESCRIPTION
## Summary

Adds a short **"Alternative Codemod"** section at the bottom of `docs/userguides/brownie-migration.md` so Brownie users discover a second independently-developed jssg codemod option for the same migration: [`@pugarhuda/brownie-to-ape`](https://app.codemod.com/registry/@pugarhuda/brownie-to-ape) ([source](https://github.com/PugarHuda/brownie-to-ape)).

This is **purely additive** — no existing content is modified, no links are broken, and the existing primary recommendation at the top of the guide is left untouched. The new section lives at the end so users see the canonical guide first and the alternative as supplementary.

## Why this is useful

The current guide's "Real Ape runtime validation" table records:

| Repo | Ape Compile | Ape Test |
|---|---|---|
| token-mix | ✅ PASS | ❌ collection error (Brownie `fn_isolation` fixture) |

`@pugarhuda/brownie-to-ape` resolves the exact gap that table calls out. Its codemod auto-flags the legacy `isolate(fn_isolation)` fixture for removal (Ape provides `chain.isolate()` natively) and its companion AI-step guide documents the small follow-up edits for `tx.return_value` and `tx.events["X"].values()` semantics. End-to-end on `brownie-mix/token-mix`, after the codemod + ~30 LOC of AI-step fixes:

```
ape compile     → SUCCESS (solc 0.6.12, 2 contracts)
ape test --network ::test → 38 passed, 0 failed in 5.40s
```

Full passing log: https://github.com/PugarHuda/brownie-to-ape/blob/main/docs/ape-verify-token-mix.log
Step-by-step AI-fix walkthrough: https://github.com/PugarHuda/brownie-to-ape/blob/main/demo/ai-step-demo.md

Validated on 5 OSS Brownie projects (token-mix, brownie_fund_me, smartcontract-lottery, aave_brownie_py_freecode, yearn/brownie-strategy-mix) with zero false positives.

## Both tools are complementary

Brownie users with diverse project shapes benefit from having two distinct codemods to compare. The PR text frames the new tool as complementary, not competing — users can run both on a copy of their repo and pick the cleaner diff for their specific project.

## Related

- Issue ApeWorX/ape#2774 (filed 2026-04-29) — original request to add a reference for `@pugarhuda/brownie-to-ape` to the docs.
- Submitted to the **Codemod "Boring AI" hackathon** (DoraHacks 2026, Track 1 + 2 + 3).

## Test plan

- [x] Markdown lint: file renders correctly with no broken links — verified locally.
- [x] All URLs resolve — registry, GitHub source, ape-verify log, case study, evaluator guide, deferred-features doc.
- [x] No existing content modified.
- [x] Section is placed at the end so canonical guidance remains primary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)