### PR TITLE
perf: skip unnecessary proxy storage checks

### DIFF
--- a/src/ape_ethereum/ecosystem.py
+++ b/src/ape_ethereum/ecosystem.py
@@ -78,6 +78,7 @@ from ape_ethereum.transactions import (
     TransactionStatusEnum,
     TransactionType,
 )
+from ape_ethereum.utils import strip_compiler_metadata, strip_push_data
 
 if TYPE_CHECKING:
     from ethpm_types import ContractType
@@ -472,12 +473,12 @@ class Ethereum(EcosystemAPI):
 
     def get_proxy_info(self, address: AddressType) -> ProxyInfo | None:
         contract_code = self.chain_manager.get_code(address)
-        if isinstance(contract_code, bytes):
-            contract_code = to_hex(contract_code)
+        code_bytes = HexBytes(contract_code)
 
-        if not (code := contract_code[2:]):
+        if not code_bytes:
             return None
 
+        code = code_bytes.hex()
         patterns = {
             ProxyType.Minimal: r"^363d3d373d3d3d363d73(.{40})5af43d82803e903d91602b57fd5bf3",
             ProxyType.ZeroAge: r"^3d3d3d3d363d3d37363d73(.{40})5af43d3d93803e602a57fd5bf3",
@@ -497,12 +498,61 @@ class Ethereum(EcosystemAPI):
                 target = self.conversion_manager.convert(match.group(1), AddressType)
                 return ProxyInfo(type=type_, target=target)
 
+        # eip-897 delegate proxy, read `proxyType()` and `implementation()`.
+        # Proxy type 1 is a forwarding proxy and may not have an executable
+        # DELEGATECALL opcode, so handle EIP-897 before the opcode gate.
+        eip897_pattern = b"\x63" + self.get_method_selector(PROXY_TYPE_ABI)
+        if eip897_pattern.hex() in code:
+            try:
+                proxy_type = ContractCall(PROXY_TYPE_ABI, address)(skip_trace=True)
+                if proxy_type not in (1, 2):
+                    raise ValueError(f"ProxyType '{proxy_type}' not permitted by EIP-897.")
+
+                target = ContractCall(IMPLEMENTATION_ABI, address)(skip_trace=True)
+                # avoid recursion
+                if target != ZERO_ADDRESS:
+                    return ProxyInfo(type=ProxyType.Delegate, target=target, abi=IMPLEMENTATION_ABI)
+
+            except (ApeException, ValueError):
+                pass
+
+        # Remaining proxy types delegate calls to their implementation. If
+        # runtime bytecode has no executable DELEGATECALL opcode, avoid storage
+        # probes and calls entirely.
+        opcodes = strip_push_data(strip_compiler_metadata(code_bytes))
+        if 0xF4 not in opcodes:
+            return None
+
         sequence_pattern = r"363d3d373d3d3d363d30545af43d82803e903d91601857fd5bf3"
         if re.match(sequence_pattern, code):
             # the implementation is stored in the slot matching proxy address
             slot = self.provider.get_storage(address, address)
             target = self.conversion_manager.convert(slot[-20:], AddressType)
             return ProxyInfo(type=ProxyType.Sequence, target=target)
+
+        # Safe >1.0.0 provides `masterCopy()`, which is also stored in slot 0.
+        # Check the bytecode marker first to avoid unrelated storage checks and calls.
+        master_copy_selector = self.get_method_selector(MASTER_COPY_ABI).hex()
+        safe_master_copy_markers = (
+            # Safe v1.1.0 through v1.4.1 compares calldata against a padded PUSH32.
+            f"7f{master_copy_selector}{'00' * 28}",
+            # Optimized builds may reconstruct the same padded selector with PUSH4 + SHL.
+            "63530ca43760e11b14",
+            # Safe v1.5.0+ compares the first 4 calldata bytes against a PUSH4.
+            f"63{master_copy_selector}",
+        )
+        if any(marker in code for marker in safe_master_copy_markers):
+            try:
+                slot_0 = self.provider.get_storage(address, 0)
+                target = self.conversion_manager.convert(slot_0[-20:], AddressType)
+                # NOTE: `target` is set in initialized proxies
+                if target != ZERO_ADDRESS and target == ContractCall(MASTER_COPY_ABI, address)(
+                    skip_trace=True
+                ):
+                    return ProxyInfo(type=ProxyType.GnosisSafe, target=target, abi=MASTER_COPY_ABI)
+
+            except ApeException:
+                pass
 
         def str_to_slot(text):
             return int(to_hex(keccak(text=text)), 16)
@@ -558,47 +608,6 @@ class Ethereum(EcosystemAPI):
                             )
                     except ApeException:
                         pass
