### PR TITLE
perf: optimize CI pipeline caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+*
+
+!Dockerfile
+!README.md
+!pyproject.toml
+!uv.lock
+!src/
+!src/**

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,7 +122,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=build-py${{ matrix.python-version }}
+          cache-from: type=gha,scope=build-py${{ matrix.python-version }}-${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=build-py${{ matrix.python-version }}-${{ matrix.target }}
           platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
 
       - name: Run container retention policy

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,9 @@ jobs:
 
       # NOTE: We need to store `uv.lock` for building with
       - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
       - uses: actions/cache@v5
         with:
           path: uv.lock

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,9 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: uv.lock
-          key: ${{ matrix.python-version }}-uv-lock
+          key: ${{ matrix.python-version }}-uv-lock-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ matrix.python-version }}-uv-lock-
       - run: uv lock --python ${{ matrix.python-version }}
 
       - name: Get version from setuptools-scm

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,6 +29,8 @@ jobs:
       uses: astral-sh/setup-uv@v7
       with:
         python-version: "3.10"
+        enable-cache: true
+        cache-dependency-glob: pyproject.toml
 
     - name: Build Docs
       run: uv sync

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,6 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: pyproject.toml
 
     - name: Build Package
       run: uv build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,12 +92,17 @@ jobs:
             uv run --no-sync python -c "
             from pathlib import Path
 
-            import ape
-            from solcx import install_solc
+            from ape_solidity._utils import get_pragma_spec_from_path, select_version
+            from solcx import get_installable_solc_versions, install_solc
 
-            compiler = ape.compilers.registered_compilers.get('.sol')
-            paths = Path('tests').rglob('*.sol')
-            versions = sorted(compiler.get_versions(paths)) if compiler else []
+            installable_versions = get_installable_solc_versions()
+            versions = set()
+            for path in Path('tests').rglob('*.sol'):
+                pragma_spec = get_pragma_spec_from_path(path)
+                if pragma_spec and (version := select_version(pragma_spec, installable_versions)):
+                    versions.add(str(version))
+
+            versions = sorted(versions)
             print('Installing Solidity compilers:', ', '.join(versions) or 'none')
             for version in versions:
                 install_solc(version, show_progress=False)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,7 +80,7 @@ jobs:
           uses: ApeWorX/geth-action@v1
 
         - name: Cache Ape Packages
-          uses: actions/cache@v4
+          uses: actions/cache@v5
           with:
             path: ~/.ape/packages
             key: ${{ runner.os }}-ape-packages-${{ hashFiles('pyproject.toml') }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,6 +73,9 @@ jobs:
               enable-cache: true
               cache-dependency-glob: pyproject.toml
 
+        - name: Install Test Environment
+          run: uv sync --no-default-groups --group test
+
         - name: Install Geth
           uses: ApeWorX/geth-action@v1
 
@@ -85,11 +88,11 @@ jobs:
               ${{ runner.os }}-ape-packages-
 
         - name: Install Project Dependencies
-          run: uv run --group test ape pm install
+          run: uv run --no-sync ape pm install
 
         - name: Run Functional Tests
           run: |
-            uv run --group test ape test \
+            uv run --no-sync ape test \
               -s -v ERROR \
               -n auto --dist loadgroup \
               -m "not hypothesis" \
@@ -98,7 +101,7 @@ jobs:
 
         - name: Run Integration Tests
           run: |
-            uv run --group test ape test \
+            uv run --no-sync ape test \
               -s -v ERROR \
               -n auto --dist loadgroup \
               -m "not hypothesis" \
@@ -107,7 +110,7 @@ jobs:
 
         - name: Run Performance Tests
           run: |
-            uv run --group test ape test \
+            uv run --no-sync ape test \
               -s -v ERROR \
               tests/performance
 
@@ -127,5 +130,8 @@ jobs:
               enable-cache: true
               cache-dependency-glob: pyproject.toml
 
+        - name: Install Test Environment
+          run: uv sync --no-default-groups --group test
+
         - name: Run Tests
-          run: uv run --group test ape test -s -m "hypothesis" --no-cov
+          run: uv run --no-sync ape test -s -m "hypothesis" --no-cov

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,9 @@ on: ["push", "pull_request"]
 
 name: Test
 
+env:
+  SETUPTOOLS_SCM_PRETEND_VERSION_FOR_ETH_APE: "0.8.999"
+
 concurrency:
   # Cancel older, in-progress jobs from the same PR, same workflow.
   # use run_id if the job is triggered by a push to ensure
@@ -15,8 +18,6 @@ jobs:
 
         steps:
         - uses: actions/checkout@v5
-          with:
-            fetch-depth: 0
 
         - name: Setup Python
           uses: astral-sh/setup-uv@v7
@@ -37,8 +38,6 @@ jobs:
 
         steps:
         - uses: actions/checkout@v5
-          with:
-            fetch-depth: 0
 
         - name: Setup Python
           uses: astral-sh/setup-uv@v7
@@ -61,8 +60,6 @@ jobs:
 
         steps:
         - uses: actions/checkout@v5
-          with:
-            fetch-depth: 0
 
         - name: Setup Python
           uses: astral-sh/setup-uv@v7
@@ -104,8 +101,6 @@ jobs:
 
         steps:
         - uses: actions/checkout@v5
-          with:
-            fetch-depth: 0
 
         - name: Setup Python
           uses: astral-sh/setup-uv@v7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -100,7 +100,7 @@ jobs:
             versions = sorted(compiler.get_versions(paths)) if compiler else []
             print('Installing Solidity compilers:', ', '.join(versions) or 'none')
             for version in versions:
-                install_solc(version, show_progress=True)
+                install_solc(version, show_progress=False)
             "
 
         - name: Cache Ape Packages

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,13 +27,13 @@ jobs:
               cache-dependency-glob: pyproject.toml
 
         - name: Run Ruff Lint
-          run: uv run --group lint ruff check .
+          run: uv run --only-group style ruff check .
 
         - name: Run Ruff Format
-          run: uv run --group lint ruff format --check .
+          run: uv run --only-group style ruff format --check .
 
         - name: Run mdformat
-          run: uv run --group lint mdformat --check *.md docs/**/*.md
+          run: uv run --only-group style mdformat --check *.md docs/**/*.md
 
     type-check:
         runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,6 +79,30 @@ jobs:
         - name: Install Geth
           uses: ApeWorX/geth-action@v1
 
