### PR TITLE
fix: keep deployments successful when verification fails

### DIFF
--- a/src/ape/api/accounts.py
+++ b/src/ape/api/accounts.py
@@ -379,7 +379,10 @@ class AccountAPI(BaseInterfaceModel, BaseAddress):
 
         if publish:
             self.local_project.deployments.track(instance)
-            self.provider.network.publish_contract(address)
+            try:
+                self.provider.network.publish_contract(address)
+            except Exception as err:
+                logger.error(f"Contract was deployed but explorer verification failed: {err}")
 
         instance.base_path = contract.base_path or self.local_project.path
         return instance

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -1701,7 +1701,10 @@ class ContractContainer(ContractTypeWrapper, ExtraAttributesMixin):
 
         if publish:
             self.local_project.deployments.track(instance)
-            self.provider.network.publish_contract(address)
+            try:
+                self.provider.network.publish_contract(address)
+            except Exception as err:
+                logger.error(f"Contract was deployed but explorer verification failed: {err}")
 
         instance.base_path = self.base_path or self.local_project.contracts_folder
         return instance

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -17,7 +17,6 @@ from ape.exceptions import (
     AliasAlreadyInUseError,
     MethodNonPayableError,
     MissingDeploymentBytecodeError,
-    NetworkError,
     ProjectError,
     SignatureError,
 )
@@ -337,12 +336,13 @@ def test_deploy_and_publish_local_network(owner, minimal_proxy_container):
 
 @explorer_test
 def test_deploy_and_publish_live_network_no_explorer(
-    owner, minimal_proxy_container, dummy_live_network
+    owner, minimal_proxy_container, dummy_live_network, ape_caplog
 ):
     dummy_live_network.__dict__["explorer"] = None
     expected_message = "Unable to publish contract - no explorer plugin installed."
-    with pytest.raises(NetworkError, match=expected_message):
-        owner.deploy(minimal_proxy_container, publish=True, required_confirmations=0)
+    contract = owner.deploy(minimal_proxy_container, publish=True, required_confirmations=0)
+    assert contract.address
+    assert expected_message in ape_caplog.head
 
 
 @explorer_test
@@ -351,6 +351,23 @@ def test_deploy_and_publish(
 ):
     contract = owner.deploy(minimal_proxy_container, publish=True, required_confirmations=0)
     mock_explorer.publish_contract.assert_called_once_with(contract.address)
+
+
+@explorer_test
+def test_deploy_and_publish_explorer_failure(
+    owner,
+    minimal_proxy_container,
+    dummy_live_network_with_explorer,
+    mock_explorer,
+    ape_caplog,
+):
+    mock_explorer.publish_contract.side_effect = RuntimeError("Verification failed.")
+    contract = owner.deploy(minimal_proxy_container, publish=True, required_confirmations=0)
+    assert contract.address
+    assert (
+        "Contract was deployed but explorer verification failed: Verification failed."
+        in ape_caplog.head
+    )
 
 
 @explorer_test

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -7,7 +7,6 @@ from ape.exceptions import (
     ArgumentsLengthError,
     MethodNonPayableError,
     MissingDeploymentBytecodeError,
-    NetworkError,
     ProjectError,
 )
 from ape_ethereum.ecosystem import ProxyType
@@ -51,12 +50,13 @@ def test_deploy_and_publish_local_network(owner, minimal_proxy_container):
 
 
 def test_deploy_and_publish_live_network_no_explorer(
-    owner, minimal_proxy_container, dummy_live_network
+    owner, minimal_proxy_container, dummy_live_network, ape_caplog
 ):
     dummy_live_network.__dict__["explorer"] = None
     expected_message = "Unable to publish contract - no explorer plugin installed."
-    with pytest.raises(NetworkError, match=expected_message):
-        minimal_proxy_container.deploy(sender=owner, publish=True, required_confirmations=0)
+    contract = minimal_proxy_container.deploy(sender=owner, publish=True, required_confirmations=0)
+    assert contract.address
+    assert expected_message in ape_caplog.head
 
 
 @explorer_test
@@ -65,6 +65,23 @@ def test_deploy_and_publish(
 ):
     contract = minimal_proxy_container.deploy(sender=owner, publish=True, required_confirmations=0)
     mock_explorer.publish_contract.assert_called_once_with(contract.address)
+
+
+@explorer_test
+def test_deploy_and_publish_explorer_failure(
+    owner,
+    minimal_proxy_container,
+    dummy_live_network_with_explorer,
+    mock_explorer,
+    ape_caplog,
+):
+    mock_explorer.publish_contract.side_effect = RuntimeError("Verification failed.")
+    contract = minimal_proxy_container.deploy(sender=owner, publish=True, required_confirmations=0)
+    assert contract.address
+    assert (
+        "Contract was deployed but explorer verification failed: Verification failed."
+        in ape_caplog.head
+    )
 
 
 @explorer_test


### PR DESCRIPTION
## Summary

- make explorer verification best-effort after a successful deployment
- preserve strict behavior for explicit `NetworkAPI.publish_contract()` calls
- cover both account and contract-container deployment entry points

## Root cause

Both deployment paths cached a successfully deployed contract and then called the active explorer synchronously. Any explorer error, including a missing explorer, API rejection, timeout, or plugin failure, propagated from `deploy()` even though the on-chain deployment had already succeeded.

## User impact

`deploy(..., publish=True)` now returns the deployed contract instance when explorer verification fails and logs the original error instead. Deployment tracking and the existing local-network guard keep their current behavior.

## Validation

- `137 passed` across `tests/functional/test_accounts.py` and `tests/functional/test_contract_container.py`
- focused publish regression tests pass for both deployment APIs
- Ruff lint and formatting checks pass for all changed files
- `git diff --check` passes

Local pre-commit mypy currently reports seven errors in three unrelated files; the same errors reproduce on a clean `upstream/main` worktree.