-
-        # Safe >1.0.0 provides `masterCopy()`, which is also stored in slot 0.
-        # Check the bytecode marker first to avoid an extra call for most non-Safe contracts.
-        master_copy_selector = self.get_method_selector(MASTER_COPY_ABI).hex()
-        safe_master_copy_markers = (
-            # Safe v1.1.0 through v1.4.1 compares calldata against a padded PUSH32.
-            f"7f{master_copy_selector}{'00' * 28}",
-            # Optimized builds may reconstruct the same padded selector with PUSH4 + SHL.
-            "63530ca43760e11b14",
-            # Safe v1.5.0+ compares the first 4 calldata bytes against a PUSH4.
-            f"63{master_copy_selector}",
-        )
-        if any(marker in code for marker in safe_master_copy_markers):
-            try:
-                slot_0 = self.provider.get_storage(address, 0)
-                target = self.conversion_manager.convert(slot_0[-20:], AddressType)
-                # NOTE: `target` is set in initialized proxies
-                if target != ZERO_ADDRESS and target == ContractCall(MASTER_COPY_ABI, address)(
-                    skip_trace=True
-                ):
-                    return ProxyInfo(type=ProxyType.GnosisSafe, target=target, abi=MASTER_COPY_ABI)
-
-            except ApeException:
-                pass
-
-        # eip-897 delegate proxy, read `proxyType()` and `implementation()`
-        # perf: only make a call when a proxyType() selector is mentioned in the code
-        eip897_pattern = b"\x63" + self.get_method_selector(PROXY_TYPE_ABI)
-        if eip897_pattern.hex() in code:
-            try:
-                proxy_type = ContractCall(PROXY_TYPE_ABI, address)(skip_trace=True)
-                if proxy_type not in (1, 2):
-                    raise ValueError(f"ProxyType '{proxy_type}' not permitted by EIP-897.")
-
-                target = ContractCall(IMPLEMENTATION_ABI, address)(skip_trace=True)
-                # avoid recursion
-                if target != ZERO_ADDRESS:
-                    return ProxyInfo(type=ProxyType.Delegate, target=target, abi=IMPLEMENTATION_ABI)
-
-            except (ApeException, ValueError):
-                pass
 
         return None
 