+        - name: Cache Solidity Compilers
+          uses: actions/cache@v5
+          with:
+            path: ~/.solcx
+            key: ${{ runner.os }}-solcx-${{ hashFiles('pyproject.toml', 'tests/**/*.sol') }}
+            restore-keys: |
+              ${{ runner.os }}-solcx-
+
+        - name: Install Solidity Compilers
+          run: |
+            uv run --no-sync python -c "
+            from pathlib import Path
+
+            import ape
+            from solcx import install_solc
+
+            compiler = ape.compilers.registered_compilers.get('.sol')
+            paths = Path('tests').rglob('*.sol')
+            versions = sorted(compiler.get_versions(paths)) if compiler else []
+            print('Installing Solidity compilers:', ', '.join(versions) or 'none')
+            for version in versions:
+                install_solc(version, show_progress=True)
+            "
+
         - name: Cache Ape Packages
           uses: actions/cache@v5
           with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,8 @@ jobs:
           uses: astral-sh/setup-uv@v7
           with:
               python-version: "3.10"
+              enable-cache: true
+              cache-dependency-glob: pyproject.toml
 
         - name: Run Ruff Lint
           run: uv run --group lint ruff check .
@@ -43,6 +45,8 @@ jobs:
           uses: astral-sh/setup-uv@v7
           with:
               python-version: "3.10"
+              enable-cache: true
+              cache-dependency-glob: pyproject.toml
 
         - name: Run MyPy
           run: uv run --group lint --group test mypy .
@@ -66,6 +70,8 @@ jobs:
           uses: astral-sh/setup-uv@v7
           with:
               python-version: ${{ matrix.python-version }}
+              enable-cache: true
+              cache-dependency-glob: pyproject.toml
 
         - name: Install Geth
           uses: ApeWorX/geth-action@v1
@@ -118,6 +124,8 @@ jobs:
           uses: astral-sh/setup-uv@v7
           with:
               python-version: "3.10"
+              enable-cache: true
+              cache-dependency-glob: pyproject.toml
 
         - name: Run Tests
           run: uv run --group test ape test -s -m "hypothesis" --no-cov

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,6 +56,7 @@ jobs:
                 python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
         env:
+          COVERAGE_ARGS: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' && '--cov=src --cov-append' || '--no-cov' }}
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         steps:
@@ -86,7 +87,7 @@ jobs:
               -s -v ERROR \
               -n auto --dist loadgroup \
               -m "not hypothesis" \
-              --cov=src --cov-append \
+              $COVERAGE_ARGS \
               tests/functional
 
         - name: Run Integration Tests
