### PR TITLE
chore: bump container retention policy action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,7 +138,7 @@ jobs:
       - name: Run container retention policy
         if: ${{ github.event_name != 'pull_request' }}
         # TODO: Use `v3` when available
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.1.0
         with:
           account: ApeWorX
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -264,7 +264,7 @@ jobs:
 
       - name: Run container retention policy
         # TODO: Use `v3` when available
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.1.0
         with:
           account: ApeWorX
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed

Bumps `snok/container-retention-policy` from `v3.0.1` to `v3.1.0` in both Container Images retention-policy steps.

## Why

The publish matrix is failing after successful image pushes because `v3.0.1` rejects GitHub's newer Actions token format before making any package API calls. Upstream `v3.1.0` includes the token parsing fix for GitHub's April 2026 token-format migration.

## Validation

- `git diff --check`
- `uv run pre-commit run --files .github/workflows/build.yaml`
