### PR TITLE
feat!: support ordered network explorers

### DIFF
--- a/docs/userguides/publishing.md
+++ b/docs/userguides/publishing.md
@@ -42,12 +42,15 @@ For more information on accessing contract instances, follow [this guide](./cont
 
 ## Publishing to Explorer
 
-If you want to publish your contracts to an explorer, you can use the [publish_contract](../methoddocs/api.html#ape.explorers.ExplorerAPI.publish_contract) on the `ExplorerAPI`.
+If you want to publish your contracts to an explorer, use the
+[publish_contract](../methoddocs/api.html#ape.explorers.ExplorerAPI.publish_contract) method on
+an `ExplorerAPI`. A network's explorers are ordered by preference, so index `0` selects the
+preferred explorer.
 
 ```python
 from ape import networks
 
-networks.provider.network.explorer.publish_contract("0x123...")
+networks.provider.network.explorers[0].publish_contract("0x123...")
 ```
 
 If you want to automatically publish the source code upon deployment, you can use the `publish=` kwarg on the `deploy` methods:

--- a/src/ape/api/networks.py
+++ b/src/ape/api/networks.py
@@ -611,8 +611,8 @@ class EcosystemAPI(ExtraAttributesMixin, BaseInterfaceModel):
         data["providers"] = []
         network = self[network_name]
 
-        if network.explorer:
-            data["explorer"] = str(network.explorer.name)
+        if network.explorers:
+            data["explorer"] = str(network.explorers[0].name)
 
         for provider_name in network.providers:
             if provider_filter and provider_name not in provider_filter:
@@ -1034,16 +1034,21 @@ class NetworkAPI(BaseInterfaceModel):
         )
 
     @cached_property
-    def explorer(self) -> "ExplorerAPI | None":
+    def explorers(self) -> tuple["ExplorerAPI", ...]:
         """
-        The block-explorer for the given network.
+        The block-explorers for the given network, in lookup order.
+
+        Sourcify is preferred when installed and supported because it does not
+        require authentication. Otherwise, plugin registration order is preserved.
 
         Returns:
-            :class:`ape.api.explorers.ExplorerAPI`, optional
+            tuple[:class:`ape.api.explorers.ExplorerAPI`, ...]
         """
         chain_id = (
             None if self.network_manager.active_provider is None else self.chain_manager.chain_id
         )
+        explorer_types: list[tuple[str, type[ExplorerAPI]]] = []
+        seen_plugins: set[str] = set()
         for plugin_name, plugin_tuple in self._plugin_explorers:
             ecosystem_name, network_name, explorer_class = plugin_tuple
 
@@ -1055,17 +1060,24 @@ class NetworkAPI(BaseInterfaceModel):
                 and self.name in plugin_config[self.ecosystem.name]
             )
 
-            # Return the first registered explorer (skipping any others)
-            if self.ecosystem.name == ecosystem_name and (
+            is_match = self.ecosystem.name == ecosystem_name and (
                 self.name == network_name or has_explorer_config
-            ):
-                return explorer_class(name=plugin_name, network=self)
-
-            elif chain_id is not None and explorer_class.supports_chain(chain_id):
+            )
+            if not is_match and chain_id is not None:
                 # NOTE: Adhoc networks will likely reach here.
-                return explorer_class(name=plugin_name, network=self)
+                is_match = explorer_class.supports_chain(chain_id)
 
-        return None  # May not have an block explorer
+            if is_match and plugin_name not in seen_plugins:
+                explorer_types.append((plugin_name, explorer_class))
+                seen_plugins.add(plugin_name)
+
+        # Stable-sort Sourcify ahead of the existing plugin registration order.
+        explorer_types.sort(key=lambda item: item[0].lower() != "sourcify")
+        explorers = tuple(
+            explorer_class(name=plugin_name, network=self)
+            for plugin_name, explorer_class in explorer_types
+        )
+        return explorers
 
     @property
     def _plugin_explorers(self) -> list[tuple]:
@@ -1390,11 +1402,12 @@ class NetworkAPI(BaseInterfaceModel):
         Args:
             address (:class:`~ape.types.address.AddressType`): The address of the contract.
         """
-        if not self.explorer:
+        if not self.explorers:
             raise NetworkError("Unable to publish contract - no explorer plugin installed.")
 
-        logger.info(f"Publishing and verifying contract using '{self.explorer.name}'.")
-        self.explorer.publish_contract(address)
+        explorer = self.explorers[0]
+        logger.info(f"Publishing and verifying contract using '{explorer.name}'.")
+        explorer.publish_contract(address)
 
     def verify_chain_id(self, chain_id: int):
         """

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -13,6 +13,7 @@ from pydantic.fields import Field
 from tqdm import tqdm  # type: ignore
 
 from ape.exceptions import (
+    APINotImplementedError,
     NetworkError,
     ProviderNotConnectedError,
     SignatureError,
@@ -31,7 +32,6 @@ from ape.utils.trace import prettify_function
 if TYPE_CHECKING:
     from ethpm_types.abi import EventABI, MethodABI
 
-    from ape.api.explorers import ExplorerAPI
     from ape.api.providers import BlockAPI
     from ape.api.trace import TraceAPI
     from ape.contracts import ContractEvent
@@ -432,11 +432,6 @@ class ReceiptAPI(ExtraAttributesMixin, BaseInterfaceModel):
         return self.provider.get_transaction_trace(self.txn_hash)
 
     @property
-    def _explorer(self) -> "ExplorerAPI | None":
-        explorers = self.provider.network.explorers
-        return explorers[0] if explorers else None
-
-    @property
     def _block_time(self) -> int:
         return self.provider.network.block_time
 
@@ -530,7 +525,17 @@ class ReceiptAPI(ExtraAttributesMixin, BaseInterfaceModel):
                 break
 
     def _log_submission(self):
-        if explorer_url := self._explorer and self._explorer.get_transaction_url(self.txn_hash):
+        explorer_url = None
+        for explorer in self.provider.network.explorers:
+            try:
+                explorer_url = explorer.get_transaction_url(self.txn_hash)
+            except APINotImplementedError:
+                continue
+
+            if explorer_url:
+                break
+
+        if explorer_url:
             log_message = f"Submitted {explorer_url}"
         else:
             log_message = f"Submitted {self.txn_hash}"

--- a/src/ape/api/transactions.py
+++ b/src/ape/api/transactions.py
@@ -433,7 +433,8 @@ class ReceiptAPI(ExtraAttributesMixin, BaseInterfaceModel):
 
     @property
     def _explorer(self) -> "ExplorerAPI | None":
-        return self.provider.network.explorer
+        explorers = self.provider.network.explorers
+        return explorers[0] if explorers else None
 
     @property
     def _block_time(self) -> int:

--- a/src/ape/contracts/base.py
+++ b/src/ape/contracts/base.py
@@ -285,7 +285,7 @@ class ContractMethodHandler(ManagerAccessMixin):
         if not self.contract.is_contract:
             raise ContractNotFoundError(
                 self.contract.address,
-                self.provider.network.explorer is not None,
+                bool(self.provider.network.explorers),
                 self.provider.network_choice,
             )
 

--- a/src/ape/managers/_contractscache.py
+++ b/src/ape/managers/_contractscache.py
@@ -454,7 +454,7 @@ class ContractCache(BaseManager):
         if not contract_type:
             # Create error message from custom exception cls.
             err = ContractNotFoundError(
-                address, self.provider.network.explorer is not None, self.provider.network_choice
+                address, bool(self.provider.network.explorers), self.provider.network_choice
             )
             # Must raise KeyError.
             raise KeyError(str(err))
@@ -825,7 +825,7 @@ class ContractCache(BaseManager):
         if not contract_type:
             raise ContractNotFoundError(
                 contract_address,
-                self.provider.network.explorer is not None,
+                bool(self.provider.network.explorers),
                 self.provider.network_choice,
             )
 
@@ -922,45 +922,44 @@ class ContractCache(BaseManager):
         self.deployments.clear_local()
 
     def _get_contract_type_from_explorer(self, address: AddressType) -> ContractType | None:
-        if not self.provider.network.explorer:
-            return None
+        for explorer in self.provider.network.explorers:
+            try:
+                contract_type = explorer.get_contract_type(address)
+            except Exception as err:
+                if "rate limit" in str(err).lower():
+                    # Don't show any additional error message during rate limit errors,
+                    # if it can be helped, as it may scare users into thinking their
+                    # contracts are not verified.
+                    message = str(err)
+                else:
+                    # Carefully word this message in a way that doesn't hint at
+                    # any one specific reason, such as un-verified source code,
+                    # which is potentially a scare for users.
+                    message = (
+                        f"Attempted to retrieve contract type from explorer '{explorer.name}' "
+                        f"from address '{address}' but encountered an exception: {err}\n"
+                    )
 
-        try:
-            contract_type = self.provider.network.explorer.get_contract_type(address)
-        except Exception as err:
-            explorer_name = self.provider.network.explorer.name
-            if "rate limit" in str(err).lower():
-                # Don't show any additional error message during rate limit errors,
-                # if it can be helped, as it may scare users into thinking their
-                # contracts are not verified.
-                message = str(err)
-            else:
-                # Carefully word this message in a way that doesn't hint at
-                # any one specific reason, such as un-verified source code,
-                # which is potentially a scare for users.
-                message = (
-                    f"Attempted to retrieve contract type from explorer '{explorer_name}' "
-                    f"from address '{address}' but encountered an exception: {err}\n"
-                )
+                logger.error(message)
+                continue
 
-            logger.error(message)
-            return None
+            if not contract_type:
+                continue
 
-        if contract_type:
             # Cache contract so faster look-up next time.
             if not isinstance(contract_type, ContractType):
-                explorer_name = self.provider.network.explorer.name
                 wrong_type = type(contract_type)
                 wrong_type_str = getattr(wrong_type, "__name__", f"{wrong_type}")
                 logger.warning(
-                    f"Explorer '{explorer_name}' returned unexpected "
+                    f"Explorer '{explorer.name}' returned unexpected "
                     f"type '{wrong_type_str}' ContractType."
                 )
-                return None
+                continue
 
             self.contract_types[address] = contract_type
+            return contract_type
 
-        return contract_type
+        return None
 
 
 def _get_combined_contract_type(

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -419,9 +419,9 @@ def dummy_live_network(chain, project):
 
 @pytest.fixture
 def dummy_live_network_with_explorer(dummy_live_network, mock_explorer):
-    dummy_live_network.__dict__["explorer"] = mock_explorer
+    dummy_live_network.__dict__["explorers"] = (mock_explorer,)
     yield dummy_live_network
-    dummy_live_network.__dict__.pop("explorer", None)
+    dummy_live_network.__dict__.pop("explorers", None)
 
 
 @pytest.fixture(scope="session")

--- a/tests/functional/geth/test_contracts_cache.py
+++ b/tests/functional/geth/test_contracts_cache.py
@@ -40,14 +40,14 @@ def test_get_proxy_from_explorer(
     with create_mock_sepolia() as network:
         # Set up our network to use our fake explorer.
         mock_explorer.get_contract_type.side_effect = get_contract_type
-        network.__dict__["explorer"] = mock_explorer
+        network.__dict__["explorers"] = (mock_explorer,)
 
         # Typical flow: user attempts to get an un-cached contract type from Etherscan.
         # That contract may be a proxy, in which case we should get a type
         # w/ both proxy ABIs and the target ABIs.
         contract_from_explorer = chain.contracts.instance_at(proxy_contract.address)
 
-        network.__dict__.pop("explorer", None)
+        network.__dict__.pop("explorers", None)
 
         # Ensure we can call proxy methods!
         assert contract_from_explorer.masterCopy  # No attr error!

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -339,7 +339,7 @@ def test_deploy_and_publish_local_network(owner, minimal_proxy_container):
 def test_deploy_and_publish_live_network_no_explorer(
     owner, minimal_proxy_container, dummy_live_network
 ):
-    dummy_live_network.__dict__["explorer"] = None
+    dummy_live_network.__dict__["explorers"] = ()
     expected_message = "Unable to publish contract - no explorer plugin installed."
     with pytest.raises(NetworkError, match=expected_message):
         owner.deploy(minimal_proxy_container, publish=True, required_confirmations=0)

--- a/tests/functional/test_contract_call_handler.py
+++ b/tests/functional/test_contract_call_handler.py
@@ -13,7 +13,7 @@ def test_struct_input(
 
 
 def test_call_contract_not_found(mocker, method_abi_with_struct_input, networks):
-    (networks.ethereum.local.__dict__ or {}).pop("explorer", None)
+    (networks.ethereum.local.__dict__ or {}).pop("explorers", None)
     contract = mocker.MagicMock()
     contract.address = ZERO_ADDRESS
     contract.is_contract = False
@@ -25,7 +25,7 @@ def test_call_contract_not_found(mocker, method_abi_with_struct_input, networks)
 
 
 def test_transact_contract_not_found(mocker, owner, method_abi_with_struct_input, networks):
-    (networks.ethereum.local.__dict__ or {}).pop("explorer", None)
+    (networks.ethereum.local.__dict__ or {}).pop("explorers", None)
     contract = mocker.MagicMock()
     contract.address = ZERO_ADDRESS
     contract.is_contract = False

--- a/tests/functional/test_contract_container.py
+++ b/tests/functional/test_contract_container.py
@@ -53,7 +53,7 @@ def test_deploy_and_publish_local_network(owner, minimal_proxy_container):
 def test_deploy_and_publish_live_network_no_explorer(
     owner, minimal_proxy_container, dummy_live_network
 ):
-    dummy_live_network.__dict__["explorer"] = None
+    dummy_live_network.__dict__["explorers"] = ()
     expected_message = "Unable to publish contract - no explorer plugin installed."
     with pytest.raises(NetworkError, match=expected_message):
         minimal_proxy_container.deploy(sender=owner, publish=True, required_confirmations=0)
@@ -206,7 +206,7 @@ def test_at_fetch_from_explorer_false(
     project_with_contract.clean()
 
     # Simulate having an explorer plugin installed (e.g. ape-etherscan).
-    eth_tester_provider.network.__dict__["explorer"] = mock_explorer
+    eth_tester_provider.network.__dict__["explorers"] = (mock_explorer,)
 
     # Attempt to create an instance. It should NOT use the explorer at all!
     instance2 = container.at(instance.address, fetch_from_explorer=False)
@@ -216,4 +216,4 @@ def test_at_fetch_from_explorer_false(
     assert mock_explorer.get_contract_type.call_count == 0
 
     # Clean up test.
-    eth_tester_provider.network.__dict__.pop("explorer")
+    eth_tester_provider.network.__dict__.pop("explorers")

--- a/tests/functional/test_contracts_cache.py
+++ b/tests/functional/test_contracts_cache.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from ethpm_types import ContractType
 
@@ -87,7 +89,7 @@ def test_instance_at_uses_given_contract_type_when_retrieval_fails(mocker, chain
 
 @explorer_test
 def test_instance_at_contract_type_not_found_local_network(chain, eth_tester_provider):
-    eth_tester_provider.network.__dict__["explorer"] = None
+    eth_tester_provider.network.__dict__["explorers"] = ()
     new_address = "0x4a986a6dca6dbF99Bc3D17F8d71aFB0D60E740F9"
     expected = rf"Failed to get contract type for address '{new_address}'."
     with pytest.raises(ContractNotFoundError, match=expected):
@@ -96,7 +98,7 @@ def test_instance_at_contract_type_not_found_local_network(chain, eth_tester_pro
 
 @explorer_test
 def test_instance_at_contract_type_not_found_live_network(chain, eth_tester_provider):
-    eth_tester_provider.network.__dict__["explorer"] = None
+    eth_tester_provider.network.__dict__["explorers"] = ()
     real_name = eth_tester_provider.network.name
     eth_tester_provider.network.name = "sepolia"
     try:
@@ -260,7 +262,7 @@ def test_cache_default_contract_type_when_used(solidity_contract_instance, chain
 
 @explorer_test
 def test_contracts_getitem_contract_not_found(chain, eth_tester_provider):
-    eth_tester_provider.network.__dict__["explorer"] = None
+    eth_tester_provider.network.__dict__["explorers"] = ()
     new_address = "0x4a986a6dca6dbF99Bc3D17F8d71aFB0D60E740F9"
     real_name = eth_tester_provider.network.name
     eth_tester_provider.network.name = "sepolia"
@@ -441,15 +443,130 @@ def test_get_attempts_explorer(
     with create_mock_sepolia() as network:
         del chain.contracts[contract.address]
         mock_explorer.get_contract_type.side_effect = get_contract_type
-        network.__dict__["explorer"] = mock_explorer
+        network.__dict__["explorers"] = (mock_explorer,)
         try:
             actual = chain.contracts.get(contract.address, detect_proxy=False)
         finally:
-            network.__dict__["explorer"] = None
+            network.__dict__["explorers"] = ()
 
         assert actual == contract.contract_type
         assert mock_explorer.get_contract_type.call_count > 0
         mock_explorer.get_contract_type.reset_mock()
+
+
+@explorer_test
+def test_get_attempts_explorer_fallback_and_caches(
+    mocker, create_mock_sepolia, chain, owner, minimal_proxy_container
+):
+    contract = owner.deploy(minimal_proxy_container)
+    sourcify = mocker.MagicMock(name="sourcify")
+    sourcify.name = "sourcify"
+    sourcify.get_contract_type.return_value = None
+    etherscan = mocker.MagicMock(name="etherscan")
+    etherscan.name = "etherscan"
+    etherscan.get_contract_type.return_value = contract.contract_type
+
+    with create_mock_sepolia() as network:
+        del chain.contracts[contract.address]
+        network.__dict__.pop("explorers", None)
+        mocker.patch(
+            "ape.api.networks.NetworkAPI.explorers",
+            new_callable=mock.PropertyMock,
+            return_value=(sourcify, etherscan),
+        )
+        actual = chain.contracts.get(contract.address, detect_proxy=False)
+        cached = chain.contracts.get(contract.address, detect_proxy=False)
+
+    assert actual == cached == contract.contract_type
+    sourcify.get_contract_type.assert_called_once_with(contract.address)
+    etherscan.get_contract_type.assert_called_once_with(contract.address)
+
+
+@explorer_test
+def test_get_attempts_explorer_fallback_after_error(
+    mocker,
+    create_mock_sepolia,
+    chain,
+    owner,
+    minimal_proxy_container,
+    ape_caplog,
+):
+    contract = owner.deploy(minimal_proxy_container)
+    sourcify = mocker.MagicMock(name="sourcify")
+    sourcify.name = "sourcify"
+    sourcify.get_contract_type.side_effect = ValueError("Sourcify unavailable")
+    etherscan = mocker.MagicMock(name="etherscan")
+    etherscan.name = "etherscan"
+    etherscan.get_contract_type.return_value = contract.contract_type
+
+    with create_mock_sepolia() as network:
+        del chain.contracts[contract.address]
+        network.__dict__.pop("explorers", None)
+        mocker.patch(
+            "ape.api.networks.NetworkAPI.explorers",
+            new_callable=mock.PropertyMock,
+            return_value=(sourcify, etherscan),
+        )
+        actual = chain.contracts.get(contract.address, detect_proxy=False)
+
+    assert actual == contract.contract_type
+    assert "explorer 'sourcify'" in ape_caplog.head
+    assert "Sourcify unavailable" in ape_caplog.head
+    sourcify.get_contract_type.assert_called_once_with(contract.address)
+    etherscan.get_contract_type.assert_called_once_with(contract.address)
+
+
+@explorer_test
+def test_get_attempts_explorer_stops_after_first_success(
+    mocker, create_mock_sepolia, chain, owner, minimal_proxy_container
+):
+    contract = owner.deploy(minimal_proxy_container)
+    sourcify = mocker.MagicMock(name="sourcify")
+    sourcify.name = "sourcify"
+    sourcify.get_contract_type.return_value = contract.contract_type
+    etherscan = mocker.MagicMock(name="etherscan")
+    etherscan.name = "etherscan"
+
+    with create_mock_sepolia() as network:
+        del chain.contracts[contract.address]
+        network.__dict__.pop("explorers", None)
+        mocker.patch(
+            "ape.api.networks.NetworkAPI.explorers",
+            new_callable=mock.PropertyMock,
+            return_value=(sourcify, etherscan),
+        )
+        actual = chain.contracts.get(contract.address, detect_proxy=False)
+
+    assert actual == contract.contract_type
+    sourcify.get_contract_type.assert_called_once_with(contract.address)
+    etherscan.get_contract_type.assert_not_called()
+
+
+@explorer_test
+def test_get_attempts_explorer_all_miss(
+    mocker, create_mock_sepolia, chain, owner, minimal_proxy_container
+):
+    contract = owner.deploy(minimal_proxy_container)
+    sourcify = mocker.MagicMock(name="sourcify")
+    sourcify.name = "sourcify"
+    sourcify.get_contract_type.return_value = None
+    etherscan = mocker.MagicMock(name="etherscan")
+    etherscan.name = "etherscan"
+    etherscan.get_contract_type.return_value = None
+
+    with create_mock_sepolia() as network:
+        del chain.contracts[contract.address]
+        network.__dict__.pop("explorers", None)
+        mocker.patch(
+            "ape.api.networks.NetworkAPI.explorers",
+            new_callable=mock.PropertyMock,
+            return_value=(sourcify, etherscan),
+        )
+        actual = chain.contracts.get(contract.address, detect_proxy=False)
+
+    assert actual is None
+    sourcify.get_contract_type.assert_called_once_with(contract.address)
+    etherscan.get_contract_type.assert_called_once_with(contract.address)
 
 
 @explorer_test
@@ -473,11 +590,11 @@ def test_get_attempts_explorer_logs_errors_from_explorer(
     with create_mock_sepolia() as network:
         del chain.contracts[contract.address]
         mock_explorer.get_contract_type.side_effect = get_contract_type
-        network.__dict__["explorer"] = mock_explorer
+        network.__dict__["explorers"] = (mock_explorer,)
         try:
             actual = chain.contracts.get(contract.address, detect_proxy=False)
         finally:
-            network.__dict__["explorer"] = None
+            network.__dict__["explorers"] = ()
 
         assert expected_log in ape_caplog.head
         assert actual is None
@@ -505,12 +622,12 @@ def test_get_attempts_explorer_logs_rate_limit_error_from_explorer(
         del chain.contracts[contract.address]
 
         mock_explorer.get_contract_type.side_effect = get_contract_type
-        network.__dict__["explorer"] = mock_explorer
+        network.__dict__["explorers"] = (mock_explorer,)
         try:
             with logger.at_level(LogLevel.INFO):
                 actual = chain.contracts.get(contract.address, detect_proxy=False)
         finally:
-            network.__dict__["explorer"] = None
+            network.__dict__["explorers"] = ()
 
         assert check_error_str in ape_caplog.head
         assert actual is None
@@ -536,7 +653,7 @@ def test_get_proxy(chain, owner, minimal_proxy_container, vyper_contract_instanc
         del chain.contracts[placeholder]
 
     minimal_proxy = owner.deploy(minimal_proxy_container, sender=owner)
-    chain.provider.network.__dict__["explorer"] = None  # Ensure no explorer, messes up test.
+    chain.provider.network.__dict__["explorers"] = ()  # Ensure no explorer, messes up test.
 
     actual = chain.contracts.get(minimal_proxy.address)
     assert actual == minimal_proxy.contract_type
@@ -551,7 +668,7 @@ def test_get_proxy_implementation_missing(chain, owner, project):
 
     proxy_container = _make_minimal_proxy(placeholder.address)
     minimal_proxy = owner.deploy(proxy_container, sender=owner)
-    chain.provider.network.__dict__["explorer"] = None  # Ensure no explorer, messes up test.
+    chain.provider.network.__dict__["explorers"] = ()  # Ensure no explorer, messes up test.
 
     if minimal_proxy.address in chain.contracts:
         # Delete the proxy but make sure it does not delete the implementation!
@@ -569,7 +686,7 @@ def test_get_proxy_pass_proxy_info(chain, owner, minimal_proxy_container, ethere
         del chain.contracts[placeholder]
 
     minimal_proxy = owner.deploy(minimal_proxy_container, sender=owner)
-    chain.provider.network.__dict__["explorer"] = None  # Ensure no explorer, messes up test.
+    chain.provider.network.__dict__["explorers"] = ()  # Ensure no explorer, messes up test.
     info = ethereum.get_proxy_info(minimal_proxy.address)
     assert info
 
@@ -592,7 +709,7 @@ def test_get_proxy_pass_proxy_info_and_no_explorer(
     Tests the condition of both passing `proxy_info=` and setting `use_explorer=False`
     when getting the ContractType of a proxy.
     """
-    explorer = dummy_live_network_with_explorer.explorer
+    explorer = dummy_live_network_with_explorer.explorers[0]
     placeholder = "0xBEbeBeBEbeBebeBeBEBEbebEBeBeBebeBeBebebe"
     if placeholder in chain.contracts:
         del chain.contracts[placeholder]

--- a/tests/functional/test_history.py
+++ b/tests/functional/test_history.py
@@ -46,7 +46,7 @@ def test_history_caches_sender_over_address_key(
             yield from [known_receipt]
 
     mock_explorer.get_account_transactions.side_effect = get_txns_patch
-    network.__dict__["explorer"] = mock_explorer
+    network.__dict__["explorers"] = (mock_explorer,)
     eth_tester_provider.network = network
 
     # Previously, this would error because the receipt was cached with the wrong sender
@@ -56,4 +56,4 @@ def test_history_caches_sender_over_address_key(
         # Actual is 0 because the receipt was cached under the sender.
         assert len(actual) == 0
     finally:
-        network.__dict__.pop("explorer", None)
+        network.__dict__.pop("explorers", None)

--- a/tests/functional/test_network_api.py
+++ b/tests/functional/test_network_api.py
@@ -375,22 +375,22 @@ def test_is_mainnet_from_config():
     assert network.is_mainnet
 
 
-def test_explorer(networks):
+def test_explorers(networks):
     """
     Local network does not have an explorer, by default.
     """
     network = networks.ethereum.local
-    network.__dict__.pop("explorer", None)  # Ensure not cached yet.
-    assert network.explorer is None
+    network.__dict__.pop("explorers", None)
+    assert network.explorers == ()
 
 
-def test_explorer_when_network_registered(networks, mocker):
+def test_explorers_when_network_registered(networks, mocker):
     """
     Tests the simple flow of having the Explorer plugin register
     the networks it supports.
     """
     network = networks.ethereum.local
-    network.__dict__.pop("explorer", None)  # Ensure not cached yet.
+    network.__dict__.pop("explorers", None)
     name = "my-explorer"
 
     def explorer_cls(*args, **kwargs):
@@ -402,17 +402,115 @@ def test_explorer_when_network_registered(networks, mocker):
         "ape.api.networks.NetworkAPI._plugin_explorers", new_callable=mock.PropertyMock
     )
     mock_plugin_explorers.return_value = [("my-example", ("ethereum", "local", explorer_cls))]
-    assert network.explorer is not None
-    assert network.explorer.name == name
+    try:
+        assert len(network.explorers) == 1
+        assert network.explorers[0].name == name
+    finally:
+        network.__dict__.pop("explorers", None)
 
 
-def test_explorer_when_adhoc_network_supported(networks, mocker):
+def test_explorers_prefer_sourcify_and_deduplicate(networks, mocker):
+    network = networks.ethereum.local
+    network.__dict__.pop("explorers", None)
+
+    class MyExplorer:
+        def __init__(self, name, network):
+            self.name = name
+            self.network = network
+
+        @classmethod
+        def supports_chain(cls, chain_id):
+            return True
+
+    mock_plugin_explorers = mocker.patch(
+        "ape.api.networks.NetworkAPI._plugin_explorers", new_callable=mock.PropertyMock
+    )
+    mock_plugin_explorers.return_value = [
+        ("etherscan", ("ethereum", "local", MyExplorer)),
+        ("sourcify", ("ethereum", "local", MyExplorer)),
+        # The same plugin may also match through ``supports_chain()``.
+        ("sourcify", ("other-ecosystem", "other-network", MyExplorer)),
+    ]
+
+    try:
+        assert [explorer.name for explorer in network.explorers] == ["sourcify", "etherscan"]
+        preferred = network.explorers[0]
+        assert preferred.name == "sourcify"
+        assert network.explorers[0] is preferred
+    finally:
+        network.__dict__.pop("explorers", None)
+
+
+def test_explorers_preserve_registration_order_without_supported_sourcify(networks, mocker):
+    network = networks.ethereum.local
+    network.__dict__.pop("explorers", None)
+
+    class MyExplorer:
+        def __init__(self, name, network):
+            self.name = name
+            self.network = network
+
+        @classmethod
+        def supports_chain(cls, chain_id):
+            return False
+
+    mock_plugin_explorers = mocker.patch(
+        "ape.api.networks.NetworkAPI._plugin_explorers", new_callable=mock.PropertyMock
+    )
+    mock_plugin_explorers.return_value = [
+        ("etherscan", ("ethereum", "local", MyExplorer)),
+        ("blockscout", ("ethereum", "local", MyExplorer)),
+        ("sourcify", ("other-ecosystem", "other-network", MyExplorer)),
+    ]
+
+    try:
+        assert [explorer.name for explorer in network.explorers] == [
+            "etherscan",
+            "blockscout",
+        ]
+    finally:
+        network.__dict__.pop("explorers", None)
+
+
+def test_explorers_when_custom_network_configured(networks, mocker):
+    network = networks.ethereum.local
+    network.__dict__.pop("explorers", None)
+
+    class MyExplorer:
+        def __init__(self, name, network):
+            self.name = name
+            self.network = network
+
+        @classmethod
+        def supports_chain(cls, chain_id):
+            return False
+
+    mocker.patch.object(
+        network.config_manager,
+        "get_config",
+        return_value={"ethereum": {"local": {"uri": "https://example.com"}}},
+    )
+    mock_plugin_explorers = mocker.patch(
+        "ape.api.networks.NetworkAPI._plugin_explorers", new_callable=mock.PropertyMock
+    )
+    mock_plugin_explorers.return_value = [
+        ("custom-explorer", ("ethereum", "other-network", MyExplorer))
+    ]
+
+    try:
+        assert len(network.explorers) == 1
+        assert network.explorers[0].name == "custom-explorer"
+    finally:
+        network.__dict__.pop("explorers", None)
+
+
+def test_explorers_when_adhoc_network_supported(networks, mocker):
     """
     Tests the flow of when a chain is supported by an explorer
     but not registered in the plugin (API-flow).
     """
     network = networks.ethereum.local
-    network.__dict__.pop("explorer", None)  # Ensure not cached yet.
+    network.__dict__.pop("explorers", None)
     NAME = "my-explorer"
 
     class MyExplorer:
@@ -433,8 +531,11 @@ def test_explorer_when_adhoc_network_supported(networks, mocker):
     mock_plugin_explorers.return_value = [
         ("my-example", ("some-other-ecosystem", "local", MyExplorer))
     ]
-    assert network.explorer is not None
-    assert network.explorer.name == NAME
+    try:
+        assert len(network.explorers) == 1
+        assert network.explorers[0].name == NAME
+    finally:
+        network.__dict__.pop("explorers", None)
 
 
 def test_evm_chains_auto_forked_networks_exist(networks):

--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -60,7 +60,7 @@ def test_minimal_proxy(ethereum, minimal_proxy_container, chain, owner):
         del chain.contracts[placeholder]
 
     minimal_proxy = owner.deploy(minimal_proxy_container, sender=owner)
-    chain.provider.network.__dict__["explorer"] = None  # Ensure no explorer, messes up test.
+    chain.provider.network.__dict__["explorers"] = ()  # Ensure no explorer, messes up test.
     actual = ethereum.get_proxy_info(minimal_proxy.address)
     assert actual is not None
     assert actual.type == ProxyType.Minimal

--- a/tests/functional/test_receipt.py
+++ b/tests/functional/test_receipt.py
@@ -5,7 +5,7 @@ from eth_utils import to_hex
 from rich.table import Table
 from rich.tree import Tree
 
-from ape.exceptions import ContractLogicError, OutOfGasError
+from ape.exceptions import APINotImplementedError, ContractLogicError, OutOfGasError
 from ape.utils import ManagerAccessMixin
 from ape_ethereum.transactions import DynamicFeeTransaction, Receipt, TransactionStatusEnum
 
@@ -37,6 +37,48 @@ def test_receipt_properties(chain, invoke_receipt):
     assert invoke_receipt.block_number == chain.blocks.head.number
     assert invoke_receipt.timestamp == chain.blocks.head.timestamp
     assert invoke_receipt.datetime == chain.blocks.head.datetime
+
+
+def test_log_submission_uses_next_explorer_for_transaction_url(mocker, invoke_receipt):
+    unsupported = mocker.MagicMock(name="unsupported")
+    unsupported.get_transaction_url.side_effect = APINotImplementedError()
+    supported = mocker.MagicMock(name="supported")
+    supported.get_transaction_url.return_value = "https://explorer.example/tx/0x123"
+    network = invoke_receipt.provider.network
+    original_explorers = network.__dict__.get("explorers")
+    network.__dict__["explorers"] = (unsupported, supported)
+    log = mocker.patch("ape.api.transactions.logger.info")
+
+    try:
+        invoke_receipt._log_submission()
+    finally:
+        if original_explorers is None:
+            network.__dict__.pop("explorers", None)
+        else:
+            network.__dict__["explorers"] = original_explorers
+
+    unsupported.get_transaction_url.assert_called_once_with(invoke_receipt.txn_hash)
+    supported.get_transaction_url.assert_called_once_with(invoke_receipt.txn_hash)
+    log.assert_called_once_with("Submitted https://explorer.example/tx/0x123")
+
+
+def test_log_submission_uses_hash_when_no_explorer_supports_transaction_url(mocker, invoke_receipt):
+    unsupported = mocker.MagicMock(name="unsupported")
+    unsupported.get_transaction_url.side_effect = APINotImplementedError()
+    network = invoke_receipt.provider.network
+    original_explorers = network.__dict__.get("explorers")
+    network.__dict__["explorers"] = (unsupported,)
+    log = mocker.patch("ape.api.transactions.logger.info")
+
+    try:
+        invoke_receipt._log_submission()
+    finally:
+        if original_explorers is None:
+            network.__dict__.pop("explorers", None)
+        else:
+            network.__dict__["explorers"] = original_explorers
+
+    log.assert_called_once_with(f"Submitted {invoke_receipt.txn_hash}")
 
 
 def test_show_trace(trace_print_capture, invoke_receipt):


### PR DESCRIPTION
## Summary

- replace `NetworkAPI.explorer` with an ordered, cached `NetworkAPI.explorers` tuple
- prefer Sourcify when it is installed and supports the active network, while preserving existing order for other explorers
- deduplicate explorer plugins that match through both registration and `supports_chain()`
- fall back across every matching explorer when contract metadata is missing or an explorer raises
- keep publishing on the first preferred explorer, while transaction URL generation falls through explorers that do not implement it

## Breaking change

`NetworkAPI.explorer` is removed. Consumers should use `NetworkAPI.explorers`; index `0` is the preferred explorer when the tuple is non-empty.

## Why

Explorer selection previously depended on installed-distribution and Pluggy registration order, and contract lookup stopped after the first explorer returned no metadata or raised. That made source discovery unreliable when multiple explorer plugins were installed.

Sourcify is preferred because it does not require authentication and has generous rate limits. If Sourcify is absent or unsupported, the existing explorer order is retained. Operations that Sourcify cannot provide, such as transaction URLs on chains without known explorer metadata, can fall through to another installed explorer.

## Validation

- `uv run pytest -q tests/functional --ignore=tests/functional/geth` — 1,650 passed, 1 skipped
- `uv run pytest -q tests/functional/geth/test_contracts_cache.py` — 1 passed
- explorer, receipt, and contract-cache focused suite — 122 passed
- transaction and receipt suite — 98 passed
- Ruff checks and formatting
- targeted mypy checks for all changed source modules
- mdformat check for the updated publishing guide