@@ -95,7 +96,7 @@ jobs:
               -s -v ERROR \
               -n auto --dist loadgroup \
               -m "not hypothesis" \
-              --cov=src --cov-append \
+              $COVERAGE_ARGS \
               tests/integration
 
         - name: Run Performance Tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -90,10 +90,23 @@ jobs:
         - name: Install Solidity Compilers
           run: |
             uv run --no-sync python -c "
+            import re
             from pathlib import Path
 
-            from ape_solidity._utils import get_pragma_spec_from_path, select_version
+            from ape.utils import pragma_str_to_specifier_set
             from solcx import get_installable_solc_versions, install_solc
+
+            def get_pragma_spec_from_path(path):
+                source = path.read_text(encoding='utf8')
+                pragma_match = next(
+                    re.finditer(r'(?:\n|^)\s*pragma\s*solidity\s*([^;\n]*)', source),
+                    None,
+                )
+                return pragma_str_to_specifier_set(pragma_match.groups()[0]) if pragma_match else None
+
+            def select_version(pragma_spec, options):
+                choices = sorted(pragma_spec.filter(options), reverse=True)
+                return choices[0] if choices else None
 
             installable_versions = get_installable_solc_versions()
             versions = set()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,6 +69,9 @@ jobs:
         - name: Install Geth
           uses: ApeWorX/geth-action@v1
 
+        - name: Install Project Dependencies
+          run: uv run --group test ape pm install
+
         - name: Run Functional Tests
           run: |
             uv run --group test ape test \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,6 +69,14 @@ jobs:
         - name: Install Geth
           uses: ApeWorX/geth-action@v1
 
+        - name: Cache Ape Packages
+          uses: actions/cache@v4
+          with:
+            path: ~/.ape/packages
+            key: ${{ runner.os }}-ape-packages-${{ hashFiles('pyproject.toml') }}
+            restore-keys: |
+              ${{ runner.os }}-ape-packages-
+
         - name: Install Project Dependencies
           run: uv run --group test ape pm install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,8 +126,15 @@ test = [  # `test` GitHub Action jobs use this
     "vyper>=0.4.3,<0.5",  # Avoid having to download Vyper binaries
     "ape-solidity>=0.8.5,<0.9",  # Needed for compiling test contracts
 ]
