### PR TITLE
chore: harden actions trust boundaries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,12 +19,12 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      CACHE_TRUST_PREFIX: pr
     permissions:
       contents: read
-      packages: write
-      attestations: write
-      id-token: write
 
     strategy:
       fail-fast: false
@@ -46,9 +46,9 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: uv.lock
-          key: ${{ matrix.python-version }}-uv-lock-${{ hashFiles('pyproject.toml') }}
+          key: ${{ env.CACHE_TRUST_PREFIX }}-${{ matrix.python-version }}-uv-lock-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
-            ${{ matrix.python-version }}-uv-lock-
+            ${{ env.CACHE_TRUST_PREFIX }}-${{ matrix.python-version }}-uv-lock-
       - run: uv lock --python ${{ matrix.python-version }}
 
       - name: Get version from setuptools-scm
@@ -131,12 +131,138 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=build-py${{ matrix.python-version }}-${{ matrix.target }}
-          cache-to: type=gha,mode=max,scope=build-py${{ matrix.python-version }}-${{ matrix.target }}
+          cache-from: type=gha,scope=${{ env.CACHE_TRUST_PREFIX }}-build-py${{ matrix.python-version }}-${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=${{ env.CACHE_TRUST_PREFIX }}-build-py${{ matrix.python-version }}-${{ matrix.target }}
           platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
 
       - name: Run container retention policy
         if: ${{ github.event_name != 'pull_request' }}
+        # TODO: Use `v3` when available
+        uses: snok/container-retention-policy@v3.0.1
+        with:
+          account: ApeWorX
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: "ape"
+          # NOTE: Keep stable/stable-slim, latest/latest-slim, all v0.8.x series, and last in v0.7.x series
+          image-tags: "!stable* !latest* !v0.8* !v0.7.23*"
+          tag-selection: both
+          cut-off: 4w
+          dry-run: ${{ github.ref != 'refs/heads/main' }}
+
+  publish:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      CACHE_TRUST_PREFIX: trusted
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        target: ["slim", "full"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Needed for setuptools-scm
+
+      # NOTE: We need to store `uv.lock` for building with
+      - uses: astral-sh/setup-uv@v7
+      - uses: actions/cache@v5
+        with:
+          path: uv.lock
+          key: ${{ env.CACHE_TRUST_PREFIX }}-${{ matrix.python-version }}-uv-lock-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ env.CACHE_TRUST_PREFIX }}-${{ matrix.python-version }}-uv-lock-
+      - run: uv lock --python ${{ matrix.python-version }}
+
+      - name: Get version from setuptools-scm
+        id: version
+        run: |
+          VERSION=$(uvx setuptools-scm)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Check if default Python version
+        id: is-default
+        run: |
+          if [ "${{ matrix.python-version }}" = "${{ env.DEFAULT_PYTHON }}" ]; then
+            echo "value=true" >> $GITHUB_OUTPUT
+          else
+            echo "value=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+            suffix=${{ matrix.target == 'slim' && '-slim' || ''}}
+          # NOTE: `latest=false` lets us manage it better here
+          tags: |
+            # For default Python version (unprefixed convenience tags)
+            # - 'latest' on push to main
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && steps.is-default.outputs.value == 'true' }}
+            # - 'stable' on release
+            type=raw,value=stable,enable=${{ github.event_name == 'release' && steps.is-default.outputs.value == 'true' }}
+            # - version tag (e.g., v0.8.43) on release
+            type=ref,event=tag,enable=${{ steps.is-default.outputs.value == 'true' }}
+
+            # For all Python versions (including default):
+            # - 'python3.x-latest' on push to main
+            type=raw,value=python${{ matrix.python-version }}-latest,enable=${{ github.ref == 'refs/heads/main' }}
+            # - 'python3.x-stable' on release
+            type=raw,value=python${{ matrix.python-version }}-stable,enable=${{ github.event_name == 'release' }}
+            # - 'python3.x-v*' on release
+            type=ref,event=tag,prefix=python${{ matrix.python-version }}-,enable=${{ github.event_name == 'release' }}
+          labels: |
+            org.opencontainers.image.title=ape
+            org.opencontainers.image.description=Build and explore on-chain with Python
+            org.opencontainers.image.url=https://apeworx.io/framework
+            org.opencontainers.image.documentation=https://docs.apeworx.io/ape/stable/userguides/quickstart
+            org.opencontainers.image.source=https://github.com/ApeWorX/ape
+            org.opencontainers.image.vendor=ApeWorX LTD
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.authors=ApeWorX LTD
+            org.opencontainers.image.base.name=python:${{ matrix.python-version }}-slim
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          target: ${{ matrix.target }}
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+            APE_VERSION=${{ steps.version.outputs.version }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.CACHE_TRUST_PREFIX }}-build-py${{ matrix.python-version }}-${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=${{ env.CACHE_TRUST_PREFIX }}-build-py${{ matrix.python-version }}-${{ matrix.target }}
+          platforms: linux/amd64,linux/arm64
+
+      - name: Run container retention policy
         # TODO: Use `v3` when available
         uses: snok/container-retention-policy@v3.0.1
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,6 +17,36 @@ concurrency:
 
 jobs:
   docs:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Setup Python
+      uses: astral-sh/setup-uv@v7
+      with:
+        python-version: "3.10"
+        enable-cache: true
+        cache-dependency-glob: pyproject.toml
+
+    - name: Build Docs
+      run: uv sync
+
+    - name: Add venv to PATH
+      run: echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH
+      # NOTE: Otherwise the next action nukes the path when it starts
+
+    - name: Ape Docs
+      uses: apeworx/sphinx-ape@main
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-docs:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,14 +8,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
 
     steps:
     - uses: actions/checkout@v5
     - uses: astral-sh/setup-uv@v7
-      with:
-        enable-cache: true
-        cache-dependency-glob: pyproject.toml
 
     - name: Build Package
       run: uv build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,9 @@ on: ["push", "pull_request"]
 
 name: Test
 
+permissions:
+  contents: read
+
 env:
   SETUPTOOLS_SCM_PRETEND_VERSION_FOR_ETH_APE: "0.8.999"
 


### PR DESCRIPTION
## What

Harden GitHub Actions trust boundaries after the recent Mini Shai-Hulud/GitHub Actions supply-chain activity.

This does not reduce test coverage. It keeps PR checks intact while separating untrusted PR execution from jobs that can publish packages, push container images, request OIDC tokens, or write repository contents.

## Changes

- Add explicit read-only default permissions to the main test workflow.
- Make the PyPI release workflow request only `contents: read` and `id-token: write`, and stop restoring the setup-uv cache in that publish path.
- Split docs into two jobs:
  - `docs` runs for pull requests with `contents: read`.
  - `publish-docs` runs for push/release events with `contents: write`, preserving the gh-pages publish path.
- Split the container workflow trust boundary:
  - PR `build` jobs are read-only and use `pr-...` cache scopes.
  - Push/release `publish` jobs keep GHCR/attestation/OIDC permissions and use `trusted-...` cache scopes.

## Why

The main risk is not `pull_request_target` here; Ape does not use it. The remaining low-hanging hardening is avoiding shared trust between PR jobs and publish jobs:

- untrusted PR code should not run in jobs with package publish or OIDC permissions;
- trusted publish jobs should not restore cache entries written by untrusted PR runs;
- release jobs should avoid dependency/tool cache restore where the time saving is not worth the trust boundary.

## Validation

- `pre-commit run --files .github/workflows/build.yaml .github/workflows/docs.yaml .github/workflows/publish.yaml .github/workflows/test.yaml`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `git diff --check`
