### PR TITLE
fix(project): auto-compile on change not working for projects outside their directory

### DIFF
--- a/src/ape/managers/project.py
+++ b/src/ape/managers/project.py
@@ -450,7 +450,9 @@ class ContractManager(BaseManager):
             if check_for_changes and self._detect_change(source_id):
                 compiled = {
                     ct.name: ct
-                    for ct in self.compiler_manager.compile(source_id, project=self.project)
+                    for ct in self.compiler_manager.compile(
+                        self.project.path / source_id, project=self.project
+                    )
                     if ct.name
                 }
                 if compiled:

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -1108,6 +1108,24 @@ class TestContractManager:
         new_count = len(small_temp_project.contracts)
         assert new_count == count - 1
 
+    def test_get_after_change_from_other_cwd(self, small_temp_project):
+        # Regression: getting a contract whose source has changed must not
+        # depend on cwd happening to equal the project root.
+        small_temp_project.load_contracts(use_cache=False)
+        source_path = small_temp_project.contracts_folder / "Other.json"
+        source_path.write_text(source_path.read_text(encoding="utf8") + "\n", encoding="utf8")
+
+        original_cwd = Path.cwd()
+        with create_tempdir() as elsewhere:
+            os.chdir(elsewhere)
+            try:
+                actual = small_temp_project.contracts.get("Other")
+            finally:
+                os.chdir(original_cwd)
+
+        assert isinstance(actual, ContractContainer)
+        assert actual.contract_type.name == "Other"
+
 
 class TestDeploymentManager:
     def test_track(self, project, owner):


### PR DESCRIPTION
### What I did

calling `.load_contracts()` directly on a `Project` outside its dir was fine but the auto-compile feature when there are changes to those contracts and it is a local project, that was not working.

### How I did it

specify path in compile hook in `.get()` method instead of naked source ID.

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