-lint = [  # `lint` GitHub Action jobs use this
+style = [  # `linting` GitHub Action job uses this
     "ruff>=0.12.0",  # Unified linter and formatter
+    "mdformat>=0.7.22",  # Auto-formatter for markdown
+    "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
+    "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
+    "mdformat-pyproject>=0.0.2",  # Allows configuring in pyproject.toml
+]
+lint = [  # `type-check` GitHub Action job uses this
+    {include-group = "style"},
     "mypy>=1.16.1,<1.17.0",  # Static type analyzer
     "types-PyYAML",  # Needed due to mypy typeshed
     "types-requests",  # Needed due to mypy typeshed
@@ -136,10 +143,6 @@ lint = [  # `lint` GitHub Action jobs use this
     "types-toml",  # Needed due to mypy typeshed
     "types-SQLAlchemy>=1.4.49",  # Needed due to mypy typeshed
     "types-python-dateutil",  # Needed due to mypy typeshed
-    "mdformat>=0.7.22",  # Auto-formatter for markdown
-    "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
-    "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
-    "mdformat-pyproject>=0.0.2",  # Allows configuring in pyproject.toml
 ]
 docs = [  # `docs` GitHub Action jobs use this
     "sphinx-ape",

--- a/src/ape/utils/rpc.py
+++ b/src/ape/utils/rpc.py
@@ -1,5 +1,6 @@
 import time
 from collections.abc import Callable
+from io import BytesIO
 from random import randint
 
 import requests
@@ -61,13 +62,13 @@ def stream_response(download_url: str, progress_bar_description: str = "Download
     total_size = int(response.headers.get("content-length", 0))
     progress_bar = tqdm(total=total_size, unit="iB", unit_scale=True, leave=False)
     progress_bar.set_description(progress_bar_description)
-    content = b""
-    for data in response.iter_content(1024, decode_unicode=True):
+    content = BytesIO()
+    for data in response.iter_content(chunk_size=2**16):
         progress_bar.update(len(data))
-        content += data
+        content.write(data)
 
     progress_bar.close()
-    return content
+    return content.getvalue()
 
 
 class RPCHeaders(CaseInsensitiveDict):

--- a/tests/functional/utils/test_rpc.py
+++ b/tests/functional/utils/test_rpc.py
@@ -1,6 +1,22 @@
 import pytest
 
-from ape.utils.rpc import RPCHeaders
+from ape.utils.rpc import RPCHeaders, stream_response
+
+
+def test_stream_response(mocker):
+    expected = b"".join(bytes([i]) * 128 for i in range(256))
+    response = mocker.MagicMock()
+    response.headers = {"content-length": str(len(expected))}
+    response.iter_content.return_value = [expected[:1024], expected[1024:]]
+
+    get = mocker.patch("ape.utils.rpc.requests.get", return_value=response)
+
+    actual = stream_response("https://example.com/package.zip")
+
+    get.assert_called_once_with("https://example.com/package.zip", stream=True)
+    response.raise_for_status.assert_called_once_with()
+    response.iter_content.assert_called_once_with(chunk_size=2**16)
+    assert actual == expected
 
 
 class TestRPCHeaders:


### PR DESCRIPTION
## Summary
This PR reduces redundant CI work without reducing test coverage. The full test matrix is preserved: ubuntu-latest and macos-latest across Python 3.10-3.14.

## Measured Impact
Compared downloaded Test workflow logs from `/Users/banteg/Downloads/logs_68136656472` before this PR and `/Users/banteg/Downloads/logs_68149028999` after this PR:

- Test workflow wall time: 20:27 -> 10:48, a 9:39 reduction / 47% faster.
- Test matrix summed runner time: 95:18 -> 68:15, a 27:03 reduction / 28% less runner time.
- Average test matrix cell: 9:32 -> 6:50.
- Ubuntu test matrix summed runner time: 39:44 -> 24:38, a 15:06 reduction / 38% less.
- macOS test matrix summed runner time: 55:35 -> 43:38, an 11:57 reduction / 22% less.
- Fast jobs improved as expected from narrower environments: linting 2:00 -> 0:10, type-check 2:39 -> 0:42, fuzzing 2:11 -> 0:24.
- Package network starts in top-level job logs dropped from 72 -> 18 OpenZeppelin zip downloads and 156 -> 27 Foundry-style subdependency clones. The new run restored the Ape package cache in all 10 test cells.

Follow-up log inspection showed the remaining slow macOS 3.13/3.14 functional-test path starts with large Solidity compiler downloads inside pytest workers, for example 33.9M and 36.0M solc progress bars before the dependency tests start. The Solidity compiler cache and no-progress installer changes were added after the measured run above, so they are expected to improve later runs but are not included in those before/after numbers.

## Changes
1. Use shallow checkouts in CI jobs

   Test, lint, type-check, and fuzzing jobs do not need full repository history. Removing fetch-depth: 0 lets actions/checkout use its shallow default and avoids unnecessary Git transfer at job startup.

2. Preinstall Ape package dependencies once per test job

   The test suite was repeatedly discovering and installing the same configured Ape dependencies from multiple pytest workers. The workflow now runs ape pm install before functional/integration/performance tests so workers can reuse the package cache instead of racing through the same network-heavy setup.

3. Cache ~/.ape/packages by runner OS and project config

   Ape package installs include OpenZeppelin release downloads and recursive package installs discovered from dependencies. Caching ~/.ape/packages lets repeated CI runs restore those installed packages. The cache key includes runner.os because package cache paths and metadata are OS-specific, and pyproject.toml because the project dependency list lives there.

4. Collect coverage in one test cell

   Coverage was being appended in every OS/Python matrix cell, multiplying coverage overhead while producing redundant reports. Coverage now runs only on ubuntu-latest / Python 3.11; the other matrix cells still run the same functional and integration tests with --no-cov.

5. Enable explicit uv caching in workflows

   setup-uv now uses enable-cache with pyproject.toml as the dependency glob in test, docs, publish, and container workflows. This makes dependency cache behavior explicit and tied to the dependency configuration.

6. Reuse a synced test environment

   Test and fuzz jobs now run one explicit uv sync --no-default-groups --group test, then use uv run --no-sync for ape commands. This avoids repeated implicit sync checks between steps and prevents test cells from installing the default dev group, which includes lint/docs/type-check-only packages.

7. Split style dependencies from type-check dependencies

   Ruff and mdformat do not need mypy or typing stubs. A new style dependency group contains only the formatting/linting tools, while lint includes style plus mypy/stubs for the type-check job. The linting job now uses uv run --only-group style, reducing environment hydration for style-only checks.

8. Save Docker build cache and trim Docker context

   Container builds now use GitHub Actions BuildKit cache scoped by Python version and image target. .dockerignore also limits the build context to Dockerfile, README.md, pyproject.toml, uv.lock, and src/, so Docker does not upload tests, docs, git metadata, or local build/cache files into every image build.

9. Cancel obsolete container builds

   The container workflow now has a concurrency group matching the test workflow behavior, so newer pushes to the same PR cancel older in-progress container builds.

10. Key uv.lock cache by project config

   The container workflow caches uv.lock per Python version and pyproject.toml hash. This keeps lock reuse across repeated runs while invalidating it when dependency configuration changes.

11. Buffer streamed package downloads

   stream_response now uses 64 KiB byte chunks and BytesIO instead of 1 KiB chunks plus repeated bytes concatenation. On the real OpenZeppelin 5.2.0 zipball path used by Ape package downloads, the local paired benchmark improved from 3.364s / 1.52 MiB/s to 2.942s / 1.73 MiB/s, about 12.5% faster. This specifically helps GitHub release zip downloads, not the separate Git clone progress bars from Foundry-style dependency repositories.

12. Update the test cache action for Node 24 readiness

   The test workflow now uses actions/cache@v5 for the Ape package cache, matching the container workflow and avoiding GitHub's Node.js 20 action deprecation warning for actions/cache@v4. This keeps the cache behavior intact while making the workflow ready for GitHub's June 2, 2026 Node 24 default.

13. Cache and preinstall Solidity compilers

   The test workflow now caches `~/.solcx` and preinstalls the Solidity compiler versions selected from the Solidity files under `tests/` before pytest starts. This targets the remaining slow macOS path where xdist workers were downloading large solc binaries during functional tests. On a local dry run, the install step selected `0.4.26`, `0.7.6`, `0.8.1`, and `0.8.35`; once cached, the same command completed without downloading.

14. Disable py-solc-x download progress in CI preinstall

   py-solc-x downloads compiler binaries from `binaries.soliditylang.org`, but its progress-enabled path streams in 1 KiB chunks and repeatedly concatenates immutable bytes. A local benchmark of the exact macOS `solc-v0.8.35` binary showed py-solc-x with progress took 61.146s for 32.3 MiB, while curl took 1.41s, aria2c took 1.57s, and py-solc-x without progress took 1.425s. The workflow now uses `show_progress=False` for compiler preinstalls so cold solc cache fills use the fast path.

15. Avoid private Ape Solidity imports during solc setup

   The solc preinstall step now reads Solidity pragmas with Ape's public `ape.utils.pragma_str_to_specifier_set` helper and local CI-only selection logic. This keeps the selected compiler set unchanged while avoiding private `ape_solidity._utils` imports and avoiding a registered compiler project scan before pytest starts.

## Validation
- uv run --only-group style ruff check .
- uv run --only-group style ruff format --check .
- uv run --only-group style mdformat --check *.md docs/**/*.md
- uv sync --no-default-groups --group test
- uv run --no-sync ape --version
- uv run --no-sync ape test tests/functional/utils/test_rpc.py -s -v ERROR --no-cov
- uv run ruff check src/ape/utils/rpc.py tests/functional/utils/test_rpc.py
- uv run ape test tests/functional/utils/test_rpc.py -s -v ERROR --no-cov
- docker buildx build --target slim --build-arg PYTHON_VERSION=3.11 --build-arg APE_VERSION=0.8.999 --load -t ape-ci-test:slim .
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yaml")'
- uv run --no-sync python -c "<discover and install Solidity compiler versions under tests/>"
- uv run --no-sync python -c "<benchmark py-solc-x solc-v0.8.35 download with and without progress/>"
- /usr/bin/time -p curl -L --fail --silent --show-error --output /private/tmp/solc-curl-0.8.35.bin https://binaries.soliditylang.org/macosx-amd64/solc-macosx-amd64-v0.8.35+commit.47b9dedd
- /usr/bin/time -p aria2c --quiet --allow-overwrite=true --file-allocation=none --max-connection-per-server=16 --split=16 --dir=/private/tmp --out=solc-aria2c-0.8.35.bin https://binaries.soliditylang.org/macosx-amd64/solc-macosx-amd64-v0.8.35+commit.47b9dedd
- pre-commit hook: check yaml
- uv run --no-sync ape test tests/functional/test_project.py::TestSourceManager -s -v ERROR -n auto --dist loadgroup --no-cov
- uv run --no-sync python -c "<discover and install Solidity compiler versions using public pragma parser/>"
