### PR TITLE
fix: avoid unnecessary Safe proxy calls

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -559,22 +559,33 @@ class Ethereum(EcosystemAPI):
                     except ApeException:
                         pass
 
-        # safe >=1.1.0 provides `masterCopy()`, which is also stored in slot 0
-        # call it and check that target matches
-        try:
-            singleton = ContractCall(MASTER_COPY_ABI, address)(skip_trace=True)
-            slot_0 = self.provider.get_storage(address, 0)
-            target = self.conversion_manager.convert(slot_0[-20:], AddressType)
-            # NOTE: `target` is set in initialized proxies
-            if target != ZERO_ADDRESS and target == singleton:
-                return ProxyInfo(type=ProxyType.GnosisSafe, target=target, abi=MASTER_COPY_ABI)
+        # Safe >1.0.0 provides `masterCopy()`, which is also stored in slot 0.
+        # Check the bytecode marker first to avoid an extra call for most non-Safe contracts.
+        master_copy_selector = self.get_method_selector(MASTER_COPY_ABI).hex()
+        safe_master_copy_markers = (
+            # Safe v1.1.0 through v1.4.1 compares calldata against a padded PUSH32.
+            f"7f{master_copy_selector}{'00' * 28}",
+            # Optimized builds may reconstruct the same padded selector with PUSH4 + SHL.
+            "63530ca43760e11b14",
+            # Safe v1.5.0+ compares the first 4 calldata bytes against a PUSH4.
+            f"63{master_copy_selector}",
+        )
+        if any(marker in code for marker in safe_master_copy_markers):
+            try:
+                slot_0 = self.provider.get_storage(address, 0)
+                target = self.conversion_manager.convert(slot_0[-20:], AddressType)
+                # NOTE: `target` is set in initialized proxies
+                if target != ZERO_ADDRESS and target == ContractCall(MASTER_COPY_ABI, address)(
+                    skip_trace=True
+                ):
+                    return ProxyInfo(type=ProxyType.GnosisSafe, target=target, abi=MASTER_COPY_ABI)
 
-        except ApeException:
-            pass
+            except ApeException:
+                pass
 
         # eip-897 delegate proxy, read `proxyType()` and `implementation()`
         # perf: only make a call when a proxyType() selector is mentioned in the code
-        eip897_pattern = b"\x63" + keccak(text="proxyType()")[:4]
+        eip897_pattern = b"\x63" + self.get_method_selector(PROXY_TYPE_ABI)
         if eip897_pattern.hex() in code:
             try:
                 proxy_type = ContractCall(PROXY_TYPE_ABI, address)(skip_trace=True)

--- a/tests/functional/data/contracts/SafeProxyV150.sol
+++ b/tests/functional/data/contracts/SafeProxyV150.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+
+pragma solidity >=0.7.0 <0.9.0;
+
+
+// Copied from https://github.com/safe-global/safe-smart-account/blob/v1.5.0/contracts/proxies/SafeProxy.sol
+
+contract SafeProxyV150 {
+    // Singleton always needs to be first declared variable, to ensure that it is at the same location in the contracts to which calls are delegated.
+    address internal singleton;
+
+    /**
+     * @notice Constructor function sets address of singleton contract.
+     * @param _singleton Singleton address.
+     */
+    constructor(address _singleton) {
+        require(_singleton != address(0), "Invalid singleton address provided");
+        singleton = _singleton;
+    }
+
+    /// @dev Fallback function forwards all transactions and returns all received return data.
+    fallback() external payable {
+        /* solhint-disable no-inline-assembly */
+        assembly {
+            let _singleton := sload(0)
+            // 0xa619486e == uint32(bytes4(keccak256("masterCopy()"))).
+            if eq(shr(224, calldataload(0)), 0xa619486e) {
+                mstore(0x6c, shl(96, _singleton))
+                return(0x60, 0x20)
+            }
+            calldatacopy(0, 0, calldatasize())
+            let success := delegatecall(gas(), _singleton, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            if iszero(success) {
+                revert(0, returndatasize())
+            }
+            return(0, returndatasize())
+        }
+        /* solhint-enable no-inline-assembly */
+    }
+}

--- a/tests/functional/geth/test_proxy.py
+++ b/tests/functional/geth/test_proxy.py
@@ -63,6 +63,17 @@ def test_gnosis_safe(project, geth_contract, owner, ethereum, chain):
 
 
 @geth_process_test
+def test_gnosis_safe_v150(project, geth_contract, owner, ethereum):
+    target = geth_contract.address
+    proxy_instance = owner.deploy(project.SafeProxyV150, target)
+
+    actual = ethereum.get_proxy_info(proxy_instance.address)
+    assert actual is not None
+    assert actual.type == ProxyType.GnosisSafe
+    assert actual.target == target
+
+
+@geth_process_test
 def test_openzeppelin(project, geth_contract, owner, ethereum, sender):
     constructor_contract = owner.deploy(project.SolFallbackAndReceive)
     target = geth_contract.address


### PR DESCRIPTION
## Summary
- gate Safe proxy detection on known masterCopy bytecode markers before calling masterCopy()
- keep the slot-0 / masterCopy equality check for validation
- add coverage for Safe v1.5.0-style selector handling

## Performance
- avoids an unconditional masterCopy() eth_call for contracts that have already missed the cheaper bytecode and storage-slot proxy checks
- reduces negative proxy-detection work for ordinary non-Safe contracts by using the already-fetched runtime bytecode as a prefilter
- still validates candidate Safe proxies with slot 0 and masterCopy() equality before returning ProxyInfo

## Tests
- uv run ruff check src/ape_ethereum/ecosystem.py tests/functional/geth/test_proxy.py
- uv run pytest tests/functional/geth/test_proxy.py -q
- uv run pytest tests/functional/test_proxy.py -q

Note: pre-commit mypy currently fails on unrelated existing errors in src/ape/cli/choices.py, src/ape/api/config.py, and later transaction mapping lines in src/ape_ethereum/ecosystem.py.