--- a/src/ape_ethereum/utils.py
+++ b/src/ape_ethereum/utils.py
@@ -1,0 +1,50 @@
+COMPILER_METADATA_KEY_PREFIXES = (
+    b"\x64ipfs",
+    b"\x65bzzr0",
+    b"\x65bzzr1",
+    b"\x64solc",
+    b"\x65vyper",
+)
+
+
+def strip_compiler_metadata(bytecode: bytes) -> bytes:
+    """
+    Strip trailing Solidity or Vyper compiler metadata from bytecode.
+    """
+    if len(bytecode) < 3:
+        return bytecode
+
+    metadata_length = int.from_bytes(bytecode[-2:], "big")
+    metadata_start = len(bytecode) - metadata_length - 2
+    if metadata_start < 0:
+        return bytecode
+
+    metadata = bytecode[metadata_start:-2]
+    if not metadata:
+        return bytecode
+
+    # Solidity and Vyper metadata are trailing CBOR maps followed by a two-byte
+    # big-endian length. Avoid full CBOR parsing here; this is only a fast
+    # sanity check that the computed offset starts with a short map containing
+    # one of the known compiler metadata keys.
+    is_short_cbor_map = 0xA0 < metadata[0] < 0xB8
+    if is_short_cbor_map and metadata[1:].startswith(COMPILER_METADATA_KEY_PREFIXES):
+        return bytecode[:metadata_start]
+
+    return bytecode
+
+
+def strip_push_data(bytecode: bytes) -> bytes:
+    """
+    Strip PUSH1 through PUSH32 arguments from bytecode, leaving opcodes only.
+    """
+    result = bytearray()
+    index = 0
+    while index < len(bytecode):
+        opcode = bytecode[index]
+        result.append(opcode)
+        index += 1
+        if 0x60 <= opcode <= 0x7F:
+            index += opcode - 0x5F
+
+    return bytes(result)

--- a/tests/functional/data/contracts/SafeProxyV150.sol
+++ b/tests/functional/data/contracts/SafeProxyV150.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity >=0.7.0 <0.8.0;
 
 
 // Copied from https://github.com/safe-global/safe-smart-account/blob/v1.5.0/contracts/proxies/SafeProxy.sol

--- a/tests/functional/geth/test_proxy.py
+++ b/tests/functional/geth/test_proxy.py
@@ -39,16 +39,18 @@ def test_uups_proxy(project, geth_contract, owner, ethereum):
 
 
 @geth_process_test
-def test_gnosis_safe(project, geth_contract, owner, ethereum, chain):
+def test_gnosis_safe(project, geth_contract, owner, ethereum, chain, mocker):
     # Setup a proxy contract.
     target = geth_contract.address
     proxy_instance = owner.deploy(project.SafeProxy, target)
 
     # (test)
+    storage_spy = mocker.spy(chain.provider.web3.eth, "get_storage_at")
     actual = ethereum.get_proxy_info(proxy_instance.address)
     assert actual is not None
     assert actual.type == ProxyType.GnosisSafe
     assert actual.target == target
+    assert storage_spy.call_count == 1
 
     # Ensure we can call the proxy-method.
     assert proxy_instance.masterCopy()
@@ -60,6 +62,16 @@ def test_gnosis_safe(project, geth_contract, owner, ethereum, chain):
     proxy_instance_ref_2 = chain.contracts.instance_at(proxy_instance.address)
     assert proxy_instance_ref_2.masterCopy()
     assert isinstance(proxy_instance_ref_2.myNumber(), int)
+
+
+@geth_process_test
+def test_non_proxy_without_delegatecall_skips_storage(geth_contract, ethereum, chain, mocker):
+    storage_spy = mocker.spy(chain.provider.web3.eth, "get_storage_at")
+
+    actual = ethereum.get_proxy_info(geth_contract.address)
+
+    assert actual is None
+    assert storage_spy.call_count == 0
 
 
 @geth_process_test

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from eth_pydantic_types import HexBytes
 
 from ape_ethereum.proxies import ProxyType
+from ape_ethereum.utils import strip_compiler_metadata, strip_push_data
 from ape_test.provider import LocalProvider
 
 if TYPE_CHECKING:
@@ -11,6 +12,46 @@ if TYPE_CHECKING:
 """
 NOTE: Most proxy tests are in `geth/test_proxy.py`.
 """
+
+
+def test_strip_compiler_metadata_solidity():
+    metadata = b"\xa2\x64ipfs\x58\x22\x12\x20" + (b"\x01" * 32) + b"\x64solc" + b"\x43\x00\x08\x12"
+    bytecode = b"\x00\xf4" + metadata + len(metadata).to_bytes(2, "big")
+
+    assert strip_compiler_metadata(bytecode) == b"\x00\xf4"
+
+
+def test_strip_compiler_metadata_vyper():
+    metadata = b"\xa1\x65vyper\x83\x00\x03\x09"
+    bytecode = b"\x00\xf4" + metadata + len(metadata).to_bytes(2, "big")
+
+    assert strip_compiler_metadata(bytecode) == b"\x00\xf4"
+
+
+def test_strip_compiler_metadata_leaves_non_metadata():
+    bytecode = bytes.fromhex("00a165627a7a72305820f4")
+
+    assert strip_compiler_metadata(bytecode) == bytecode
+
+
+def test_strip_compiler_metadata_leaves_unknown_cbor_tail():
+    tail = b"\xa1\x63foo\x01"
+    bytecode = b"\x00\xf4" + tail + len(tail).to_bytes(2, "big")
+
+    assert strip_compiler_metadata(bytecode) == bytecode
+
+
+def test_strip_push_data():
+    assert strip_push_data(bytes.fromhex("61f4ff5ff4")) == bytes.fromhex("615ff4")
+
+
+def test_composed_bytecode_strippers_ignore_push_data_and_compiler_metadata():
+    metadata = b"\xa1\x65vyper\x83\x00\x03\x09"
+    bytecode = b"\x00" + metadata + len(metadata).to_bytes(2, "big")
+
+    assert 0xF4 in strip_push_data(strip_compiler_metadata(b"\xf4"))
+    assert 0xF4 not in strip_push_data(strip_compiler_metadata(bytes.fromhex("61f4ff")))
+    assert 0xF4 not in strip_push_data(strip_compiler_metadata(bytecode))
 
 
 def test_minimal_proxy(ethereum, minimal_proxy_container, chain, owner):


### PR DESCRIPTION
## Summary
- move bytecode-marker-gated Safe and EIP-897 checks ahead of generic storage-slot probing
- use an executable `DELEGATECALL` opcode gate before Sequence, Safe, and generic storage-backed proxy probes
- keep EIP-897 detection before the opcode gate because forwarding proxies expose `proxyType()`/`implementation()` but may not contain `DELEGATECALL`
- add public bytecode utilities for stripping compiler metadata and PUSH arguments before opcode scans
- keep bytecode normalization at the `get_proxy_info()` boundary with `HexBytes`, so the utilities operate on bytes directly

## Performance implications
Proxy detection is a hot path where contract code is usually already cached, but storage reads and `eth_call`s still hit the node. This change uses cached runtime bytecode to reject contracts that cannot delegate before doing heavier proxy probes, while preserving the EIP-897 forwarding-proxy exception.

That mainly improves non-proxy contracts and Safe/storage-slot paths:

| Case | Before warm RPCs | After warm RPCs | Effect |
|---|---:|---:|---|
| WETH non-proxy | 5 `get_storage` | 0 | avoids all storage probes |
| USDT non-proxy | 5 `get_storage` | 0 | avoids all storage probes |
| USDC proxy | 3 `get_storage` | 3 `get_storage` | unchanged for real storage-backed proxy |
| Yearn Safe | 6 `get_storage` + 1 `eth_call` | 1 `get_storage` + 1 `eth_call` | reaches Safe detection before generic slots |

Cold paths still pay the expected `get_code` lookup first, then follow the same reduced storage/call behavior.

## Validation
Benchmarked against a local mainnet Reth archive node at `http://127.0.0.1:8545`.

- `uv run ruff check src/ape_ethereum/ecosystem.py src/ape_ethereum/utils.py tests/functional/geth/test_proxy.py tests/functional/test_proxy.py`
- `uv run ruff format --check src/ape_ethereum/ecosystem.py src/ape_ethereum/utils.py tests/functional/geth/test_proxy.py tests/functional/test_proxy.py`
- `uv run pytest tests/functional/geth/test_proxy.py tests/functional/test_proxy.py`
- live before/after benchmark against local Reth archive node